### PR TITLE
Fix CI: resolve type errors and reduce complexity

### DIFF
--- a/src/muninn/parsers/ios/show_environment.py
+++ b/src/muninn/parsers/ios/show_environment.py
@@ -196,6 +196,36 @@ class ShowEnvironmentParser(BaseParser[ShowEnvironmentResult]):
         return entry
 
     @classmethod
+    def _parse_sensor_line(
+        cls,
+        line: str,
+        has_thresholds: bool,
+        cols: tuple[int, int, int, int] | None,
+    ) -> tuple[str, str, SensorEntry] | None:
+        """Parse a single sensor data line.
+
+        Returns (slot, sensor_name, entry) or None if the line is not valid.
+        """
+        threshold_str: str | None = None
+
+        if has_thresholds and cols is not None:
+            parsed = cls._parse_line_columns(line, cols)
+            if parsed is None:
+                return None
+            slot, sensor_name, state, reading_str, threshold_str = parsed
+        else:
+            parsed_split = cls._parse_line_split(line)
+            if parsed_split is None:
+                return None
+            slot, sensor_name, state, reading_str = parsed_split
+
+        entry = cls._build_entry(state, reading_str, threshold_str)
+        if entry is None:
+            return None
+
+        return slot, sensor_name, entry
+
+    @classmethod
     def _parse_sensors(
         cls,
         lines: list[str],
@@ -211,23 +241,11 @@ class ShowEnvironmentParser(BaseParser[ShowEnvironmentResult]):
             if line.strip().startswith("Power") and "Supply" in line:
                 break
 
-            threshold_str: str | None = None
-
-            if has_thresholds and cols is not None:
-                parsed = cls._parse_line_columns(line, cols)
-                if parsed is None:
-                    continue
-                slot, sensor_name, state, reading_str, threshold_str = parsed
-            else:
-                parsed_split = cls._parse_line_split(line)
-                if parsed_split is None:
-                    continue
-                slot, sensor_name, state, reading_str = parsed_split
-
-            entry = cls._build_entry(state, reading_str, threshold_str)
-            if entry is None:
+            result = cls._parse_sensor_line(line, has_thresholds, cols)
+            if result is None:
                 continue
 
+            slot, sensor_name, entry = result
             if slot not in sensors:
                 sensors[slot] = {}
             sensors[slot][sensor_name] = entry

--- a/src/muninn/parsers/ios/show_inventory.py
+++ b/src/muninn/parsers/ios/show_inventory.py
@@ -62,6 +62,27 @@ class ShowInventoryParser(BaseParser[ShowInventoryResult]):
         return value
 
     @classmethod
+    def _build_item(
+        cls, name: str, descr: str, pid_match: re.Match[str]
+    ) -> InventoryItem:
+        """Build an InventoryItem from a PID/VID/SN regex match."""
+        pid = cls._normalize_value(pid_match.group("pid"))
+        vid = cls._normalize_value(pid_match.group("vid"))
+        sn = cls._normalize_value(pid_match.group("sn"))
+
+        item: InventoryItem = {
+            "name": name,
+            "description": descr,
+        }
+        if pid:
+            item["pid"] = pid
+        if vid:
+            item["vid"] = vid
+        if sn:
+            item["serial_number"] = sn
+        return item
+
+    @classmethod
     def parse(cls, output: str) -> ShowInventoryResult:
         """Parse 'show inventory' output.
 
@@ -75,44 +96,25 @@ class ShowInventoryParser(BaseParser[ShowInventoryResult]):
             ValueError: If no inventory items found.
         """
         inventory: dict[str, InventoryItem] = {}
-        lines = output.splitlines()
-
         current_name: str | None = None
         current_descr: str | None = None
 
-        for line in lines:
+        for line in output.splitlines():
             line = line.strip()
             if not line:
                 continue
 
-            # Try to match NAME/DESCR line
             name_match = cls._NAME_DESCR_PATTERN.match(line)
             if name_match:
                 current_name = name_match.group("name")
                 current_descr = name_match.group("descr")
                 continue
 
-            # Try to match PID/VID/SN line
             pid_match = cls._PID_VID_SN_PATTERN.match(line)
             if pid_match and current_name is not None:
-                pid = cls._normalize_value(pid_match.group("pid"))
-                vid = cls._normalize_value(pid_match.group("vid"))
-                sn = cls._normalize_value(pid_match.group("sn"))
-
-                item: InventoryItem = {
-                    "name": current_name,
-                    "description": current_descr or "",
-                }
-                if pid:
-                    item["pid"] = pid
-                if vid:
-                    item["vid"] = vid
-                if sn:
-                    item["serial_number"] = sn
-
-                inventory[current_name] = item
-
-                # Reset for next item
+                inventory[current_name] = cls._build_item(
+                    current_name, current_descr or "", pid_match
+                )
                 current_name = None
                 current_descr = None
 

--- a/src/muninn/parsers/ios/show_vlan.py
+++ b/src/muninn/parsers/ios/show_vlan.py
@@ -144,9 +144,36 @@ def _handle_wrapped_name(
     return _col_field(line, _NAME_COL), "", "", i
 
 
-def _parse_basic_table(lines: list[str]) -> dict[str, dict]:
+def _parse_vlan_line(line: str, lines: list[str], i: int) -> tuple[str, VlanEntry, int]:
+    """Parse a new VLAN line, handling wrapped names.
+
+    Returns (vlan_id, entry, new_index).
+    """
+    vlan_field = line[:4].strip()
+    name = _col_field(line, _NAME_COL, _STATUS_COL)
+    status = _col_field(line, _STATUS_COL, _PORTS_COL)
+    ports_str = _col_field(line, _PORTS_COL)
+
+    if name and status not in _VALID_STATUSES:
+        name, status, ports_str, i = _handle_wrapped_name(line, lines, i)
+
+    entry: VlanEntry = {
+        "vlan_id": int(vlan_field),
+        "name": name,
+        "status": status,
+        "ports": _normalize_ports(ports_str),
+        "type": "",
+        "said": 0,
+        "mtu": 0,
+        "trans1": 0,
+        "trans2": 0,
+    }
+    return vlan_field, entry, i
+
+
+def _parse_basic_table(lines: list[str]) -> dict[str, VlanEntry]:
     """Parse the basic VLAN table (Name/Status/Ports)."""
-    vlans: dict[str, dict] = {}
+    vlans: dict[str, VlanEntry] = {}
     current_vlan_id: str | None = None
 
     i = 0
@@ -161,19 +188,8 @@ def _parse_basic_table(lines: list[str]) -> dict[str, dict]:
 
         vlan_field = line[:4].strip()
         if vlan_field and vlan_field.isdigit():
-            name = _col_field(line, _NAME_COL, _STATUS_COL)
-            status = _col_field(line, _STATUS_COL, _PORTS_COL)
-            ports_str = _col_field(line, _PORTS_COL)
-
-            if name and status not in _VALID_STATUSES:
-                name, status, ports_str, i = _handle_wrapped_name(line, lines, i)
-
-            vlans[vlan_field] = {
-                "vlan_id": int(vlan_field),
-                "name": name,
-                "status": status,
-                "ports": _normalize_ports(ports_str),
-            }
+            vlan_field, entry, i = _parse_vlan_line(line, lines, i)
+            vlans[vlan_field] = entry
             current_vlan_id = vlan_field
         elif current_vlan_id is not None:
             ports_str = _col_field(line, _PORTS_COL)
@@ -185,20 +201,20 @@ def _parse_basic_table(lines: list[str]) -> dict[str, dict]:
     return vlans
 
 
-def _set_optional_int(entry: dict, key: str, value: int | None) -> None:
-    """Set an optional integer field, omitting if None."""
-    if value is not None:
-        entry[key] = value
-
-
-def _merge_extended_fields(entry: dict, parts: list[str]) -> None:
+def _merge_extended_fields(entry: VlanEntry, parts: list[str]) -> None:
     """Merge extended table fields into a VLAN entry."""
     entry["type"] = parts[1]
     entry["said"] = int(parts[2])
     entry["mtu"] = int(parts[3])
-    _set_optional_int(entry, "parent", _to_int_or_none(parts[4]))
-    _set_optional_int(entry, "ring_no", _to_int_or_none(parts[5]))
-    _set_optional_int(entry, "bridge_no", _to_int_or_none(parts[6]))
+    parent = _to_int_or_none(parts[4])
+    if parent is not None:
+        entry["parent"] = parent
+    ring_no = _to_int_or_none(parts[5])
+    if ring_no is not None:
+        entry["ring_no"] = ring_no
+    bridge_no = _to_int_or_none(parts[6])
+    if bridge_no is not None:
+        entry["bridge_no"] = bridge_no
     if parts[7] != "-":
         entry["stp"] = parts[7]
     if parts[8] != "-":
@@ -207,7 +223,7 @@ def _merge_extended_fields(entry: dict, parts: list[str]) -> None:
     entry["trans2"] = int(parts[10])
 
 
-def _parse_extended_table(lines: list[str], vlans: dict[str, dict]) -> None:
+def _parse_extended_table(lines: list[str], vlans: dict[str, VlanEntry]) -> None:
     """Parse the extended VLAN table and merge into vlans dict."""
     for line in lines:
         stripped = line.strip()
@@ -229,7 +245,7 @@ def _parse_extended_table(lines: list[str], vlans: dict[str, dict]) -> None:
             _merge_extended_fields(entry, parts)
 
 
-def _parse_arehops(lines: list[str], vlans: dict[str, dict]) -> None:
+def _parse_arehops(lines: list[str], vlans: dict[str, VlanEntry]) -> None:
     """Parse the AREHops/STEHops/Backup CRF table."""
     for line in lines:
         stripped = line.strip()
@@ -262,6 +278,30 @@ def _parse_remote_span(lines: list[str]) -> list[int]:
     return sorted(result)
 
 
+def _parse_private_vlan_line(
+    line: str, pri_col: int, sec_col: int, type_col: int, ports_col: int
+) -> PrivateVlanEntry | None:
+    """Parse a single private VLAN data line into an entry."""
+    padded = line.ljust(ports_col + 80)
+    pri_str = padded[pri_col:sec_col].strip()
+    sec_str = padded[sec_col:type_col].strip()
+    type_str = padded[type_col:ports_col].strip()
+    ports_str = padded[ports_col:].strip()
+
+    if not sec_str or not sec_str.isdigit():
+        return None
+
+    entry: PrivateVlanEntry = {
+        "secondary": int(sec_str),
+        "type": type_str,
+        "ports": _normalize_ports(ports_str),
+    }
+    if pri_str and pri_str.lower() != "none":
+        entry["primary"] = int(pri_str)
+
+    return entry
+
+
 def _parse_private_vlans(
     lines: list[str],
 ) -> list[PrivateVlanEntry]:
@@ -288,24 +328,9 @@ def _parse_private_vlans(
         if not stripped or _SEPARATOR.match(stripped):
             continue
 
-        padded = line.ljust(ports_col + 80)
-        pri_str = padded[pri_col:sec_col].strip()
-        sec_str = padded[sec_col:type_col].strip()
-        type_str = padded[type_col:ports_col].strip()
-        ports_str = padded[ports_col:].strip()
-
-        if not sec_str or not sec_str.isdigit():
-            continue
-
-        entry: PrivateVlanEntry = {
-            "secondary": int(sec_str),
-            "type": type_str,
-            "ports": _normalize_ports(ports_str),
-        }
-        if pri_str and pri_str.lower() != "none":
-            entry["primary"] = int(pri_str)
-
-        entries.append(entry)
+        entry = _parse_private_vlan_line(line, pri_col, sec_col, type_col, ports_col)
+        if entry is not None:
+            entries.append(entry)
 
     return entries
 

--- a/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_binding.py
+++ b/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_binding.py
@@ -61,7 +61,7 @@ class ShowIpDhcpSnoopingBindingParser(BaseParser[ShowIpDhcpSnoopingBindingResult
         Raises:
             ValueError: If the output cannot be parsed.
         """
-        result: ShowIpDhcpSnoopingBindingResult = {}
+        result: ShowIpDhcpSnoopingBindingResult = {"total_bindings": 0}
 
         for line in output.splitlines():
             line = line.strip()

--- a/src/muninn/parsers/iosxe/show_ip_vrf.py
+++ b/src/muninn/parsers/iosxe/show_ip_vrf.py
@@ -44,6 +44,27 @@ class ShowIpVrfParser(BaseParser[ShowIpVrfResult]):
     _CONTINUATION_PATTERN = re.compile(r"^\s+(?P<interface>\S+)\s*$")
 
     @classmethod
+    def _is_skip_line(cls, line: str) -> bool:
+        """Check if a line should be skipped (header, empty, prompt)."""
+        stripped = line.strip()
+        if not stripped or "Default RD" in line or line.startswith("#"):
+            return True
+        return "#" in line and "show" in line
+
+    @classmethod
+    def _process_vrf_match(cls, match: re.Match[str]) -> VrfEntry:
+        """Build a VrfEntry from a VRF pattern match."""
+        default_rd = match.group("default_rd").strip()
+        interface = match.group("interface")
+
+        entry: VrfEntry = {
+            "interfaces": [canonical_interface_name(interface)],
+        }
+        if default_rd != "<not set>":
+            entry["default_rd"] = default_rd
+        return entry
+
+    @classmethod
     def parse(cls, output: str) -> ShowIpVrfResult:
         """Parse 'show ip vrf' output.
 
@@ -60,34 +81,16 @@ class ShowIpVrfParser(BaseParser[ShowIpVrfResult]):
         current_vrf: str | None = None
 
         for line in output.splitlines():
-            # Skip header and empty lines
-            if not line.strip() or "Default RD" in line or line.startswith("#"):
+            if cls._is_skip_line(line):
                 continue
 
-            # Skip prompt lines
-            if "#" in line and "show" in line:
-                continue
-
-            # Try to match a new VRF entry
             match = cls._VRF_PATTERN.match(line)
             if match:
                 name = match.group("name")
-                default_rd = match.group("default_rd").strip()
-                interface = match.group("interface")
-
-                entry: VrfEntry = {
-                    "interfaces": [canonical_interface_name(interface)],
-                }
-
-                # Only include default_rd if it's set
-                if default_rd != "<not set>":
-                    entry["default_rd"] = default_rd
-
-                vrfs[name] = entry
+                vrfs[name] = cls._process_vrf_match(match)
                 current_vrf = name
                 continue
 
-            # Try to match a continuation line
             cont_match = cls._CONTINUATION_PATTERN.match(line)
             if cont_match and current_vrf:
                 interface = cont_match.group("interface")

--- a/src/muninn/parsers/iosxe/show_macsec_summary.py
+++ b/src/muninn/parsers/iosxe/show_macsec_summary.py
@@ -1,6 +1,7 @@
 """Parser for 'show macsec summary' command on IOS-XE."""
 
 import re
+from collections.abc import Callable
 from typing import NotRequired, TypedDict
 
 from netutils.interface import canonical_interface_name
@@ -74,7 +75,7 @@ class ShowMacsecSummaryParser(BaseParser[ShowMacsecSummaryResult]):
         if len(parts) < 2:
             return False
         interface = cls._normalize_interface(parts[0].strip())
-        entry: dict[str, object] = {"extension": parts[1].strip()}
+        entry: MacsecCapableInterface = {"extension": parts[1].strip()}
         if len(parts) >= 3 and parts[2].strip():
             entry["installed_rx_sc"] = int(parts[2].strip())
         result["macsec_capable"][interface] = entry
@@ -94,6 +95,52 @@ class ShowMacsecSummaryParser(BaseParser[ShowMacsecSummaryResult]):
             "vlan": int(parts[2].strip()),
         }
         return True
+
+    _HEADER_MODE_MAP: list[tuple[re.Pattern[str], str]] = [
+        (_SUMMARY_HEADER, "summary"),
+        (_CAPABLE_HEADER, "capable"),
+        (_ENABLED_HEADER, "enabled"),
+    ]
+
+    @classmethod
+    def _match_header(cls, line: str) -> str | None:
+        """Return the mode name if line matches a section header."""
+        for pattern, mode in cls._HEADER_MODE_MAP:
+            if pattern.match(line):
+                return mode
+        return None
+
+    @classmethod
+    def _has_data(cls, result: ShowMacsecSummaryResult) -> bool:
+        """Check if any MACsec data was parsed."""
+        return bool(
+            result["summary_interfaces"]
+            or result["macsec_capable"]
+            or result["macsec_enabled"]
+        )
+
+    @classmethod
+    def _process_line(
+        cls,
+        line: str,
+        mode: str | None,
+        result: ShowMacsecSummaryResult,
+        handlers: dict[str, Callable[[list[str], ShowMacsecSummaryResult], bool]],
+    ) -> tuple[str | None, bool]:
+        """Process a single line. Returns (new_mode, should_return_early)."""
+        if cls._NO_CHANNELS_PATTERN.match(line):
+            result["has_secure_channels"] = False
+            return mode, True
+
+        header_mode = cls._match_header(line)
+        if header_mode is not None:
+            return header_mode, False
+
+        parts = re.split(r"\s{2,}", line)
+        if mode in handlers:
+            handlers[mode](parts, result)
+
+        return mode, False
 
     @classmethod
     def parse(cls, output: str) -> ShowMacsecSummaryResult:
@@ -123,37 +170,14 @@ class ShowMacsecSummaryParser(BaseParser[ShowMacsecSummaryResult]):
 
         for line in output.splitlines():
             line = line.strip()
-            if not line:
+            if not line or cls._SEPARATOR.match(line):
                 continue
 
-            if cls._NO_CHANNELS_PATTERN.match(line):
-                result["has_secure_channels"] = False
+            mode, early_return = cls._process_line(line, mode, result, handlers)
+            if early_return:
                 return result
 
-            if cls._SUMMARY_HEADER.match(line):
-                mode = "summary"
-                continue
-
-            if cls._CAPABLE_HEADER.match(line):
-                mode = "capable"
-                continue
-
-            if cls._ENABLED_HEADER.match(line):
-                mode = "enabled"
-                continue
-
-            if cls._SEPARATOR.match(line):
-                continue
-
-            parts = re.split(r"\s{2,}", line)
-            if mode in handlers and handlers[mode](parts, result):
-                continue
-
-        if (
-            result["summary_interfaces"]
-            or result["macsec_capable"]
-            or result["macsec_enabled"]
-        ):
+        if cls._has_data(result):
             return result
 
         msg = "No MACsec summary data found"

--- a/src/muninn/parsers/nxos/show_ip_arp_summary.py
+++ b/src/muninn/parsers/nxos/show_ip_arp_summary.py
@@ -18,17 +18,36 @@ class ShowIpArpSummaryResult(TypedDict):
     total: int
 
 
+_RESOLVED_PATTERN = re.compile(r"^Resolved\s*:\s*(?P<value>\d+)$", re.I)
+_INCOMPLETE_PATTERN = re.compile(
+    r"^Incomplete\s*:\s*(?P<value>\d+)\s*\(Throttled\s*:\s*(?P<throttled>\d+)\)$",
+    re.I,
+)
+_UNKNOWN_PATTERN = re.compile(r"^Unknown\s*:\s*(?P<value>\d+)$", re.I)
+_TOTAL_PATTERN = re.compile(r"^Total\s*:\s*(?P<value>\d+)$", re.I)
+
+# Maps each pattern to a list of (group_name, result_key) pairs to extract
+_FIELD_PATTERNS: list[tuple[re.Pattern[str], list[tuple[str, str]]]] = [
+    (_RESOLVED_PATTERN, [("value", "resolved")]),
+    (_INCOMPLETE_PATTERN, [("value", "incomplete"), ("throttled", "throttled")]),
+    (_UNKNOWN_PATTERN, [("value", "unknown")]),
+    (_TOTAL_PATTERN, [("value", "total")]),
+]
+
+
+def _match_arp_line(line: str, result: dict[str, int]) -> None:
+    """Try matching a line against all ARP summary patterns."""
+    for pattern, fields in _FIELD_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            for group_name, key in fields:
+                result[key] = int(m.group(group_name))
+            return
+
+
 @register(OS.CISCO_NXOS, "show ip arp summary")
 class ShowIpArpSummaryParser(BaseParser[ShowIpArpSummaryResult]):
     """Parser for 'show ip arp summary' command."""
-
-    _RESOLVED_PATTERN = re.compile(r"^Resolved\s*:\s*(?P<value>\d+)$", re.I)
-    _INCOMPLETE_PATTERN = re.compile(
-        r"^Incomplete\s*:\s*(?P<value>\d+)\s*\(Throttled\s*:\s*(?P<throttled>\d+)\)$",
-        re.I,
-    )
-    _UNKNOWN_PATTERN = re.compile(r"^Unknown\s*:\s*(?P<value>\d+)$", re.I)
-    _TOTAL_PATTERN = re.compile(r"^Total\s*:\s*(?P<value>\d+)$", re.I)
 
     @classmethod
     def parse(cls, output: str) -> ShowIpArpSummaryResult:
@@ -49,27 +68,7 @@ class ShowIpArpSummaryParser(BaseParser[ShowIpArpSummaryResult]):
             line = line.strip()
             if not line:
                 continue
-
-            match = cls._RESOLVED_PATTERN.match(line)
-            if match:
-                result["resolved"] = int(match.group("value"))
-                continue
-
-            match = cls._INCOMPLETE_PATTERN.match(line)
-            if match:
-                result["incomplete"] = int(match.group("value"))
-                result["throttled"] = int(match.group("throttled"))
-                continue
-
-            match = cls._UNKNOWN_PATTERN.match(line)
-            if match:
-                result["unknown"] = int(match.group("value"))
-                continue
-
-            match = cls._TOTAL_PATTERN.match(line)
-            if match:
-                result["total"] = int(match.group("value"))
-                continue
+            _match_arp_line(line, result)
 
         required = ("resolved", "incomplete", "throttled", "unknown", "total")
         missing = [key for key in required if key not in result]

--- a/src/muninn/parsers/nxos/show_ip_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_ip_interface_brief.py
@@ -60,6 +60,68 @@ class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
     _UNNUMBERED_SOURCE_PATTERN = re.compile(r"^\s+\((?P<source>\S+)\)\s*$")
 
     @classmethod
+    def _handle_vrf_header(cls, line: str, vrfs: dict[str, VrfEntry]) -> str | None:
+        """Match a VRF header and initialize it. Returns VRF name or None."""
+        vrf_match = cls._VRF_PATTERN.search(line)
+        if not vrf_match:
+            return None
+        name = vrf_match.group("vrf_name")
+        vrfs[name] = VrfEntry(vrf_id=int(vrf_match.group("vrf_id")), interfaces={})
+        return name
+
+    @classmethod
+    def _handle_interface(
+        cls, stripped: str, vrfs: dict[str, VrfEntry], current_vrf: str
+    ) -> str | None:
+        """Match an interface entry and add it. Returns interface name or None."""
+        intf_match = cls._INTERFACE_PATTERN.match(stripped)
+        if not intf_match:
+            return None
+        interface = canonical_interface_name(intf_match.group("interface"))
+        entry: InterfaceBriefEntry = {
+            "ip_address": intf_match.group("ip_address"),
+            "protocol_status": intf_match.group("protocol").lower(),
+            "link_status": intf_match.group("link").lower(),
+            "admin_status": intf_match.group("admin").lower(),
+        }
+        vrfs[current_vrf]["interfaces"][interface] = entry
+        return interface
+
+    @classmethod
+    def _is_skip_line(cls, stripped: str) -> bool:
+        """Check if a line should be skipped."""
+        return not stripped or ("Interface" in stripped and "IP Address" in stripped)
+
+    @classmethod
+    def _handle_unnumbered(
+        cls,
+        line: str,
+        vrfs: dict[str, VrfEntry],
+        current_vrf: str,
+        last_interface: str,
+    ) -> bool:
+        """Handle unnumbered source continuation line. Returns True if matched."""
+        unnumbered_match = cls._UNNUMBERED_SOURCE_PATTERN.match(line)
+        if not unnumbered_match:
+            return False
+        source = unnumbered_match.group("source")
+        vrfs[current_vrf]["interfaces"][last_interface]["unnumbered_source"] = (
+            canonical_interface_name(source)
+        )
+        return True
+
+    @staticmethod
+    def _validate_result(vrfs: dict[str, VrfEntry]) -> None:
+        """Validate that parsed data contains VRFs and interfaces."""
+        if not vrfs:
+            msg = "No VRFs found in output"
+            raise ValueError(msg)
+        total_interfaces = sum(len(v["interfaces"]) for v in vrfs.values())
+        if total_interfaces == 0:
+            msg = "No interfaces found in output"
+            raise ValueError(msg)
+
+    @classmethod
     def parse(cls, output: str) -> ShowIpInterfaceBriefResult:
         """Parse 'show ip interface brief' output on NX-OS.
 
@@ -74,57 +136,27 @@ class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
         """
         vrfs: dict[str, VrfEntry] = {}
         current_vrf: str | None = None
-        current_vrf_id: int | None = None
         last_interface: str | None = None
 
         for line in output.splitlines():
-            # Skip empty lines and headers
             stripped = line.strip()
-            if not stripped or "Interface" in stripped and "IP Address" in stripped:
+            if cls._is_skip_line(stripped):
                 continue
 
-            # Try to match VRF header
-            vrf_match = cls._VRF_PATTERN.search(line)
-            if vrf_match:
-                current_vrf = vrf_match.group("vrf_name")
-                current_vrf_id = int(vrf_match.group("vrf_id"))
-                vrfs[current_vrf] = VrfEntry(vrf_id=current_vrf_id, interfaces={})
+            vrf_name = cls._handle_vrf_header(line, vrfs)
+            if vrf_name is not None:
+                current_vrf = vrf_name
                 last_interface = None
                 continue
 
-            # Try to match unnumbered source continuation line
-            unnumbered_match = cls._UNNUMBERED_SOURCE_PATTERN.match(line)
-            if unnumbered_match and current_vrf and last_interface:
-                source = unnumbered_match.group("source")
-                vrfs[current_vrf]["interfaces"][last_interface]["unnumbered_source"] = (
-                    canonical_interface_name(source)
-                )
-                continue
+            if current_vrf and last_interface:
+                if cls._handle_unnumbered(line, vrfs, current_vrf, last_interface):
+                    continue
 
-            # Try to match interface entry
-            intf_match = cls._INTERFACE_PATTERN.match(stripped)
-            if intf_match and current_vrf:
-                interface = canonical_interface_name(intf_match.group("interface"))
-                ip_address = intf_match.group("ip_address")
+            if current_vrf:
+                intf = cls._handle_interface(stripped, vrfs, current_vrf)
+                if intf is not None:
+                    last_interface = intf
 
-                entry: InterfaceBriefEntry = {
-                    "ip_address": ip_address,
-                    "protocol_status": intf_match.group("protocol").lower(),
-                    "link_status": intf_match.group("link").lower(),
-                    "admin_status": intf_match.group("admin").lower(),
-                }
-
-                vrfs[current_vrf]["interfaces"][interface] = entry
-                last_interface = interface
-
-        if not vrfs:
-            msg = "No VRFs found in output"
-            raise ValueError(msg)
-
-        # Check if any interfaces were found
-        total_interfaces = sum(len(v["interfaces"]) for v in vrfs.values())
-        if total_interfaces == 0:
-            msg = "No interfaces found in output"
-            raise ValueError(msg)
-
+        cls._validate_result(vrfs)
         return ShowIpInterfaceBriefResult(vrfs=vrfs)

--- a/src/muninn/parsers/nxos/show_vlan_access_map.py
+++ b/src/muninn/parsers/nxos/show_vlan_access_map.py
@@ -22,15 +22,33 @@ class ShowVlanAccessMapResult(TypedDict):
     access_map_id: dict[str, dict[str, dict[str, AccessMapMatch]]]
 
 
+_MAP_PATTERN = re.compile(r"^Vlan\s+access-map\s+(?P<name>\S+)\s+(?P<seq>\d+)$", re.I)
+_MATCH_PATTERN = re.compile(r"^match\s+(?P<protocol>\S+):\s*(?P<value>\S+)$", re.I)
+_ACTION_PATTERN = re.compile(r"^action:\s+(?P<action>\S+)$", re.I)
+
+
+def _parse_access_map_line(line: str, state: dict[str, str | None]) -> None:
+    """Try matching a line against access-map patterns and update state."""
+    m = _MAP_PATTERN.match(line)
+    if m:
+        state["access_map_name"] = m.group("name")
+        state["sequence"] = m.group("seq")
+        return
+
+    m = _MATCH_PATTERN.match(line)
+    if m:
+        state["match_protocol"] = m.group("protocol")
+        state["match_value"] = m.group("value")
+        return
+
+    m = _ACTION_PATTERN.match(line)
+    if m:
+        state["action_value"] = m.group("action")
+
+
 @register(OS.CISCO_NXOS, "show vlan access-map")
 class ShowVlanAccessMapParser(BaseParser[ShowVlanAccessMapResult]):
     """Parser for 'show vlan access-map' command."""
-
-    _MAP_PATTERN = re.compile(
-        r"^Vlan\s+access-map\s+(?P<name>\S+)\s+(?P<seq>\d+)$", re.I
-    )
-    _MATCH_PATTERN = re.compile(r"^match\s+(?P<protocol>\S+):\s*(?P<value>\S+)$", re.I)
-    _ACTION_PATTERN = re.compile(r"^action:\s+(?P<action>\S+)$", re.I)
 
     @classmethod
     def parse(cls, output: str) -> ShowVlanAccessMapResult:
@@ -45,52 +63,31 @@ class ShowVlanAccessMapParser(BaseParser[ShowVlanAccessMapResult]):
         Raises:
             ValueError: If the output cannot be parsed.
         """
-        access_map_name: str | None = None
-        sequence: str | None = None
-        match_protocol: str | None = None
-        match_value: str | None = None
-        action_value: str | None = None
+        state: dict[str, str | None] = {
+            "access_map_name": None,
+            "sequence": None,
+            "match_protocol": None,
+            "match_value": None,
+            "action_value": None,
+        }
 
         for line in output.splitlines():
             line = line.strip()
-            if not line:
-                continue
+            if line:
+                _parse_access_map_line(line, state)
 
-            match = cls._MAP_PATTERN.match(line)
-            if match:
-                access_map_name = match.group("name")
-                sequence = match.group("seq")
-                continue
-
-            match = cls._MATCH_PATTERN.match(line)
-            if match:
-                match_protocol = match.group("protocol")
-                match_value = match.group("value")
-                continue
-
-            match = cls._ACTION_PATTERN.match(line)
-            if match:
-                action_value = match.group("action")
-                continue
-
-        if (
-            access_map_name is None
-            or sequence is None
-            or match_protocol is None
-            or match_value is None
-            or action_value is None
-        ):
+        if any(v is None for v in state.values()):
             msg = "Incomplete access-map output"
             raise ValueError(msg)
 
         result = {
             "access_map_id": {
-                access_map_name: {
+                state["access_map_name"]: {
                     "access_map_sequence": {
-                        sequence: {
-                            "access_map_action_value": action_value,
-                            "access_map_match_protocol": match_protocol,
-                            "access_map_match_protocol_value": match_value,
+                        state["sequence"]: {
+                            "access_map_action_value": state["action_value"],
+                            "access_map_match_protocol": state["match_protocol"],
+                            "access_map_match_protocol_value": state["match_value"],
                         }
                     }
                 }

--- a/src/muninn/parsers/nxos/show_vlan_filter.py
+++ b/src/muninn/parsers/nxos/show_vlan_filter.py
@@ -35,6 +35,16 @@ class ShowVlanFilterParser(BaseParser[ShowVlanFilterResult]):
     )
 
     @classmethod
+    def _expand_vlans(
+        cls, vlan_str: str, tag: str, vlan_id: dict[str, VlanFilterEntry]
+    ) -> None:
+        """Expand a comma-separated VLAN string and add entries."""
+        for v in vlan_str.split(","):
+            v = v.strip()
+            if v:
+                vlan_id[v] = {"access_map_tag": tag}
+
+    @classmethod
     def parse(cls, output: str) -> ShowVlanFilterResult:
         """Parse 'show vlan filter' output.
 
@@ -62,11 +72,9 @@ class ShowVlanFilterParser(BaseParser[ShowVlanFilterResult]):
 
             match = cls._VLANS_PATTERN.match(line)
             if match and access_map_tag:
-                vlans = [
-                    v.strip() for v in match.group("vlans").split(",") if v.strip()
-                ]
-                for vlan_id in vlans:
-                    result["vlan_id"][vlan_id] = {"access_map_tag": access_map_tag}
+                cls._expand_vlans(
+                    match.group("vlans"), access_map_tag, result["vlan_id"]
+                )
 
         if not result["vlan_id"]:
             msg = "No matching VLAN filter entries found"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,7 +6,7 @@ import pytest
 
 from muninn import registry
 from muninn.exceptions import ParserNotFoundError
-from muninn.os import OS, CiscoIOSXE, CiscoNXOS
+from muninn.os import OS, CiscoIOSXE, CiscoNXOS, OperatingSystem
 from muninn.parser import BaseParser
 
 
@@ -185,7 +185,7 @@ class TestGetParser:
         ],
     )
     def test_normalizes_on_lookup(
-        self, lookup_os: str | OS | type, lookup_cmd: str
+        self, lookup_os: str | OS | type[OperatingSystem], lookup_cmd: str
     ) -> None:
         """OS and command are normalized during lookup."""
 


### PR DESCRIPTION
## Summary
- Fix 4 type-check errors caught by `ty` across show_vlan, show_ip_dhcp_snooping_binding, show_macsec_summary, and test_registry
- Reduce cyclomatic complexity below C threshold (xenon --max-absolute B) in 13 blocks across 8 parser files by extracting helper methods
- All 275 tests pass, all CI checks (ty, xenon, ruff, pytest) clean

## Test plan
- [x] `uv run ty check .` passes with no errors
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/` passes
- [x] `uv run pytest` — all 275 tests pass
- [x] `uv run ruff check .` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)