### PR TITLE
feat: add parser for 'show sdwan bfd summary' on IOS-XE

### DIFF
--- a/changes/345.parser_added
+++ b/changes/345.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show sdwan bfd summary' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_sdwan_bfd_summary.py
+++ b/src/muninn/parsers/iosxe/show_sdwan_bfd_summary.py
@@ -1,0 +1,85 @@
+"""Parser for 'show sdwan bfd summary' command on IOS-XE."""
+
+import re
+from typing import TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ShowSdwanBfdSummaryResult(TypedDict):
+    """Schema for 'show sdwan bfd summary' parsed output."""
+
+    sessions_total: int
+    sessions_up: int
+    sessions_max: int
+    sessions_flap: int
+    poll_interval: int
+
+
+_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^sessions-total\s+(?P<value>\d+)$"), "sessions_total"),
+    (re.compile(r"^sessions-up\s+(?P<value>\d+)$"), "sessions_up"),
+    (re.compile(r"^sessions-max\s+(?P<value>\d+)$"), "sessions_max"),
+    (re.compile(r"^sessions-flap\s+(?P<value>\d+)$"), "sessions_flap"),
+    (re.compile(r"^poll-interval\s+(?P<value>\d+)$"), "poll_interval"),
+)
+
+_REQUIRED_FIELDS = (
+    "sessions_total",
+    "sessions_up",
+    "sessions_max",
+    "sessions_flap",
+    "poll_interval",
+)
+
+
+def _match_bfd_line(line: str, result: dict[str, int]) -> None:
+    """Try matching a line against all BFD summary field patterns."""
+    for pattern, field in _FIELD_PATTERNS:
+        match = pattern.match(line)
+        if match:
+            result[field] = int(match.group("value"))
+            return
+
+
+@register(OS.CISCO_IOSXE, "show sdwan bfd summary")
+class ShowSdwanBfdSummaryParser(BaseParser[ShowSdwanBfdSummaryResult]):
+    """Parser for 'show sdwan bfd summary' command.
+
+    Example output:
+        sessions-total         4
+        sessions-up            4
+        sessions-max           4
+        sessions-flap          4
+        poll-interval          600000
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSdwanBfdSummaryResult:
+        """Parse 'show sdwan bfd summary' output.
+
+        Args:
+            output: Raw CLI output from 'show sdwan bfd summary' command.
+
+        Returns:
+            Parsed BFD summary data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        result: dict[str, int] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            _match_bfd_line(line, result)
+
+        missing = [f for f in _REQUIRED_FIELDS if f not in result]
+        if missing:
+            msg = f"Missing BFD summary fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return cast(ShowSdwanBfdSummaryResult, result)

--- a/tests/parsers/iosxe/show_sdwan_bfd_summary/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_sdwan_bfd_summary/001_basic/expected.json
@@ -1,0 +1,7 @@
+{
+    "poll_interval": 600000,
+    "sessions_flap": 4,
+    "sessions_max": 4,
+    "sessions_total": 4,
+    "sessions_up": 4
+}

--- a/tests/parsers/iosxe/show_sdwan_bfd_summary/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_sdwan_bfd_summary/001_basic/input.txt
@@ -1,0 +1,7 @@
+
+# show bfd summary
+sessions-total         4
+sessions-up            4
+sessions-max           4
+sessions-flap          4
+poll-interval          600000

--- a/tests/parsers/iosxe/show_sdwan_bfd_summary/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_sdwan_bfd_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic BFD summary with four sessions
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_sdwan_bfd_summary/002_high_values/expected.json
+++ b/tests/parsers/iosxe/show_sdwan_bfd_summary/002_high_values/expected.json
@@ -1,0 +1,7 @@
+{
+    "poll_interval": 300000,
+    "sessions_flap": 12,
+    "sessions_max": 256,
+    "sessions_total": 128,
+    "sessions_up": 96
+}

--- a/tests/parsers/iosxe/show_sdwan_bfd_summary/002_high_values/input.txt
+++ b/tests/parsers/iosxe/show_sdwan_bfd_summary/002_high_values/input.txt
@@ -1,0 +1,5 @@
+sessions-total         128
+sessions-up            96
+sessions-max           256
+sessions-flap          12
+poll-interval          300000

--- a/tests/parsers/iosxe/show_sdwan_bfd_summary/002_high_values/metadata.yaml
+++ b/tests/parsers/iosxe/show_sdwan_bfd_summary/002_high_values/metadata.yaml
@@ -1,0 +1,3 @@
+description: BFD summary with high session counts and some sessions down
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add parser for `show sdwan bfd summary` command on Cisco IOS-XE devices
- Extracts BFD session statistics: total, up, max, flap counts and poll interval
- Includes two test cases covering basic output and high-value edge case

## Test plan

- [x] Parser tests pass (`uv run pytest tests/parsers/iosxe/show_sdwan_bfd_summary/ -v`)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity check passes
- [x] All pre-commit hooks pass

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)