### PR TITLE
feat: add parser for 'show ip bgp summary vrf' on NX-OS

### DIFF
--- a/src/muninn/parsers/nxos/show_ip_bgp_summary_vrf.py
+++ b/src/muninn/parsers/nxos/show_ip_bgp_summary_vrf.py
@@ -1,0 +1,310 @@
+"""Parser for 'show ip bgp summary vrf' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class NeighborEntry(TypedDict):
+    """Schema for a single BGP neighbor entry."""
+
+    bgp_version: int
+    remote_as: int
+    msg_rcvd: int
+    msg_sent: int
+    table_version: int
+    in_queue: int
+    out_queue: int
+    up_down: str
+    state_pfx_rcd: str
+
+
+class AddressFamilyEntry(TypedDict):
+    """Schema for a single address family within a VRF."""
+
+    router_id: NotRequired[str]
+    local_as: NotRequired[int]
+    table_version: NotRequired[int]
+    config_peers: NotRequired[int]
+    capable_peers: NotRequired[int]
+    neighbors: dict[str, NeighborEntry]
+
+
+class VrfEntry(TypedDict):
+    """Schema for a single VRF."""
+
+    address_families: dict[str, AddressFamilyEntry]
+
+
+class ShowIpBgpSummaryVrfResult(TypedDict):
+    """Schema for 'show ip bgp summary vrf' parsed output on NX-OS."""
+
+    vrfs: dict[str, VrfEntry]
+
+
+# --- Compiled regex patterns ---
+
+_VRF_AF_RE = re.compile(
+    r"^BGP summary information for VRF (\S+),\s*address family (.+?)\s*$"
+)
+
+_ROUTER_ID_RE = re.compile(r"^BGP router identifier (\S+),\s*local AS number (\d+)\s*$")
+
+_TABLE_VERSION_RE = re.compile(
+    r"^BGP table version is (\d+),\s*.+?\s+config peers (\d+),"
+    r"\s*capable peers (\d+)\s*$"
+)
+
+# Standard neighbor header line
+_NEIGHBOR_HEADER_RE = re.compile(
+    r"^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+"
+    r"TblVer\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd"
+)
+
+# Type breakdown header (L2VPN EVPN) - we skip these lines
+_TYPE_HEADER_RE = re.compile(r"^\s*Neighbor\s+T\s+AS\s+PfxRcd")
+
+# Single-line neighbor entry: all fields on one line
+_NEIGHBOR_SINGLE_RE = re.compile(
+    r"^(?P<neighbor>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<as>\d+)\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<tbl_ver>\d+)\s+"
+    r"(?P<inq>\d+)\s+"
+    r"(?P<outq>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfx>\S+)\s*$"
+)
+
+# Wrapped neighbor: first line has neighbor, version, AS only
+_NEIGHBOR_WRAP_FIRST_RE = re.compile(
+    r"^(?P<neighbor>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<as>\d+)\s*$"
+)
+
+# Wrapped neighbor continuation (indented, remaining fields)
+_NEIGHBOR_WRAP_CONT_RE = re.compile(
+    r"^\s+(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<tbl_ver>\d+)\s+"
+    r"(?P<inq>\d+)\s+"
+    r"(?P<outq>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfx>\S+)\s*$"
+)
+
+
+def _build_neighbor_entry(
+    version: str,
+    remote_as: str,
+    msg_rcvd: str,
+    msg_sent: str,
+    tbl_ver: str,
+    inq: str,
+    outq: str,
+    up_down: str,
+    state_pfx: str,
+) -> NeighborEntry:
+    """Build a NeighborEntry from parsed string fields."""
+    return {
+        "bgp_version": int(version),
+        "remote_as": int(remote_as),
+        "msg_rcvd": int(msg_rcvd),
+        "msg_sent": int(msg_sent),
+        "table_version": int(tbl_ver),
+        "in_queue": int(inq),
+        "out_queue": int(outq),
+        "up_down": up_down,
+        "state_pfx_rcd": state_pfx,
+    }
+
+
+def _entry_from_single(m: re.Match[str]) -> tuple[str, NeighborEntry]:
+    """Build neighbor IP and entry from a single-line match."""
+    return m.group("neighbor"), _build_neighbor_entry(
+        version=m.group("version"),
+        remote_as=m.group("as"),
+        msg_rcvd=m.group("msg_rcvd"),
+        msg_sent=m.group("msg_sent"),
+        tbl_ver=m.group("tbl_ver"),
+        inq=m.group("inq"),
+        outq=m.group("outq"),
+        up_down=m.group("up_down"),
+        state_pfx=m.group("state_pfx"),
+    )
+
+
+def _entry_from_wrap(
+    wrap: dict[str, str], m_cont: re.Match[str]
+) -> tuple[str, NeighborEntry]:
+    """Build neighbor IP and entry from a wrapped two-line match."""
+    return wrap["neighbor"], _build_neighbor_entry(
+        version=wrap["version"],
+        remote_as=wrap["as"],
+        msg_rcvd=m_cont.group("msg_rcvd"),
+        msg_sent=m_cont.group("msg_sent"),
+        tbl_ver=m_cont.group("tbl_ver"),
+        inq=m_cont.group("inq"),
+        outq=m_cont.group("outq"),
+        up_down=m_cont.group("up_down"),
+        state_pfx=m_cont.group("state_pfx"),
+    )
+
+
+def _parse_header_fields(
+    stripped: str,
+    af_entry: AddressFamilyEntry,
+) -> bool:
+    """Try to parse router-id or table-version from a line.
+
+    Returns True if the line was consumed as a header field.
+    """
+    m_rid = _ROUTER_ID_RE.match(stripped)
+    if m_rid:
+        af_entry["router_id"] = m_rid.group(1)
+        af_entry["local_as"] = int(m_rid.group(2))
+        return True
+
+    m_tv = _TABLE_VERSION_RE.match(stripped)
+    if m_tv:
+        af_entry["table_version"] = int(m_tv.group(1))
+        af_entry["config_peers"] = int(m_tv.group(2))
+        af_entry["capable_peers"] = int(m_tv.group(3))
+        return True
+
+    return False
+
+
+def _save_af_entry(
+    vrfs: dict[str, VrfEntry],
+    vrf_name: str | None,
+    af_name: str | None,
+    af_entry: AddressFamilyEntry | None,
+) -> None:
+    """Save an address family entry into the VRF structure."""
+    if vrf_name is None or af_name is None or af_entry is None:
+        return
+
+    if vrf_name not in vrfs:
+        vrfs[vrf_name] = {"address_families": {}}
+    vrfs[vrf_name]["address_families"][af_name] = af_entry
+
+
+def _parse_neighbor_line(
+    line: str,
+    stripped: str,
+    neighbors: dict[str, NeighborEntry],
+    pending_wrap: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Parse a single neighbor line, returning updated pending_wrap.
+
+    Handles single-line entries, wrapped first lines, and
+    wrapped continuation lines.
+    """
+    # Handle wrapped continuation
+    if pending_wrap is not None:
+        m_cont = _NEIGHBOR_WRAP_CONT_RE.match(line)
+        if m_cont:
+            ip, entry = _entry_from_wrap(pending_wrap, m_cont)
+            neighbors[ip] = entry
+        return None
+
+    if not stripped:
+        return None
+
+    # Single-line neighbor
+    m_single = _NEIGHBOR_SINGLE_RE.match(stripped)
+    if m_single:
+        ip, entry = _entry_from_single(m_single)
+        neighbors[ip] = entry
+        return None
+
+    # Wrapped first line (long AS number)
+    m_wrap = _NEIGHBOR_WRAP_FIRST_RE.match(stripped)
+    if m_wrap:
+        return {
+            "neighbor": m_wrap.group("neighbor"),
+            "version": m_wrap.group("version"),
+            "as": m_wrap.group("as"),
+        }
+
+    return None
+
+
+@register(OS.CISCO_NXOS, "show ip bgp summary vrf")
+class ShowIpBgpSummaryVrfParser(BaseParser["ShowIpBgpSummaryVrfResult"]):
+    """Parser for 'show ip bgp summary vrf' on NX-OS.
+
+    Parses VRF-scoped BGP summary information showing neighbor state
+    and prefix counts across multiple VRFs and address families.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpBgpSummaryVrfResult:
+        """Parse 'show ip bgp summary vrf' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed BGP summary keyed by VRF, address family,
+            then neighbor IP.
+        """
+        vrfs: dict[str, VrfEntry] = {}
+        lines = output.splitlines()
+
+        current_vrf: str | None = None
+        current_af: str | None = None
+        af_entry: AddressFamilyEntry | None = None
+        in_neighbor_table = False
+        in_type_table = False
+        pending_wrap: dict[str, str] | None = None
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Detect VRF/AF section header
+            m_vrf = _VRF_AF_RE.match(stripped)
+            if m_vrf:
+                _save_af_entry(vrfs, current_vrf, current_af, af_entry)
+                current_vrf = m_vrf.group(1)
+                current_af = m_vrf.group(2)
+                af_entry = {"neighbors": {}}
+                in_neighbor_table = False
+                in_type_table = False
+                pending_wrap = None
+                continue
+
+            if af_entry is None:
+                continue
+
+            if _parse_header_fields(stripped, af_entry):
+                continue
+
+            # Table headers toggle parsing mode
+            if _TYPE_HEADER_RE.match(stripped):
+                in_type_table = True
+                in_neighbor_table = False
+                pending_wrap = None
+                continue
+            if _NEIGHBOR_HEADER_RE.match(stripped):
+                in_neighbor_table = True
+                in_type_table = False
+                pending_wrap = None
+                continue
+
+            if in_type_table or not in_neighbor_table:
+                continue
+
+            pending_wrap = _parse_neighbor_line(
+                line, stripped, af_entry["neighbors"], pending_wrap
+            )
+
+        _save_af_entry(vrfs, current_vrf, current_af, af_entry)
+        return {"vrfs": vrfs}

--- a/tests/parsers/nxos/show_ip_bgp_summary_vrf/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp_summary_vrf/001_basic/expected.json
@@ -1,0 +1,188 @@
+{
+    "vrfs": {
+        "RED": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "192.168.1.2": {
+                            "bgp_version": 4,
+                            "remote_as": 65002,
+                            "msg_rcvd": 1143238,
+                            "msg_sent": 1065438,
+                            "table_version": 110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "10w4d",
+                            "state_pfx_rcd": "7"
+                        }
+                    },
+                    "router_id": "192.168.1.1",
+                    "local_as": 65001,
+                    "table_version": 110,
+                    "config_peers": 1,
+                    "capable_peers": 1
+                }
+            }
+        },
+        "WHITE": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "192.168.2.2": {
+                            "bgp_version": 4,
+                            "remote_as": 65012,
+                            "msg_rcvd": 1142321,
+                            "msg_sent": 1065438,
+                            "table_version": 114,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "10w4d",
+                            "state_pfx_rcd": "7"
+                        }
+                    },
+                    "router_id": "192.168.2.1",
+                    "local_as": 65011,
+                    "table_version": 114,
+                    "config_peers": 1,
+                    "capable_peers": 1
+                }
+            }
+        },
+        "BLUE": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "192.168.3.2": {
+                            "bgp_version": 4,
+                            "remote_as": 65022,
+                            "msg_rcvd": 672804,
+                            "msg_sent": 639789,
+                            "table_version": 16,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "10w4d",
+                            "state_pfx_rcd": "1"
+                        },
+                        "192.168.3.3": {
+                            "bgp_version": 4,
+                            "remote_as": 65023,
+                            "msg_rcvd": 672792,
+                            "msg_sent": 639791,
+                            "table_version": 16,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "10w4d",
+                            "state_pfx_rcd": "1"
+                        }
+                    },
+                    "router_id": "192.168.3.1",
+                    "local_as": 65021,
+                    "table_version": 16,
+                    "config_peers": 2,
+                    "capable_peers": 2
+                }
+            }
+        },
+        "PURPLE": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "10.101.1.1": {
+                            "bgp_version": 4,
+                            "remote_as": 4233316914,
+                            "msg_rcvd": 14111081,
+                            "msg_sent": 14037706,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "5w1d",
+                            "state_pfx_rcd": "100"
+                        },
+                        "10.101.1.4": {
+                            "bgp_version": 4,
+                            "remote_as": 4255544594,
+                            "msg_rcvd": 14124621,
+                            "msg_sent": 14051162,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "5w1d",
+                            "state_pfx_rcd": "0"
+                        },
+                        "111.111.111.111": {
+                            "bgp_version": 4,
+                            "remote_as": 4244433330,
+                            "msg_rcvd": 57508,
+                            "msg_sent": 53320,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2w4d",
+                            "state_pfx_rcd": "28"
+                        },
+                        "144.144.144.144": {
+                            "bgp_version": 4,
+                            "remote_as": 33331,
+                            "msg_rcvd": 888166,
+                            "msg_sent": 836265,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "8w1d",
+                            "state_pfx_rcd": "8"
+                        },
+                        "155.155.155.155": {
+                            "bgp_version": 4,
+                            "remote_as": 33331,
+                            "msg_rcvd": 887898,
+                            "msg_sent": 835708,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "8w1d",
+                            "state_pfx_rcd": "8"
+                        },
+                        "192.168.111.1": {
+                            "bgp_version": 4,
+                            "remote_as": 11112,
+                            "msg_rcvd": 652276,
+                            "msg_sent": 570942,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w0d",
+                            "state_pfx_rcd": "4"
+                        },
+                        "192.168.111.2": {
+                            "bgp_version": 4,
+                            "remote_as": 11111,
+                            "msg_rcvd": 502385,
+                            "msg_sent": 501240,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "3d03h",
+                            "state_pfx_rcd": "1"
+                        },
+                        "192.168.111.6": {
+                            "bgp_version": 4,
+                            "remote_as": 11111,
+                            "msg_rcvd": 124617,
+                            "msg_sent": 124458,
+                            "table_version": 1922,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2w2d",
+                            "state_pfx_rcd": "1"
+                        }
+                    },
+                    "router_id": "1.1.1.1",
+                    "local_as": 65001,
+                    "table_version": 1922,
+                    "config_peers": 8,
+                    "capable_peers": 8
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp_summary_vrf/001_basic/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp_summary_vrf/001_basic/input.txt
@@ -1,0 +1,58 @@
+BGP summary information for VRF RED, address family IPv4 Unicast
+BGP router identifier 192.168.1.1, local AS number 65001
+BGP table version is 110, IPv4 Unicast config peers 1, capable peers 1
+8 network entries and 8 paths using 1152 bytes of memory
+BGP attribute entries [6/864], BGP AS path entries [4/64]
+BGP community entries [3/124], BGP clusterlist entries [0/0]
+7 received paths for inbound soft reconfiguration
+7 identical, 0 modified, 0 filtered received paths using 0 bytes
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.1.2     4 65002 1143238 1065438      110    0    0    10w4d 7
+
+BGP summary information for VRF WHITE, address family IPv4 Unicast
+BGP router identifier 192.168.2.1, local AS number 65011
+BGP table version is 114, IPv4 Unicast config peers 1, capable peers 1
+8 network entries and 8 paths using 1152 bytes of memory
+BGP attribute entries [6/864], BGP AS path entries [4/64]
+BGP community entries [3/124], BGP clusterlist entries [0/0]
+7 received paths for inbound soft reconfiguration
+7 identical, 0 modified, 0 filtered received paths using 0 bytes
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.2.2     4 65012 1142321 1065438      114    0    0    10w4d 7
+
+BGP summary information for VRF BLUE, address family IPv4 Unicast
+BGP router identifier 192.168.3.1, local AS number 65021
+BGP table version is 16, IPv4 Unicast config peers 2, capable peers 2
+2 network entries and 3 paths using 368 bytes of memory
+BGP attribute entries [4/576], BGP AS path entries [1/22]
+BGP community entries [3/124], BGP clusterlist entries [0/0]
+2 received paths for inbound soft reconfiguration
+0 identical, 2 modified, 0 filtered received paths using 16 bytes
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.3.2     4 65022  672804  639789       16    0    0    10w4d 1
+192.168.3.3     4 65023  672792  639791       16    0    0    10w4d 1
+
+BGP summary information for VRF PURPLE, address family IPv4 Unicast
+BGP router identifier 1.1.1.1, local AS number 65001
+BGP table version is 1922, IPv4 Unicast config peers 8, capable peers 8
+53 network entries and 58 paths using 13168 bytes of memory
+BGP attribute entries [34/5440], BGP AS path entries [17/430]
+BGP community entries [11/372], BGP clusterlist entries [0/0]
+59 received paths for inbound soft reconfiguration
+6 identical, 44 modified, 9 filtered received paths using 1180 bytes
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.101.1.1      4 4233316914
+                        14111081 14037706     1922    0    0     5w1d 100
+10.101.1.4      4 4255544594
+                        14124621 14051162     1922    0    0     5w1d 0
+111.111.111.111 4 4244433330
+                          57508   53320     1922    0    0     2w4d 28
+144.144.144.144 4 33331  888166  836265     1922    0    0     8w1d 8
+155.155.155.155 4 33331  887898  835708     1922    0    0     8w1d 8
+192.168.111.1  4 11112  652276  570942     1922    0    0     1w0d 4
+192.168.111.2   4 11111  502385  501240     1922    0    0    3d03h 1
+192.168.111.6   4 11111  124617  124458     1922    0    0     2w2d 1

--- a/tests/parsers/nxos/show_ip_bgp_summary_vrf/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp_summary_vrf/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with BGP neighbors including wrapped long AS numbers
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_bgp_summary_vrf/002_all_summary_vrf/expected.json
+++ b/tests/parsers/nxos/show_ip_bgp_summary_vrf/002_all_summary_vrf/expected.json
@@ -1,0 +1,277 @@
+{
+    "vrfs": {
+        "AMB": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {}
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "BLU": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "10.25.113.1": {
+                            "bgp_version": 4,
+                            "remote_as": 65001,
+                            "msg_rcvd": 21968368,
+                            "msg_sent": 22451737,
+                            "table_version": 2301549,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "24w2d",
+                            "state_pfx_rcd": "0"
+                        }
+                    },
+                    "router_id": "172.16.101.101",
+                    "local_as": 65161,
+                    "table_version": 2301549,
+                    "config_peers": 1,
+                    "capable_peers": 1
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "GRN": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {}
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "GRY": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {}
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "NPE": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {}
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "RED": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {}
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "TRI": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "10.23.1.74": {
+                            "bgp_version": 4,
+                            "remote_as": 65171,
+                            "msg_rcvd": 3078819,
+                            "msg_sent": 3074406,
+                            "table_version": 8526,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2w5d",
+                            "state_pfx_rcd": "24"
+                        }
+                    },
+                    "router_id": "172.16.101.123",
+                    "local_as": 65161,
+                    "table_version": 8526,
+                    "config_peers": 1,
+                    "capable_peers": 1
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                }
+            }
+        },
+        "default": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbors": {
+                        "172.16.14.2": {
+                            "bgp_version": 4,
+                            "remote_as": 65164,
+                            "msg_rcvd": 8429603,
+                            "msg_sent": 8531693,
+                            "table_version": 14450,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1d08h",
+                            "state_pfx_rcd": "2"
+                        },
+                        "172.16.31.1": {
+                            "bgp_version": 4,
+                            "remote_as": 65191,
+                            "msg_rcvd": 8081582,
+                            "msg_sent": 8260415,
+                            "table_version": 14450,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w0d",
+                            "state_pfx_rcd": "2"
+                        },
+                        "172.16.31.17": {
+                            "bgp_version": 4,
+                            "remote_as": 65193,
+                            "msg_rcvd": 8167842,
+                            "msg_sent": 8348036,
+                            "table_version": 14450,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w0d",
+                            "state_pfx_rcd": "2"
+                        },
+                        "172.16.102.2": {
+                            "bgp_version": 4,
+                            "remote_as": 65161,
+                            "msg_rcvd": 1166456,
+                            "msg_sent": 1165743,
+                            "table_version": 14450,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2y0w",
+                            "state_pfx_rcd": "28"
+                        },
+                        "172.16.151.2": {
+                            "bgp_version": 4,
+                            "remote_as": 65162,
+                            "msg_rcvd": 1074723,
+                            "msg_sent": 1073151,
+                            "table_version": 14450,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w1d",
+                            "state_pfx_rcd": "18"
+                        }
+                    },
+                    "router_id": "172.16.101.37",
+                    "local_as": 65161,
+                    "table_version": 14450,
+                    "config_peers": 5,
+                    "capable_peers": 5
+                },
+                "IPv6 Unicast": {
+                    "neighbors": {}
+                },
+                "VPNv4 Unicast": {
+                    "neighbors": {}
+                },
+                "VPNv6 Unicast": {
+                    "neighbors": {}
+                },
+                "IPv4 MVPN": {
+                    "neighbors": {}
+                },
+                "IPv6 MVPN": {
+                    "neighbors": {}
+                },
+                "L2VPN EVPN": {
+                    "neighbors": {
+                        "172.23.129.240": {
+                            "bgp_version": 4,
+                            "remote_as": 65191,
+                            "msg_rcvd": 8081498,
+                            "msg_sent": 8246843,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w0d",
+                            "state_pfx_rcd": "6"
+                        },
+                        "172.23.133.240": {
+                            "bgp_version": 4,
+                            "remote_as": 65193,
+                            "msg_rcvd": 8167863,
+                            "msg_sent": 8334538,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w0d",
+                            "state_pfx_rcd": "6"
+                        },
+                        "172.16.101.33": {
+                            "bgp_version": 4,
+                            "remote_as": 65161,
+                            "msg_rcvd": 40997672,
+                            "msg_sent": 23273121,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2y11w",
+                            "state_pfx_rcd": "1782"
+                        },
+                        "172.16.101.34": {
+                            "bgp_version": 4,
+                            "remote_as": 65161,
+                            "msg_rcvd": 40992491,
+                            "msg_sent": 23273008,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2y11w",
+                            "state_pfx_rcd": "1782"
+                        },
+                        "172.16.201.37": {
+                            "bgp_version": 4,
+                            "remote_as": 65162,
+                            "msg_rcvd": 23261970,
+                            "msg_sent": 26520909,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1w1d",
+                            "state_pfx_rcd": "698"
+                        },
+                        "172.16.201.38": {
+                            "bgp_version": 4,
+                            "remote_as": 65162,
+                            "msg_rcvd": 23309853,
+                            "msg_sent": 26564632,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "2y2w",
+                            "state_pfx_rcd": "698"
+                        },
+                        "172.16.255.42": {
+                            "bgp_version": 4,
+                            "remote_as": 65164,
+                            "msg_rcvd": 20901792,
+                            "msg_sent": 21346308,
+                            "table_version": 63025110,
+                            "in_queue": 0,
+                            "out_queue": 0,
+                            "up_down": "1d08h",
+                            "state_pfx_rcd": "14"
+                        }
+                    },
+                    "router_id": "172.16.101.37",
+                    "local_as": 65161,
+                    "table_version": 63025110,
+                    "config_peers": 7,
+                    "capable_peers": 7
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_bgp_summary_vrf/002_all_summary_vrf/input.txt
+++ b/tests/parsers/nxos/show_ip_bgp_summary_vrf/002_all_summary_vrf/input.txt
@@ -1,0 +1,92 @@
+BGP summary information for VRF AMB, address family IPv4 Unicast
+
+BGP summary information for VRF AMB, address family IPv6 Unicast
+
+BGP summary information for VRF BLU, address family IPv4 Unicast
+BGP router identifier 172.16.101.101, local AS number 65161
+BGP table version is 2301549, IPv4 Unicast config peers 1, capable peers 1
+827 network entries and 1406 paths using 105308 bytes of memory
+BGP attribute entries [107/18404], BGP AS path entries [26/272]
+BGP community entries [0/0], BGP clusterlist entries [6/24]
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.25.113.1     4 65001 21968368 22451737  2301549    0    0    24w2d 0
+
+BGP summary information for VRF BLU, address family IPv6 Unicast
+
+BGP summary information for VRF GRN, address family IPv4 Unicast
+
+BGP summary information for VRF GRN, address family IPv6 Unicast
+
+BGP summary information for VRF GRY, address family IPv4 Unicast
+
+BGP summary information for VRF GRY, address family IPv6 Unicast
+
+BGP summary information for VRF NPE, address family IPv4 Unicast
+
+BGP summary information for VRF NPE, address family IPv6 Unicast
+
+BGP summary information for VRF RED, address family IPv4 Unicast
+
+BGP summary information for VRF RED, address family IPv6 Unicast
+
+BGP summary information for VRF TRI, address family IPv4 Unicast
+BGP router identifier 172.16.101.123, local AS number 65161
+BGP table version is 8526, IPv4 Unicast config peers 1, capable peers 1
+55 network entries and 102 paths using 9940 bytes of memory
+BGP attribute entries [11/1892], BGP AS path entries [8/80]
+BGP community entries [0/0], BGP clusterlist entries [6/24]
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.23.1.74      4 65171 3078819 3074406     8526    0    0     2w5d 24
+
+BGP summary information for VRF TRI, address family IPv6 Unicast
+
+BGP summary information for VRF default, address family IPv4 Unicast
+BGP router identifier 172.16.101.37, local AS number 65161
+BGP table version is 14450, IPv4 Unicast config peers 5, capable peers 5
+36 network entries and 56 paths using 11184 bytes of memory
+BGP attribute entries [24/4128], BGP AS path entries [13/102]
+BGP community entries [0/0], BGP clusterlist entries [6/24]
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+172.16.14.2     4 65164 8429603 8531693    14450    0    0    1d08h 2
+172.16.31.1     4 65191 8081582 8260415    14450    0    0     1w0d 2
+172.16.31.17    4 65193 8167842 8348036    14450    0    0     1w0d 2
+172.16.102.2    4 65161 1166456 1165743    14450    0    0     2y0w 28
+172.16.151.2    4 65162 1074723 1073151    14450    0    0     1w1d 18
+
+BGP summary information for VRF default, address family IPv6 Unicast
+
+BGP summary information for VRF default, address family VPNv4 Unicast
+
+BGP summary information for VRF default, address family VPNv6 Unicast
+
+BGP summary information for VRF default, address family IPv4 MVPN
+
+BGP summary information for VRF default, address family IPv6 MVPN
+
+BGP summary information for VRF default, address family L2VPN EVPN
+BGP router identifier 172.16.101.37, local AS number 65161
+BGP table version is 63025110, L2VPN EVPN config peers 7, capable peers 7
+4630 network entries and 8017 paths using 1210960 bytes of memory
+BGP attribute entries [796/136912], BGP AS path entries [31/334]
+BGP community entries [0/0], BGP clusterlist entries [6/24]
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+172.23.129.240  4 65191 8081498 8246843 63025110    0    0     1w0d 6
+172.23.133.240  4 65193 8167863 8334538 63025110    0    0     1w0d 6
+172.16.101.33   4 65161 40997672 23273121 63025110    0    0    2y11w 1782
+172.16.101.34   4 65161 40992491 23273008 63025110    0    0    2y11w 1782
+172.16.201.37   4 65162 23261970 26520909 63025110    0    0     1w1d 698
+172.16.201.38   4 65162 23309853 26564632 63025110    0    0     2y2w 698
+172.16.255.42   4 65164 20901792 21346308 63025110    0    0    1d08h 14
+
+Neighbor        T    AS PfxRcd     Type-2     Type-3     Type-4     Type-5
+172.23.129.240  I 65191 6          0          0          0          6
+172.23.133.240  I 65193 6          0          0          0          6
+172.16.101.33   I 65161 1782       1434       14         0          334
+172.16.101.34   I 65161 1782       1434       14         0          334
+172.16.201.37   E 65162 698        481        7          0          210
+172.16.201.38   E 65162 698        481        7          0          210
+172.16.255.42   I 65164 14         0          0          0          14

--- a/tests/parsers/nxos/show_ip_bgp_summary_vrf/002_all_summary_vrf/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_bgp_summary_vrf/002_all_summary_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: All VRF summary with multiple address families including empty VRFs and L2VPN EVPN
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add parser for `show ip bgp summary vrf` command on NX-OS, supporting VRF-scoped BGP summary output
- Handles multiple VRFs and address families (IPv4 Unicast, IPv6 Unicast, L2VPN EVPN, etc.)
- Supports both single-line and wrapped neighbor entries (long 4-byte AS numbers that wrap across two lines)
- Correctly skips L2VPN EVPN type breakdown tables (Type-2/3/4/5 summary)
- Includes 2 test cases from ntc-templates reference data

Closes #35

## Test plan

- [x] `001_basic` - Multiple VRFs with BGP neighbors including wrapped long AS numbers (4 VRFs, 12 neighbors)
- [x] `002_all_summary_vrf` - All VRF summary with multiple address families including empty VRFs and L2VPN EVPN (8 VRFs, 21 address families, 13 neighbors)
- [x] All 545 tests pass (`uv run pytest`)
- [x] Linting passes (`uv run ruff check && uv run ruff format --check`)
- [x] Complexity check passes (`xenon`)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)