### PR TITLE
feat: add parser for 'show dmvpn' on IOS-XE

### DIFF
--- a/changes/342.parser_added
+++ b/changes/342.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show dmvpn' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_dmvpn.py
+++ b/src/muninn/parsers/iosxe/show_dmvpn.py
@@ -1,0 +1,258 @@
+"""Parser for 'show dmvpn' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class DmvpnPeerEntry(TypedDict):
+    """Schema for a single DMVPN NHRP peer entry."""
+
+    peer_nbma_address: str
+    peer_tunnel_address: str
+    state: str
+    uptime: str
+    attribute: str
+    entry_count: int
+
+
+class DmvpnInterfaceEntry(TypedDict):
+    """Schema for a DMVPN tunnel interface."""
+
+    type: str
+    nhrp_peer_count: int
+    peers: dict[str, DmvpnPeerEntry]
+    address_family: NotRequired[str]
+
+
+class ShowDmvpnResult(TypedDict):
+    """Schema for 'show dmvpn' parsed output."""
+
+    interfaces: dict[str, DmvpnInterfaceEntry]
+
+
+# Interface section header: "Interface: Tunnel100, IPv4 NHRP Details"
+_INTERFACE_PATTERN = re.compile(
+    r"^Interface:\s*(?P<interface>\S+),\s*(?P<af>\S+)\s+NHRP\s+Details"
+)
+
+# Type line: "Type:Spoke, NHRP Peers:2,"
+_TYPE_PATTERN = re.compile(
+    r"^Type:\s*(?P<type>\S+),\s*NHRP\s+Peers:\s*(?P<peer_count>\d+)"
+)
+
+# Full peer row with entry count, NBMA, tunnel addr, state, uptime, attrb
+_PEER_ROW_PATTERN = re.compile(
+    r"^\s*(?P<ent>\d+)\s+"
+    r"(?P<nbma>\S+)\s+"
+    r"(?P<tunnel>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<uptime>\S+)\s+"
+    r"(?P<attrb>\S+)\s*$"
+)
+
+# Continuation row (no entry count, starts with tunnel IP after stripping)
+_CONTINUATION_PATTERN = re.compile(
+    r"^(?P<tunnel>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<uptime>\S+)\s+"
+    r"(?P<attrb>\S+)\s*$"
+)
+
+# NBMA-only line (long address like IPv6 that wraps to next line)
+_NBMA_ONLY_PATTERN = re.compile(r"^\s*(?P<ent>\d+)\s+(?P<nbma>\S+)\s*$")
+
+# Separator and header lines to skip
+_SKIP_PATTERN = re.compile(r"^[-=]+$|^#\s*Ent|^Ent\s+Peer|^Legend:|^\s+[A-Z#]")
+
+
+def _is_skip_line(line: str) -> bool:
+    """Return True for legend, header, separator, and decoration lines."""
+    if not line:
+        return True
+    if line.startswith(("Legend:", "=", "-")):
+        return True
+    if _SKIP_PATTERN.match(line):
+        return True
+    return False
+
+
+def _build_peer_key(nbma: str, tunnel: str) -> str:
+    """Build a unique key for a peer entry."""
+    return f"{nbma}_{tunnel}"
+
+
+@register(OS.CISCO_IOSXE, "show dmvpn")
+class ShowDmvpnParser(BaseParser[ShowDmvpnResult]):
+    """Parser for 'show dmvpn' command.
+
+    Example output:
+        Interface: Tunnel100, IPv4 NHRP Details
+        Type:Spoke, NHRP Peers:2,
+
+         # Ent  Peer NBMA Addr Peer Tunnel Add State  UpDn Tm Attrb
+         ----- --------------- --------------- ----- -------- -----
+             1 10.200.0.3           10.253.0.1    UP 03:19:46     S
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowDmvpnResult:
+        """Parse 'show dmvpn' output.
+
+        Args:
+            output: Raw CLI output from 'show dmvpn' command.
+
+        Returns:
+            Parsed DMVPN data keyed by tunnel interface.
+
+        Raises:
+            ValueError: If no DMVPN interfaces found in output.
+        """
+        interfaces: dict[str, DmvpnInterfaceEntry] = {}
+        lines = output.splitlines()
+        idx = 0
+        while idx < len(lines):
+            line = lines[idx].strip()
+            intf_match = _INTERFACE_PATTERN.match(line)
+            if intf_match:
+                idx = _parse_interface_section(lines, idx, intf_match, interfaces)
+            else:
+                idx += 1
+
+        if not interfaces:
+            msg = "No DMVPN interfaces found in output"
+            raise ValueError(msg)
+
+        return ShowDmvpnResult(interfaces=interfaces)
+
+
+def _parse_interface_section(
+    lines: list[str],
+    idx: int,
+    intf_match: re.Match[str],
+    interfaces: dict[str, DmvpnInterfaceEntry],
+) -> int:
+    """Parse a single interface section. Returns the next line index."""
+    interface_name = intf_match.group("interface")
+    af = intf_match.group("af")
+    idx += 1
+
+    # Look for the Type line
+    intf_type = "Unknown"
+    peer_count = 0
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        type_match = _TYPE_PATTERN.match(stripped)
+        if type_match:
+            intf_type = type_match.group("type")
+            peer_count = int(type_match.group("peer_count"))
+            idx += 1
+            break
+        if _INTERFACE_PATTERN.match(stripped):
+            break
+        idx += 1
+
+    peers: dict[str, DmvpnPeerEntry] = {}
+    pending_nbma: str | None = None
+    pending_ent: int = 0
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+
+        if _INTERFACE_PATTERN.match(stripped):
+            break
+
+        if _is_skip_line(stripped):
+            idx += 1
+            continue
+
+        idx, pending_nbma, pending_ent = _parse_peer_line(
+            stripped,
+            peers,
+            pending_nbma,
+            pending_ent,
+            idx,
+        )
+
+    entry = DmvpnInterfaceEntry(
+        type=intf_type,
+        nhrp_peer_count=peer_count,
+        peers=peers,
+    )
+    if af != "IPv4":
+        entry["address_family"] = af
+
+    interfaces[interface_name] = entry
+    return idx
+
+
+def _parse_peer_line(
+    line: str,
+    peers: dict[str, DmvpnPeerEntry],
+    pending_nbma: str | None,
+    pending_ent: int,
+    idx: int,
+) -> tuple[int, str | None, int]:
+    """Parse a single peer data line. Returns (next_idx, pending_nbma, pending_ent)."""
+    # Full peer row
+    peer_match = _PEER_ROW_PATTERN.match(line)
+    if peer_match:
+        _add_peer(peers, peer_match)
+        nbma = peer_match.group("nbma")
+        ent = int(peer_match.group("ent"))
+        return idx + 1, nbma, ent
+
+    # Continuation row (additional tunnel for same NBMA, or tunnel after wrapped NBMA)
+    cont_match = _CONTINUATION_PATTERN.match(line)
+    if cont_match:
+        nbma = pending_nbma or "UNKNOWN"
+        ent = pending_ent or 1
+        _add_continuation_peer(peers, cont_match, nbma, ent)
+        return idx + 1, pending_nbma, pending_ent
+
+    # NBMA-only line (long address wraps)
+    nbma_match = _NBMA_ONLY_PATTERN.match(line)
+    if nbma_match:
+        return idx + 1, nbma_match.group("nbma"), int(nbma_match.group("ent"))
+
+    return idx + 1, None, 0
+
+
+def _add_peer(
+    peers: dict[str, DmvpnPeerEntry],
+    match: re.Match[str],
+) -> None:
+    """Add a peer entry from a full row match."""
+    nbma = match.group("nbma")
+    tunnel = match.group("tunnel")
+    key = _build_peer_key(nbma, tunnel)
+    peers[key] = DmvpnPeerEntry(
+        peer_nbma_address=nbma,
+        peer_tunnel_address=tunnel,
+        state=match.group("state"),
+        uptime=match.group("uptime"),
+        attribute=match.group("attrb"),
+        entry_count=int(match.group("ent")),
+    )
+
+
+def _add_continuation_peer(
+    peers: dict[str, DmvpnPeerEntry],
+    match: re.Match[str],
+    nbma: str,
+    ent: int,
+) -> None:
+    """Add a peer entry from a continuation line."""
+    tunnel = match.group("tunnel")
+    key = _build_peer_key(nbma, tunnel)
+    peers[key] = DmvpnPeerEntry(
+        peer_nbma_address=nbma,
+        peer_tunnel_address=tunnel,
+        state=match.group("state"),
+        uptime=match.group("uptime"),
+        attribute=match.group("attrb"),
+        entry_count=ent,
+    )

--- a/src/muninn/parsers/iosxe/show_dmvpn.py
+++ b/src/muninn/parsers/iosxe/show_dmvpn.py
@@ -80,9 +80,9 @@ def _is_skip_line(line: str) -> bool:
     return False
 
 
-def _build_peer_key(nbma: str, tunnel: str) -> str:
-    """Build a unique key for a peer entry."""
-    return f"{nbma}_{tunnel}"
+def _build_peer_key(entry_number: int) -> str:
+    """Build a stable key for a peer entry."""
+    return str(entry_number)
 
 
 @register(OS.CISCO_IOSXE, "show dmvpn")
@@ -158,6 +158,7 @@ def _parse_interface_section(
     peers: dict[str, DmvpnPeerEntry] = {}
     pending_nbma: str | None = None
     pending_ent: int = 0
+    peer_index = 1
 
     while idx < len(lines):
         stripped = lines[idx].strip()
@@ -169,12 +170,13 @@ def _parse_interface_section(
             idx += 1
             continue
 
-        idx, pending_nbma, pending_ent = _parse_peer_line(
+        idx, pending_nbma, pending_ent, peer_index = _parse_peer_line(
             stripped,
             peers,
             pending_nbma,
             pending_ent,
             idx,
+            peer_index,
         )
 
     entry = DmvpnInterfaceEntry(
@@ -195,43 +197,52 @@ def _parse_peer_line(
     pending_nbma: str | None,
     pending_ent: int,
     idx: int,
-) -> tuple[int, str | None, int]:
-    """Parse a single peer data line. Returns (next_idx, pending_nbma, pending_ent)."""
+    peer_index: int,
+) -> tuple[int, str | None, int, int]:
+    """Parse a single peer data line.
+
+    Returns (next_idx, pending_nbma, pending_ent, next_peer_index).
+    """
     # Full peer row
     peer_match = _PEER_ROW_PATTERN.match(line)
     if peer_match:
-        _add_peer(peers, peer_match)
+        _add_peer(peers, peer_match, peer_index)
         nbma = peer_match.group("nbma")
         ent = int(peer_match.group("ent"))
-        return idx + 1, nbma, ent
+        return idx + 1, nbma, ent, peer_index + 1
 
     # Continuation row (additional tunnel for same NBMA, or tunnel after wrapped NBMA)
     cont_match = _CONTINUATION_PATTERN.match(line)
     if cont_match:
         nbma = pending_nbma or "UNKNOWN"
         ent = pending_ent or 1
-        _add_continuation_peer(peers, cont_match, nbma, ent)
-        return idx + 1, pending_nbma, pending_ent
+        _add_continuation_peer(peers, cont_match, nbma, ent, peer_index)
+        return idx + 1, pending_nbma, pending_ent, peer_index + 1
 
     # NBMA-only line (long address wraps)
     nbma_match = _NBMA_ONLY_PATTERN.match(line)
     if nbma_match:
-        return idx + 1, nbma_match.group("nbma"), int(nbma_match.group("ent"))
+        return (
+            idx + 1,
+            nbma_match.group("nbma"),
+            int(nbma_match.group("ent")),
+            peer_index,
+        )
 
-    return idx + 1, None, 0
+    return idx + 1, None, 0, peer_index
 
 
 def _add_peer(
     peers: dict[str, DmvpnPeerEntry],
     match: re.Match[str],
+    peer_index: int,
 ) -> None:
     """Add a peer entry from a full row match."""
     nbma = match.group("nbma")
-    tunnel = match.group("tunnel")
-    key = _build_peer_key(nbma, tunnel)
+    key = _build_peer_key(peer_index)
     peers[key] = DmvpnPeerEntry(
         peer_nbma_address=nbma,
-        peer_tunnel_address=tunnel,
+        peer_tunnel_address=match.group("tunnel"),
         state=match.group("state"),
         uptime=match.group("uptime"),
         attribute=match.group("attrb"),
@@ -244,13 +255,13 @@ def _add_continuation_peer(
     match: re.Match[str],
     nbma: str,
     ent: int,
+    peer_index: int,
 ) -> None:
     """Add a peer entry from a continuation line."""
-    tunnel = match.group("tunnel")
-    key = _build_peer_key(nbma, tunnel)
+    key = _build_peer_key(peer_index)
     peers[key] = DmvpnPeerEntry(
         peer_nbma_address=nbma,
-        peer_tunnel_address=tunnel,
+        peer_tunnel_address=match.group("tunnel"),
         state=match.group("state"),
         uptime=match.group("uptime"),
         attribute=match.group("attrb"),

--- a/tests/parsers/iosxe/show_dmvpn/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_dmvpn/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "interfaces": {
+        "Tunnel100": {
+            "nhrp_peer_count": 2,
+            "peers": {
+                "10.200.0.3_10.253.0.1": {
+                    "attribute": "S",
+                    "entry_count": 1,
+                    "peer_nbma_address": "10.200.0.3",
+                    "peer_tunnel_address": "10.253.0.1",
+                    "state": "UP",
+                    "uptime": "03:19:46"
+                },
+                "10.202.0.170_10.253.0.2": {
+                    "attribute": "S",
+                    "entry_count": 1,
+                    "peer_nbma_address": "10.202.0.170",
+                    "peer_tunnel_address": "10.253.0.2",
+                    "state": "NHRP",
+                    "uptime": "48w0d"
+                }
+            },
+            "type": "Spoke"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_dmvpn/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_dmvpn/001_basic/expected.json
@@ -3,7 +3,7 @@
         "Tunnel100": {
             "nhrp_peer_count": 2,
             "peers": {
-                "10.200.0.3_10.253.0.1": {
+                "1": {
                     "attribute": "S",
                     "entry_count": 1,
                     "peer_nbma_address": "10.200.0.3",
@@ -11,7 +11,7 @@
                     "state": "UP",
                     "uptime": "03:19:46"
                 },
-                "10.202.0.170_10.253.0.2": {
+                "2": {
                     "attribute": "S",
                     "entry_count": 1,
                     "peer_nbma_address": "10.202.0.170",

--- a/tests/parsers/iosxe/show_dmvpn/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_dmvpn/001_basic/input.txt
@@ -1,0 +1,16 @@
+Legend: Attrb --> S - Static, D - Dynamic, I - Incomplete
+        N - NATed, L - Local, X - No Socket
+        T1 - Route Installed, T2 - Nexthop-override
+        C - CTS Capable
+        # Ent --> Number of NHRP entries with same NBMA peer
+        NHS Status: E --> Expecting Replies, R --> Responding, W --> Waiting
+        UpDn Time --> Up or Down Time for a Tunnel
+==========================================================================
+
+Interface: Tunnel100, IPv4 NHRP Details
+Type:Spoke, NHRP Peers:2,
+
+ # Ent  Peer NBMA Addr Peer Tunnel Add State  UpDn Tm Attrb
+ ----- --------------- --------------- ----- -------- -----
+     1 10.200.0.3           10.253.0.1    UP 03:19:46     S
+     1 10.202.0.170         10.253.0.2  NHRP    48w0d     S

--- a/tests/parsers/iosxe/show_dmvpn/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_dmvpn/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic spoke output with two NHRP peers
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/expected.json
+++ b/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/expected.json
@@ -1,0 +1,56 @@
+{
+    "interfaces": {
+        "Tunnel84": {
+            "nhrp_peer_count": 1,
+            "peers": {
+                "172.30.84.1_172.29.0.1": {
+                    "attribute": "SC",
+                    "entry_count": 1,
+                    "peer_nbma_address": "172.30.84.1",
+                    "peer_tunnel_address": "172.29.0.1",
+                    "state": "NHRP",
+                    "uptime": "never"
+                }
+            },
+            "type": "Spoke"
+        },
+        "Tunnel90": {
+            "nhrp_peer_count": 3,
+            "peers": {
+                "172.29.0.1_172.30.90.1": {
+                    "attribute": "S",
+                    "entry_count": 1,
+                    "peer_nbma_address": "172.29.0.1",
+                    "peer_tunnel_address": "172.30.90.1",
+                    "state": "IKE",
+                    "uptime": "3w5d"
+                },
+                "172.29.0.2_172.30.90.2": {
+                    "attribute": "S",
+                    "entry_count": 2,
+                    "peer_nbma_address": "172.29.0.2",
+                    "peer_tunnel_address": "172.30.90.2",
+                    "state": "UP",
+                    "uptime": "6d12h"
+                },
+                "172.29.0.2_172.30.90.25": {
+                    "attribute": "S",
+                    "entry_count": 2,
+                    "peer_nbma_address": "172.29.0.2",
+                    "peer_tunnel_address": "172.30.90.25",
+                    "state": "UP",
+                    "uptime": "6d12h"
+                },
+                "172.29.134.1_172.30.72.72": {
+                    "attribute": "DT1",
+                    "entry_count": 2,
+                    "peer_nbma_address": "172.29.134.1",
+                    "peer_tunnel_address": "172.30.72.72",
+                    "state": "UP",
+                    "uptime": "00:29:40"
+                }
+            },
+            "type": "Spoke"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/expected.json
+++ b/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/expected.json
@@ -3,7 +3,7 @@
         "Tunnel84": {
             "nhrp_peer_count": 1,
             "peers": {
-                "172.30.84.1_172.29.0.1": {
+                "1": {
                     "attribute": "SC",
                     "entry_count": 1,
                     "peer_nbma_address": "172.30.84.1",
@@ -17,7 +17,7 @@
         "Tunnel90": {
             "nhrp_peer_count": 3,
             "peers": {
-                "172.29.0.1_172.30.90.1": {
+                "1": {
                     "attribute": "S",
                     "entry_count": 1,
                     "peer_nbma_address": "172.29.0.1",
@@ -25,7 +25,7 @@
                     "state": "IKE",
                     "uptime": "3w5d"
                 },
-                "172.29.0.2_172.30.90.2": {
+                "2": {
                     "attribute": "S",
                     "entry_count": 2,
                     "peer_nbma_address": "172.29.0.2",
@@ -33,7 +33,7 @@
                     "state": "UP",
                     "uptime": "6d12h"
                 },
-                "172.29.0.2_172.30.90.25": {
+                "3": {
                     "attribute": "S",
                     "entry_count": 2,
                     "peer_nbma_address": "172.29.0.2",
@@ -41,7 +41,15 @@
                     "state": "UP",
                     "uptime": "6d12h"
                 },
-                "172.29.134.1_172.30.72.72": {
+                "4": {
+                    "attribute": "DT2",
+                    "entry_count": 2,
+                    "peer_nbma_address": "172.29.134.1",
+                    "peer_tunnel_address": "172.30.72.72",
+                    "state": "UP",
+                    "uptime": "00:29:40"
+                },
+                "5": {
                     "attribute": "DT1",
                     "entry_count": 2,
                     "peer_nbma_address": "172.29.134.1",

--- a/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/input.txt
+++ b/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/input.txt
@@ -1,0 +1,26 @@
+Legend: Attrb --> S - Static, D - Dynamic, I - Incomplete
+        N - NATed, L - Local, X - No Socket
+        T1 - Route Installed, T2 - Nexthop-override
+        C - CTS Capable
+        # Ent --> Number of NHRP entries with same NBMA peer
+        NHS Status: E --> Expecting Replies, R --> Responding, W --> Waiting
+        UpDn Time --> Up or Down Time for a Tunnel
+==========================================================================
+
+Interface: Tunnel84, IPv4 NHRP Details
+Type:Spoke, NHRP Peers:1,
+
+ # Ent  Peer NBMA Addr Peer Tunnel Add State  UpDn Tm Attrb
+ ----- --------------- --------------- ----- -------- -----
+     1 172.30.84.1          172.29.0.1  NHRP    never    SC
+
+Interface: Tunnel90, IPv4 NHRP Details
+Type:Spoke, NHRP Peers:3,
+
+ # Ent  Peer NBMA Addr Peer Tunnel Add State  UpDn Tm Attrb
+ ----- --------------- --------------- ----- -------- -----
+     1 172.29.0.1          172.30.90.1   IKE     3w5d     S
+     2 172.29.0.2          172.30.90.2    UP    6d12h     S
+                           172.30.90.25   UP    6d12h     S
+     2 172.29.134.1       172.30.72.72    UP 00:29:40   DT2
+                          172.30.72.72    UP 00:29:40   DT1

--- a/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/metadata.yaml
+++ b/tests/parsers/iosxe/show_dmvpn/002_multiple_interfaces/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces with multi-entry peers and continuation rows
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/expected.json
+++ b/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/expected.json
@@ -1,0 +1,26 @@
+{
+    "interfaces": {
+        "Tunnel1": {
+            "nhrp_peer_count": 2,
+            "peers": {
+                "2001:DB8:1201::122_192.2.1.122": {
+                    "attribute": "D",
+                    "entry_count": 1,
+                    "peer_nbma_address": "2001:DB8:1201::122",
+                    "peer_tunnel_address": "192.2.1.122",
+                    "state": "UP",
+                    "uptime": "00:02:19"
+                },
+                "2001:DB8:1202::123_192.3.1.123": {
+                    "attribute": "D",
+                    "entry_count": 1,
+                    "peer_nbma_address": "2001:DB8:1202::123",
+                    "peer_tunnel_address": "192.3.1.123",
+                    "state": "UP",
+                    "uptime": "00:02:08"
+                }
+            },
+            "type": "Hub"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/expected.json
+++ b/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/expected.json
@@ -3,7 +3,7 @@
         "Tunnel1": {
             "nhrp_peer_count": 2,
             "peers": {
-                "2001:DB8:1201::122_192.2.1.122": {
+                "1": {
                     "attribute": "D",
                     "entry_count": 1,
                     "peer_nbma_address": "2001:DB8:1201::122",
@@ -11,7 +11,7 @@
                     "state": "UP",
                     "uptime": "00:02:19"
                 },
-                "2001:DB8:1202::123_192.3.1.123": {
+                "2": {
                     "attribute": "D",
                     "entry_count": 1,
                     "peer_nbma_address": "2001:DB8:1202::123",

--- a/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/input.txt
+++ b/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/input.txt
@@ -1,0 +1,18 @@
+Legend: Attrb --> S - Static, D - Dynamic, I - Incomplete
+	N - NATed, L - Local, X - No Socket
+	T1 - Route Installed, T2 - Nexthop-override, B - BGP
+	C - CTS Capable, I2 - Temporary
+	# Ent --> Number of NHRP entries with same NBMA peer
+	NHS Status: E --> Expecting Replies, R --> Responding, W --> Waiting
+	UpDn Time --> Up or Down Time for a Tunnel
+==========================================================================
+
+Interface: Tunnel1, IPv4 NHRP Details
+Type:Hub, NHRP Peers:2,
+
+ # Ent  Peer NBMA Addr Peer Tunnel Add State  UpDn Tm Attrb
+ ----- --------------- --------------- ----- -------- -----
+     1 2001:DB8:1201::122
+                           192.2.1.122    UP 00:02:19     D
+     1 2001:DB8:1202::123
+                           192.3.1.123    UP 00:02:08     D

--- a/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/metadata.yaml
+++ b/tests/parsers/iosxe/show_dmvpn/003_hub_with_ipv6_nbma/metadata.yaml
@@ -1,0 +1,3 @@
+description: Hub type with IPv6 NBMA addresses that wrap to continuation lines
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add section-based parser for `show dmvpn` command on IOS-XE
- Handles multiple tunnel interfaces, multi-entry peers with continuation rows, and IPv6 NBMA addresses that wrap across lines
- Includes 3 test cases: basic spoke, multiple interfaces with continuation rows, and hub with IPv6 NBMA addresses

## Test plan

- [x] `uv run pytest tests/parsers/test_parsers.py -k "show_dmvpn" -v` -- 3 tests pass
- [x] `uv run ruff check` -- no issues
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` -- passes
- [x] `uv run pre-commit run --all-files` -- all hooks pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)