### PR TITLE
feat: add parser for 'show stack-power' on IOS-XE

### DIFF
--- a/changes/343.parser_added
+++ b/changes/343.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show stack-power' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_stack_power.py
+++ b/src/muninn/parsers/iosxe/show_stack_power.py
@@ -1,0 +1,175 @@
+"""Parser for 'show stack-power' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class SwitchPowerEntry(TypedDict):
+    """Schema for per-switch power allocation within a power stack."""
+
+    power_supply_a: int
+    power_supply_b: int
+    power_budget: int
+    allocated_power: int
+    available_power: int
+    consumed_power_sys: int
+    consumed_power_poe: int
+
+
+class PowerStackEntry(TypedDict):
+    """Schema for a single power stack."""
+
+    mode: str
+    topology: str
+    total_power: int
+    reserved_power: int
+    allocated_power: int
+    available_power: int
+    num_switches: int
+    num_power_supplies: int
+    switches: NotRequired[dict[str, SwitchPowerEntry]]
+
+
+class ShowStackPowerResult(TypedDict):
+    """Schema for 'show stack-power' parsed output."""
+
+    power_stacks: dict[str, PowerStackEntry]
+
+
+# Summary table row pattern:
+# Powerstack-1  SP-PS  Stndaln  1100  0  575  525  1  1
+_SUMMARY_PATTERN = re.compile(
+    r"^(?P<name>\S+)\s+"
+    r"(?P<mode>\S+)\s+"
+    r"(?P<topology>\S+)\s+"
+    r"(?P<total_power>\d+)\s+"
+    r"(?P<reserved_power>\d+)\s+"
+    r"(?P<allocated_power>\d+)\s+"
+    r"(?P<available_power>\d+)\s+"
+    r"(?P<num_switches>\d+)\s+"
+    r"(?P<num_ps>\d+)\s*$"
+)
+
+# Per-switch detail row pattern:
+# 1  Powerstack-1  1100  0  1100  575  525  155/0
+# Handles optional spaces around the slash in consumed power
+_SWITCH_PATTERN = re.compile(
+    r"^(?P<sw_num>\d+)\s+"
+    r"(?P<name>\S+)\s+"
+    r"(?P<ps_a>\d+)\s+"
+    r"(?P<ps_b>\d+)\s+"
+    r"(?P<budget>\d+)\s+"
+    r"(?P<alloc>\d+)\s+"
+    r"(?P<avail>\d+)\s+"
+    r"(?P<sys>\d+)\s*/\s*(?P<poe>\d+)\s*$"
+)
+
+_SKIP_PATTERN = re.compile(
+    r"^(?:"
+    r"Power\s|"  # Header lines like "Power Stack ..." or "Power       Stack ..."
+    r"Name\s|"  # Column header continuation
+    r"SW\s|"  # Per-switch section header
+    r"Totals:|"  # Totals row
+    r"-{2,}"  # Separator lines
+    r")"
+)
+
+
+def _is_skip_line(line: str) -> bool:
+    """Check if a line should be skipped (header, separator, totals, empty)."""
+    if not line:
+        return True
+    return _SKIP_PATTERN.match(line) is not None
+
+
+@register(OS.CISCO_IOSXE, "show stack-power")
+class ShowStackPowerParser(BaseParser[ShowStackPowerResult]):
+    """Parser for 'show stack-power' command.
+
+    Example output:
+        Power Stack  Stack  Stack   Total  Rsvd   Alloc  Unused Num Num
+        Name         Mode   Topolgy Pwr(W) Pwr(W) Pwr(W) Pwr(W) SW  PS
+        Powerstack-1 SP-PS  Stndaln 1100   0      575    525    1   1
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowStackPowerResult:
+        """Parse 'show stack-power' output.
+
+        Args:
+            output: Raw CLI output from 'show stack-power' command.
+
+        Returns:
+            Parsed data with power stacks keyed by stack name.
+
+        Raises:
+            ValueError: If no power stacks found in output.
+        """
+        power_stacks: dict[str, PowerStackEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if _is_skip_line(line):
+                continue
+
+            summary_match = _SUMMARY_PATTERN.match(line)
+            if summary_match:
+                _process_summary_match(summary_match, power_stacks)
+                continue
+
+            switch_match = _SWITCH_PATTERN.match(line)
+            if switch_match:
+                _process_switch_match(switch_match, power_stacks)
+
+        if not power_stacks:
+            msg = "No power stacks found in output"
+            raise ValueError(msg)
+
+        return ShowStackPowerResult(power_stacks=power_stacks)
+
+
+def _process_summary_match(
+    match: re.Match[str],
+    power_stacks: dict[str, PowerStackEntry],
+) -> None:
+    """Process a summary table row match and add to power_stacks."""
+    name = match.group("name")
+    power_stacks[name] = PowerStackEntry(
+        mode=match.group("mode"),
+        topology=match.group("topology"),
+        total_power=int(match.group("total_power")),
+        reserved_power=int(match.group("reserved_power")),
+        allocated_power=int(match.group("allocated_power")),
+        available_power=int(match.group("available_power")),
+        num_switches=int(match.group("num_switches")),
+        num_power_supplies=int(match.group("num_ps")),
+    )
+
+
+def _process_switch_match(
+    match: re.Match[str],
+    power_stacks: dict[str, PowerStackEntry],
+) -> None:
+    """Process a per-switch detail row match and add to the parent stack."""
+    name = match.group("name")
+    sw_num = match.group("sw_num")
+
+    if name not in power_stacks:
+        return
+
+    if "switches" not in power_stacks[name]:
+        power_stacks[name]["switches"] = {}
+
+    power_stacks[name]["switches"][sw_num] = SwitchPowerEntry(
+        power_supply_a=int(match.group("ps_a")),
+        power_supply_b=int(match.group("ps_b")),
+        power_budget=int(match.group("budget")),
+        allocated_power=int(match.group("alloc")),
+        available_power=int(match.group("avail")),
+        consumed_power_sys=int(match.group("sys")),
+        consumed_power_poe=int(match.group("poe")),
+    )

--- a/tests/parsers/iosxe/show_stack-power/001_two_stacks/expected.json
+++ b/tests/parsers/iosxe/show_stack-power/001_two_stacks/expected.json
@@ -1,0 +1,46 @@
+{
+    "power_stacks": {
+        "Powerstack-1": {
+            "allocated_power": 575,
+            "available_power": 525,
+            "mode": "SP-PS",
+            "num_power_supplies": 1,
+            "num_switches": 1,
+            "reserved_power": 0,
+            "switches": {
+                "1": {
+                    "allocated_power": 575,
+                    "available_power": 525,
+                    "consumed_power_poe": 0,
+                    "consumed_power_sys": 155,
+                    "power_budget": 1100,
+                    "power_supply_a": 1100,
+                    "power_supply_b": 0
+                }
+            },
+            "topology": "Stndaln",
+            "total_power": 1100
+        },
+        "Powerstack-2": {
+            "allocated_power": 575,
+            "available_power": 525,
+            "mode": "SP-PS",
+            "num_power_supplies": 1,
+            "num_switches": 1,
+            "reserved_power": 0,
+            "switches": {
+                "2": {
+                    "allocated_power": 575,
+                    "available_power": 525,
+                    "consumed_power_poe": 0,
+                    "consumed_power_sys": 155,
+                    "power_budget": 1100,
+                    "power_supply_a": 1100,
+                    "power_supply_b": 0
+                }
+            },
+            "topology": "Stndaln",
+            "total_power": 1100
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_stack-power/001_two_stacks/input.txt
+++ b/tests/parsers/iosxe/show_stack-power/001_two_stacks/input.txt
@@ -1,0 +1,13 @@
+Power       Stack   Stack    Total   Rsvd    Alloc    Sw_Avail Num Num
+Name         Mode   Topolgy  Pwr(W)  Pwr(W)  Pwr(W)   Pwr(W)   SW   PS
+-------------------- ------ ------- ------ ------ ------ ------ ----- -----
+Powerstack-1 SP-PS  Stndaln   1100    0       575     525       1 1
+Powerstack-2 SP-PS  Stndaln   1100    0       575     525       1 1
+
+   Power Stack   PS-A PS-B Power    Alloc    Poe_Avail Consumd Pwr
+SW Name          (W) (W)   Budgt(W) Power(W) Pwr(W)    Sys/PoE(W)
+-- -------------------- ----- ----- -------- -------- -------- ------------
+1 Powerstack-1   1100 0    1100       575     525      155/0
+2 Powerstack-2   1100 0    1100       575     525      155/0
+-- -------------------- ----- ----- -------- -------- -------- ------------
+Totals:                               1150    1050      310/0

--- a/tests/parsers/iosxe/show_stack-power/001_two_stacks/metadata.yaml
+++ b/tests/parsers/iosxe/show_stack-power/001_two_stacks/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two standalone power stacks with per-switch detail
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_stack-power/002_ring_topology/expected.json
+++ b/tests/parsers/iosxe/show_stack-power/002_ring_topology/expected.json
@@ -1,0 +1,52 @@
+{
+    "power_stacks": {
+        "Powerstack-1": {
+            "allocated_power": 1180,
+            "available_power": 3900,
+            "mode": "SP-PS",
+            "num_power_supplies": 5,
+            "num_switches": 4,
+            "reserved_power": 35,
+            "switches": {
+                "1": {
+                    "allocated_power": 240,
+                    "available_power": 960,
+                    "consumed_power_poe": 0,
+                    "consumed_power_sys": 129,
+                    "power_budget": 1200,
+                    "power_supply_a": 0,
+                    "power_supply_b": 0
+                },
+                "2": {
+                    "allocated_power": 240,
+                    "available_power": 990,
+                    "consumed_power_poe": 0,
+                    "consumed_power_sys": 131,
+                    "power_budget": 1230,
+                    "power_supply_a": 1100,
+                    "power_supply_b": 715
+                },
+                "3": {
+                    "allocated_power": 240,
+                    "available_power": 990,
+                    "consumed_power_poe": 0,
+                    "consumed_power_sys": 127,
+                    "power_budget": 1230,
+                    "power_supply_a": 1100,
+                    "power_supply_b": 1100
+                },
+                "4": {
+                    "allocated_power": 460,
+                    "available_power": 960,
+                    "consumed_power_poe": 0,
+                    "consumed_power_sys": 143,
+                    "power_budget": 1420,
+                    "power_supply_a": 1100,
+                    "power_supply_b": 0
+                }
+            },
+            "topology": "Ring",
+            "total_power": 5115
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_stack-power/002_ring_topology/input.txt
+++ b/tests/parsers/iosxe/show_stack-power/002_ring_topology/input.txt
@@ -1,0 +1,14 @@
+Power Stack          Stack    Stack    Total    Rsvd    Alloc    Unused  Num  Num
+Name                 Mode     Topolgy  Pwr(W)   Pwr(W)  Pwr(W)   Pwr(W)  SW   PS
+-------------------- ------   -------  ------   ------  ------   ------  ---  --
+Powerstack-1         SP-PS    Ring     5115     35      1180     3900    4    5
+
+    Power Stack          PS-A     PS-B   Power     Alloc      Avail   Consumd Pwr
+SW  Name                 (W)      (W)    Budgt(W)  Power(W)   Pwr(W)  Sys/PoE(W)
+--  -------------------- -----    -----  --------  --------   ------  -----------
+1   Powerstack-1         0        0      1200      240        960     129 /0
+2   Powerstack-1         1100     715    1230      240        990     131 /0
+3   Powerstack-1         1100     1100   1230      240        990     127 /0
+4   Powerstack-1         1100     0      1420      460        960     143 /0
+--  -------------------- -----    -----  --------  --------   ------  ----------
+Totals:                                            1180       3900    530 /0

--- a/tests/parsers/iosxe/show_stack-power/002_ring_topology/metadata.yaml
+++ b/tests/parsers/iosxe/show_stack-power/002_ring_topology/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single stack with ring topology and four switches
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_stack-power/003_summary_only/expected.json
+++ b/tests/parsers/iosxe/show_stack-power/003_summary_only/expected.json
@@ -1,0 +1,34 @@
+{
+    "power_stacks": {
+        "Powerstack-1": {
+            "allocated_power": 200,
+            "available_power": 485,
+            "mode": "SP-PS",
+            "num_power_supplies": 1,
+            "num_switches": 1,
+            "reserved_power": 30,
+            "topology": "Stndaln",
+            "total_power": 715
+        },
+        "Powerstack-11": {
+            "allocated_power": 295,
+            "available_power": 390,
+            "mode": "SP-PS",
+            "num_power_supplies": 1,
+            "num_switches": 1,
+            "reserved_power": 30,
+            "topology": "Stndaln",
+            "total_power": 715
+        },
+        "Powerstack-12": {
+            "allocated_power": 200,
+            "available_power": 485,
+            "mode": "SP-PS",
+            "num_power_supplies": 1,
+            "num_switches": 1,
+            "reserved_power": 30,
+            "topology": "Stndaln",
+            "total_power": 715
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_stack-power/003_summary_only/input.txt
+++ b/tests/parsers/iosxe/show_stack-power/003_summary_only/input.txt
@@ -1,0 +1,6 @@
+Power Stack           Stack   Stack    Total   Rsvd    Alloc   Unused  Num  Num
+Name                  Mode    Topolgy  Pwr(W)  Pwr(W)  Pwr(W)  Pwr(W)  SW   PS
+--------------------  ------  -------  ------  ------  ------  ------  ---  ---
+Powerstack-1          SP-PS   Stndaln  715     30      200     485     1    1
+Powerstack-11         SP-PS   Stndaln  715     30      295     390     1    1
+Powerstack-12         SP-PS   Stndaln  715     30      200     485     1    1

--- a/tests/parsers/iosxe/show_stack-power/003_summary_only/metadata.yaml
+++ b/tests/parsers/iosxe/show_stack-power/003_summary_only/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple standalone stacks without per-switch detail section
+platform: Catalyst 3850
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add parser for `show stack-power` command on IOS-XE (Catalyst stacks)
- Parses power stack summary (mode, topology, total/reserved/allocated/available power, switch and PS counts)
- Parses per-switch detail section (power supply A/B wattage, power budget, allocated/available power, consumed sys/PoE power)
- Handles output with and without per-switch detail sections (e.g., Catalyst 3850 summary-only output)

## Test plan

- [x] 001_two_stacks: Two standalone power stacks with per-switch detail rows
- [x] 002_ring_topology: Single stack with ring topology and four switches
- [x] 003_summary_only: Multiple standalone stacks without per-switch detail section (Catalyst 3850)
- [x] ruff check and format pass
- [x] xenon complexity check passes (max-absolute B)
- [x] pre-commit hooks all pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)