### PR TITLE
feat: add parser for 'show arp' on IOS

### DIFF
--- a/changes/349.parser_added
+++ b/changes/349.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show arp' on IOS.

--- a/src/muninn/parsers/ios/show_arp.py
+++ b/src/muninn/parsers/ios/show_arp.py
@@ -1,0 +1,91 @@
+"""Parser for 'show arp' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ArpEntry(TypedDict):
+    """Schema for a single ARP entry."""
+
+    hardware_addr: str
+    type: str
+    age: NotRequired[int]
+    interface: NotRequired[str]
+
+
+class ShowArpResult(TypedDict):
+    """Schema for 'show arp' parsed output."""
+
+    arp_entries: dict[str, ArpEntry]
+
+
+@register(OS.CISCO_IOS, "show arp")
+class ShowArpParser(BaseParser[ShowArpResult]):
+    """Parser for 'show arp' command.
+
+    Example output:
+        Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+        Internet  10.1.18.122             -   58bf.eaff.e5b6  ARPA   GigabitEthernet0/0
+        Internet  10.1.18.1              45   0012.7fff.04d7  ARPA   GigabitEthernet0/0
+    """
+
+    _ARP_ENTRY_PATTERN = re.compile(
+        r"^Internet\s+"
+        r"(?P<address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+        r"(?P<age>-|\d+)\s+"
+        r"(?P<hardware_addr>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})\s+"
+        r"(?P<type>\S+)"
+        r"(?:\s+(?P<interface>\S+))?",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowArpResult:
+        """Parse 'show arp' output.
+
+        Args:
+            output: Raw CLI output from 'show arp' command.
+
+        Returns:
+            Parsed ARP entries keyed by IP address.
+
+        Raises:
+            ValueError: If no ARP entries found.
+        """
+        arp_entries: dict[str, ArpEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = cls._ARP_ENTRY_PATTERN.match(line)
+            if match:
+                address = match.group("address")
+                age_str = match.group("age")
+                hardware_addr = match.group("hardware_addr").lower()
+                entry_type = match.group("type")
+                interface = match.group("interface")
+
+                entry: ArpEntry = {
+                    "hardware_addr": hardware_addr,
+                    "type": entry_type,
+                }
+
+                if age_str != "-":
+                    entry["age"] = int(age_str)
+
+                if interface:
+                    entry["interface"] = interface
+
+                arp_entries[address] = entry
+
+        if not arp_entries:
+            msg = "No ARP entries found in output"
+            raise ValueError(msg)
+
+        return ShowArpResult(arp_entries=arp_entries)

--- a/tests/parsers/ios/show_arp/001_basic/expected.json
+++ b/tests/parsers/ios/show_arp/001_basic/expected.json
@@ -1,0 +1,27 @@
+{
+    "arp_entries": {
+        "10.1.18.1": {
+            "age": 45,
+            "hardware_addr": "0012.7fff.04d7",
+            "interface": "GigabitEthernet0/0",
+            "type": "ARPA"
+        },
+        "10.1.18.122": {
+            "hardware_addr": "58bf.eaff.e5b6",
+            "interface": "GigabitEthernet0/0",
+            "type": "ARPA"
+        },
+        "10.1.18.13": {
+            "age": 142,
+            "hardware_addr": "00b0.c2ff.5932",
+            "interface": "GigabitEthernet0/0",
+            "type": "ARPA"
+        },
+        "10.1.18.254": {
+            "age": 247,
+            "hardware_addr": "5cf3.fcff.d09b",
+            "interface": "GigabitEthernet0/0",
+            "type": "ARPA"
+        }
+    }
+}

--- a/tests/parsers/ios/show_arp/001_basic/input.txt
+++ b/tests/parsers/ios/show_arp/001_basic/input.txt
@@ -1,0 +1,5 @@
+Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+Internet  10.1.18.122             -   58bf.eaff.e5b6  ARPA   GigabitEthernet0/0
+Internet  10.1.18.1              45   0012.7fff.04d7  ARPA   GigabitEthernet0/0
+Internet  10.1.18.13            142   00b0.c2ff.5932  ARPA   GigabitEthernet0/0
+Internet  10.1.18.254           247   5cf3.fcff.d09b  ARPA   GigabitEthernet0/0

--- a/tests/parsers/ios/show_arp/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_arp/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic ARP table with multiple entries across different interfaces
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_arp/002_incomplete_entry/expected.json
+++ b/tests/parsers/ios/show_arp/002_incomplete_entry/expected.json
@@ -1,0 +1,26 @@
+{
+    "arp_entries": {
+        "1.2.3.4": {
+            "age": 0,
+            "hardware_addr": "c4ad.3425.b7be",
+            "interface": "FastEthernet4",
+            "type": "ARPA"
+        },
+        "1.2.3.5": {
+            "hardware_addr": "c4f7.d564.b71a",
+            "interface": "FastEthernet4",
+            "type": "ARPA"
+        },
+        "10.100.88.1": {
+            "hardware_addr": "c4f7.d564.b716",
+            "interface": "Vlan10",
+            "type": "ARPA"
+        },
+        "10.152.1.229": {
+            "age": 0,
+            "hardware_addr": "488f.5a5a.87ea",
+            "interface": "Vlan1",
+            "type": "ARPA"
+        }
+    }
+}

--- a/tests/parsers/ios/show_arp/002_incomplete_entry/input.txt
+++ b/tests/parsers/ios/show_arp/002_incomplete_entry/input.txt
@@ -1,0 +1,6 @@
+Protocol  Address          Age (min)  Hardware Addr   Type   Interface
+Internet  10.100.88.1             -   c4f7.d564.b716  ARPA   Vlan10
+Internet  10.100.88.199           0   Incomplete      ARPA
+Internet  10.152.1.229            0   488f.5a5a.87ea  ARPA   Vlan1
+Internet  1.2.3.4                 0   c4ad.3425.b7be  ARPA   FastEthernet4
+Internet  1.2.3.5                 -   c4f7.d564.b71a  ARPA   FastEthernet4

--- a/tests/parsers/ios/show_arp/002_incomplete_entry/metadata.yaml
+++ b/tests/parsers/ios/show_arp/002_incomplete_entry/metadata.yaml
@@ -1,0 +1,3 @@
+description: ARP table with incomplete entry that has no MAC address or interface
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add a new parser for the `show arp` command on Cisco IOS
- Extracts ARP table entries keyed by IP address with hardware address, type, age, and interface fields
- Gracefully skips incomplete ARP entries (e.g., entries with "Incomplete" instead of a MAC address)

## Test plan

- [x] 001_basic: Standard ARP table with multiple entries on the same interface
- [x] 002_incomplete_entry: ARP table containing an incomplete entry that should be skipped
- [x] All quality checks pass (ruff, xenon, pre-commit)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)