### PR TITLE
feat: add parser for 'show file systems' on IOS-XE

### DIFF
--- a/changes/341.parser_added
+++ b/changes/341.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show file systems' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_file_systems.py
+++ b/src/muninn/parsers/iosxe/show_file_systems.py
@@ -1,0 +1,93 @@
+"""Parser for 'show file systems' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class FileSystemEntry(TypedDict):
+    """Schema for a single file system entry."""
+
+    type: str
+    flags: str
+    is_default: bool
+    size: NotRequired[int]
+    free: NotRequired[int]
+
+
+class ShowFileSystemsResult(TypedDict):
+    """Schema for 'show file systems' parsed output.
+
+    Keyed by file system prefix (e.g., "flash:", "nvram:").
+    """
+
+    file_systems: dict[str, FileSystemEntry]
+
+
+_ROW_PATTERN = re.compile(
+    r"^(?P<default>\*)?\s*"
+    r"(?P<size>\d+|-)\s+"
+    r"(?P<free>\d+|-)\s+"
+    r"(?P<type>\S+)\s+"
+    r"(?P<flags>r[wo])\s+"
+    r"(?P<prefix>\S+)\s*$"
+)
+
+
+@register(OS.CISCO_IOSXE, "show file systems")
+class ShowFileSystemsParser(BaseParser[ShowFileSystemsResult]):
+    """Parser for 'show file systems' command.
+
+    Example output:
+           Size(b)       Free(b)      Type  Flags  Prefixes
+        *  11353194496    9936510976      disk     rw   flash:
+              2097152       2057602     nvram     rw   nvram:
+    """
+
+    _ROW_PATTERN = _ROW_PATTERN
+
+    @classmethod
+    def parse(cls, output: str) -> ShowFileSystemsResult:
+        """Parse 'show file systems' output.
+
+        Args:
+            output: Raw CLI output from 'show file systems' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        file_systems: dict[str, FileSystemEntry] = {}
+
+        for line in output.splitlines():
+            cleaned = line.strip()
+            match = cls._ROW_PATTERN.match(cleaned)
+            if not match:
+                continue
+
+            prefix = match.group("prefix")
+            entry = FileSystemEntry(
+                type=match.group("type"),
+                flags=match.group("flags"),
+                is_default=match.group("default") == "*",
+            )
+
+            size_str = match.group("size")
+            free_str = match.group("free")
+            if size_str != "-":
+                entry["size"] = int(size_str)
+            if free_str != "-":
+                entry["free"] = int(free_str)
+
+            file_systems[prefix] = entry
+
+        if not file_systems:
+            msg = "No file system entries found in output"
+            raise ValueError(msg)
+
+        return ShowFileSystemsResult(file_systems=file_systems)

--- a/tests/parsers/iosxe/show_file_systems/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_file_systems/001_basic/expected.json
@@ -1,0 +1,92 @@
+{
+    "file_systems": {
+        "cns:": {
+            "flags": "ro",
+            "is_default": false,
+            "type": "opaque"
+        },
+        "crashinfo:": {
+            "flags": "rw",
+            "free": 1561067520,
+            "is_default": false,
+            "size": 1651314688,
+            "type": "disk"
+        },
+        "flash:": {
+            "flags": "rw",
+            "free": 9936510976,
+            "is_default": true,
+            "size": 11353194496,
+            "type": "disk"
+        },
+        "ftp:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "http:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "https:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "null:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "opaque"
+        },
+        "nvram:": {
+            "flags": "rw",
+            "free": 2057602,
+            "is_default": false,
+            "size": 2097152,
+            "type": "nvram"
+        },
+        "rcp:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "scp:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "sftp:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "system:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "opaque"
+        },
+        "tar:": {
+            "flags": "ro",
+            "is_default": false,
+            "type": "opaque"
+        },
+        "tftp:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "network"
+        },
+        "tmpsys:": {
+            "flags": "rw",
+            "is_default": false,
+            "type": "opaque"
+        },
+        "webui:": {
+            "flags": "ro",
+            "free": 3758395392,
+            "is_default": false,
+            "size": 3846701056,
+            "type": "disk"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_file_systems/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_file_systems/001_basic/input.txt
@@ -1,0 +1,19 @@
+File Systems:
+
+       Size(b)       Free(b)      Type  Flags  Prefixes
+             -             -    opaque     rw   system:
+             -             -    opaque     rw   tmpsys:
+    1651314688    1561067520      disk     rw   crashinfo:
+*  11353194496    9936510976      disk     rw   flash:
+    3846701056    3758395392      disk     ro   webui:
+             -             -    opaque     rw   null:
+             -             -    opaque     ro   tar:
+             -             -   network     rw   tftp:
+       2097152       2057602     nvram     rw   nvram:
+             -             -   network     rw   rcp:
+             -             -   network     rw   http:
+             -             -   network     rw   ftp:
+             -             -   network     rw   scp:
+             -             -   network     rw   sftp:
+             -             -   network     rw   https:
+             -             -    opaque     ro   cns:

--- a/tests/parsers/iosxe/show_file_systems/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_file_systems/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard output with multiple file system types including disk, opaque, network, and nvram
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_file_systems/002_single_entry/expected.json
+++ b/tests/parsers/iosxe/show_file_systems/002_single_entry/expected.json
@@ -1,0 +1,18 @@
+{
+    "file_systems": {
+        "flash:": {
+            "flags": "rw",
+            "free": 2695892992,
+            "is_default": true,
+            "size": 3903578112,
+            "type": "disk"
+        },
+        "nvram:": {
+            "flags": "rw",
+            "free": 2081594,
+            "is_default": false,
+            "size": 2097152,
+            "type": "nvram"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_file_systems/002_single_entry/input.txt
+++ b/tests/parsers/iosxe/show_file_systems/002_single_entry/input.txt
@@ -1,0 +1,5 @@
+File Systems:
+
+       Size(b)       Free(b)      Type  Flags  Prefixes
+*   3903578112    2695892992      disk     rw   flash:
+       2097152       2081594     nvram     rw   nvram:

--- a/tests/parsers/iosxe/show_file_systems/002_single_entry/metadata.yaml
+++ b/tests/parsers/iosxe/show_file_systems/002_single_entry/metadata.yaml
@@ -1,0 +1,3 @@
+description: Minimal output with only flash and nvram file systems
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show file systems` command on Cisco IOS-XE
- Parses tabular output into structured data keyed by filesystem prefix (e.g., `flash:`, `nvram:`)
- Each entry includes type, flags, default indicator, and optional size/free fields
- Includes 2 test cases: full output with 16 file systems, and minimal output with 2 entries

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_file_systems" -v` — 2 tests pass
- [x] `uv run ruff check` — no issues
- [x] `uv run xenon --max-absolute B` — complexity within limits
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)