### PR TITLE
feat: add parser for 'show nve peers' on IOS-XE

### DIFF
--- a/changes/347.parser_added
+++ b/changes/347.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show nve peers' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_nve_peers.py
+++ b/src/muninn/parsers/iosxe/show_nve_peers.py
@@ -1,0 +1,99 @@
+"""Parser for 'show nve peers' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class NvePeerEntry(TypedDict):
+    """Schema for a single NVE peer entry."""
+
+    vni: int
+    type: str
+    peer_ip: str
+    rmac_num_rt: str
+    evni: int
+    state: str
+    flags: NotRequired[str]
+    uptime: str
+
+
+class ShowNvePeersResult(TypedDict):
+    """Schema for 'show nve peers' parsed output."""
+
+    peers: dict[str, list[NvePeerEntry]]
+
+
+@register(OS.CISCO_IOSXE, "show nve peers")
+class ShowNvePeersParser(BaseParser[ShowNvePeersResult]):
+    """Parser for 'show nve peers' command.
+
+    Example output::
+
+        nve1 3000101 L3CP 20.0.101.2 5c71...fb60 3000101 UP A/M/4 4d21h
+        nve1 200051  L2CP 20.0.101.2 3           200051  UP N/A   4d17h
+    """
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+"
+        r"(?P<vni>\d+)\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<peer_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+        r"(?P<rmac_num_rt>\S+)\s+"
+        r"(?P<evni>\d+)\s+"
+        r"(?P<state>\S+)\s+"
+        r"(?P<flags>\S+)\s+"
+        r"(?P<uptime>\S+)$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowNvePeersResult:
+        """Parse 'show nve peers' output.
+
+        Args:
+            output: Raw CLI output from 'show nve peers' command.
+
+        Returns:
+            Parsed data with peers keyed by interface name.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        peers: dict[str, list[NvePeerEntry]] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if match:
+                interface = match.group("interface")
+                flags = match.group("flags")
+
+                entry: NvePeerEntry = {
+                    "vni": int(match.group("vni")),
+                    "type": match.group("type"),
+                    "peer_ip": match.group("peer_ip"),
+                    "rmac_num_rt": match.group("rmac_num_rt"),
+                    "evni": int(match.group("evni")),
+                    "state": match.group("state"),
+                    "uptime": match.group("uptime"),
+                }
+
+                if flags != "N/A":
+                    entry["flags"] = flags
+
+                if interface not in peers:
+                    peers[interface] = []
+
+                peers[interface].append(entry)
+
+        if not peers:
+            msg = "No NVE peers found in output"
+            raise ValueError(msg)
+
+        return ShowNvePeersResult(peers=peers)

--- a/src/muninn/parsers/iosxe/show_nve_peers.py
+++ b/src/muninn/parsers/iosxe/show_nve_peers.py
@@ -8,12 +8,10 @@ from muninn.parser import BaseParser
 from muninn.registry import register
 
 
-class NvePeerEntry(TypedDict):
-    """Schema for a single NVE peer entry."""
+class NvePeerVniEntry(TypedDict):
+    """Schema for a single NVE peer VNI entry."""
 
-    vni: int
     type: str
-    peer_ip: str
     rmac_num_rt: str
     evni: int
     state: str
@@ -24,7 +22,7 @@ class NvePeerEntry(TypedDict):
 class ShowNvePeersResult(TypedDict):
     """Schema for 'show nve peers' parsed output."""
 
-    peers: dict[str, list[NvePeerEntry]]
+    peers: dict[str, dict[str, dict[str, NvePeerVniEntry]]]
 
 
 @register(OS.CISCO_IOSXE, "show nve peers")
@@ -57,12 +55,12 @@ class ShowNvePeersParser(BaseParser[ShowNvePeersResult]):
             output: Raw CLI output from 'show nve peers' command.
 
         Returns:
-            Parsed data with peers keyed by interface name.
+            Parsed data keyed by interface name, peer IP, and VNI.
 
         Raises:
             ValueError: If the output cannot be parsed.
         """
-        peers: dict[str, list[NvePeerEntry]] = {}
+        peers: dict[str, dict[str, dict[str, NvePeerVniEntry]]] = {}
 
         for line in output.splitlines():
             line = line.strip()
@@ -74,10 +72,11 @@ class ShowNvePeersParser(BaseParser[ShowNvePeersResult]):
                 interface = match.group("interface")
                 flags = match.group("flags")
 
-                entry: NvePeerEntry = {
-                    "vni": int(match.group("vni")),
+                peer_ip = match.group("peer_ip")
+                vni = match.group("vni")
+
+                entry: NvePeerVniEntry = {
                     "type": match.group("type"),
-                    "peer_ip": match.group("peer_ip"),
                     "rmac_num_rt": match.group("rmac_num_rt"),
                     "evni": int(match.group("evni")),
                     "state": match.group("state"),
@@ -88,9 +87,11 @@ class ShowNvePeersParser(BaseParser[ShowNvePeersResult]):
                     entry["flags"] = flags
 
                 if interface not in peers:
-                    peers[interface] = []
+                    peers[interface] = {}
+                if peer_ip not in peers[interface]:
+                    peers[interface][peer_ip] = {}
 
-                peers[interface].append(entry)
+                peers[interface][peer_ip][vni] = entry
 
         if not peers:
             msg = "No NVE peers found in output"

--- a/tests/parsers/iosxe/show_nve_peers/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_nve_peers/001_basic/expected.json
@@ -1,0 +1,66 @@
+{
+    "peers": {
+        "nve1": [
+            {
+                "evni": 1033,
+                "flags": "A/M",
+                "peer_ip": "192.168.111.81",
+                "rmac_num_rt": "0200.c0a8.433c",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "6d22h",
+                "vni": 1033
+            },
+            {
+                "evni": 1033,
+                "flags": "A/M",
+                "peer_ip": "192.168.111.48",
+                "rmac_num_rt": "cc7f.76a5.3c56",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "6d22h",
+                "vni": 1033
+            },
+            {
+                "evni": 1031,
+                "flags": "A/M",
+                "peer_ip": "192.168.111.81",
+                "rmac_num_rt": "0200.c0a8.433c",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "6d22h",
+                "vni": 1031
+            },
+            {
+                "evni": 1031,
+                "flags": "A/M",
+                "peer_ip": "192.168.111.48",
+                "rmac_num_rt": "cc7f.76a5.3c56",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "6d22h",
+                "vni": 1031
+            },
+            {
+                "evni": 1032,
+                "flags": "A/M",
+                "peer_ip": "192.168.111.48",
+                "rmac_num_rt": "cc7f.76a5.3c56",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "6d22h",
+                "vni": 1032
+            },
+            {
+                "evni": 1036,
+                "flags": "A/M",
+                "peer_ip": "192.168.111.48",
+                "rmac_num_rt": "cc7f.76a5.3c56",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "6d22h",
+                "vni": 1036
+            }
+        ]
+    }
+}

--- a/tests/parsers/iosxe/show_nve_peers/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_nve_peers/001_basic/expected.json
@@ -1,66 +1,58 @@
 {
     "peers": {
-        "nve1": [
-            {
-                "evni": 1033,
-                "flags": "A/M",
-                "peer_ip": "192.168.111.81",
-                "rmac_num_rt": "0200.c0a8.433c",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "6d22h",
-                "vni": 1033
+        "nve1": {
+            "192.168.111.48": {
+                "1031": {
+                    "evni": 1031,
+                    "flags": "A/M",
+                    "rmac_num_rt": "cc7f.76a5.3c56",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "6d22h"
+                },
+                "1032": {
+                    "evni": 1032,
+                    "flags": "A/M",
+                    "rmac_num_rt": "cc7f.76a5.3c56",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "6d22h"
+                },
+                "1033": {
+                    "evni": 1033,
+                    "flags": "A/M",
+                    "rmac_num_rt": "cc7f.76a5.3c56",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "6d22h"
+                },
+                "1036": {
+                    "evni": 1036,
+                    "flags": "A/M",
+                    "rmac_num_rt": "cc7f.76a5.3c56",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "6d22h"
+                }
             },
-            {
-                "evni": 1033,
-                "flags": "A/M",
-                "peer_ip": "192.168.111.48",
-                "rmac_num_rt": "cc7f.76a5.3c56",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "6d22h",
-                "vni": 1033
-            },
-            {
-                "evni": 1031,
-                "flags": "A/M",
-                "peer_ip": "192.168.111.81",
-                "rmac_num_rt": "0200.c0a8.433c",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "6d22h",
-                "vni": 1031
-            },
-            {
-                "evni": 1031,
-                "flags": "A/M",
-                "peer_ip": "192.168.111.48",
-                "rmac_num_rt": "cc7f.76a5.3c56",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "6d22h",
-                "vni": 1031
-            },
-            {
-                "evni": 1032,
-                "flags": "A/M",
-                "peer_ip": "192.168.111.48",
-                "rmac_num_rt": "cc7f.76a5.3c56",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "6d22h",
-                "vni": 1032
-            },
-            {
-                "evni": 1036,
-                "flags": "A/M",
-                "peer_ip": "192.168.111.48",
-                "rmac_num_rt": "cc7f.76a5.3c56",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "6d22h",
-                "vni": 1036
+            "192.168.111.81": {
+                "1031": {
+                    "evni": 1031,
+                    "flags": "A/M",
+                    "rmac_num_rt": "0200.c0a8.433c",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "6d22h"
+                },
+                "1033": {
+                    "evni": 1033,
+                    "flags": "A/M",
+                    "rmac_num_rt": "0200.c0a8.433c",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "6d22h"
+                }
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/iosxe/show_nve_peers/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_nve_peers/001_basic/input.txt
@@ -1,0 +1,7 @@
+Interface  VNI      Type Peer-IP          RMAC/Num_RTs   eVNI     state flags UP time
+nve1       1033 L3CP 192.168.111.81   0200.c0a8.433c 1033   UP   A/M 6d22h
+nve1       1033 L3CP 192.168.111.48   cc7f.76a5.3c56 1033   UP   A/M 6d22h
+nve1       1031 L3CP 192.168.111.81   0200.c0a8.433c 1031   UP   A/M 6d22h
+nve1       1031 L3CP 192.168.111.48   cc7f.76a5.3c56 1031   UP   A/M 6d22h
+nve1       1032 L3CP 192.168.111.48   cc7f.76a5.3c56 1032   UP   A/M 6d22h
+nve1       1036 L3CP 192.168.111.48   cc7f.76a5.3c56 1036   UP   A/M 6d22h

--- a/tests/parsers/iosxe/show_nve_peers/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_nve_peers/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple NVE peers with L3CP type across multiple VNIs
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_nve_peers/002_single_peer/expected.json
+++ b/tests/parsers/iosxe/show_nve_peers/002_single_peer/expected.json
@@ -1,0 +1,25 @@
+{
+    "peers": {
+        "nve1": [
+            {
+                "evni": 3000101,
+                "flags": "A/M/4",
+                "peer_ip": "20.0.101.2",
+                "rmac_num_rt": "5c71.0dfe.fb60",
+                "state": "UP",
+                "type": "L3CP",
+                "uptime": "4d21h",
+                "vni": 3000101
+            },
+            {
+                "evni": 200051,
+                "peer_ip": "20.0.101.2",
+                "rmac_num_rt": "3",
+                "state": "UP",
+                "type": "L2CP",
+                "uptime": "4d17h",
+                "vni": 200051
+            }
+        ]
+    }
+}

--- a/tests/parsers/iosxe/show_nve_peers/002_single_peer/expected.json
+++ b/tests/parsers/iosxe/show_nve_peers/002_single_peer/expected.json
@@ -1,25 +1,23 @@
 {
     "peers": {
-        "nve1": [
-            {
-                "evni": 3000101,
-                "flags": "A/M/4",
-                "peer_ip": "20.0.101.2",
-                "rmac_num_rt": "5c71.0dfe.fb60",
-                "state": "UP",
-                "type": "L3CP",
-                "uptime": "4d21h",
-                "vni": 3000101
-            },
-            {
-                "evni": 200051,
-                "peer_ip": "20.0.101.2",
-                "rmac_num_rt": "3",
-                "state": "UP",
-                "type": "L2CP",
-                "uptime": "4d17h",
-                "vni": 200051
+        "nve1": {
+            "20.0.101.2": {
+                "200051": {
+                    "evni": 200051,
+                    "rmac_num_rt": "3",
+                    "state": "UP",
+                    "type": "L2CP",
+                    "uptime": "4d17h"
+                },
+                "3000101": {
+                    "evni": 3000101,
+                    "flags": "A/M/4",
+                    "rmac_num_rt": "5c71.0dfe.fb60",
+                    "state": "UP",
+                    "type": "L3CP",
+                    "uptime": "4d21h"
+                }
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/iosxe/show_nve_peers/002_single_peer/input.txt
+++ b/tests/parsers/iosxe/show_nve_peers/002_single_peer/input.txt
@@ -1,0 +1,3 @@
+Interface  VNI      Type Peer-IP          RMAC/Num_RTs   eVNI     state flags UP time
+nve1       3000101  L3CP 20.0.101.2       5c71.0dfe.fb60 3000101    UP  A/M/4 4d21h
+nve1       200051   L2CP 20.0.101.2       3              200051     UP   N/A  4d17h

--- a/tests/parsers/iosxe/show_nve_peers/002_single_peer/metadata.yaml
+++ b/tests/parsers/iosxe/show_nve_peers/002_single_peer/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed L2CP and L3CP peers with N/A flags omitted
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show nve peers` command on Cisco IOS-XE
- Parses NVE VXLAN peer table including VNI, type (L2CP/L3CP), peer IP, RMAC/Num_RTs, eVNI, state, flags, and uptime
- Includes two test cases: multiple peers with L3CP type, and mixed L2CP/L3CP with optional flags handling

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_nve_peers -v` — 2 tests pass
- [x] `uv run ruff check` — no lint issues
- [x] `uv run xenon --max-absolute B` — complexity within bounds
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)