### PR TITLE
feat: add parser for 'show endpoint-tracker tracker-group' on IOS-XE

### DIFF
--- a/changes/339.parser_added
+++ b/changes/339.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show endpoint-tracker tracker-group' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_endpoint_tracker_tracker_group.py
+++ b/src/muninn/parsers/iosxe/show_endpoint_tracker_tracker_group.py
@@ -1,0 +1,98 @@
+"""Parser for 'show endpoint-tracker tracker-group' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class TrackerGroupEntry(TypedDict):
+    """Schema for a single tracker group entry."""
+
+    element_trackers: list[str]
+    status: str
+    rtt_in_msec: list[str]
+    probe_ids: list[int]
+
+
+class ShowEndpointTrackerTrackerGroupResult(TypedDict):
+    """Schema for 'show endpoint-tracker tracker-group' parsed output."""
+
+    tracker_groups: dict[str, TrackerGroupEntry]
+
+
+@register(OS.CISCO_IOSXE, "show endpoint-tracker tracker-group")
+class ShowEndpointTrackerTrackerGroupParser(
+    BaseParser[ShowEndpointTrackerTrackerGroupResult],
+):
+    """Parser for 'show endpoint-tracker tracker-group' command.
+
+    Example output:
+        Tracker Name       Element trackers name  Status
+        group-udp-tcp      tcp-10002, udp-10002   UP(UP OR UP)
+        group2             track1, track2         UP(UP OR UP)
+    """
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<name>\S+)\s+"
+        r"(?P<trackers>.+?)\s{2,}"
+        r"(?P<status>\S+\([^)]+\))\s+"
+        r"(?P<rtt>.+?)\s{2,}"
+        r"(?P<probe_ids>[\d,\s]+)$"
+    )
+
+    @classmethod
+    def _is_skip_line(cls, line: str) -> bool:
+        """Check if a line should be skipped."""
+        stripped = line.strip()
+        if not stripped:
+            return True
+        if "Tracker Name" in line or "Element trackers" in line:
+            return True
+        if "show endpoint" in line or stripped.startswith("#"):
+            return True
+        return "#" in line and "show" in line
+
+    @classmethod
+    def _parse_csv_list(cls, value: str) -> list[str]:
+        """Parse a comma-separated string into a list of stripped values."""
+        return [v.strip() for v in value.split(",")]
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEndpointTrackerTrackerGroupResult:
+        """Parse 'show endpoint-tracker tracker-group' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed tracker group data keyed by tracker name.
+
+        Raises:
+            ValueError: If no tracker groups found.
+        """
+        tracker_groups: dict[str, TrackerGroupEntry] = {}
+
+        for line in output.splitlines():
+            if cls._is_skip_line(line):
+                continue
+
+            match = cls._ROW_PATTERN.match(line.strip())
+            if match:
+                name = match.group("name")
+                tracker_groups[name] = TrackerGroupEntry(
+                    element_trackers=cls._parse_csv_list(match.group("trackers")),
+                    status=match.group("status"),
+                    rtt_in_msec=cls._parse_csv_list(match.group("rtt")),
+                    probe_ids=[
+                        int(p) for p in cls._parse_csv_list(match.group("probe_ids"))
+                    ],
+                )
+
+        if not tracker_groups:
+            msg = "No tracker groups found in output"
+            raise ValueError(msg)
+
+        return ShowEndpointTrackerTrackerGroupResult(tracker_groups=tracker_groups)

--- a/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/001_basic/expected.json
@@ -1,0 +1,49 @@
+{
+    "tracker_groups": {
+        "group-udp-tcp-10001": {
+            "element_trackers": [
+                "tcp-10002",
+                "udp-10002"
+            ],
+            "probe_ids": [
+                7,
+                8
+            ],
+            "rtt_in_msec": [
+                "1",
+                "1"
+            ],
+            "status": "UP(UP OR UP)"
+        },
+        "group2": {
+            "element_trackers": [
+                "track1",
+                "track2"
+            ],
+            "probe_ids": [
+                201,
+                202
+            ],
+            "rtt_in_msec": [
+                "14",
+                "14"
+            ],
+            "status": "UP(UP OR UP)"
+        },
+        "group3": {
+            "element_trackers": [
+                "track1",
+                "track2"
+            ],
+            "probe_ids": [
+                0,
+                0
+            ],
+            "rtt_in_msec": [
+                "Timeout",
+                "Timeout"
+            ],
+            "status": "DOWN(DOWN OR DOWN)"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/001_basic/input.txt
@@ -1,0 +1,6 @@
+show endpoint-tracker tracker-group
+
+Tracker Name            Element trackers name    Status                 RTT in msec       Probe ID
+group-udp-tcp-10001     tcp-10002, udp-10002      UP(UP OR UP)          1, 1              7, 8
+group2                  track1, track2            UP(UP OR UP)          14, 14            201, 202
+group3                  track1, track2            DOWN(DOWN OR DOWN)    Timeout, Timeout  0, 0

--- a/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple tracker groups with UP and DOWN states including Timeout RTT values
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/002_and_logic_with_down/expected.json
+++ b/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/002_and_logic_with_down/expected.json
@@ -1,0 +1,34 @@
+{
+    "tracker_groups": {
+        "trkgrp_endpoint": {
+            "element_trackers": [
+                "trk_google-web1",
+                "trk_umbrella1"
+            ],
+            "probe_ids": [
+                5,
+                6
+            ],
+            "rtt_in_msec": [
+                "16",
+                "3"
+            ],
+            "status": "UP(UP AND UP)"
+        },
+        "trkgrp_grp1": {
+            "element_trackers": [
+                "trk_google-web",
+                "trk_umbrella"
+            ],
+            "probe_ids": [
+                5,
+                6
+            ],
+            "rtt_in_msec": [
+                "16",
+                "3"
+            ],
+            "status": "UP(UP OR UP)"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/002_and_logic_with_down/input.txt
+++ b/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/002_and_logic_with_down/input.txt
@@ -1,0 +1,3 @@
+Tracker Name                     Element trackers name              Status                       RTT in msec      Probe ID
+trkgrp_grp1                      trk_google-web, trk_umbrella       UP(UP OR UP)                 16, 3            5, 6
+trkgrp_endpoint                  trk_google-web1, trk_umbrella1     UP(UP AND UP)                16, 3            5, 6

--- a/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/002_and_logic_with_down/metadata.yaml
+++ b/tests/parsers/iosxe/show_endpoint-tracker_tracker-group/002_and_logic_with_down/metadata.yaml
@@ -1,0 +1,3 @@
+description: Tracker groups using both OR and AND boolean logic
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show endpoint-tracker tracker-group` command on Cisco IOS-XE
- Parses tracker group names, element trackers, status (with OR/AND boolean logic), RTT values, and probe IDs from tabular CLI output
- Includes 2 test cases: basic multi-group output with UP/DOWN/Timeout states, and AND/OR boolean logic variants

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k "endpoint" -v` -- 2 tests pass
- [x] `uv run ruff check` -- clean
- [x] `uv run xenon --max-absolute B` -- passes
- [x] `uv run pre-commit run --all-files` -- all hooks pass

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)