### PR TITLE
feat: add parser for 'show ip bgp' on NX-OS

### DIFF
--- a/src/muninn/parsers/nxos/show_ip_bgp.py
+++ b/src/muninn/parsers/nxos/show_ip_bgp.py
@@ -1,0 +1,438 @@
+"""Parser for 'show ip bgp' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PathEntry(TypedDict):
+    """Schema for a single BGP path."""
+
+    status_codes: str
+    path_type: str
+    next_hop: str
+    metric: NotRequired[int]
+    locprf: NotRequired[int]
+    weight: int
+    as_path: str
+    origin: str
+
+
+class RouteEntry(TypedDict):
+    """Schema for a single BGP route (network prefix)."""
+
+    paths: list[PathEntry]
+
+
+class RouteDistinguisherEntry(TypedDict):
+    """Schema for a Route Distinguisher group."""
+
+    rd_vrf: NotRequired[str]
+    routes: dict[str, RouteEntry]
+
+
+class AddressFamilyEntry(TypedDict):
+    """Schema for a single address family."""
+
+    table_version: int
+    router_id: str
+    routes: NotRequired[dict[str, RouteEntry]]
+    route_distinguishers: NotRequired[dict[str, RouteDistinguisherEntry]]
+
+
+class VrfEntry(TypedDict):
+    """Schema for a single VRF."""
+
+    address_families: dict[str, AddressFamilyEntry]
+
+
+class ShowIpBgpResult(TypedDict):
+    """Schema for 'show ip bgp' parsed output on NX-OS."""
+
+    vrfs: dict[str, VrfEntry]
+
+
+# --- Section and header patterns ---
+_VRF_AF_RE = re.compile(
+    r"^BGP routing table information for VRF (\S+),\s*address family (.+?)\s*$"
+)
+_TABLE_VERSION_RE = re.compile(
+    r"^BGP table version is (\d+),\s*[Ll]ocal\s+[Rr]outer\s+ID\s+is\s+(\S+)\s*$",
+)
+_COLUMN_HEADER_RE = re.compile(
+    r"^\s*Network\s+Next\s+Hop\s+Metric\s+LocPrf\s+Weight\s+Path"
+)
+_RD_RE = re.compile(r"^Route Distinguisher:\s*(\S+)(?:\s+\(VRF\s+(\S+)\))?\s*$")
+
+# Valid characters for route line detection
+_STATUS_CHARS = frozenset("*sxSdh ")
+_PATH_TYPE_CHARS = frozenset("ieclraI ")
+
+
+def _is_noise_line(stripped: str) -> bool:
+    """Return True if a stripped line is a prompt/noise line."""
+    if not stripped:
+        return True
+    if stripped.endswith("#") or "#show " in stripped.lower():
+        return True
+    return stripped.startswith("Load for ") or stripped.startswith("Time source ")
+
+
+def _strip_noise(lines: list[str]) -> list[str]:
+    """Strip leading and trailing prompt/noise lines."""
+    result: list[str] = []
+    started = False
+    for line in lines:
+        if not started:
+            if _is_noise_line(line.strip()):
+                continue
+            started = True
+        result.append(line)
+    while result and _is_noise_line(result[-1].strip()):
+        result.pop()
+    return result
+
+
+def _split_sections(
+    lines: list[str],
+) -> list[tuple[str, str, list[str]]]:
+    """Split output into (vrf, af, lines) sections."""
+    sections: list[tuple[str, str, list[str]]] = []
+    current_vrf: str | None = None
+    current_af: str | None = None
+    current_lines: list[str] = []
+
+    for line in lines:
+        m = _VRF_AF_RE.match(line)
+        if m:
+            if current_vrf is not None or current_lines:
+                vrf = current_vrf or "default"
+                af = current_af or "IPv4 Unicast"
+                sections.append((vrf, af, current_lines))
+            current_vrf = m.group(1)
+            current_af = m.group(2)
+            current_lines = []
+        else:
+            current_lines.append(line)
+
+    # Final section
+    if current_lines:
+        vrf = current_vrf or "default"
+        af = current_af or "IPv4 Unicast"
+        sections.append((vrf, af, current_lines))
+
+    return sections
+
+
+def _find_column_positions(
+    lines: list[str],
+) -> tuple[int, int, int, int, int] | None:
+    """Find column start positions from the header line.
+
+    Returns (nexthop, metric, locprf, weight, path) start positions,
+    or None if no header found.
+    """
+    for line in lines:
+        if _COLUMN_HEADER_RE.match(line):
+            nh = line.index("Next")
+            m = line.index("Metric")
+            lp = line.index("LocPrf")
+            w = line.index("Weight")
+            p = line.index("Path")
+            return (nh, m, lp, w, p)
+    return None
+
+
+def _safe_slice(line: str, start: int, end: int) -> str:
+    """Extract a substring from line[start:end], handling short lines."""
+    if start >= len(line):
+        return ""
+    return line[start : min(end, len(line))].strip()
+
+
+def _parse_origin_and_path(path_field: str) -> tuple[str, str]:
+    """Split path field into (as_path, origin)."""
+    if not path_field:
+        return ("", "")
+    # Origin code is the last token
+    tokens = path_field.split()
+    if not tokens:
+        return ("", "")
+    origin = tokens[-1]
+    as_path = " ".join(tokens[:-1])
+    return (as_path, origin)
+
+
+def _is_route_line(line: str) -> bool:
+    """Check if a line is a BGP route entry (starts with status chars)."""
+    if len(line) < 3:
+        return False
+    return line[0] in _STATUS_CHARS and line[2] in _PATH_TYPE_CHARS
+
+
+def _build_path_entry(
+    status_codes: str,
+    path_type: str,
+    next_hop: str,
+    metric_str: str,
+    locprf_str: str,
+    weight_str: str,
+    path_field: str,
+) -> PathEntry | None:
+    """Build a PathEntry from raw field strings."""
+    if not next_hop:
+        return None
+    try:
+        weight = int(weight_str)
+    except (ValueError, TypeError):
+        return None
+
+    as_path, origin = _parse_origin_and_path(path_field)
+    entry: PathEntry = {
+        "status_codes": status_codes,
+        "path_type": path_type,
+        "next_hop": next_hop,
+        "weight": weight,
+        "as_path": as_path,
+        "origin": origin,
+    }
+    if metric_str:
+        entry["metric"] = int(metric_str)
+    if locprf_str:
+        entry["locprf"] = int(locprf_str)
+    return entry
+
+
+def _parse_data_fields(
+    line: str,
+    cols: tuple[int, int, int, int, int],
+) -> tuple[str, str, str, str, str]:
+    """Extract (next_hop, metric, locprf, weight, path) from a line."""
+    nh_col, m_col, lp_col, w_col, p_col = cols
+    next_hop = _safe_slice(line, nh_col, m_col)
+    metric = _safe_slice(line, m_col, lp_col)
+    locprf = _safe_slice(line, lp_col, w_col)
+    weight = _safe_slice(line, w_col, p_col)
+    path = line[p_col:].strip() if p_col < len(line) else ""
+    return (next_hop, metric, locprf, weight, path)
+
+
+def _parse_route_line(
+    line: str,
+    cols: tuple[int, int, int, int, int],
+) -> tuple[str, str, str, PathEntry | None]:
+    """Parse a route line into (status_codes, path_type, network, path_entry).
+
+    Returns empty network for continuation routes.
+    Returns None path_entry if the line only contains a wrapped network.
+    """
+    status_codes = line[0:2].rstrip()
+    path_type = line[2] if len(line) > 2 else ""
+    nh_col = cols[0]
+
+    next_hop, metric, locprf, weight, path = _parse_data_fields(line, cols)
+
+    # A valid next_hop must contain '.' (IPv4) or ':' (IPv6).
+    # Long IPv6 prefixes can bleed past the network column, so a stray
+    # character in the next_hop column doesn't count.
+    has_nexthop = bool(next_hop) and ("." in next_hop or ":" in next_hop)
+
+    # When there's no valid next_hop, this is a wrapped network line.
+    # Take the full remaining text as the network prefix.
+    if not has_nexthop:
+        network = line[3:].strip() if len(line) > 3 else ""
+        return (status_codes, path_type, network, None)
+
+    network = line[3:nh_col].strip() if len(line) > 3 else ""
+    entry = _build_path_entry(
+        status_codes, path_type, next_hop, metric, locprf, weight, path
+    )
+    return (status_codes, path_type, network, entry)
+
+
+def _parse_continuation_line(
+    line: str,
+    cols: tuple[int, int, int, int, int],
+    status_codes: str = "",
+    path_type: str = "",
+) -> PathEntry | None:
+    """Parse an indented continuation line (tab or space) as a path entry."""
+    next_hop, metric, locprf, weight, path = _parse_data_fields(line, cols)
+    if not next_hop:
+        return None
+    return _build_path_entry(
+        status_codes, path_type, next_hop, metric, locprf, weight, path
+    )
+
+
+def _add_path_to_routes(
+    routes: dict[str, RouteEntry],
+    network: str,
+    path_entry: PathEntry,
+) -> None:
+    """Add a path entry to the routes dict under the given network."""
+    if network not in routes:
+        routes[network] = {"paths": []}
+    routes[network]["paths"].append(path_entry)
+
+
+def _handle_rd_line(
+    m: re.Match[str],
+    rd_entries: dict[str, RouteDistinguisherEntry],
+) -> str:
+    """Process a Route Distinguisher line, return the RD key."""
+    rd = m.group(1)
+    rd_vrf = m.group(2)
+    if rd not in rd_entries:
+        entry: RouteDistinguisherEntry = {"routes": {}}
+        if rd_vrf:
+            entry["rd_vrf"] = rd_vrf
+        rd_entries[rd] = entry
+    return rd
+
+
+class _RouteState:
+    """Mutable state for route parsing."""
+
+    __slots__ = (
+        "current_network",
+        "pending_status",
+        "pending_path_type",
+        "awaiting_data",
+    )
+
+    def __init__(self) -> None:
+        self.current_network: str | None = None
+        self.pending_status: str = ""
+        self.pending_path_type: str = ""
+        self.awaiting_data: bool = False
+
+
+def _handle_route_line(
+    line: str,
+    cols: tuple[int, int, int, int, int],
+    target: dict[str, RouteEntry],
+    state: _RouteState,
+) -> None:
+    """Process a single BGP route line, updating state and target."""
+    status, ptype, network, path_entry = _parse_route_line(line, cols)
+
+    if network:
+        state.current_network = network
+        state.pending_status = status
+        state.pending_path_type = ptype
+        state.awaiting_data = False
+
+    # Wrapped line (network only, no data yet)
+    if path_entry is None:
+        if network and "/" in network:
+            state.awaiting_data = True
+        return
+
+    # Apply pending status/path_type from wrapped network line
+    if state.awaiting_data and not network:
+        path_entry["status_codes"] = state.pending_status
+        path_entry["path_type"] = state.pending_path_type
+        state.awaiting_data = False
+
+    if state.current_network and path_entry:
+        _add_path_to_routes(target, state.current_network, path_entry)
+
+
+def _parse_routes(
+    lines: list[str],
+    cols: tuple[int, int, int, int, int],
+) -> tuple[dict[str, RouteEntry], dict[str, RouteDistinguisherEntry]]:
+    """Parse all route entries from section lines.
+
+    Returns (routes, route_distinguishers).
+    """
+    direct_routes: dict[str, RouteEntry] = {}
+    rd_entries: dict[str, RouteDistinguisherEntry] = {}
+    current_rd: str | None = None
+    state = _RouteState()
+
+    for line in lines:
+        m = _RD_RE.match(line)
+        if m:
+            current_rd = _handle_rd_line(m, rd_entries)
+            continue
+
+        if current_rd is not None:
+            target = rd_entries[current_rd]["routes"]
+        else:
+            target = direct_routes
+
+        # Tab/space-indented continuation (aggregate extra paths)
+        if line and line[0] in ("\t", " ") and not _is_route_line(line):
+            path_entry = _parse_continuation_line(line, cols)
+            if path_entry and state.current_network:
+                _add_path_to_routes(target, state.current_network, path_entry)
+            continue
+
+        if _is_route_line(line):
+            _handle_route_line(line, cols, target, state)
+
+    return (direct_routes, rd_entries)
+
+
+def _parse_section_header(
+    lines: list[str],
+) -> tuple[int, str] | None:
+    """Extract table version and router ID from section lines."""
+    for line in lines:
+        m = _TABLE_VERSION_RE.match(line)
+        if m:
+            return (int(m.group(1)), m.group(2))
+    return None
+
+
+def _parse_section(lines: list[str]) -> AddressFamilyEntry | None:
+    """Parse a single VRF/AF section."""
+    header = _parse_section_header(lines)
+    cols = _find_column_positions(lines)
+    if header is None or cols is None:
+        return None
+
+    table_version, router_id = header
+    direct_routes, rd_entries = _parse_routes(lines, cols)
+
+    entry: AddressFamilyEntry = {
+        "table_version": table_version,
+        "router_id": router_id,
+    }
+
+    if rd_entries:
+        entry["route_distinguishers"] = rd_entries
+    if direct_routes:
+        entry["routes"] = direct_routes
+
+    return entry
+
+
+@register(OS.CISCO_NXOS, "show ip bgp")
+class ShowIpBgpParser(BaseParser["ShowIpBgpResult"]):
+    """Parser for 'show ip bgp' on NX-OS."""
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpBgpResult:
+        """Parse 'show ip bgp' output."""
+        raw_lines = output.splitlines()
+        lines = _strip_noise(raw_lines)
+
+        sections = _split_sections(lines)
+        vrfs: dict[str, VrfEntry] = {}
+
+        for vrf_name, af_name, section_lines in sections:
+            parsed = _parse_section(section_lines)
+            if parsed is None:
+                continue
+
+            if vrf_name not in vrfs:
+                vrfs[vrf_name] = {"address_families": {}}
+            vrfs[vrf_name]["address_families"][af_name] = parsed
+
+        return {"vrfs": vrfs}

--- a/tests/parsers/nxos/show_ip_bgp/001_basic_routes/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp/001_basic_routes/expected.json
@@ -1,0 +1,93 @@
+{
+    "vrfs": {
+        "default": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "table_version": 100,
+                    "router_id": "10.10.0.1",
+                    "routes": {
+                        "10.10.0.1/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "l",
+                                    "next_hop": "0.0.0.0",
+                                    "locprf": 100,
+                                    "weight": 32768,
+                                    "as_path": "",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "10.10.0.2/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "x",
+                                    "path_type": "e",
+                                    "next_hop": "10.10.2.1",
+                                    "weight": 0,
+                                    "as_path": "64102 64002",
+                                    "origin": "i"
+                                },
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "10.10.1.1",
+                                    "weight": 0,
+                                    "as_path": "64101 64002",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "10.10.0.201/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "10.10.2.1",
+                                    "weight": 0,
+                                    "as_path": "64102 64201",
+                                    "origin": "i"
+                                },
+                                {
+                                    "status_codes": "*",
+                                    "path_type": "e",
+                                    "next_hop": "10.10.1.1",
+                                    "weight": 0,
+                                    "as_path": "64101 64201",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "100.100.100.108/30": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "10.10.2.1",
+                                    "weight": 0,
+                                    "as_path": "64102 {64201 64202}",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "10.16.1.0/24": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "r",
+                                    "next_hop": "0.0.0.0",
+                                    "metric": 4444,
+                                    "locprf": 100,
+                                    "weight": 32768,
+                                    "as_path": "",
+                                    "origin": "?"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp/001_basic_routes/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp/001_basic_routes/input.txt
@@ -1,0 +1,14 @@
+BGP routing table information for VRF default, address family IPv4 Unicast
+BGP table version is 100, local router ID is 10.10.0.1
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+*>l10.10.0.1/32       0.0.0.0                           100      32768 i
+x e10.10.0.2/32       10.10.2.1                                      0 64102 64002 i
+*>e                   10.10.1.1                                      0 64101 64002 i
+*>e10.10.0.201/32     10.10.2.1                                      0 64102 64201 i
+* e                   10.10.1.1                                      0 64101 64201 i
+*>e100.100.100.108/30 10.10.2.1                                      0 64102 {64201 64202} i
+*>r10.16.1.0/24       0.0.0.0               4444        100      32768 ?

--- a/tests/parsers/nxos/show_ip_bgp/001_basic_routes/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp/001_basic_routes/metadata.yaml
@@ -1,0 +1,3 @@
+description: Various status codes, multipath, AS-SETs, deleted routes, continuation routes for same network
+platform: Nexus 9000
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_bgp/002_multi_vrf/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp/002_multi_vrf/expected.json
@@ -1,0 +1,109 @@
+{
+    "vrfs": {
+        "default": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "table_version": 4,
+                    "router_id": "10.253.253.253",
+                    "routes": {
+                        "10.253.253.253/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "l",
+                                    "next_hop": "0.0.0.0",
+                                    "locprf": 100,
+                                    "weight": 32768,
+                                    "as_path": "",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "10.254.254.254/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "10.255.255.254",
+                                    "weight": 0,
+                                    "as_path": "65535",
+                                    "origin": "i"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "vrf_a": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "table_version": 7,
+                    "router_id": "10.0.0.0",
+                    "routes": {
+                        "10.0.0.0/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "l",
+                                    "next_hop": "0.0.0.0",
+                                    "locprf": 100,
+                                    "weight": 32768,
+                                    "as_path": "",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "10.1.1.1/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "10.255.255.2",
+                                    "weight": 0,
+                                    "as_path": "65535",
+                                    "origin": "i"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "vrf_b": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "table_version": 8,
+                    "router_id": "10.0.2.0",
+                    "routes": {
+                        "10.0.2.0/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "l",
+                                    "next_hop": "0.0.0.0",
+                                    "locprf": 100,
+                                    "weight": 32768,
+                                    "as_path": "",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "10.3.3.1/32": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "10.255.255.6",
+                                    "weight": 0,
+                                    "as_path": "65535",
+                                    "origin": "i"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp/002_multi_vrf/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp/002_multi_vrf/input.txt
@@ -1,0 +1,29 @@
+BGP routing table information for VRF default, address family IPv4 Unicast
+BGP table version is 4, Local Router ID is 10.253.253.253
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup, 2 - best2
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+*>l10.253.253.253/32  0.0.0.0                           100      32768 i
+*>e10.254.254.254/32  10.255.255.254                                 0 65535 i
+
+BGP routing table information for VRF vrf_a, address family IPv4 Unicast
+BGP table version is 7, Local Router ID is 10.0.0.0
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup, 2 - best2
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+*>l10.0.0.0/32        0.0.0.0                           100      32768 i
+*>e10.1.1.1/32        10.255.255.2                                   0 65535 i
+
+BGP routing table information for VRF vrf_b, address family IPv4 Unicast
+BGP table version is 8, Local Router ID is 10.0.2.0
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup, 2 - best2
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+*>l10.0.2.0/32        0.0.0.0                           100      32768 i
+*>e10.3.3.1/32        10.255.255.6                                   0 65535 i

--- a/tests/parsers/nxos/show_ip_bgp/002_multi_vrf/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp/002_multi_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with local and external routes, simple paths
+platform: Nexus 9000
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_bgp/003_route_distinguisher/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp/003_route_distinguisher/expected.json
@@ -1,0 +1,137 @@
+{
+    "vrfs": {
+        "default": {
+            "address_families": {
+                "VPNv4 Unicast": {
+                    "table_version": 23,
+                    "router_id": "10.186.101.1",
+                    "route_distinguishers": {
+                        "1:100": {
+                            "rd_vrf": "vpn1",
+                            "routes": {
+                                "10.4.1.0/24": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "l",
+                                            "next_hop": "0.0.0.0",
+                                            "locprf": 100,
+                                            "weight": 32768,
+                                            "as_path": "",
+                                            "origin": "i"
+                                        }
+                                    ]
+                                },
+                                "10.16.1.0/24": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "r",
+                                            "next_hop": "0.0.0.0",
+                                            "metric": 4444,
+                                            "locprf": 100,
+                                            "weight": 32768,
+                                            "as_path": "",
+                                            "origin": "?"
+                                        }
+                                    ]
+                                },
+                                "10.16.0.0/8": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "i",
+                                            "next_hop": "10.186.0.2",
+                                            "metric": 0,
+                                            "locprf": 100,
+                                            "weight": 0,
+                                            "as_path": "",
+                                            "origin": "?"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "2:100": {
+                            "rd_vrf": "vpn2",
+                            "routes": {
+                                "10.16.1.0/24": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "r",
+                                            "next_hop": "0.0.0.0",
+                                            "metric": 4444,
+                                            "locprf": 100,
+                                            "weight": 32768,
+                                            "as_path": "",
+                                            "origin": "?"
+                                        }
+                                    ]
+                                },
+                                "10.106.0.0/8": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "r",
+                                            "next_hop": "0.0.0.0",
+                                            "metric": 4444,
+                                            "locprf": 100,
+                                            "weight": 32768,
+                                            "as_path": "",
+                                            "origin": "?"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "VPNv6 Unicast": {
+                    "table_version": 7,
+                    "router_id": "10.186.101.1",
+                    "route_distinguishers": {
+                        "1:100": {
+                            "rd_vrf": "vpn1",
+                            "routes": {
+                                "2001:11::1/128": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "r",
+                                            "next_hop": "0::",
+                                            "metric": 0,
+                                            "locprf": 100,
+                                            "weight": 32768,
+                                            "as_path": "",
+                                            "origin": "?"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "2:100": {
+                            "rd_vrf": "vpn2",
+                            "routes": {
+                                "2001:11::1/128": {
+                                    "paths": [
+                                        {
+                                            "status_codes": "*>",
+                                            "path_type": "r",
+                                            "next_hop": "0::",
+                                            "metric": 0,
+                                            "locprf": 100,
+                                            "weight": 32768,
+                                            "as_path": "",
+                                            "origin": "?"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp/003_route_distinguisher/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp/003_route_distinguisher/input.txt
@@ -1,0 +1,28 @@
+BGP routing table information for VRF default, address family VPNv4 Unicast
+BGP table version is 23, Local Router ID is 10.186.101.1
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+Route Distinguisher: 1:100    (VRF vpn1)
+*>l10.4.1.0/24         0.0.0.0                           100      32768 i
+*>r10.16.1.0/24        0.0.0.0               4444        100      32768 ?
+*>i10.16.0.0/8         10.186.0.2               0        100          0 ?
+
+Route Distinguisher: 2:100    (VRF vpn2)
+*>r10.16.1.0/24        0.0.0.0               4444        100      32768 ?
+*>r10.106.0.0/8        0.0.0.0               4444        100      32768 ?
+
+BGP routing table information for VRF default, address family VPNv6 Unicast
+BGP table version is 7, Local Router ID is 10.186.101.1
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+Route Distinguisher: 1:100    (VRF vpn1)
+*>r2001:11::1/128     0::                      0        100      32768 ?
+
+Route Distinguisher: 2:100    (VRF vpn2)
+*>r2001:11::1/128     0::                      0        100      32768 ?

--- a/tests/parsers/nxos/show_ip_bgp/003_route_distinguisher/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp/003_route_distinguisher/metadata.yaml
@@ -1,0 +1,3 @@
+description: VPNv4 and VPNv6 with Route Distinguisher groups, multiple RDs per address family
+platform: Nexus 9000v
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_bgp/004_ipv6_wrapped_networks/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp/004_ipv6_wrapped_networks/expected.json
@@ -1,0 +1,61 @@
+{
+    "vrfs": {
+        "default": {
+            "address_families": {
+                "IPv6 Unicast": {
+                    "table_version": 177,
+                    "router_id": "1.1.1.1",
+                    "routes": {
+                        "110:110:110::110/128": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "r",
+                                    "next_hop": "0::",
+                                    "metric": 0,
+                                    "locprf": 100,
+                                    "weight": 32768,
+                                    "as_path": "",
+                                    "origin": "?"
+                                }
+                            ]
+                        },
+                        "122:122::122:122/128": {
+                            "paths": [
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "e",
+                                    "next_hop": "99:99:99::99",
+                                    "weight": 30,
+                                    "as_path": "2",
+                                    "origin": "i"
+                                }
+                            ]
+                        },
+                        "123:123::123:123/128": {
+                            "paths": [
+                                {
+                                    "status_codes": "",
+                                    "path_type": "e",
+                                    "next_hop": "99:99:99::99",
+                                    "weight": 10,
+                                    "as_path": "2",
+                                    "origin": "i"
+                                },
+                                {
+                                    "status_codes": "*>",
+                                    "path_type": "i",
+                                    "next_hop": "98:98:98::98",
+                                    "locprf": 100,
+                                    "weight": 20,
+                                    "as_path": "3 2",
+                                    "origin": "i"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp/004_ipv6_wrapped_networks/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp/004_ipv6_wrapped_networks/input.txt
@@ -1,0 +1,14 @@
+BGP routing table information for VRF default, address family IPv6 Unicast
+BGP table version is 177, Local Router ID is 1.1.1.1
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup, 2 - best2
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+*>r110:110:110::110/128
+                      0::                      0        100      32768 ?
+*>e122:122::122:122/128
+                      99:99:99::99                                  30 2 i
+  e123:123::123:123/128
+                      99:99:99::99                                  10 2 i
+*>i                   98:98:98::98                      100         20 3 2 i

--- a/tests/parsers/nxos/show_ip_bgp/004_ipv6_wrapped_networks/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp/004_ipv6_wrapped_networks/metadata.yaml
@@ -1,0 +1,3 @@
+description: IPv6 Unicast with long prefixes wrapping to next line, continuation routes
+platform: Nexus 9000v
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds a new parser for the `show ip bgp` command on NX-OS (Cisco Nexus)
- Supports IPv4/IPv6 Unicast, VPNv4/VPNv6 address families with Route Distinguisher groups
- Handles multi-VRF output, continuation routes, AS-SET notation, and IPv6 wrapped network prefixes
- Column-position detection from header line for reliable field extraction

## Test plan
- [x] 001_basic_routes — Various status codes, multipath, AS-SETs, deleted routes, continuation routes
- [x] 002_multi_vrf — Three VRFs with local and external routes
- [x] 003_route_distinguisher — VPNv4/VPNv6 with multiple RD groups per address family
- [x] 004_ipv6_wrapped_networks — Long IPv6 prefixes wrapping to next line with continuation routes
- [x] All 547 tests pass
- [x] Pre-commit hooks pass (ruff, xenon complexity, JSON formatting)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)