### PR TITLE
feat: add parser for 'show feature' on NX-OS

### DIFF
--- a/changes/346.parser_added
+++ b/changes/346.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show feature' on NX-OS.

--- a/src/muninn/parsers/nxos/show_feature.py
+++ b/src/muninn/parsers/nxos/show_feature.py
@@ -1,0 +1,89 @@
+"""Parser for 'show feature' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class FeatureInstanceEntry(TypedDict):
+    """Schema for a single feature instance."""
+
+    state: str
+    running: NotRequired[bool]
+
+
+class FeatureEntry(TypedDict):
+    """Schema for a single feature with its instances."""
+
+    instances: dict[str, FeatureInstanceEntry]
+
+
+class ShowFeatureResult(TypedDict):
+    """Schema for 'show feature' parsed output."""
+
+    features: dict[str, FeatureEntry]
+
+
+@register(OS.CISCO_NXOS, "show feature")
+class ShowFeatureParser(BaseParser[ShowFeatureResult]):
+    """Parser for 'show feature' command.
+
+    Example output:
+        Feature Name          Instance  State
+        --------------------  --------  --------
+        bash-shell             1          enabled
+        bgp                    1          disabled
+        ospf                   1          enabled (not-running)
+    """
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<feature>\S+)\s+(?P<instance>\d+)\s+"
+        r"(?P<state>enabled|disabled)(?:\s*\((?P<qualifier>[^)]+)\))?$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowFeatureResult:
+        """Parse 'show feature' output.
+
+        Args:
+            output: Raw CLI output from 'show feature' command.
+
+        Returns:
+            Parsed feature data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        features: dict[str, FeatureEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if not match:
+                continue
+
+            feature_name = match.group("feature")
+            instance = match.group("instance")
+            state = match.group("state")
+            qualifier = match.group("qualifier")
+
+            instance_entry = FeatureInstanceEntry(state=state)
+            if qualifier == "not-running":
+                instance_entry["running"] = False
+
+            if feature_name not in features:
+                features[feature_name] = FeatureEntry(instances={})
+
+            features[feature_name]["instances"][instance] = instance_entry
+
+        if not features:
+            msg = "No feature entries found in output"
+            raise ValueError(msg)
+
+        return ShowFeatureResult(features=features)

--- a/tests/parsers/nxos/show_feature/001_basic/expected.json
+++ b/tests/parsers/nxos/show_feature/001_basic/expected.json
@@ -1,0 +1,37 @@
+{
+    "features": {
+        "bash-shell": {
+            "instances": {
+                "1": {
+                    "state": "disabled"
+                }
+            }
+        },
+        "bgp": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                }
+            }
+        },
+        "eigrp": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                },
+                "2": {
+                    "running": false,
+                    "state": "enabled"
+                },
+                "3": {
+                    "running": false,
+                    "state": "enabled"
+                },
+                "4": {
+                    "running": false,
+                    "state": "enabled"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_feature/001_basic/input.txt
+++ b/tests/parsers/nxos/show_feature/001_basic/input.txt
@@ -1,0 +1,8 @@
+Feature Name          Instance  State
+--------------------  --------  --------
+bash-shell             1          disabled
+bgp                    1          enabled
+eigrp                  1          enabled
+eigrp                  2          enabled(not-running)
+eigrp                  3          enabled(not-running)
+eigrp                  4          enabled(not-running)

--- a/tests/parsers/nxos/show_feature/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_feature/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with enabled, disabled, and enabled(not-running) features
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_feature/002_many_instances/expected.json
+++ b/tests/parsers/nxos/show_feature/002_many_instances/expected.json
@@ -1,0 +1,78 @@
+{
+    "features": {
+        "bash-shell": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                }
+            }
+        },
+        "bfd": {
+            "instances": {
+                "1": {
+                    "state": "disabled"
+                }
+            }
+        },
+        "bgp": {
+            "instances": {
+                "1": {
+                    "state": "disabled"
+                }
+            }
+        },
+        "dhcp": {
+            "instances": {
+                "1": {
+                    "state": "disabled"
+                }
+            }
+        },
+        "hsrp_engine": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                }
+            }
+        },
+        "interface-vlan": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                }
+            }
+        },
+        "lacp": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                }
+            }
+        },
+        "lldp": {
+            "instances": {
+                "1": {
+                    "state": "enabled"
+                }
+            }
+        },
+        "ospf": {
+            "instances": {
+                "1": {
+                    "running": false,
+                    "state": "enabled"
+                },
+                "2": {
+                    "state": "enabled"
+                },
+                "3": {
+                    "state": "enabled"
+                },
+                "4": {
+                    "running": false,
+                    "state": "enabled"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_feature/002_many_instances/input.txt
+++ b/tests/parsers/nxos/show_feature/002_many_instances/input.txt
@@ -1,0 +1,14 @@
+Feature Name          Instance  State
+--------------------  --------  --------
+bash-shell             1          enabled
+bfd                    1          disabled
+bgp                    1          disabled
+dhcp                   1          disabled
+hsrp_engine            1          enabled
+interface-vlan         1          enabled
+lacp                   1          enabled
+lldp                   1          enabled
+ospf                   1          enabled (not-running)
+ospf                   2          enabled
+ospf                   3          enabled
+ospf                   4          enabled (not-running)

--- a/tests/parsers/nxos/show_feature/002_many_instances/metadata.yaml
+++ b/tests/parsers/nxos/show_feature/002_many_instances/metadata.yaml
@@ -1,0 +1,3 @@
+description: Large output with many features and instances including space-separated qualifiers
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show feature` command on NX-OS that extracts feature names, instance numbers, and states (enabled/disabled) with not-running qualifier detection
- Handles both `enabled(not-running)` and `enabled (not-running)` output formats
- Includes two test cases: basic output and multi-instance features

Closes #94

## Test plan
- [x] `uv run pytest tests/parsers/nxos/show_feature/ -v` -- 2 tests passing
- [x] `uv run ruff check` -- no issues
- [x] `uv run xenon --max-absolute B` -- complexity within limits
- [x] `uv run pre-commit run --all-files` -- all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)