### PR TITLE
feat: add parser for 'show hsrp all' on NX-OS

### DIFF
--- a/src/muninn/parsers/nxos/show_hsrp_all.py
+++ b/src/muninn/parsers/nxos/show_hsrp_all.py
@@ -1,0 +1,372 @@
+"""Parser for 'show hsrp all' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PreemptionDelay(TypedDict):
+    """Schema for HSRP preemption delay values."""
+
+    reload: NotRequired[int]
+    minimum: NotRequired[int]
+    sync: NotRequired[int]
+
+
+class StandbyRouter(TypedDict):
+    """Schema for HSRP standby router info."""
+
+    address: str
+    priority: NotRequired[int]
+
+
+class ActiveRouter(TypedDict):
+    """Schema for HSRP active router info."""
+
+    address: str
+    priority: NotRequired[int]
+
+
+class HsrpGroupEntry(TypedDict):
+    """Schema for a single HSRP group entry."""
+
+    interface: str
+    group: int
+    version: int
+    address_family: str
+    local_state: str
+    priority: int
+    configured_priority: int
+    preempt: bool
+    forwarding_threshold_lower: int
+    forwarding_threshold_upper: int
+    preemption_delay: NotRequired[PreemptionDelay]
+    hellotime: int
+    holdtime: int
+    virtual_ip: str
+    secondary_virtual_ips: NotRequired[list[str]]
+    active_router: ActiveRouter
+    standby_router: StandbyRouter
+    authentication_type: NotRequired[str]
+    authentication_value: NotRequired[str]
+    virtual_mac_address: str
+    state_changes: int
+    last_state_change: str
+    ip_redundancy_name: str
+
+
+class ShowHsrpAllResult(TypedDict):
+    """Schema for 'show hsrp all' parsed output."""
+
+    groups: dict[str, HsrpGroupEntry]
+
+
+@register(OS.CISCO_NXOS, "show hsrp all")
+class ShowHsrpAllParser(BaseParser[ShowHsrpAllResult]):
+    """Parser for 'show hsrp all' command on NX-OS.
+
+    Parses operational HSRP state including group priorities, virtual IPs,
+    active/standby routers, authentication, and timers.
+    """
+
+    # Vlan100 - Group 100 (HSRP-V2) (IPv4)
+    _HEADER_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+-\s+Group\s+(?P<group>\d+)\s+"
+        r"\(HSRP-V(?P<version>\d+)\)\s+\((?P<af>\S+)\)"
+    )
+
+    # Local state is Active, priority 250 (Cfged 250), may preempt
+    _STATE_PATTERN = re.compile(
+        r"Local state is (?P<state>.+?),\s+priority\s+(?P<priority>\d+)\s+"
+        r"\(Cfged\s+(?P<cfged_priority>\d+)\)"
+        r"(?P<preempt>,\s+may preempt)?"
+    )
+
+    # Forwarding threshold(for vPC), lower: 1 upper: 250
+    _THRESHOLD_PATTERN = re.compile(
+        r"Forwarding threshold\(for vPC\),\s+lower:\s+(?P<lower>\d+)\s+"
+        r"upper:\s+(?P<upper>\d+)"
+    )
+
+    # Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+    _PREEMPTION_DELAY_PATTERN = re.compile(
+        r"Preemption Delay \(Seconds\)\s+(?P<delays>.+)"
+    )
+    _DELAY_VALUE_PATTERN = re.compile(r"(?P<key>Reload|Minimum|Sync):(?P<value>\d+)")
+
+    # Hellotime 3 sec, holdtime 10 sec
+    _TIMER_PATTERN = re.compile(
+        r"Hellotime\s+(?P<hello>\d+)\s+sec,\s+holdtime\s+(?P<hold>\d+)\s+sec"
+    )
+
+    # Virtual IP address is 192.168.100.1 (Cfged)
+    _VIP_PATTERN = re.compile(r"Virtual IP address is (?P<vip>\S+)")
+
+    # Secondary Virtual IP address is 192.168.100.193
+    _SECONDARY_VIP_INLINE_PATTERN = re.compile(
+        r"Secondary Virtual IP address is (?P<vip>\S+)"
+    )
+
+    # Active router is local
+    # Active router is 172.17.1.2, priority 150 expires in 0.661000 sec(s)
+    _ACTIVE_ROUTER_PATTERN = re.compile(
+        r"Active router is (?P<address>\S+?)\s*"
+        r"(?:,\s*priority\s+(?P<priority>\d+)\s+expires in .+)?$"
+    )
+
+    # Standby router is 192.168.100.69 , priority 200 expires in 10.174000 sec(s)
+    # Standby router is local
+    _STANDBY_ROUTER_PATTERN = re.compile(
+        r"Standby router is (?P<address>\S+?)\s*"
+        r"(?:,\s*priority\s+(?P<priority>\d+)\s+expires in .+)?$"
+    )
+
+    # Authentication MD5, key-string "dr-hsrp"
+    # Authentication MD5, key-chain HSRP-AUTH
+    # Authentication text "cisco"
+    _AUTH_PATTERN = re.compile(
+        r"Authentication\s+(?P<type>\S+?)(?:,\s+(?P<method>key-string|key-chain)\s+"
+        r'(?:"(?P<quoted_value>[^"]+)"|(?P<plain_value>\S+))|\s+"(?P<text_value>[^"]+)")'
+    )
+
+    # Virtual mac address is 0000.0c9f.f384 (Default MAC)
+    _VMAC_PATTERN = re.compile(r"Virtual mac address is (?P<vmac>\S+)")
+
+    # 2 state changes, last state change 1y27w
+    _STATE_CHANGES_PATTERN = re.compile(
+        r"(?P<changes>\d+) state changes?, last state change (?P<last>.+)"
+    )
+
+    # IP redundancy name is hsrp-Vlan100-100 (default)
+    _REDUNDANCY_NAME_PATTERN = re.compile(r"IP redundancy name is (?P<name>\S+)")
+
+    # Secondary VIP listed under "Secondary VIP(s):" section
+    _SECONDARY_VIP_LIST_PATTERN = re.compile(
+        r"^\s+(?P<vip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s*$"
+    )
+
+    @classmethod
+    def _new_entry(cls, match: re.Match[str]) -> HsrpGroupEntry:
+        """Create a new HSRP group entry from a header match."""
+        return HsrpGroupEntry(
+            interface=match.group("interface"),
+            group=int(match.group("group")),
+            version=int(match.group("version")),
+            address_family=match.group("af"),
+            local_state="",
+            priority=0,
+            configured_priority=0,
+            preempt=False,
+            forwarding_threshold_lower=0,
+            forwarding_threshold_upper=0,
+            hellotime=0,
+            holdtime=0,
+            virtual_ip="",
+            active_router=ActiveRouter(address=""),
+            standby_router=StandbyRouter(address=""),
+            virtual_mac_address="",
+            state_changes=0,
+            last_state_change="",
+            ip_redundancy_name="",
+        )
+
+    @classmethod
+    def _parse_router(cls, match: re.Match[str]) -> ActiveRouter | StandbyRouter:
+        """Parse an active or standby router match into a typed dict."""
+        result: ActiveRouter = {"address": match.group("address")}
+        if match.group("priority"):
+            result["priority"] = int(match.group("priority"))
+        return result
+
+    @classmethod
+    def _parse_preemption_delay(cls, delays_str: str) -> PreemptionDelay:
+        """Parse preemption delay key-value pairs."""
+        delay_values: PreemptionDelay = {}
+        for dv_match in cls._DELAY_VALUE_PATTERN.finditer(delays_str):
+            key = dv_match.group("key").lower()
+            value = int(dv_match.group("value"))
+            delay_values[key] = value  # type: ignore[literal-required]
+        return delay_values
+
+    @classmethod
+    def _parse_authentication(cls, match: re.Match[str]) -> tuple[str, str]:
+        """Parse authentication type and value from a match.
+
+        Returns:
+            Tuple of (auth_type, auth_value).
+        """
+        auth_type = match.group("type")
+        if auth_type.lower() == "text":
+            return "text", match.group("text_value")
+        method = match.group("method")
+        value = match.group("quoted_value") or match.group("plain_value")
+        return f"{auth_type}, {method}", value
+
+    @classmethod
+    def _add_secondary_vip(cls, entry: HsrpGroupEntry, vip: str) -> None:
+        """Add a secondary VIP to the entry, avoiding duplicates."""
+        if "secondary_virtual_ips" not in entry:
+            entry["secondary_virtual_ips"] = []
+        if vip not in entry["secondary_virtual_ips"]:
+            entry["secondary_virtual_ips"].append(vip)
+
+    @classmethod
+    def _parse_line(cls, stripped: str, entry: HsrpGroupEntry) -> bool:
+        """Parse a single line and update the entry. Returns True if matched."""
+        state_match = cls._STATE_PATTERN.search(stripped)
+        if state_match:
+            entry["local_state"] = state_match.group("state")
+            entry["priority"] = int(state_match.group("priority"))
+            entry["configured_priority"] = int(state_match.group("cfged_priority"))
+            entry["preempt"] = state_match.group("preempt") is not None
+            return True
+
+        threshold_match = cls._THRESHOLD_PATTERN.search(stripped)
+        if threshold_match:
+            entry["forwarding_threshold_lower"] = int(threshold_match.group("lower"))
+            entry["forwarding_threshold_upper"] = int(threshold_match.group("upper"))
+            return True
+
+        preempt_match = cls._PREEMPTION_DELAY_PATTERN.search(stripped)
+        if preempt_match:
+            delay_values = cls._parse_preemption_delay(preempt_match.group("delays"))
+            if delay_values:
+                entry["preemption_delay"] = delay_values
+            return True
+
+        timer_match = cls._TIMER_PATTERN.search(stripped)
+        if timer_match:
+            entry["hellotime"] = int(timer_match.group("hello"))
+            entry["holdtime"] = int(timer_match.group("hold"))
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_vip_and_router_line(cls, stripped: str, entry: HsrpGroupEntry) -> bool:
+        """Parse VIP and router lines. Returns True if matched."""
+        sec_vip_match = cls._SECONDARY_VIP_INLINE_PATTERN.search(stripped)
+        if sec_vip_match:
+            cls._add_secondary_vip(entry, sec_vip_match.group("vip"))
+            return True
+
+        if "Secondary" not in stripped:
+            vip_match = cls._VIP_PATTERN.search(stripped)
+            if vip_match:
+                entry["virtual_ip"] = vip_match.group("vip")
+                return True
+
+        if stripped.startswith("Active router"):
+            active_match = cls._ACTIVE_ROUTER_PATTERN.search(stripped)
+            if active_match:
+                entry["active_router"] = cls._parse_router(active_match)
+                return True
+
+        if stripped.startswith("Standby router"):
+            standby_match = cls._STANDBY_ROUTER_PATTERN.search(stripped)
+            if standby_match:
+                entry["standby_router"] = cls._parse_router(standby_match)
+                return True
+
+        return False
+
+    @classmethod
+    def _parse_metadata_line(cls, stripped: str, entry: HsrpGroupEntry) -> bool:
+        """Parse auth, MAC, state changes, and redundancy name.
+
+        Returns True if matched.
+        """
+        auth_match = cls._AUTH_PATTERN.search(stripped)
+        if auth_match:
+            auth_type, auth_value = cls._parse_authentication(auth_match)
+            entry["authentication_type"] = auth_type
+            entry["authentication_value"] = auth_value
+            return True
+
+        vmac_match = cls._VMAC_PATTERN.search(stripped)
+        if vmac_match:
+            entry["virtual_mac_address"] = vmac_match.group("vmac")
+            return True
+
+        sc_match = cls._STATE_CHANGES_PATTERN.search(stripped)
+        if sc_match:
+            entry["state_changes"] = int(sc_match.group("changes"))
+            entry["last_state_change"] = sc_match.group("last")
+            return True
+
+        rn_match = cls._REDUNDANCY_NAME_PATTERN.search(stripped)
+        if rn_match:
+            entry["ip_redundancy_name"] = rn_match.group("name")
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_entry_line(
+        cls,
+        stripped: str,
+        entry: HsrpGroupEntry,
+    ) -> None:
+        """Dispatch a stripped line to the appropriate sub-parser."""
+        if cls._parse_line(stripped, entry):
+            return
+        if cls._parse_vip_and_router_line(stripped, entry):
+            return
+        cls._parse_metadata_line(stripped, entry)
+
+    @classmethod
+    def parse(cls, output: str) -> ShowHsrpAllResult:
+        """Parse 'show hsrp all' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed HSRP groups keyed by 'Interface/Group'.
+
+        Raises:
+            ValueError: If no HSRP groups found in output.
+        """
+        groups: dict[str, HsrpGroupEntry] = {}
+        current_entry: HsrpGroupEntry | None = None
+        in_secondary_vip_section = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                in_secondary_vip_section = False
+                continue
+
+            header_match = cls._HEADER_PATTERN.match(stripped)
+            if header_match:
+                in_secondary_vip_section = False
+                current_entry = cls._new_entry(header_match)
+                intf = header_match.group("interface")
+                grp = header_match.group("group")
+                groups[f"{intf}/{grp}"] = current_entry
+                continue
+
+            if current_entry is None:
+                continue
+
+            if in_secondary_vip_section:
+                vip_match = cls._SECONDARY_VIP_LIST_PATTERN.match(line)
+                if vip_match:
+                    cls._add_secondary_vip(current_entry, vip_match.group("vip"))
+                    continue
+                in_secondary_vip_section = False
+
+            if stripped.startswith("Secondary VIP(s):"):
+                in_secondary_vip_section = True
+                continue
+
+            cls._parse_entry_line(stripped, current_entry)
+
+        if not groups:
+            msg = "No HSRP groups found in output"
+            raise ValueError(msg)
+
+        return ShowHsrpAllResult(groups=groups)

--- a/tests/parsers/nxos/show_hsrp_all/001_multi_group/expected.json
+++ b/tests/parsers/nxos/show_hsrp_all/001_multi_group/expected.json
@@ -1,0 +1,436 @@
+{
+    "groups": {
+        "Vlan100/100": {
+            "interface": "Vlan100",
+            "group": 100,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 3,
+            "holdtime": 10,
+            "virtual_ip": "192.168.100.1",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "192.168.100.69",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.f384",
+            "state_changes": 2,
+            "last_state_change": "1y27w",
+            "ip_redundancy_name": "hsrp-Vlan100-100",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "secondary_virtual_ips": [
+                "192.168.100.193"
+            ],
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "dr-hsrp"
+        },
+        "Vlan200/200": {
+            "interface": "Vlan200",
+            "group": 200,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.11.4.254",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.11.4.253",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fd48",
+            "state_changes": 2,
+            "last_state_change": "1y0w",
+            "ip_redundancy_name": "hsrp-Vlan200-200",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "hq-hsrp"
+        },
+        "Vlan201/201": {
+            "interface": "Vlan201",
+            "group": 201,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.11.5.30",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.11.5.29",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fd49",
+            "state_changes": 2,
+            "last_state_change": "1y0w",
+            "ip_redundancy_name": "hsrp-Vlan201-201",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "hq-hsrp"
+        },
+        "Vlan210/210": {
+            "interface": "Vlan210",
+            "group": 210,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.12.9.254",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.12.9.253",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fdb6",
+            "state_changes": 2,
+            "last_state_change": "1y0w",
+            "ip_redundancy_name": "hsrp-Vlan210-210",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "hq-hsrp"
+        },
+        "Vlan211/211": {
+            "interface": "Vlan211",
+            "group": 211,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.12.10.62",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.12.10.61",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fdb7",
+            "state_changes": 2,
+            "last_state_change": "1y0w",
+            "ip_redundancy_name": "hsrp-Vlan211-211",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "hq-hsrp"
+        },
+        "Vlan220/220": {
+            "interface": "Vlan220",
+            "group": 220,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.13.12.254",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.13.12.253",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fe24",
+            "state_changes": 2,
+            "last_state_change": "1y0w",
+            "ip_redundancy_name": "hsrp-Vlan220-220",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "hq-hsrp"
+        },
+        "Vlan221/221": {
+            "interface": "Vlan221",
+            "group": 221,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.13.13.30",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.13.13.29",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fe25",
+            "state_changes": 2,
+            "last_state_change": "1y0w",
+            "ip_redundancy_name": "hsrp-Vlan221-221",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "hq-hsrp"
+        },
+        "Vlan300/300": {
+            "interface": "Vlan300",
+            "group": 300,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 250,
+            "configured_priority": 250,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 250,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.16.0.254",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "172.16.0.253",
+                "priority": 200
+            },
+            "virtual_mac_address": "0000.0c9f.fed8",
+            "state_changes": 14,
+            "last_state_change": "1y2w",
+            "ip_redundancy_name": "hsrp-Vlan300-300",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "dr-hsrp"
+        },
+        "Vlan416/416": {
+            "interface": "Vlan416",
+            "group": 416,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Standby",
+            "priority": 130,
+            "configured_priority": 130,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 130,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.17.1.1",
+            "active_router": {
+                "address": "172.17.1.2",
+                "priority": 150
+            },
+            "standby_router": {
+                "address": "local"
+            },
+            "virtual_mac_address": "0000.0c9f.ff4c",
+            "state_changes": 105,
+            "last_state_change": "21w5d",
+            "ip_redundancy_name": "hsrp-Vlan416-416",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "core-hsrp"
+        },
+        "Vlan417/417": {
+            "interface": "Vlan417",
+            "group": 417,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Standby",
+            "priority": 130,
+            "configured_priority": 130,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 130,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.17.1.17",
+            "active_router": {
+                "address": "172.17.1.18",
+                "priority": 150
+            },
+            "standby_router": {
+                "address": "local"
+            },
+            "virtual_mac_address": "0000.0c9f.ff4d",
+            "state_changes": 418,
+            "last_state_change": "21w5d",
+            "ip_redundancy_name": "hsrp-Vlan417-417",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "core-hsrp"
+        },
+        "Vlan418/418": {
+            "interface": "Vlan418",
+            "group": 418,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Standby",
+            "priority": 130,
+            "configured_priority": 130,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 130,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.17.1.33",
+            "active_router": {
+                "address": "172.17.1.2",
+                "priority": 150
+            },
+            "standby_router": {
+                "address": "local"
+            },
+            "virtual_mac_address": "0000.0c9f.ff4e",
+            "state_changes": 102,
+            "last_state_change": "21w5d",
+            "ip_redundancy_name": "hsrp-Vlan418-418",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "core-hsrp"
+        },
+        "Vlan419/419": {
+            "interface": "Vlan419",
+            "group": 419,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Standby",
+            "priority": 130,
+            "configured_priority": 130,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 130,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.17.1.49",
+            "active_router": {
+                "address": "172.17.1.50",
+                "priority": 150
+            },
+            "standby_router": {
+                "address": "local"
+            },
+            "virtual_mac_address": "0000.0c9f.ff4f",
+            "state_changes": 448,
+            "last_state_change": "21w5d",
+            "ip_redundancy_name": "hsrp-Vlan419-419",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "core-hsrp"
+        },
+        "Vlan420/420": {
+            "interface": "Vlan420",
+            "group": 420,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Standby",
+            "priority": 130,
+            "configured_priority": 130,
+            "preempt": true,
+            "forwarding_threshold_lower": 1,
+            "forwarding_threshold_upper": 130,
+            "hellotime": 1,
+            "holdtime": 3,
+            "virtual_ip": "172.17.1.65",
+            "active_router": {
+                "address": "172.17.1.66",
+                "priority": 150
+            },
+            "standby_router": {
+                "address": "local"
+            },
+            "virtual_mac_address": "0000.0c9f.ff50",
+            "state_changes": 103,
+            "last_state_change": "21w5d",
+            "ip_redundancy_name": "hsrp-Vlan420-420",
+            "preemption_delay": {
+                "reload": 120,
+                "minimum": 60,
+                "sync": 60
+            },
+            "authentication_type": "MD5, key-string",
+            "authentication_value": "core-hsrp"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_hsrp_all/001_multi_group/input.txt
+++ b/tests/parsers/nxos/show_hsrp_all/001_multi_group/input.txt
@@ -1,0 +1,184 @@
+Vlan100 - Group 100 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 3 sec, holdtime 10 sec
+  Next hello sent in 2.676000 sec(s)
+  Virtual IP address is 192.168.100.1 (Cfged)
+     Secondary Virtual IP address is 192.168.100.193
+  Active router is local
+  Standby router is 192.168.100.69 , priority 200 expires in 10.174000 sec(s)
+  Authentication MD5, key-string "dr-hsrp"
+  Virtual mac address is 0000.0c9f.f384 (Default MAC)
+  2 state changes, last state change 1y27w
+  IP redundancy name is hsrp-Vlan100-100 (default)
+  Secondary VIP(s):
+                  192.168.100.193
+
+Vlan200 - Group 200 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.448000 sec(s)
+  Virtual IP address is 172.11.4.254 (Cfged)
+  Active router is local
+  Standby router is 172.11.4.253 , priority 200 expires in 2.551000 sec(s)
+  Authentication MD5, key-string "hq-hsrp"
+  Virtual mac address is 0000.0c9f.fd48 (Default MAC)
+  2 state changes, last state change 1y0w
+  IP redundancy name is hsrp-Vlan200-200 (default)
+
+Vlan201 - Group 201 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.484000 sec(s)
+  Virtual IP address is 172.11.5.30 (Cfged)
+  Active router is local
+  Standby router is 172.11.5.29 , priority 200 expires in 2.551000 sec(s)
+  Authentication MD5, key-string "hq-hsrp"
+  Virtual mac address is 0000.0c9f.fd49 (Default MAC)
+  2 state changes, last state change 1y0w
+  IP redundancy name is hsrp-Vlan201-201 (default)
+
+Vlan210 - Group 210 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.420000 sec(s)
+  Virtual IP address is 172.12.9.254 (Cfged)
+  Active router is local
+  Standby router is 172.12.9.253 , priority 200 expires in 2.873000 sec(s)
+  Authentication MD5, key-string "hq-hsrp"
+  Virtual mac address is 0000.0c9f.fdb6 (Default MAC)
+  2 state changes, last state change 1y0w
+  IP redundancy name is hsrp-Vlan210-210 (default)
+
+Vlan211 - Group 211 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.695000 sec(s)
+  Virtual IP address is 172.12.10.62 (Cfged)
+  Active router is local
+  Standby router is 172.12.10.61 , priority 200 expires in 2.873000 sec(s)
+  Authentication MD5, key-string "hq-hsrp"
+  Virtual mac address is 0000.0c9f.fdb7 (Default MAC)
+  2 state changes, last state change 1y0w
+  IP redundancy name is hsrp-Vlan211-211 (default)
+
+Vlan220 - Group 220 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.484000 sec(s)
+  Virtual IP address is 172.13.12.254 (Cfged)
+  Active router is local
+  Standby router is 172.13.12.253 , priority 200 expires in 2.281000 sec(s)
+  Authentication MD5, key-string "hq-hsrp"
+  Virtual mac address is 0000.0c9f.fe24 (Default MAC)
+  2 state changes, last state change 1y0w
+  IP redundancy name is hsrp-Vlan220-220 (default)
+
+Vlan221 - Group 221 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.614000 sec(s)
+  Virtual IP address is 172.13.13.30 (Cfged)
+  Active router is local
+  Standby router is 172.13.13.29 , priority 200 expires in 2.281000 sec(s)
+  Authentication MD5, key-string "hq-hsrp"
+  Virtual mac address is 0000.0c9f.fe25 (Default MAC)
+  2 state changes, last state change 1y0w
+  IP redundancy name is hsrp-Vlan221-221 (default)
+
+Vlan300 - Group 300 (HSRP-V2) (IPv4)
+  Local state is Active, priority 250 (Cfged 250), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 250
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.448000 sec(s)
+  Virtual IP address is 172.16.0.254 (Cfged)
+  Active router is local
+  Standby router is 172.16.0.253 , priority 200 expires in 2.551000 sec(s)
+  Authentication MD5, key-string "dr-hsrp"
+  Virtual mac address is 0000.0c9f.fed8 (Default MAC)
+  14 state changes, last state change 1y2w
+  IP redundancy name is hsrp-Vlan300-300 (default)
+
+Vlan416 - Group 416 (HSRP-V2) (IPv4)
+  Local state is Standby, priority 130 (Cfged 130), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 130
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.231000 sec(s)
+  Virtual IP address is 172.17.1.1 (Cfged)
+  Active router is 172.17.1.2, priority 150 expires in 0.661000 sec(s)
+  Standby router is local
+  Authentication MD5, key-string "core-hsrp"
+  Virtual mac address is 0000.0c9f.ff4c (Default MAC)
+  105 state changes, last state change 21w5d
+  IP redundancy name is hsrp-Vlan416-416 (default)
+
+Vlan417 - Group 417 (HSRP-V2) (IPv4)
+  Local state is Standby, priority 130 (Cfged 130), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 130
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.610000 sec(s)
+  Virtual IP address is 172.17.1.17 (Cfged)
+  Active router is 172.17.1.18, priority 150 expires in 1.531000 sec(s)
+  Standby router is local
+  Authentication MD5, key-string "core-hsrp"
+  Virtual mac address is 0000.0c9f.ff4d (Default MAC)
+  418 state changes, last state change 21w5d
+  IP redundancy name is hsrp-Vlan417-417 (default)
+
+Vlan418 - Group 418 (HSRP-V2) (IPv4)
+  Local state is Standby, priority 130 (Cfged 130), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 130
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.422000 sec(s)
+  Virtual IP address is 172.17.1.33 (Cfged)
+  Active router is 172.17.1.2, priority 150 expires in 0.081000 sec(s)
+  Standby router is local
+  Authentication MD5, key-string "core-hsrp"
+  Virtual mac address is 0000.0c9f.ff4e (Default MAC)
+  102 state changes, last state change 21w5d
+  IP redundancy name is hsrp-Vlan418-418 (default)
+
+Vlan419 - Group 419 (HSRP-V2) (IPv4)
+  Local state is Standby, priority 130 (Cfged 130), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 130
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.886000 sec(s)
+  Virtual IP address is 172.17.1.49 (Cfged)
+  Active router is 172.17.1.50, priority 150 expires in 2.281000 sec(s)
+  Standby router is local
+  Authentication MD5, key-string "core-hsrp"
+  Virtual mac address is 0000.0c9f.ff4f (Default MAC)
+  448 state changes, last state change 21w5d
+  IP redundancy name is hsrp-Vlan419-419 (default)
+
+Vlan420 - Group 420 (HSRP-V2) (IPv4)
+  Local state is Standby, priority 130 (Cfged 130), may preempt
+    Forwarding threshold(for vPC), lower: 1 upper: 130
+  Preemption Delay (Seconds) Reload:120 Minimum:60 Sync:60
+  Hellotime 1 sec, holdtime 3 sec
+  Next hello sent in 0.301000 sec(s)
+  Virtual IP address is 172.17.1.65 (Cfged)
+  Active router is 172.17.1.66, priority 150 expires in 0.081000 sec(s)
+  Standby router is local
+  Authentication MD5, key-string "core-hsrp"
+  Virtual mac address is 0000.0c9f.ff50 (Default MAC)
+  103 state changes, last state change 21w5d
+  IP redundancy name is hsrp-Vlan420-420 (default)

--- a/tests/parsers/nxos/show_hsrp_all/001_multi_group/metadata.yaml
+++ b/tests/parsers/nxos/show_hsrp_all/001_multi_group/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple HSRP groups across VLANs with active and standby states, secondary VIPs
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_hsrp_all/002_single_group/expected.json
+++ b/tests/parsers/nxos/show_hsrp_all/002_single_group/expected.json
@@ -1,0 +1,35 @@
+{
+    "groups": {
+        "Vlan650/650": {
+            "interface": "Vlan650",
+            "group": 650,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 150,
+            "configured_priority": 150,
+            "preempt": true,
+            "forwarding_threshold_lower": 0,
+            "forwarding_threshold_upper": 150,
+            "hellotime": 3,
+            "holdtime": 10,
+            "virtual_ip": "100.100.100.225",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "100.100.100.227",
+                "priority": 100
+            },
+            "virtual_mac_address": "0000.0fff.f28a",
+            "state_changes": 1,
+            "last_state_change": "1y36w",
+            "ip_redundancy_name": "hsrp-Vlan650-650",
+            "preemption_delay": {
+                "reload": 120
+            },
+            "authentication_type": "text",
+            "authentication_value": "cisco"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_hsrp_all/002_single_group/input.txt
+++ b/tests/parsers/nxos/show_hsrp_all/002_single_group/input.txt
@@ -1,0 +1,13 @@
+Vlan650 - Group 650 (HSRP-V2) (IPv4)
+  Local state is Active, priority 150 (Cfged 150), may preempt
+    Forwarding threshold(for vPC), lower: 0 upper: 150
+  Preemption Delay (Seconds) Reload:120
+  Hellotime 3 sec, holdtime 10 sec
+  Next hello sent in 1.486000 sec(s)
+  Virtual IP address is 100.100.100.225 (Cfged)
+  Active router is local
+  Standby router is 100.100.100.227 , priority 100 expires in 8.224000 sec(s)
+  Authentication text "cisco"
+  Virtual mac address is 0000.0fff.f28a (Default MAC)
+  1 state changes, last state change 1y36w
+  IP redundancy name is hsrp-Vlan650-650 (default)

--- a/tests/parsers/nxos/show_hsrp_all/002_single_group/metadata.yaml
+++ b/tests/parsers/nxos/show_hsrp_all/002_single_group/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single HSRP group with text authentication
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_hsrp_all/003_mixed_states/expected.json
+++ b/tests/parsers/nxos/show_hsrp_all/003_mixed_states/expected.json
@@ -1,0 +1,96 @@
+{
+    "groups": {
+        "Vlan123/123": {
+            "interface": "Vlan123",
+            "group": 123,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Active",
+            "priority": 200,
+            "configured_priority": 200,
+            "preempt": true,
+            "forwarding_threshold_lower": 0,
+            "forwarding_threshold_upper": 200,
+            "hellotime": 3,
+            "holdtime": 10,
+            "virtual_ip": "10.0.2.1",
+            "active_router": {
+                "address": "local"
+            },
+            "standby_router": {
+                "address": "10.0.2.3",
+                "priority": 100
+            },
+            "virtual_mac_address": "0000.0c9f.1234",
+            "state_changes": 2,
+            "last_state_change": "24w0d",
+            "ip_redundancy_name": "hsrp-Vlan123-123",
+            "preemption_delay": {
+                "minimum": 180
+            },
+            "authentication_type": "MD5, key-chain",
+            "authentication_value": "HSRP-AUTH"
+        },
+        "Vlan456/456": {
+            "interface": "Vlan456",
+            "group": 456,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Initial(Interface Down)",
+            "priority": 200,
+            "configured_priority": 200,
+            "preempt": true,
+            "forwarding_threshold_lower": 0,
+            "forwarding_threshold_upper": 200,
+            "hellotime": 3,
+            "holdtime": 10,
+            "virtual_ip": "10.0.3.1",
+            "active_router": {
+                "address": "unknown"
+            },
+            "standby_router": {
+                "address": "unknown"
+            },
+            "virtual_mac_address": "0000.0c9f.1235",
+            "state_changes": 0,
+            "last_state_change": "never",
+            "ip_redundancy_name": "hsrp-Vlan456-456",
+            "preemption_delay": {
+                "minimum": 180
+            },
+            "authentication_type": "MD5, key-chain",
+            "authentication_value": "HSRP-AUTH"
+        },
+        "Vlan789/789": {
+            "interface": "Vlan789",
+            "group": 789,
+            "version": 2,
+            "address_family": "IPv4",
+            "local_state": "Standby",
+            "priority": 100,
+            "configured_priority": 100,
+            "preempt": true,
+            "forwarding_threshold_lower": 0,
+            "forwarding_threshold_upper": 100,
+            "hellotime": 3,
+            "holdtime": 10,
+            "virtual_ip": "10.0.4.254",
+            "active_router": {
+                "address": "10.0.4.253",
+                "priority": 200
+            },
+            "standby_router": {
+                "address": "local"
+            },
+            "virtual_mac_address": "0000.0c9f.1236",
+            "state_changes": 1,
+            "last_state_change": "24w0d",
+            "ip_redundancy_name": "hsrp-Vlan789-789",
+            "preemption_delay": {
+                "minimum": 180
+            },
+            "authentication_type": "MD5, key-chain",
+            "authentication_value": "HSRP-AUTH"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_hsrp_all/003_mixed_states/input.txt
+++ b/tests/parsers/nxos/show_hsrp_all/003_mixed_states/input.txt
@@ -1,0 +1,40 @@
+Vlan123 - Group 123 (HSRP-V2) (IPv4)
+  Local state is Active, priority 200 (Cfged 200), may preempt
+    Forwarding threshold(for vPC), lower: 0 upper: 200
+  Preemption Delay (Seconds) Minimum:180
+  Hellotime 3 sec, holdtime 10 sec
+  Next hello sent in 2.259000 sec(s)
+  Virtual IP address is 10.0.2.1 (Cfged)
+  Active router is local
+  Standby router is 10.0.2.3 , priority 100 expires in 7.338000 sec(s)
+  Authentication MD5, key-chain HSRP-AUTH
+  Virtual mac address is 0000.0c9f.1234 (Default MAC)
+  2 state changes, last state change 24w0d
+  IP redundancy name is hsrp-Vlan123-123 (default)
+
+Vlan456 - Group 456 (HSRP-V2) (IPv4)
+  Local state is Initial(Interface Down), priority 200 (Cfged 200), may preempt
+    Forwarding threshold(for vPC), lower: 0 upper: 200
+  Preemption Delay (Seconds) Minimum:180
+  Hellotime 3 sec, holdtime 10 sec
+  Virtual IP address is 10.0.3.1 (Cfged)
+  Active router is unknown
+  Standby router is unknown
+  Authentication MD5, key-chain HSRP-AUTH
+  Virtual mac address is 0000.0c9f.1235 (Default MAC)
+  0 state changes, last state change never
+  IP redundancy name is hsrp-Vlan456-456 (default)
+
+Vlan789 - Group 789 (HSRP-V2) (IPv4)
+  Local state is Standby, priority 100 (Cfged 100), may preempt
+    Forwarding threshold(for vPC), lower: 0 upper: 100
+  Preemption Delay (Seconds) Minimum:180
+  Hellotime 3 sec, holdtime 10 sec
+  Next hello sent in 0.161000 sec(s)
+  Virtual IP address is 10.0.4.254 (Cfged)
+  Active router is 10.0.4.253, priority 200 expires in 8.317000 sec(s)
+  Standby router is local
+  Authentication MD5, key-chain HSRP-AUTH
+  Virtual mac address is 0000.0c9f.1236 (Default MAC)
+  1 state changes, last state change 24w0d
+  IP redundancy name is hsrp-Vlan789-789 (default)

--- a/tests/parsers/nxos/show_hsrp_all/003_mixed_states/metadata.yaml
+++ b/tests/parsers/nxos/show_hsrp_all/003_mixed_states/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed HSRP states including Initial(Interface Down) and key-chain authentication
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add parser for `show hsrp all` on NX-OS, parsing full operational HSRP state per group
- Supports HSRP-V1/V2, IPv4, multiple authentication types (text, MD5 key-string, MD5 key-chain), secondary VIPs, active/standby/initial states
- Groups keyed by `Interface/Group` (e.g. `Vlan100/100`) with typed dict schema including priority, preemption, timers, virtual IP/MAC, router info, and state change tracking
- 3 test cases covering: multi-group with secondary VIPs (13 groups), single group with text auth, mixed states including `Initial(Interface Down)` with key-chain auth

Closes #43

## Test plan

- [x] All 3 golden test cases pass (`uv run pytest tests/parsers/ -k "show_hsrp_all" -v`)
- [x] Full test suite passes (546 tests)
- [x] Ruff check and format clean
- [x] Xenon complexity check passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)