### PR TITLE
feat: add parser for 'show nve vni' on IOS-XE

### DIFF
--- a/changes/344.parser_added
+++ b/changes/344.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show nve vni' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_nve_vni.py
+++ b/src/muninn/parsers/iosxe/show_nve_vni.py
@@ -1,0 +1,123 @@
+"""Parser for 'show nve vni' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class NveVniEntry(TypedDict):
+    """Schema for a single NVE VNI entry."""
+
+    interface: str
+    vni: int
+    vni_state: str
+    mode: str
+    cfg: str
+    multicast_group: NotRequired[str]
+    vlan: NotRequired[int]
+    vrf: NotRequired[str]
+
+
+class ShowNveVniResult(TypedDict):
+    """Schema for 'show nve vni' parsed output."""
+
+    vnis: dict[str, NveVniEntry]
+
+
+def _normalize(value: str | None) -> str | None:
+    """Normalize sentinel values to None."""
+    if value is None:
+        return None
+    value = value.strip()
+    if not value or value in ("--", "N/A"):
+        return None
+    return value
+
+
+@register(OS.CISCO_IOSXE, "show nve vni")
+class ShowNveVniParser(BaseParser[ShowNveVniResult]):
+    """Parser for 'show nve vni' command.
+
+    Example output:
+        Interface  VNI        Multicast-group VNI state  Mode  VLAN  cfg vrf
+        nve1       30000      N/A             BD Down/Re L3CP  N/A   CLI red
+        nve1       20011      N/A             Up         L2CP  11    CLI N/A
+    """
+
+    # Match data rows: interface, VNI, multicast-group, VNI state, mode,
+    # VLAN/BD, cfg, vrf.
+    # VNI state can be multi-word (e.g. "BD Down/Re") so we capture up to the
+    # mode token (L2CP/L3CP/L2DP/L3DP etc).
+    _ROW_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+"
+        r"(?P<vni>\d+)\s+"
+        r"(?P<mcast>\S+)\s+"
+        r"(?P<vni_state>.+?)\s+"
+        r"(?P<mode>L[23][CD]P)\s+"
+        r"(?P<vlan>\S+)\s+"
+        r"(?P<cfg>\S+)\s+"
+        r"(?P<vrf>\S+)\s*$"
+    )
+
+    @classmethod
+    def _is_header_line(cls, line: str) -> bool:
+        """Check if a line is a table header."""
+        return "VNI" in line and "Multicast" in line
+
+    @classmethod
+    def _build_entry(cls, match: re.Match[str]) -> NveVniEntry:
+        """Build an NveVniEntry from a regex match."""
+        vlan_raw = _normalize(match.group("vlan"))
+        mcast_raw = _normalize(match.group("mcast"))
+        vrf_raw = _normalize(match.group("vrf"))
+
+        entry: NveVniEntry = {
+            "interface": match.group("interface"),
+            "vni": int(match.group("vni")),
+            "vni_state": match.group("vni_state").strip(),
+            "mode": match.group("mode"),
+            "cfg": match.group("cfg"),
+        }
+
+        if mcast_raw:
+            entry["multicast_group"] = mcast_raw
+        if vlan_raw:
+            entry["vlan"] = int(vlan_raw)
+        if vrf_raw:
+            entry["vrf"] = vrf_raw
+
+        return entry
+
+    @classmethod
+    def parse(cls, output: str) -> ShowNveVniResult:
+        """Parse 'show nve vni' output.
+
+        Args:
+            output: Raw CLI output from 'show nve vni' command.
+
+        Returns:
+            Parsed NVE VNI data keyed by VNI number.
+
+        Raises:
+            ValueError: If no VNI entries found in output.
+        """
+        vnis: dict[str, NveVniEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line or cls._is_header_line(line):
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if match:
+                vni_id = match.group("vni")
+                vnis[vni_id] = cls._build_entry(match)
+
+        if not vnis:
+            msg = "No NVE VNI entries found in output"
+            raise ValueError(msg)
+
+        return ShowNveVniResult(vnis=vnis)

--- a/tests/parsers/iosxe/show_nve_vni/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_nve_vni/001_basic/expected.json
@@ -1,0 +1,44 @@
+{
+    "vnis": {
+        "20011": {
+            "cfg": "CLI",
+            "interface": "nve1",
+            "mode": "L2CP",
+            "vlan": 11,
+            "vni": 20011,
+            "vni_state": "Up"
+        },
+        "20012": {
+            "cfg": "CLI",
+            "interface": "nve1",
+            "mode": "L2CP",
+            "vlan": 12,
+            "vni": 20012,
+            "vni_state": "Up"
+        },
+        "20013": {
+            "cfg": "CLI",
+            "interface": "nve1",
+            "mode": "L2CP",
+            "multicast_group": "229.1.1.3",
+            "vni": 20013,
+            "vni_state": "BD Down/Re"
+        },
+        "20014": {
+            "cfg": "CLI",
+            "interface": "nve1",
+            "mode": "L2CP",
+            "multicast_group": "229.1.1.4",
+            "vni": 20014,
+            "vni_state": "BD Down/Re"
+        },
+        "30000": {
+            "cfg": "CLI",
+            "interface": "nve1",
+            "mode": "L3CP",
+            "vni": 30000,
+            "vni_state": "BD Down/Re",
+            "vrf": "red"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_nve_vni/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_nve_vni/001_basic/input.txt
@@ -1,0 +1,6 @@
+Interface  VNI        Multicast-group VNI state  Mode  VLAN  cfg vrf
+nve1       30000      N/A             BD Down/Re L3CP  N/A   CLI red
+nve1       20014      229.1.1.4       BD Down/Re L2CP  N/A   CLI N/A
+nve1       20013      229.1.1.3       BD Down/Re L2CP  N/A   CLI N/A
+nve1       20012      N/A             Up         L2CP  12    CLI N/A
+nve1       20011      N/A             Up         L2CP  11    CLI N/A

--- a/tests/parsers/iosxe/show_nve_vni/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_nve_vni/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VNI entries with mixed L2CP/L3CP modes and states
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_nve_vni/002_single_entry/expected.json
+++ b/tests/parsers/iosxe/show_nve_vni/002_single_entry/expected.json
@@ -1,0 +1,12 @@
+{
+    "vnis": {
+        "20011": {
+            "cfg": "CLI",
+            "interface": "nve1",
+            "mode": "L2CP",
+            "vlan": 11,
+            "vni": 20011,
+            "vni_state": "Up"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_nve_vni/002_single_entry/input.txt
+++ b/tests/parsers/iosxe/show_nve_vni/002_single_entry/input.txt
@@ -1,0 +1,2 @@
+Interface  VNI        Multicast-group VNI state  Mode  VLAN  cfg vrf
+nve1       20011      N/A             Up         L2CP  11    CLI N/A

--- a/tests/parsers/iosxe/show_nve_vni/002_single_entry/metadata.yaml
+++ b/tests/parsers/iosxe/show_nve_vni/002_single_entry/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single VNI entry with Up state
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show nve vni` command on Cisco IOS-XE
- Parses NVE VNI table output into structured data keyed by VNI ID
- Handles multicast group, VNI state (including multi-word states like "BD Down/Re"), mode, VLAN, cfg, and VRF fields
- Includes 2 test cases: multi-entry and single-entry

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_nve_vni -v` — 2 tests pass
- [x] `uv run ruff check` and `uv run ruff format` — clean
- [x] `uv run xenon --max-absolute B` — passes
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)