### PR TITLE
feat: register 'show ip interface brief' parser for IOS

### DIFF
--- a/src/muninn/parsers/iosxe/show_ip_interface_brief.py
+++ b/src/muninn/parsers/iosxe/show_ip_interface_brief.py
@@ -1,4 +1,4 @@
-"""Parser for 'show ip interface brief' command on IOS-XE."""
+"""Parser for 'show ip interface brief' command on IOS and IOS-XE."""
 
 import re
 from typing import TypedDict

--- a/tests/parsers/ios/show_ip_interface_brief/002_classic_ios_interfaces/expected.json
+++ b/tests/parsers/ios/show_ip_interface_brief/002_classic_ios_interfaces/expected.json
@@ -1,0 +1,46 @@
+{
+    "interfaces": {
+        "FastEthernet0/0": {
+            "ip_address": "192.168.1.1",
+            "ok": "YES",
+            "method": "manual",
+            "status": "up",
+            "protocol": "up"
+        },
+        "FastEthernet0/1": {
+            "ip_address": "unassigned",
+            "ok": "YES",
+            "method": "unset",
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "Serial0/0/0": {
+            "ip_address": "10.1.1.1",
+            "ok": "YES",
+            "method": "manual",
+            "status": "up",
+            "protocol": "up"
+        },
+        "Serial0/0/1": {
+            "ip_address": "unassigned",
+            "ok": "YES",
+            "method": "unset",
+            "status": "down",
+            "protocol": "down"
+        },
+        "Vlan1": {
+            "ip_address": "172.16.0.1",
+            "ok": "YES",
+            "method": "NVRAM",
+            "status": "up",
+            "protocol": "up"
+        },
+        "Vlan100": {
+            "ip_address": "10.100.0.1",
+            "ok": "YES",
+            "method": "NVRAM",
+            "status": "up",
+            "protocol": "down"
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_interface_brief/002_classic_ios_interfaces/input.txt
+++ b/tests/parsers/ios/show_ip_interface_brief/002_classic_ios_interfaces/input.txt
@@ -1,0 +1,7 @@
+Interface                  IP-Address      OK? Method Status                Protocol
+FastEthernet0/0            192.168.1.1     YES manual up                    up
+FastEthernet0/1            unassigned      YES unset  administratively down down
+Serial0/0/0                10.1.1.1        YES manual up                    up
+Serial0/0/1                unassigned      YES unset  down                  down
+Vlan1                      172.16.0.1      YES NVRAM  up                    up
+Vlan100                    10.100.0.1      YES NVRAM  up                    down

--- a/tests/parsers/ios/show_ip_interface_brief/002_classic_ios_interfaces/metadata.yaml
+++ b/tests/parsers/ios/show_ip_interface_brief/002_classic_ios_interfaces/metadata.yaml
@@ -1,0 +1,3 @@
+description: Classic IOS interfaces with FastEthernet, Serial, and VLAN SVIs
+platform: Cisco 2811
+software_version: IOS 15.1


### PR DESCRIPTION
## Summary

- **Investigation**: The existing IOS-XE `show ip interface brief` parser (`src/muninn/parsers/iosxe/show_ip_interface_brief.py`) was already registered for both IOS and IOS-XE via dual `@register` decorators, and the output format is identical between the two platforms
- **Test coverage**: An IOS-specific test case (`001_basic`) already existed from the original parser commit. Added a second test case (`002_classic_ios_interfaces`) covering classic IOS interface types: FastEthernet, Serial, and VLAN SVIs
- **Docstring**: Updated the module docstring to reflect that the parser covers both IOS and IOS-XE

Closes #37

## Test plan

- [x] Verified parser produces correct output for IOS sample data from ntc-templates
- [x] Both IOS test cases pass: `uv run pytest tests/parsers/test_parsers.py -k "ios/show_ip_interface_brief" -v`
- [x] Full test suite passes (542 tests)
- [x] Linting passes (`ruff check` and `ruff format`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)