### PR TITLE
fix: preserve NX-OS mgmt0 interface name in canonical_interface_name shim

### DIFF
--- a/src/muninn/parsers/ios/show_cdp_neighbors.py
+++ b/src/muninn/parsers/ios/show_cdp_neighbors.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class CdpNeighborEntry(TypedDict):
@@ -40,7 +39,7 @@ def _normalize_interface(intf: str) -> str:
     """Normalize IOS-style interface (e.g. 'Gig 0/0') to canonical form."""
     collapsed = _COLLAPSE_SPACE.sub(r"\1\2", intf.strip())
     collapsed = _REMAP_SER.sub(r"Se\1", collapsed)
-    return canonical_interface_name(collapsed)
+    return canonical_interface_name(collapsed, os=OS.CISCO_IOS)
 
 
 @register(OS.CISCO_IOS, "show cdp neighbors")

--- a/src/muninn/parsers/ios/show_interfaces.py
+++ b/src/muninn/parsers/ios/show_interfaces.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class InputQueueEntry(TypedDict):
@@ -550,7 +549,9 @@ def _apply_tunnel_source(m: re.Match[str], tunnel: TunnelInfo) -> None:
     """Apply tunnel source/destination fields from a match."""
     tunnel["source"] = m.group(1)
     if m.group(2):
-        tunnel["source_interface"] = canonical_interface_name(m.group(2))
+        tunnel["source_interface"] = canonical_interface_name(
+            m.group(2), os=OS.CISCO_IOS
+        )
     if m.group(3):
         tunnel["destination"] = m.group(3)
 
@@ -626,7 +627,7 @@ def _parse_port_channel(lines: list[str]) -> PortChannelInfo:
         if m:
             pc["members"].append(
                 {
-                    "interface": canonical_interface_name(m.group(1)),
+                    "interface": canonical_interface_name(m.group(1), os=OS.CISCO_IOS),
                     "duplex": m.group(2).strip(),
                     "speed": m.group(3),
                 }
@@ -645,7 +646,7 @@ def _parse_port_channel(lines: list[str]) -> PortChannelInfo:
             for name in member_str.split():
                 pc["members"].append(
                     {
-                        "interface": canonical_interface_name(name),
+                        "interface": canonical_interface_name(name, os=OS.CISCO_IOS),
                         "duplex": "",
                         "speed": "",
                     }
@@ -699,7 +700,9 @@ def _parse_header_fields(line: str, entry: dict) -> bool:
 
     m = _UNNUMBERED_RE.match(line)
     if m:
-        entry["unnumbered_interface"] = canonical_interface_name(m.group(1))
+        entry["unnumbered_interface"] = canonical_interface_name(
+            m.group(1), os=OS.CISCO_IOS
+        )
         entry["ip_address"] = m.group(2)
         return True
 
@@ -886,7 +889,7 @@ class ShowInterfacesParser(BaseParser[ShowInterfacesResult]):
             parsed = _parse_block(block_lines)
             if parsed is None:
                 continue
-            name = canonical_interface_name(raw_name)
+            name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
             interfaces[name] = parsed
 
         return {"interfaces": interfaces}

--- a/src/muninn/parsers/ios/show_ip_ospf_interface.py
+++ b/src/muninn/parsers/ios/show_ip_ospf_interface.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class TopologyEntry(TypedDict):
@@ -278,7 +277,9 @@ def _parse_address_area(lines: list[str], entry: dict) -> None:
 
         m = _UNNUMBERED_ADDR_RE.match(line)
         if m:
-            entry["unnumbered_interface"] = canonical_interface_name(m.group(1))
+            entry["unnumbered_interface"] = canonical_interface_name(
+                m.group(1), os=OS.CISCO_IOS
+            )
             entry["unnumbered_address"] = m.group(2)
 
 
@@ -549,7 +550,7 @@ class ShowIpOspfInterfaceParser(BaseParser[ShowIpOspfInterfaceResult]):
             parsed = _parse_block(block_lines)
             if parsed is None:
                 continue
-            name = canonical_interface_name(raw_name)
+            name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
             interfaces[name] = parsed
 
         return {"interfaces": interfaces}

--- a/src/muninn/parsers/ios/show_ip_route.py
+++ b/src/muninn/parsers/ios/show_ip_route.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # --- Protocol code to name mapping ---
 _PROTOCOL_MAP: dict[str, str] = {
@@ -205,7 +204,7 @@ def _safe_interface(name: str) -> str:
     # Some values like age strings should not be normalized
     if re.match(r"^\d+[wdhms:]", name):
         return name
-    return canonical_interface_name(name)
+    return canonical_interface_name(name, os=OS.CISCO_IOS)
 
 
 def _classify_age_or_interface(token: str, hop: NextHopEntry) -> None:

--- a/src/muninn/parsers/ios/show_ipv6_route.py
+++ b/src/muninn/parsers/ios/show_ipv6_route.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # Header: "IPv6 Routing Table - {vrf} - {count} entries"
 _HEADER_RE = re.compile(r"^IPv6 Routing Table\s*-\s*(\S+)\s*-\s*(\d+)\s+entries\s*$")
@@ -62,14 +61,14 @@ def _parse_via(via_text: str) -> NextHopEntry:
     if via_text.endswith(", directly connected"):
         entry["type"] = "directly connected"
         iface_part = via_text.removesuffix(", directly connected").strip()
-        entry["interface"] = canonical_interface_name(iface_part)
+        entry["interface"] = canonical_interface_name(iface_part, os=OS.CISCO_IOS)
         return entry
 
     # Check for "receive" suffix
     if via_text.endswith(", receive"):
         entry["type"] = "receive"
         iface_part = via_text.removesuffix(", receive").strip()
-        entry["interface"] = canonical_interface_name(iface_part)
+        entry["interface"] = canonical_interface_name(iface_part, os=OS.CISCO_IOS)
         return entry
 
     # Split on ", " to separate next-hop from interface
@@ -99,10 +98,10 @@ def _apply_interface(entry: NextHopEntry, raw: str) -> None:
     """Extract interface name and optional VRF from raw string."""
     if "%" in raw:
         iface, vrf = raw.split("%", maxsplit=1)
-        entry["interface"] = canonical_interface_name(iface)
+        entry["interface"] = canonical_interface_name(iface, os=OS.CISCO_IOS)
         entry["interface_vrf"] = vrf
     else:
-        entry["interface"] = canonical_interface_name(raw)
+        entry["interface"] = canonical_interface_name(raw, os=OS.CISCO_IOS)
 
 
 def _parse_header(line: str) -> tuple[str, int] | None:

--- a/src/muninn/parsers/ios/show_lldp_neighbors.py
+++ b/src/muninn/parsers/ios/show_lldp_neighbors.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class LldpNeighborEntry(TypedDict):
@@ -70,7 +69,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
     def _normalize_port_id(cls, port_id: str) -> str:
         """Normalize port_id if it looks like an interface name."""
         if cls._INTERFACE_PATTERN.match(port_id):
-            return canonical_interface_name(port_id)
+            return canonical_interface_name(port_id, os=OS.CISCO_IOS)
         return port_id
 
     @classmethod
@@ -108,7 +107,9 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
 
             if match:
                 device_id = match.group("device_id")
-                local_intf = canonical_interface_name(match.group("local_intf"))
+                local_intf = canonical_interface_name(
+                    match.group("local_intf"), os=OS.CISCO_IOS
+                )
                 hold_time = int(match.group("hold_time"))
                 capability = match.group("capability")
                 port_id = cls._normalize_port_id(match.group("port_id"))

--- a/src/muninn/parsers/ios/show_mac_address_table.py
+++ b/src/muninn/parsers/ios/show_mac_address_table.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # Separator patterns that indicate header/divider lines to skip
 _HEADER_RE = re.compile(
@@ -132,7 +131,7 @@ def _normalize_port(port: str) -> str:
         return stripped
     # Try canonical_interface_name for interface-like values
     try:
-        return canonical_interface_name(stripped)
+        return canonical_interface_name(stripped, os=OS.CISCO_IOS)
     except Exception:
         return stripped
 

--- a/src/muninn/parsers/ios/show_power_inline.py
+++ b/src/muninn/parsers/ios/show_power_inline.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # Null-equivalent values for device and class fields
 _NULL_VALUES = frozenset({"n/a", "none", ""})
@@ -106,7 +105,7 @@ def _parse_interface_line(
     if raw_name.lower() in ("interface", "module"):
         return None
 
-    name = canonical_interface_name(raw_name)
+    name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
     entry: InterfaceEntry = {
         "admin": m.group(2).lower(),
         "oper": m.group(3).lower(),

--- a/src/muninn/parsers/ios/show_spanning_tree.py
+++ b/src/muninn/parsers/ios/show_spanning_tree.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # --- Role and status normalization maps ---
 _ROLE_MAP: dict[str, str] = {
@@ -152,7 +151,7 @@ def _parse_root_id(lines: list[str]) -> tuple[RootIdEntry, bool]:
         m = _PORT_RE.match(line)
         if m:
             root["port_number"] = int(m.group(1))
-            root["port_name"] = canonical_interface_name(m.group(2))
+            root["port_name"] = canonical_interface_name(m.group(2), os=OS.CISCO_IOS)
             continue
 
         m = _TIMERS_RE.match(line)
@@ -209,7 +208,7 @@ def _parse_interfaces(lines: list[str]) -> dict[str, InterfaceEntry]:
             continue
 
         raw_name = m.group(1)
-        name = canonical_interface_name(raw_name)
+        name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
         role_abbr = m.group(2).lower()
         status_abbr = m.group(3).rstrip("*").lower()
 

--- a/src/muninn/parsers/ios/show_standby_brief.py
+++ b/src/muninn/parsers/ios/show_standby_brief.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # Header line that marks the start of tabular data
 _HEADER_RE = re.compile(
@@ -98,7 +97,7 @@ def _parse_data_lines(lines: list[str]) -> list[HsrpGroupEntry]:
 
         raw_interface = data_match.group("interface")
         if raw_interface:
-            last_interface = canonical_interface_name(raw_interface)
+            last_interface = canonical_interface_name(raw_interface, os=OS.CISCO_IOS)
         interface = last_interface or ""
 
         entry: HsrpGroupEntry = {

--- a/src/muninn/parsers/ios/show_vlan.py
+++ b/src/muninn/parsers/ios/show_vlan.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class VlanEntry(TypedDict):
@@ -80,7 +79,9 @@ def _normalize_ports(port_str: str) -> list[str]:
     if not port_str:
         return []
     return [
-        canonical_interface_name(p.strip()) for p in port_str.split(",") if p.strip()
+        canonical_interface_name(p.strip(), os=OS.CISCO_IOS)
+        for p in port_str.split(",")
+        if p.strip()
     ]
 
 

--- a/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_binding.py
+++ b/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_binding.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class DhcpSnoopingBindingEntry(TypedDict):
@@ -46,7 +45,7 @@ class ShowIpDhcpSnoopingBindingParser(BaseParser[ShowIpDhcpSnoopingBindingResult
 
     @staticmethod
     def _normalize_interface(interface: str) -> str:
-        return canonical_interface_name(interface)
+        return canonical_interface_name(interface, os=OS.CISCO_IOSXE)
 
     @classmethod
     def parse(cls, output: str) -> ShowIpDhcpSnoopingBindingResult:

--- a/src/muninn/parsers/iosxe/show_ip_interface_brief.py
+++ b/src/muninn/parsers/iosxe/show_ip_interface_brief.py
@@ -3,11 +3,10 @@
 import re
 from typing import TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class InterfaceBriefEntry(TypedDict):
@@ -70,7 +69,9 @@ class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
 
             match = cls._INTERFACE_PATTERN.match(line)
             if match:
-                interface = canonical_interface_name(match.group("interface"))
+                interface = canonical_interface_name(
+                    match.group("interface"), os=OS.CISCO_IOSXE
+                )
                 interfaces[interface] = InterfaceBriefEntry(
                     ip_address=match.group("ip_address"),
                     ok=match.group("ok").upper(),

--- a/src/muninn/parsers/iosxe/show_ip_ospf_neighbor.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_neighbor.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class OspfNeighborEntry(TypedDict):
@@ -70,7 +69,9 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
 
             match = cls._NEIGHBOR_PATTERN.match(line)
             if match:
-                interface = canonical_interface_name(match.group("interface"))
+                interface = canonical_interface_name(
+                    match.group("interface"), os=OS.CISCO_IOSXE
+                )
                 neighbor_id = match.group("neighbor_id")
                 role = match.group("role")
 

--- a/src/muninn/parsers/iosxe/show_ip_vrf.py
+++ b/src/muninn/parsers/iosxe/show_ip_vrf.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class VrfEntry(TypedDict):
@@ -58,7 +57,7 @@ class ShowIpVrfParser(BaseParser[ShowIpVrfResult]):
         interface = match.group("interface")
 
         entry: VrfEntry = {
-            "interfaces": [canonical_interface_name(interface)],
+            "interfaces": [canonical_interface_name(interface, os=OS.CISCO_IOSXE)],
         }
         if default_rd != "<not set>":
             entry["default_rd"] = default_rd
@@ -95,7 +94,7 @@ class ShowIpVrfParser(BaseParser[ShowIpVrfResult]):
             if cont_match and current_vrf:
                 interface = cont_match.group("interface")
                 vrfs[current_vrf]["interfaces"].append(
-                    canonical_interface_name(interface)
+                    canonical_interface_name(interface, os=OS.CISCO_IOSXE)
                 )
 
         if not vrfs:

--- a/src/muninn/parsers/iosxe/show_mac_address_table_dynamic.py
+++ b/src/muninn/parsers/iosxe/show_mac_address_table_dynamic.py
@@ -3,11 +3,10 @@
 import re
 from typing import TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class MacAddressEntry(TypedDict):
@@ -39,7 +38,7 @@ class ShowMacAddressTableDynamicParser(BaseParser[ShowMacAddressTableDynamicResu
 
     @staticmethod
     def _normalize_interface(interface: str) -> str:
-        return canonical_interface_name(interface)
+        return canonical_interface_name(interface, os=OS.CISCO_IOSXE)
 
     @classmethod
     def parse(cls, output: str) -> ShowMacAddressTableDynamicResult:

--- a/src/muninn/parsers/iosxe/show_macsec_summary.py
+++ b/src/muninn/parsers/iosxe/show_macsec_summary.py
@@ -4,11 +4,10 @@ import re
 from collections.abc import Callable
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class MacsecSummaryInterface(TypedDict):
@@ -53,7 +52,7 @@ class ShowMacsecSummaryParser(BaseParser[ShowMacsecSummaryResult]):
 
     @staticmethod
     def _normalize_interface(interface: str) -> str:
-        return canonical_interface_name(interface)
+        return canonical_interface_name(interface, os=OS.CISCO_IOSXE)
 
     @classmethod
     def _parse_summary_parts(

--- a/src/muninn/parsers/nxos/show_cdp_neighbors.py
+++ b/src/muninn/parsers/nxos/show_cdp_neighbors.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class CdpNeighborEntry(TypedDict):
@@ -73,7 +72,7 @@ class ShowCdpNeighborsParser(BaseParser[ShowCdpNeighborsResult]):
     def _normalize_port_id(cls, port_id: str) -> str:
         """Normalize port_id if it looks like an interface name."""
         if cls._INTERFACE_PATTERN.match(port_id):
-            return canonical_interface_name(port_id)
+            return canonical_interface_name(port_id, os=OS.CISCO_NXOS)
         return port_id
 
     @classmethod
@@ -115,7 +114,9 @@ class ShowCdpNeighborsParser(BaseParser[ShowCdpNeighborsResult]):
         match: re.Match[str],
     ) -> tuple[str, CdpNeighborEntry]:
         """Parse common fields from a CDP neighbor match."""
-        local_intf = canonical_interface_name(match.group("local_intf"))
+        local_intf = canonical_interface_name(
+            match.group("local_intf"), os=OS.CISCO_NXOS
+        )
         hold_time = int(match.group("hold_time"))
         capability = cls._normalize_capabilities(match.group("capability"))
         platform = match.group("platform")

--- a/src/muninn/parsers/nxos/show_interface_status.py
+++ b/src/muninn/parsers/nxos/show_interface_status.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class InterfaceStatusEntry(TypedDict):
@@ -94,7 +93,7 @@ class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
 
             match = cls._INTERFACE_PATTERN.match(stripped)
             if match:
-                port = canonical_interface_name(match.group("port"))
+                port = canonical_interface_name(match.group("port"), os=OS.CISCO_NXOS)
                 name = cls._normalize_value(match.group("name"))
                 status = match.group("status")
                 vlan = cls._normalize_value(match.group("vlan"))

--- a/src/muninn/parsers/nxos/show_ip_arp.py
+++ b/src/muninn/parsers/nxos/show_ip_arp.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class ArpEntry(TypedDict):
@@ -71,7 +70,7 @@ class ShowIpArpParser(BaseParser[ShowIpArpResult]):
                 interface = match.group("interface")
 
                 entry: ArpEntry = {
-                    "interface": canonical_interface_name(interface),
+                    "interface": canonical_interface_name(interface, os=OS.CISCO_NXOS),
                 }
 
                 # Add age only if not "-" (static entry)

--- a/src/muninn/parsers/nxos/show_ip_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_ip_interface_brief.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class InterfaceBriefEntry(TypedDict):
@@ -77,7 +76,9 @@ class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
         intf_match = cls._INTERFACE_PATTERN.match(stripped)
         if not intf_match:
             return None
-        interface = canonical_interface_name(intf_match.group("interface"))
+        interface = canonical_interface_name(
+            intf_match.group("interface"), os=OS.CISCO_NXOS
+        )
         entry: InterfaceBriefEntry = {
             "ip_address": intf_match.group("ip_address"),
             "protocol_status": intf_match.group("protocol").lower(),
@@ -106,7 +107,7 @@ class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
             return False
         source = unnumbered_match.group("source")
         vrfs[current_vrf]["interfaces"][last_interface]["unnumbered_source"] = (
-            canonical_interface_name(source)
+            canonical_interface_name(source, os=OS.CISCO_NXOS)
         )
         return True
 

--- a/src/muninn/parsers/nxos/show_ip_ospf_interface.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_interface.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class OspfInterfaceEntry(TypedDict):
@@ -178,7 +177,9 @@ def _parse_address_and_process(lines: list[str], entry: dict) -> None:
 
         m = _UNNUMBERED_RE.match(line)
         if m:
-            entry["unnumbered_interface"] = canonical_interface_name(m.group(1))
+            entry["unnumbered_interface"] = canonical_interface_name(
+                m.group(1), os=OS.CISCO_NXOS
+            )
             entry["ip_address"] = m.group(2)
             continue
 
@@ -323,7 +324,7 @@ def _normalize_interface_name(raw_name: str) -> str:
     # be passed through canonical_interface_name
     if raw_name.startswith(("SL", "VL")):
         return raw_name
-    return canonical_interface_name(raw_name)
+    return canonical_interface_name(raw_name, os=OS.CISCO_NXOS)
 
 
 @register(OS.CISCO_NXOS, "show ip ospf interface")

--- a/src/muninn/parsers/nxos/show_ip_route.py
+++ b/src/muninn/parsers/nxos/show_ip_route.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class NextHop(TypedDict):
@@ -176,7 +175,7 @@ def _build_nexthop(
 
     interface = nh_match.group("interface")
     if interface:
-        nexthop["interface"] = canonical_interface_name(interface)
+        nexthop["interface"] = canonical_interface_name(interface, os=OS.CISCO_NXOS)
 
     for key in ("process", "route_type", "tunnelid", "encap"):
         val = proto_fields.get(key)

--- a/src/muninn/parsers/nxos/show_ipv6_route.py
+++ b/src/muninn/parsers/nxos/show_ipv6_route.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class NextHop(TypedDict):
@@ -226,7 +225,7 @@ def _build_next_hop(match: re.Match[str]) -> NextHop:
 
     interface = match.group("interface")
     if interface:
-        hop["interface"] = canonical_interface_name(interface)
+        hop["interface"] = canonical_interface_name(interface, os=OS.CISCO_NXOS)
 
     # Parse the trailing portion after protocol for route_type and tag
     tail = match.group("tail") or ""

--- a/src/muninn/parsers/nxos/show_lldp_neighbors.py
+++ b/src/muninn/parsers/nxos/show_lldp_neighbors.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class LldpNeighborEntry(TypedDict):
@@ -73,7 +72,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
             lowered = port_id.lower()
             if lowered.startswith("ethernet"):
                 port_id = "Eth" + port_id[8:]
-            return canonical_interface_name(port_id)
+            return canonical_interface_name(port_id, os=OS.CISCO_NXOS)
         return port_id
 
     @classmethod
@@ -138,7 +137,9 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
         if not match:
             return False
 
-        local_intf = canonical_interface_name(match.group("local_intf"))
+        local_intf = canonical_interface_name(
+            match.group("local_intf"), os=OS.CISCO_NXOS
+        )
         device_id = match.group("device_id").strip()
         entry = cls._build_entry(
             hold_time=int(match.group("hold_time")),
@@ -162,7 +163,9 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
         if not match:
             return False
 
-        local_intf = canonical_interface_name(match.group("local_intf"))
+        local_intf = canonical_interface_name(
+            match.group("local_intf"), os=OS.CISCO_NXOS
+        )
         entry = cls._build_entry(
             hold_time=int(match.group("hold_time")),
             port_id=match.group("port_id"),
@@ -198,7 +201,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
         ):
             device_id = detail_state["system_name"] or detail_state["chassis_id"]
             if isinstance(device_id, str) and device_id.lower() != "not advertised":
-                local_intf = canonical_interface_name(local_port)
+                local_intf = canonical_interface_name(local_port, os=OS.CISCO_NXOS)
                 entry = cls._build_entry(
                     hold_time=hold_time,
                     port_id=port_id,

--- a/src/muninn/parsers/nxos/show_mac_address_table.py
+++ b/src/muninn/parsers/nxos/show_mac_address_table.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 # Entry flag character to descriptive string mapping
 _ENTRY_FLAG_MAP: dict[str, str] = {
@@ -96,7 +95,7 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
         # Normalize interface abbreviations (Eth -> Ethernet, Po -> Port-channel)
         # but leave special values like Drop, sup-eth1(R), vPC Peer-Link(R) as-is
         if _INTERFACE_PORT_PATTERN.match(port_raw):
-            port_raw = canonical_interface_name(port_raw)
+            port_raw = canonical_interface_name(port_raw, os=OS.CISCO_NXOS)
 
         entry: MacTableEntry = {
             "mac_address": match.group("mac").lower(),

--- a/src/muninn/parsers/nxos/show_port_channel_summary.py
+++ b/src/muninn/parsers/nxos/show_port_channel_summary.py
@@ -3,11 +3,10 @@
 import re
 from typing import TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class PortChannelMember(TypedDict):
@@ -106,7 +105,9 @@ class ShowPortChannelSummaryParser(BaseParser[ShowPortChannelSummaryResult]):
             return members
 
         for match in cls._MEMBER_PATTERN.finditer(members_str):
-            interface = canonical_interface_name(match.group("interface"))
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.CISCO_NXOS
+            )
             flag = match.group("flag")
             status = _MEMBER_STATUS_MAP.get(flag, flag.lower())
 
@@ -165,7 +166,9 @@ class ShowPortChannelSummaryParser(BaseParser[ShowPortChannelSummaryResult]):
             po_match = cls._PORT_CHANNEL_PATTERN.match(line)
             if po_match:
                 group = int(po_match.group("group"))
-                name = canonical_interface_name(po_match.group("name"))
+                name = canonical_interface_name(
+                    po_match.group("name"), os=OS.CISCO_NXOS
+                )
                 flags = po_match.group("flags")
                 po_type = po_match.group("type")
                 protocol = po_match.group("protocol")

--- a/src/muninn/parsers/nxos/show_vlan.py
+++ b/src/muninn/parsers/nxos/show_vlan.py
@@ -3,11 +3,10 @@
 import re
 from typing import NotRequired, TypedDict
 
-from netutils.interface import canonical_interface_name
-
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class PrivateVlanInfo(TypedDict):
@@ -74,7 +73,9 @@ def _normalize_ports(port_str: str) -> list[str]:
     if not port_str:
         return []
     return [
-        canonical_interface_name(p.strip()) for p in port_str.split(",") if p.strip()
+        canonical_interface_name(p.strip(), os=OS.CISCO_NXOS)
+        for p in port_str.split(",")
+        if p.strip()
     ]
 
 

--- a/src/muninn/utils.py
+++ b/src/muninn/utils.py
@@ -1,0 +1,33 @@
+"""Utility functions for parser implementations."""
+
+from netutils.interface import canonical_interface_name as _upstream_canonical
+
+from muninn.os import OS
+
+# NX-OS interface prefixes that netutils incorrectly canonicalizes.
+# mgmt0 is native on Nexus and should not become Management0.
+_NXOS_PASSTHROUGH_PREFIXES = ("mgmt",)
+
+
+def canonical_interface_name(name: str, *, os: OS | None = None) -> str:
+    """Return the canonical form of an interface name.
+
+    Thin shim around ``netutils.interface.canonical_interface_name`` that
+    corrects platform-specific quirks.
+
+    Args:
+        name: Raw interface name (e.g. ``"Eth1/1"``, ``"mgmt0"``).
+        os: Operating system context.  When *OS.CISCO_NXOS*, the NX-OS
+            native ``mgmt0`` form is preserved instead of being expanded
+            to ``Management0``.
+
+    Returns:
+        Canonical interface name string.
+    """
+    if os is OS.CISCO_NXOS:
+        name_lower = name.lower()
+        for prefix in _NXOS_PASSTHROUGH_PREFIXES:
+            if name_lower.startswith(prefix):
+                return name
+
+    return _upstream_canonical(name)

--- a/tests/parsers/nxos/show_cdp_neighbors/001_basic/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors/001_basic/expected.json
@@ -1,6 +1,6 @@
 {
     "neighbors": {
-        "Management0": {
+        "mgmt0": {
             "PERIMETER": {
                 "hold_time": 179,
                 "capabilities": "R S I",

--- a/tests/parsers/nxos/show_cdp_neighbors/003_single_line_mixed_capabilities/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors/003_single_line_mixed_capabilities/expected.json
@@ -1,6 +1,6 @@
 {
     "neighbors": {
-        "Management0": {
+        "mgmt0": {
             "Switch": {
                 "hold_time": 163,
                 "platform": "WS-C2960-24TC",

--- a/tests/parsers/nxos/show_cdp_neighbors/004_wrapped_with_mgmt/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors/004_wrapped_with_mgmt/expected.json
@@ -1,6 +1,6 @@
 {
     "neighbors": {
-        "Management0": {
+        "mgmt0": {
             "Mgmt-switch": {
                 "hold_time": 148,
                 "platform": "WS-C4948-10GE",

--- a/tests/parsers/nxos/show_cdp_neighbors/005_large_mixed_platforms/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors/005_large_mixed_platforms/expected.json
@@ -1,6 +1,6 @@
 {
     "neighbors": {
-        "Management0": {
+        "mgmt0": {
             "bkcmnasa3a2h.na.tech.cnb": {
                 "hold_time": 165,
                 "platform": "WS-C2960X-48L",

--- a/tests/parsers/nxos/show_interface_status/001_various_interfaces/expected.json
+++ b/tests/parsers/nxos/show_interface_status/001_various_interfaces/expected.json
@@ -1,6 +1,6 @@
 {
     "interfaces": {
-        "Management0": {
+        "mgmt0": {
             "status": "connected",
             "vlan": "routed",
             "duplex": "full",

--- a/tests/parsers/nxos/show_interface_status/006_fex_and_mixed_speeds/expected.json
+++ b/tests/parsers/nxos/show_interface_status/006_fex_and_mixed_speeds/expected.json
@@ -16,7 +16,7 @@
             "vlan": "trunk",
             "type": "10g"
         },
-        "Management0": {
+        "mgmt0": {
             "status": "connected",
             "duplex": "full",
             "speed": "1000",

--- a/tests/parsers/nxos/show_interface_status/008_missing_type_field/expected.json
+++ b/tests/parsers/nxos/show_interface_status/008_missing_type_field/expected.json
@@ -1,6 +1,6 @@
 {
     "interfaces": {
-        "Management0": {
+        "mgmt0": {
             "status": "connected",
             "duplex": "full",
             "speed": "100",

--- a/tests/parsers/nxos/show_ip_arp/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ip_arp/001_basic/expected.json
@@ -13,7 +13,7 @@
         "10.3.1.101": {
             "age": "00:06:06",
             "mac_address": "d46d.5031.88b0",
-            "interface": "Management0"
+            "interface": "mgmt0"
         }
     }
 }

--- a/tests/parsers/nxos/show_ip_arp/003_large_table_with_subinterfaces/expected.json
+++ b/tests/parsers/nxos/show_ip_arp/003_large_table_with_subinterfaces/expected.json
@@ -11,42 +11,42 @@
             "mac_address": "3c60.f40e.f9c4"
         },
         "10.3.1.101": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:06:06",
             "mac_address": "d46d.5031.88b0"
         },
         "10.3.1.102": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:18:18",
             "mac_address": "e0ac.b16b.e940"
         },
         "10.3.1.104": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:17:17",
             "mac_address": "e5ac.b16c.aac8"
         },
         "10.3.1.105": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:13:08",
             "mac_address": "d46d.503c.beb0"
         },
         "10.3.0.20": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:15:11",
             "mac_address": "487b.6bad.7b36"
         },
         "10.3.0.250": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:14:56",
             "mac_address": "0000.0c9f.fa14"
         },
         "10.3.0.251": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:07:08",
             "mac_address": "03c5.a4e8.c342"
         },
         "10.3.0.252": {
-            "interface": "Management0",
+            "interface": "mgmt0",
             "age": "00:14:14",
             "mac_address": "02c5.a4ea.56c2"
         },

--- a/tests/parsers/nxos/show_ip_interface_brief/001_multi_vrf/expected.json
+++ b/tests/parsers/nxos/show_ip_interface_brief/001_multi_vrf/expected.json
@@ -26,7 +26,7 @@
         "management": {
             "vrf_id": 2,
             "interfaces": {
-                "Management0": {
+                "mgmt0": {
                     "ip_address": "192.168.149.11",
                     "protocol_status": "up",
                     "link_status": "up",

--- a/tests/parsers/nxos/show_ip_interface_brief/004_three_vrfs_with_forward_enabled/expected.json
+++ b/tests/parsers/nxos/show_ip_interface_brief/004_three_vrfs_with_forward_enabled/expected.json
@@ -38,7 +38,7 @@
         "management": {
             "vrf_id": 2,
             "interfaces": {
-                "Management0": {
+                "mgmt0": {
                     "ip_address": "10.143.253.22",
                     "protocol_status": "up",
                     "link_status": "up",

--- a/tests/parsers/nxos/show_lldp_neighbors/002_ntc_multiline_with_empty_capabilities/expected.json
+++ b/tests/parsers/nxos/show_lldp_neighbors/002_ntc_multiline_with_empty_capabilities/expected.json
@@ -1,6 +1,6 @@
 {
     "neighbors": {
-        "Management0": {
+        "mgmt0": {
             "dcx3.org.local": {
                 "hold_time": 120,
                 "capabilities": "B",

--- a/tests/parsers/test_expected_normalization.py
+++ b/tests/parsers/test_expected_normalization.py
@@ -6,9 +6,16 @@ import json
 from pathlib import Path
 from typing import TypeAlias
 
-from netutils.interface import canonical_interface_name
+from muninn.os import OS
+from muninn.utils import canonical_interface_name
 
 PARSERS_TEST_DIR = Path(__file__).parent
+
+_DIR_TO_OS: dict[str, OS] = {
+    "ios": OS.CISCO_IOS,
+    "iosxe": OS.CISCO_IOSXE,
+    "nxos": OS.CISCO_NXOS,
+}
 
 JSONValue: TypeAlias = (
     dict[str, "JSONValue"] | list["JSONValue"] | str | int | float | bool | None
@@ -43,23 +50,23 @@ def _looks_like_interface(value: str) -> bool:
     return bool(interface_pattern.match(value))
 
 
-def _normalize_string(value: str) -> str:
+def _normalize_string(value: str, *, os: OS | None = None) -> str:
     if _looks_like_interface(value):
-        return canonical_interface_name(value)
+        return canonical_interface_name(value, os=os)
     return value
 
 
-def _normalize(value: JSONValue) -> JSONValue:
+def _normalize(value: JSONValue, *, os: OS | None = None) -> JSONValue:
     if isinstance(value, dict):
         normalized: dict[str, JSONValue] = {}
         for key, item in value.items():
-            norm_key = _normalize_string(key) if isinstance(key, str) else key
-            normalized[norm_key] = _normalize(item)
+            norm_key = _normalize_string(key, os=os) if isinstance(key, str) else key
+            normalized[norm_key] = _normalize(item, os=os)
         return normalized
     if isinstance(value, list):
-        return [_normalize(item) for item in value]
+        return [_normalize(item, os=os) for item in value]
     if isinstance(value, str):
-        return _normalize_string(value)
+        return _normalize_string(value, os=os)
     return value
 
 
@@ -124,7 +131,10 @@ def test_expected_outputs_use_canonical_interfaces() -> None:
 
     for expected_path in _discover_expected_files():
         expected = json.loads(expected_path.read_text())
-        normalized = _normalize(expected)
+        rel = expected_path.relative_to(PARSERS_TEST_DIR)
+        os_dir = rel.parts[0] if rel.parts else ""
+        os_val = _DIR_TO_OS.get(os_dir)
+        normalized = _normalize(expected, os=os_val)
         if normalized != expected:
             failures.append(str(expected_path.relative_to(PARSERS_TEST_DIR)))
 


### PR DESCRIPTION
## Summary
- netutils `canonical_interface_name("mgmt0")` incorrectly returns `Management0` — on NX-OS, `mgmt0` is the native canonical form
- Adds `src/muninn/utils.py` with an OS-aware shim around `canonical_interface_name` that preserves `mgmt0` on NX-OS
- Migrates all 28 parsers to import from `muninn.utils` instead of `netutils.interface`, passing their OS context
- Updates 12 NX-OS test fixtures where `Management0` is now correctly `mgmt0`
- Updates the normalization test to be OS-aware

## Test plan
- [x] All 579 tests pass
- [x] Pre-commit hooks pass (ruff, xenon, bandit)
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)