### PR TITLE
feat: add parser for 'show lldp neighbors' on NX-OS

### DIFF
--- a/src/muninn/parsers/nxos/show_lldp_neighbors.py
+++ b/src/muninn/parsers/nxos/show_lldp_neighbors.py
@@ -1,0 +1,210 @@
+"""Parser for 'show lldp neighbors' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from netutils.interface import canonical_interface_name
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class LldpNeighborEntry(TypedDict):
+    """Schema for a single LLDP neighbor entry."""
+
+    hold_time: int
+    port_id: str
+    capabilities: NotRequired[str]
+
+
+class ShowLldpNeighborsResult(TypedDict):
+    """Schema for 'show lldp neighbors' parsed output."""
+
+    neighbors: dict[str, dict[str, LldpNeighborEntry]]
+    total_entries: NotRequired[int]
+
+
+@register(OS.CISCO_NXOS, "show lldp neighbors")
+class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
+    """Parser for 'show lldp neighbors' command on NX-OS.
+
+    Parses LLDP neighbor information showing connected devices.
+    Handles both single-line entries and multiline entries where
+    the device hostname wraps to a second line.
+    """
+
+    # Pattern for entries where everything is on one line
+    # nx-osv9000-2         Eth1/3          120        BR          Ethernet1/3
+    # cr-ebc.org.local  Eth3/1          120        BR           Fo1/0/8
+    _SINGLE_LINE_PATTERN = re.compile(
+        r"^(?P<device_id>\S+)\s+"
+        r"(?P<local_intf>(?:Eth|mgmt|Gig|Fas|Ten|Po)\S*)\s+"
+        r"(?P<hold_time>\d+)\s+"
+        r"(?P<capability>(?:[A-Za-z]\s*)*?)\s*"
+        r"(?P<port_id>\S+)$"
+    )
+
+    # Pattern for wrapped device ID - just the device ID on its own line
+    # nx-osv9000-3-long-name.com
+    # fw1-clinical-partner   (may have trailing whitespace)
+    _DEVICE_ID_ONLY_PATTERN = re.compile(r"^(?P<device_id>\S+)\s*$")
+
+    # Pattern for continuation line after wrapped device ID
+    #                      Eth1/1          120        BR          Ethernet1/1
+    #                      Eth1/5          120                     ethernet1/9
+    _CONTINUATION_PATTERN = re.compile(
+        r"^\s+(?P<local_intf>(?:Eth|mgmt|Gig|Fas|Ten|Po)\S*)\s+"
+        r"(?P<hold_time>\d+)\s+"
+        r"(?P<capability>(?:[A-Za-z]\s*)*?)\s*"
+        r"(?P<port_id>\S+)$"
+    )
+
+    # Pattern for total entries line
+    _TOTAL_PATTERN = re.compile(r"^Total entries displayed:\s*(?P<total>\d+)", re.I)
+
+    # Pattern to detect if port_id looks like an interface
+    _INTERFACE_PATTERN = re.compile(
+        r"^(?:Gi(?:g(?:abit)?)?|Fa(?:s(?:t)?)?|Eth?|Te(?:n)?|Fo(?:r(?:ty)?)?|"
+        r"Hu(?:n(?:dred)?)?|mgmt|Lo|Vlan|Po|Tu|Se|nve|ethernet)\d",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _normalize_port_id(cls, port_id: str) -> str:
+        """Normalize port_id if it looks like an interface name."""
+        if cls._INTERFACE_PATTERN.match(port_id):
+            return canonical_interface_name(port_id)
+        return port_id
+
+    @classmethod
+    def _normalize_capabilities(cls, cap_str: str) -> str | None:
+        """Normalize capability string to space-separated format.
+
+        Args:
+            cap_str: Raw capability string (may have extra spaces).
+
+        Returns:
+            Space-separated capabilities or None if empty.
+        """
+        caps = cap_str.split()
+        if not caps:
+            return None
+        return " ".join(caps)
+
+    @classmethod
+    def _is_skippable_line(cls, line: str) -> bool:
+        """Return True if the line is a header/legend or blank."""
+        stripped = line.strip()
+        if not stripped:
+            return True
+        if "Device ID" in line or "Capability codes:" in line:
+            return True
+        legend_prefixes = ("(R)", "(B)", "(W)", "(T)", "(C)", "(P)", "(S)", "(O)")
+        return stripped.startswith(legend_prefixes)
+
+    @classmethod
+    def _parse_total_entries(cls, line: str) -> int | None:
+        """Parse the total entries line if present."""
+        total_match = cls._TOTAL_PATTERN.match(line.strip())
+        if total_match:
+            return int(total_match.group("total"))
+        return None
+
+    @classmethod
+    def _parse_entry_fields(
+        cls,
+        match: re.Match[str],
+    ) -> tuple[str, LldpNeighborEntry]:
+        """Parse common fields from an LLDP neighbor match."""
+        local_intf = canonical_interface_name(match.group("local_intf"))
+        hold_time = int(match.group("hold_time"))
+        capability = cls._normalize_capabilities(match.group("capability"))
+        port_id = cls._normalize_port_id(match.group("port_id"))
+
+        entry: LldpNeighborEntry = {
+            "hold_time": hold_time,
+            "port_id": port_id,
+        }
+        if capability:
+            entry["capabilities"] = capability
+
+        return local_intf, entry
+
+    @classmethod
+    def _add_neighbor(
+        cls,
+        neighbors: dict[str, dict[str, LldpNeighborEntry]],
+        local_intf: str,
+        device_id: str,
+        entry: LldpNeighborEntry,
+    ) -> None:
+        if local_intf not in neighbors:
+            neighbors[local_intf] = {}
+        neighbors[local_intf][device_id] = entry
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLldpNeighborsResult:
+        """Parse 'show lldp neighbors' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed LLDP neighbors keyed by local interface, then device_id.
+
+        Raises:
+            ValueError: If no neighbors found.
+        """
+        neighbors: dict[str, dict[str, LldpNeighborEntry]] = {}
+        total_entries: int | None = None
+        pending_device_id: str | None = None
+
+        for line in output.splitlines():
+            # Skip header and capability legend
+            if cls._is_skippable_line(line):
+                continue
+
+            # Check for total entries line
+            parsed_total = cls._parse_total_entries(line)
+            if parsed_total is not None:
+                total_entries = parsed_total
+                continue
+
+            # Try continuation pattern first (for wrapped device ID)
+            if pending_device_id:
+                cont_match = cls._CONTINUATION_PATTERN.match(line)
+                if cont_match:
+                    local_intf, entry = cls._parse_entry_fields(cont_match)
+                    cls._add_neighbor(
+                        neighbors,
+                        local_intf,
+                        pending_device_id,
+                        entry,
+                    )
+                    pending_device_id = None
+                    continue
+
+            # Try single-line pattern
+            single_match = cls._SINGLE_LINE_PATTERN.match(line.strip())
+            if single_match:
+                device_id = single_match.group("device_id")
+                local_intf, entry = cls._parse_entry_fields(single_match)
+                cls._add_neighbor(neighbors, local_intf, device_id, entry)
+                pending_device_id = None
+                continue
+
+            # Try device ID only pattern (for wrapped entries)
+            device_only_match = cls._DEVICE_ID_ONLY_PATTERN.match(line.strip())
+            if device_only_match:
+                pending_device_id = device_only_match.group("device_id")
+
+        if not neighbors:
+            msg = "No LLDP neighbors found in output"
+            raise ValueError(msg)
+
+        result: ShowLldpNeighborsResult = {"neighbors": neighbors}
+        if total_entries is not None:
+            result["total_entries"] = total_entries
+
+        return result

--- a/tests/parsers/nxos/show_lldp_neighbors/001_basic/expected.json
+++ b/tests/parsers/nxos/show_lldp_neighbors/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "neighbors": {
+        "Ethernet1/1": {
+            "nx-osv9000-3-long-name.com": {
+                "hold_time": 120,
+                "port_id": "Ethernet1/1",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet1/2": {
+            "nx-osv9000-4-extremely-long-name": {
+                "hold_time": 120,
+                "port_id": "Ethernet1/1",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet1/3": {
+            "nx-osv9000-2": {
+                "hold_time": 120,
+                "port_id": "Ethernet1/3",
+                "capabilities": "BR"
+            }
+        }
+    },
+    "total_entries": 3
+}

--- a/tests/parsers/nxos/show_lldp_neighbors/001_basic/input.txt
+++ b/tests/parsers/nxos/show_lldp_neighbors/001_basic/input.txt
@@ -1,0 +1,10 @@
+Capability codes:
+  (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+  (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+Device ID            Local Intf      Hold-time  Capability  Port ID
+nx-osv9000-3-long-name.com
+                     Eth1/1          120        BR          Ethernet1/1
+nx-osv9000-4-extremely-long-name
+                     Eth1/2          120        BR          Ethernet1/1
+nx-osv9000-2         Eth1/3          120        BR          Ethernet1/3
+Total entries displayed: 3

--- a/tests/parsers/nxos/show_lldp_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_lldp_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic LLDP neighbors with single-line and wrapped entries
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_lldp_neighbors/002_multiline/expected.json
+++ b/tests/parsers/nxos/show_lldp_neighbors/002_multiline/expected.json
@@ -1,0 +1,102 @@
+{
+    "neighbors": {
+        "Management0": {
+            "dcx3.org.local": {
+                "hold_time": 120,
+                "port_id": "GigabitEthernet1/0/37",
+                "capabilities": "B"
+            }
+        },
+        "Ethernet1/1": {
+            "r2-services": {
+                "hold_time": 120,
+                "port_id": "Ethernet1/1",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet1/3": {
+            "dx1.org.local": {
+                "hold_time": 120,
+                "port_id": "TenGigabitEthernet1/1/1",
+                "capabilities": "B"
+            }
+        },
+        "Ethernet1/5": {
+            "fw1-clinical-partner": {
+                "hold_time": 120,
+                "port_id": "ethernet1/9"
+            }
+        },
+        "Ethernet1/6": {
+            "fw1-clinical-partner": {
+                "hold_time": 120,
+                "port_id": "ethernet1/10"
+            }
+        },
+        "Ethernet1/7": {
+            "fw2-clinical-partner": {
+                "hold_time": 120,
+                "port_id": "ethernet1/9"
+            }
+        },
+        "Ethernet1/8": {
+            "fw2-clinical-partner": {
+                "hold_time": 120,
+                "port_id": "ethernet1/10"
+            }
+        },
+        "Ethernet3/1": {
+            "cr-ebc.org.local": {
+                "hold_time": 120,
+                "port_id": "FortyGigabitEthernet1/0/8",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet3/13": {
+            "r2-services": {
+                "hold_time": 120,
+                "port_id": "Ethernet3/13",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet3/23": {
+            "fw1-services": {
+                "hold_time": 120,
+                "port_id": "ethernet1/21"
+            }
+        },
+        "Ethernet3/24": {
+            "fw2-services": {
+                "hold_time": 120,
+                "port_id": "ethernet1/23"
+            }
+        },
+        "Ethernet4/1": {
+            "cr-park.org.local": {
+                "hold_time": 120,
+                "port_id": "FortyGigabitEthernet1/0/8",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet4/13": {
+            "r2-services": {
+                "hold_time": 120,
+                "port_id": "Ethernet4/13",
+                "capabilities": "BR"
+            }
+        },
+        "Ethernet4/23": {
+            "fw1-services": {
+                "hold_time": 120,
+                "port_id": "ethernet1/22"
+            }
+        },
+        "Ethernet4/24": {
+            "fw2-services": {
+                "hold_time": 120,
+                "port_id": "ethernet1/24"
+            }
+        }
+    },
+    "total_entries": 15
+}

--- a/tests/parsers/nxos/show_lldp_neighbors/002_multiline/input.txt
+++ b/tests/parsers/nxos/show_lldp_neighbors/002_multiline/input.txt
@@ -1,0 +1,28 @@
+r1-services# show lldp neighbor
+Capability codes:
+  (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+  (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+Device ID            Local Intf      Hold-time  Capability  Port ID
+dcx3.org.local
+                     mgmt0           120        B            Gi1/0/37
+r2-services          Eth1/1          120        BR           Eth1/1
+dx1.org.local
+                     Eth1/3          120        B            Te1/1/1
+fw1-clinical-partner
+                     Eth1/5          120                     ethernet1/9
+fw1-clinical-partner
+                     Eth1/6          120                     ethernet1/10
+fw2-clinical-partner
+                     Eth1/7          120                     ethernet1/9
+fw2-clinical-partner
+                     Eth1/8          120                     ethernet1/10
+cr-ebc.org.local  Eth3/1          120        BR           Fo1/0/8
+r2-services          Eth3/13         120        BR           Eth3/13
+fw1-services         Eth3/23         120                     ethernet1/21
+fw2-services         Eth3/24         120                     ethernet1/23
+cr-park.org.local
+                     Eth4/1          120        BR           Fo1/0/8
+r2-services          Eth4/13         120        BR           Eth4/13
+fw1-services         Eth4/23         120                     ethernet1/22
+fw2-services         Eth4/24         120                     ethernet1/24
+Total entries displayed: 15

--- a/tests/parsers/nxos/show_lldp_neighbors/002_multiline/metadata.yaml
+++ b/tests/parsers/nxos/show_lldp_neighbors/002_multiline/metadata.yaml
@@ -1,0 +1,3 @@
+description: LLDP neighbors with multiline hostnames, empty capabilities, and prompt line
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add NX-OS parser for `show lldp neighbors` command that extracts neighbor device ID, local interface, hold time, capabilities, and port ID
- Handles multiline entries where long device hostnames wrap to a second line, and entries with empty capability fields (e.g., firewalls)
- Neighbors keyed by canonical local interface name, then by device ID, following the same pattern as the existing CDP neighbors parser

Closes #44

## Test plan
- [x] `001_basic` - Standard output with both single-line and wrapped hostname entries (3 neighbors)
- [x] `002_multiline` - Real-world output with 15 neighbors including prompt line, empty capabilities, mgmt0 interface, and multiple wrapped hostnames
- [x] All pre-commit hooks pass (ruff check, ruff format, xenon complexity)
- [x] `uv run pytest tests/parsers/test_parsers.py -k "show_lldp_neighbors"` -- 2/2 NX-OS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)