### PR TITLE
feat: add parser for 'show ip bgp summary' on NX-OS

### DIFF
--- a/src/muninn/parsers/nxos/show_ip_bgp_summary.py
+++ b/src/muninn/parsers/nxos/show_ip_bgp_summary.py
@@ -1,0 +1,193 @@
+"""Parser for 'show ip bgp summary' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class NeighborEntry(TypedDict):
+    """Schema for a single BGP neighbor entry."""
+
+    bgp_version: int
+    remote_as: int
+    msg_rcvd: int
+    msg_sent: int
+    table_version: int
+    in_queue: int
+    out_queue: int
+    up_down: str
+    state_pfx_received: str
+
+
+class ShowIpBgpSummaryResult(TypedDict):
+    """Schema for 'show ip bgp summary' parsed output on NX-OS."""
+
+    router_id: str
+    local_as: int
+    vrf: str
+    address_family: NotRequired[str]
+    neighbors: dict[str, NeighborEntry]
+
+
+# --- Regex patterns ---
+
+_VRF_AF_RE = re.compile(
+    r"^BGP summary information for VRF (\S+),\s*address family (.+?)\s*$"
+)
+
+_ROUTER_ID_RE = re.compile(r"^BGP router identifier (\S+),\s*local AS number (\d+)\s*$")
+
+# Neighbor data line with all fields on one line.
+# State/PfxRcd can be a number or a string like "Idle" or
+# "Idle (Admin)".
+_NEIGHBOR_RE = re.compile(
+    r"^(?P<neighbor>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<remote_as>\d+)\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<tbl_ver>\d+)\s+"
+    r"(?P<inq>\d+)\s+"
+    r"(?P<outq>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfx>.+?)\s*$"
+)
+
+# Partial neighbor line: IP, version, AS only (wraps to next line)
+_NEIGHBOR_PARTIAL_RE = re.compile(
+    r"^(?P<neighbor>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<remote_as>\d+)\s*$"
+)
+
+# Continuation line for a wrapped neighbor entry
+_CONTINUATION_RE = re.compile(
+    r"^\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<tbl_ver>\d+)\s+"
+    r"(?P<inq>\d+)\s+"
+    r"(?P<outq>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfx>.+?)\s*$"
+)
+
+
+def _build_neighbor_entry(
+    version: str,
+    remote_as: str,
+    msg_rcvd: str,
+    msg_sent: str,
+    tbl_ver: str,
+    inq: str,
+    outq: str,
+    up_down: str,
+    state_pfx: str,
+) -> NeighborEntry:
+    """Build a NeighborEntry from raw string fields."""
+    return {
+        "bgp_version": int(version),
+        "remote_as": int(remote_as),
+        "msg_rcvd": int(msg_rcvd),
+        "msg_sent": int(msg_sent),
+        "table_version": int(tbl_ver),
+        "in_queue": int(inq),
+        "out_queue": int(outq),
+        "up_down": up_down,
+        "state_pfx_received": state_pfx,
+    }
+
+
+@register(OS.CISCO_NXOS, "show ip bgp summary")
+class ShowIpBgpSummaryParser(BaseParser["ShowIpBgpSummaryResult"]):
+    """Parser for 'show ip bgp summary' on NX-OS."""
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpBgpSummaryResult:
+        """Parse 'show ip bgp summary' output."""
+        vrf = "default"
+        address_family: str | None = None
+        router_id = ""
+        local_as = 0
+        neighbors: dict[str, NeighborEntry] = {}
+
+        # State for handling wrapped neighbor lines
+        pending_neighbor: str | None = None
+        pending_version: str = ""
+        pending_remote_as: str = ""
+
+        for line in output.splitlines():
+            # VRF and address family header
+            m = _VRF_AF_RE.match(line)
+            if m:
+                vrf = m.group(1)
+                address_family = m.group(2)
+                continue
+
+            # Router ID and local AS
+            m = _ROUTER_ID_RE.match(line)
+            if m:
+                router_id = m.group(1)
+                local_as = int(m.group(2))
+                continue
+
+            # Handle continuation of a wrapped neighbor line
+            if pending_neighbor is not None:
+                m = _CONTINUATION_RE.match(line)
+                if m:
+                    entry = _build_neighbor_entry(
+                        pending_version,
+                        pending_remote_as,
+                        m.group("msg_rcvd"),
+                        m.group("msg_sent"),
+                        m.group("tbl_ver"),
+                        m.group("inq"),
+                        m.group("outq"),
+                        m.group("up_down"),
+                        m.group("state_pfx"),
+                    )
+                    neighbors[pending_neighbor] = entry
+                    pending_neighbor = None
+                    continue
+                # If continuation didn't match, clear pending state
+                pending_neighbor = None
+
+            # Full neighbor line
+            m = _NEIGHBOR_RE.match(line)
+            if m:
+                entry = _build_neighbor_entry(
+                    m.group("version"),
+                    m.group("remote_as"),
+                    m.group("msg_rcvd"),
+                    m.group("msg_sent"),
+                    m.group("tbl_ver"),
+                    m.group("inq"),
+                    m.group("outq"),
+                    m.group("up_down"),
+                    m.group("state_pfx"),
+                )
+                neighbors[m.group("neighbor")] = entry
+                continue
+
+            # Partial neighbor line (wraps to next line)
+            m = _NEIGHBOR_PARTIAL_RE.match(line)
+            if m:
+                pending_neighbor = m.group("neighbor")
+                pending_version = m.group("version")
+                pending_remote_as = m.group("remote_as")
+                continue
+
+        result: ShowIpBgpSummaryResult = {
+            "router_id": router_id,
+            "local_as": local_as,
+            "vrf": vrf,
+            "neighbors": neighbors,
+        }
+
+        if address_family is not None:
+            result["address_family"] = address_family
+
+        return result

--- a/tests/parsers/nxos/show_ip_bgp_summary/001_multicast_with_wrapped_neighbor/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp_summary/001_multicast_with_wrapped_neighbor/expected.json
@@ -1,0 +1,151 @@
+{
+    "router_id": "2.2.2.3",
+    "local_as": 102,
+    "vrf": "default",
+    "neighbors": {
+        "10.0.0.100": {
+            "bgp_version": 4,
+            "remote_as": 64497,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "table_version": 0,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "03:20:10",
+            "state_pfx_received": "Idle"
+        },
+        "192.168.1.3": {
+            "bgp_version": 4,
+            "remote_as": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "table_version": 0,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "01:51:38",
+            "state_pfx_received": "Idle"
+        },
+        "10.0.0.1": {
+            "bgp_version": 4,
+            "remote_as": 65000,
+            "msg_rcvd": 2746767,
+            "msg_sent": 2396274,
+            "table_version": 512185206,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "3w0d",
+            "state_pfx_received": "558720"
+        },
+        "10.0.0.2": {
+            "bgp_version": 4,
+            "remote_as": 65001,
+            "msg_rcvd": 2855873,
+            "msg_sent": 2409742,
+            "table_version": 512185206,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "3w0d",
+            "state_pfx_received": "558720"
+        },
+        "10.0.0.3": {
+            "bgp_version": 4,
+            "remote_as": 65002,
+            "msg_rcvd": 695143,
+            "msg_sent": 689871,
+            "table_version": 512185203,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "1y10w",
+            "state_pfx_received": "0"
+        },
+        "10.0.0.4": {
+            "bgp_version": 4,
+            "remote_as": 65003,
+            "msg_rcvd": 1030294,
+            "msg_sent": 1220041,
+            "table_version": 512185206,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "1y50w",
+            "state_pfx_received": "1351"
+        },
+        "10.0.0.5": {
+            "bgp_version": 4,
+            "remote_as": 65004,
+            "msg_rcvd": 26552304,
+            "msg_sent": 14931352,
+            "table_version": 512185206,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "19w5d",
+            "state_pfx_received": "558720"
+        },
+        "10.0.0.6": {
+            "bgp_version": 4,
+            "remote_as": 65005,
+            "msg_rcvd": 26532908,
+            "msg_sent": 14931123,
+            "table_version": 512185206,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "19w5d",
+            "state_pfx_received": "558720"
+        },
+        "10.0.0.7": {
+            "bgp_version": 4,
+            "remote_as": 65006,
+            "msg_rcvd": 12245684,
+            "msg_sent": 9181569,
+            "table_version": 512185203,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "1y10w",
+            "state_pfx_received": "82"
+        },
+        "10.0.0.8": {
+            "bgp_version": 4,
+            "remote_as": 65007,
+            "msg_rcvd": 12250936,
+            "msg_sent": 9181571,
+            "table_version": 512185203,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "1y10w",
+            "state_pfx_received": "82"
+        },
+        "10.0.0.9": {
+            "bgp_version": 4,
+            "remote_as": 65008,
+            "msg_rcvd": 222146,
+            "msg_sent": 14368489,
+            "table_version": 512185203,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "22w0d",
+            "state_pfx_received": "0"
+        },
+        "10.0.0.10": {
+            "bgp_version": 4,
+            "remote_as": 65009,
+            "msg_rcvd": 26930508,
+            "msg_sent": 942614,
+            "table_version": 512185203,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "1y10w",
+            "state_pfx_received": "Idle (Admin)"
+        },
+        "10.0.0.11": {
+            "bgp_version": 4,
+            "remote_as": 65010,
+            "msg_rcvd": 2655204,
+            "msg_sent": 14931352,
+            "table_version": 512185206,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "1w5d",
+            "state_pfx_received": "4452"
+        }
+    },
+    "address_family": "IPv4 Multicast"
+}

--- a/tests/parsers/nxos/show_ip_bgp_summary/001_multicast_with_wrapped_neighbor/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp_summary/001_multicast_with_wrapped_neighbor/input.txt
@@ -1,0 +1,21 @@
+BGP summary information for VRF default, address family IPv4 Multicast
+BGP router identifier 2.2.2.3, local AS number 102
+BGP table version is 5, IPv4 Multicast config peers 2, capable peers 0
+1 network entries and 1 paths using 104 bytes of memory
+BGP attribute entries [1/124], BGP AS path entries [0/0]
+BGP community entries [0/0], BGP clusterlist entries [0/0]
+Neighbor V AS MsgRcvd MsgSent TblVer InQ OutQ Up/Down State/PfxRcd
+10.0.0.100 4 64497 0 0 0 0 0 03:20:10 Idle
+192.168.1.3 4 0 0 0 0 0 0 01:51:38 Idle
+10.0.0.1        4        65000 2746767 2396274 512185206    0    0 3w0d       558720
+10.0.0.2        4        65001 2855873 2409742 512185206    0    0 3w0d       558720
+10.0.0.3        4        65002  695143  689871 512185203    0    0 1y10w           0
+10.0.0.4        4        65003 1030294 1220041 512185206    0    0 1y50w        1351
+10.0.0.5        4        65004 26552304 14931352 512185206    0    0 19w5d      558720
+10.0.0.6        4        65005 26532908 14931123 512185206    0    0 19w5d      558720
+10.0.0.7        4        65006 12245684 9181569 512185203    0    0 1y10w          82
+10.0.0.8        4        65007 12250936 9181571 512185203    0    0 1y10w          82
+10.0.0.9        4        65008  222146 14368489 512185203    0    0 22w0d           0
+10.0.0.10       4        65009 26930508  942614 512185203    0    0 1y10w     Idle (Admin)
+10.0.0.11       4        65010
+                               2655204 14931352 512185206   0    0 1w5d      4452

--- a/tests/parsers/nxos/show_ip_bgp_summary/001_multicast_with_wrapped_neighbor/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp_summary/001_multicast_with_wrapped_neighbor/metadata.yaml
@@ -1,0 +1,3 @@
+description: IPv4 Multicast address family with multiple eBGP peers, Idle states, and a wrapped neighbor line
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_bgp_summary/002_basic_ibgp/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp_summary/002_basic_ibgp/expected.json
@@ -1,0 +1,106 @@
+{
+    "router_id": "10.0.0.1",
+    "local_as": 6230,
+    "vrf": "default",
+    "neighbors": {
+        "10.0.0.81": {
+            "bgp_version": 4,
+            "remote_as": 132,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "table_version": 1,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "never",
+            "state_pfx_received": "Idle (Admin)"
+        },
+        "10.0.0.66": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363273,
+            "msg_sent": 392165,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "9"
+        },
+        "10.0.0.67": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363277,
+            "msg_sent": 392110,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "9"
+        },
+        "10.0.0.74": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363274,
+            "msg_sent": 392168,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "10"
+        },
+        "10.0.0.75": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363277,
+            "msg_sent": 392137,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "10"
+        },
+        "10.0.0.82": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363272,
+            "msg_sent": 392239,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "2"
+        },
+        "10.0.0.83": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363274,
+            "msg_sent": 392149,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "2"
+        },
+        "10.0.0.90": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363272,
+            "msg_sent": 392205,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "1"
+        },
+        "10.0.0.91": {
+            "bgp_version": 4,
+            "remote_as": 6230,
+            "msg_rcvd": 363274,
+            "msg_sent": 392176,
+            "table_version": 39619,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "6w1d",
+            "state_pfx_received": "1"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp_summary/002_basic_ibgp/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp_summary/002_basic_ibgp/input.txt
@@ -1,0 +1,26 @@
+BGP router identifier 10.0.0.1, local AS number 6230
+BGP table version is 39619, main routing table version 39619
+972 network entries using 241056 bytes of memory
+2762 path entries using 375632 bytes of memory
+124/52 BGP path/bestpath attribute entries using 34720 bytes of memory
+48 BGP AS-PATH entries using 1888 bytes of memory
+4 BGP community entries using 144 bytes of memory
+1 BGP extended community entries using 24 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 653464 total bytes of memory
+905 received paths for inbound soft reconfiguration
+BGP attribute entries [9/3240], BGP AS path entries [1/6]
+BGP community entries [0/0], BGP clusterlist entries [0/0]
+BGP activity 2303/1331 prefixes, 43670/40908 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.0.0.81    4         132       0       0        1    0    0 never    Idle (Admin)
+10.0.0.66   4        6230  363273  392165    39619    0    0 6w1d            9
+10.0.0.67   4        6230  363277  392110    39619    0    0 6w1d            9
+10.0.0.74   4        6230  363274  392168    39619    0    0 6w1d           10
+10.0.0.75   4        6230  363277  392137    39619    0    0 6w1d           10
+10.0.0.82   4        6230  363272  392239    39619    0    0 6w1d            2
+10.0.0.83   4        6230  363274  392149    39619    0    0 6w1d            2
+10.0.0.90   4        6230  363272  392205    39619    0    0 6w1d            1
+10.0.0.91   4        6230  363274  392176    39619    0    0 6w1d            1

--- a/tests/parsers/nxos/show_ip_bgp_summary/002_basic_ibgp/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp_summary/002_basic_ibgp/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic iBGP summary with multiple peers in established state and one admin-down peer
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ip bgp summary` command on NX-OS (Cisco Nexus)
- Handles VRF/address-family headers, router ID, local AS, and neighbor table parsing
- Supports wrapped neighbor lines where data continues on the next line
- Supports various State/PfxRcd values including numeric prefix counts, `Idle`, `Idle (Admin)`, and `never` uptime

Closes #32

## Test plan
- [x] Test case 001: IPv4 Multicast AF with 13 neighbors including eBGP peers, Idle states, and a wrapped neighbor line
- [x] Test case 002: Basic iBGP summary with 9 peers in established state and one admin-down peer (no VRF header)
- [x] All pre-commit hooks pass (ruff, xenon, JSON formatting)
- [x] `uv run pytest tests/parsers/ -k "nxos/show_ip_bgp_summary"` -- 2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)