### PR TITLE
feat: add parser for 'show etherchannel summary' on IOS

### DIFF
--- a/changes/351.parser_added
+++ b/changes/351.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show etherchannel summary' on IOS.

--- a/src/muninn/parsers/ios/show_etherchannel_summary.py
+++ b/src/muninn/parsers/ios/show_etherchannel_summary.py
@@ -1,7 +1,7 @@
 """Parser for 'show etherchannel summary' command on IOS."""
 
 import re
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -74,7 +74,7 @@ def _parse_port_channel_status(raw: str) -> tuple[str, str, str]:
     if not match:
         msg = f"Cannot parse port-channel status: {raw}"
         raise ValueError(msg)
-    name = match.group(1)
+    name = canonical_interface_name(match.group(1))
     flags = match.group(2)
     layer = _LAYER_MAP.get(flags[0], flags[0])
     status = _STATUS_MAP.get(flags[1], flags[1])
@@ -140,11 +140,8 @@ def _add_continuation_ports(
 def _validate_required_fields(
     num_channel_groups: int | None,
     num_aggregators: int | None,
-) -> tuple[int, int]:
+) -> None:
     """Validate that required summary fields were found.
-
-    Returns:
-        Tuple of (num_channel_groups, num_aggregators).
 
     Raises:
         ValueError: If required fields are missing.
@@ -157,7 +154,6 @@ def _validate_required_fields(
     if missing:
         msg = f"Missing required fields: {', '.join(missing)}"
         raise ValueError(msg)
-    return num_channel_groups, num_aggregators
 
 
 @register(OS.CISCO_IOS, "show etherchannel summary")
@@ -213,12 +209,10 @@ class ShowEtherchannelSummaryParser(BaseParser[ShowEtherchannelSummaryResult]):
             if current_group is not None and _CONTINUATION_PORT_PATTERN.match(line):
                 _add_continuation_ports(port_channels, current_group, stripped)
 
-        groups, aggregators = _validate_required_fields(
-            num_channel_groups, num_aggregators
-        )
+        _validate_required_fields(num_channel_groups, num_aggregators)
 
         return ShowEtherchannelSummaryResult(
-            num_channel_groups=groups,
-            num_aggregators=aggregators,
+            num_channel_groups=cast(int, num_channel_groups),
+            num_aggregators=cast(int, num_aggregators),
             port_channels=port_channels,
         )

--- a/src/muninn/parsers/ios/show_etherchannel_summary.py
+++ b/src/muninn/parsers/ios/show_etherchannel_summary.py
@@ -1,0 +1,224 @@
+"""Parser for 'show etherchannel summary' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class MemberPort(TypedDict):
+    """Schema for a single port-channel member port."""
+
+    status: str
+    interface: str
+
+
+class PortChannelEntry(TypedDict):
+    """Schema for a single port-channel group entry."""
+
+    port_channel: str
+    port_channel_status: str
+    layer: str
+    protocol: NotRequired[str]
+    members: NotRequired[dict[str, MemberPort]]
+
+
+class ShowEtherchannelSummaryResult(TypedDict):
+    """Schema for 'show etherchannel summary' parsed output."""
+
+    num_channel_groups: int
+    num_aggregators: int
+    port_channels: dict[str, PortChannelEntry]
+
+
+_STATUS_MAP: dict[str, str] = {
+    "D": "down",
+    "U": "in-use",
+}
+
+_LAYER_MAP: dict[str, str] = {
+    "R": "Layer3",
+    "S": "Layer2",
+}
+
+_GROUP_LINE_PATTERN = re.compile(
+    r"^(?P<group>\d+)\s+"
+    r"(?P<po_status>\S+\([A-Za-z]+\))\s+"
+    r"(?P<protocol>\S+)"
+    r"(?P<ports>.*)",
+)
+
+_NUM_CHANNEL_GROUPS_PATTERN = re.compile(
+    r"Number of channel-groups in use:\s*(?P<value>\d+)",
+)
+
+_NUM_AGGREGATORS_PATTERN = re.compile(
+    r"Number of aggregators:\s*(?P<value>\d+)",
+)
+
+_CONTINUATION_PORT_PATTERN = re.compile(
+    r"^\s+\S+\([^)]+\)",
+)
+
+
+def _parse_port_channel_status(raw: str) -> tuple[str, str, str]:
+    """Extract port-channel name, layer, and status from e.g. 'Po1(SU)'.
+
+    Returns:
+        Tuple of (port_channel_name, layer, status).
+    """
+    match = re.match(r"(\S+?)\(([A-Za-z]+)\)", raw)
+    if not match:
+        msg = f"Cannot parse port-channel status: {raw}"
+        raise ValueError(msg)
+    name = match.group(1)
+    flags = match.group(2)
+    layer = _LAYER_MAP.get(flags[0], flags[0])
+    status = _STATUS_MAP.get(flags[1], flags[1])
+    return name, layer, status
+
+
+def _parse_member_ports(text: str) -> dict[str, MemberPort]:
+    """Parse member port entries like 'Gi2(bndl) Gi3(P)' into a dict."""
+    members: dict[str, MemberPort] = {}
+    for match in re.finditer(r"(\S+?)\(([^)]+)\)", text):
+        raw_iface = match.group(1)
+        port_status = match.group(2)
+        iface = canonical_interface_name(raw_iface)
+        members[iface] = MemberPort(
+            interface=iface,
+            status=port_status,
+        )
+    return members
+
+
+def _build_group_entry(match: re.Match[str]) -> tuple[str, PortChannelEntry]:
+    """Build a PortChannelEntry from a group line regex match.
+
+    Returns:
+        Tuple of (group_id, entry).
+    """
+    group = match.group("group")
+    po_name, layer, status = _parse_port_channel_status(
+        match.group("po_status"),
+    )
+    protocol = match.group("protocol")
+    ports_text = match.group("ports")
+
+    entry = PortChannelEntry(
+        port_channel=po_name,
+        port_channel_status=status,
+        layer=layer,
+    )
+
+    if protocol != "-":
+        entry["protocol"] = protocol
+
+    members = _parse_member_ports(ports_text)
+    if members:
+        entry["members"] = members
+
+    return group, entry
+
+
+def _add_continuation_ports(
+    port_channels: dict[str, PortChannelEntry],
+    group: str,
+    line: str,
+) -> None:
+    """Add member ports from a continuation line to an existing group."""
+    members = _parse_member_ports(line)
+    if members:
+        existing = port_channels[group].get("members", {})
+        existing.update(members)
+        port_channels[group]["members"] = existing
+
+
+def _validate_required_fields(
+    num_channel_groups: int | None,
+    num_aggregators: int | None,
+) -> tuple[int, int]:
+    """Validate that required summary fields were found.
+
+    Returns:
+        Tuple of (num_channel_groups, num_aggregators).
+
+    Raises:
+        ValueError: If required fields are missing.
+    """
+    missing = []
+    if num_channel_groups is None:
+        missing.append("num_channel_groups")
+    if num_aggregators is None:
+        missing.append("num_aggregators")
+    if missing:
+        msg = f"Missing required fields: {', '.join(missing)}"
+        raise ValueError(msg)
+    return num_channel_groups, num_aggregators
+
+
+@register(OS.CISCO_IOS, "show etherchannel summary")
+class ShowEtherchannelSummaryParser(BaseParser[ShowEtherchannelSummaryResult]):
+    """Parser for 'show etherchannel summary' command.
+
+    Example output:
+        Group  Port-channel  Protocol    Ports
+        1      Po1(SU)         LACP      Te6/4(P)       Te3/5(P)
+        3      Po3(SU)         LACP      Te4/2(P)       Te2/2(P)
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEtherchannelSummaryResult:
+        """Parse 'show etherchannel summary' output.
+
+        Args:
+            output: Raw CLI output from 'show etherchannel summary' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        num_channel_groups: int | None = None
+        num_aggregators: int | None = None
+        port_channels: dict[str, PortChannelEntry] = {}
+        current_group: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = _NUM_CHANNEL_GROUPS_PATTERN.search(stripped)
+            if match:
+                num_channel_groups = int(match.group("value"))
+                continue
+
+            match = _NUM_AGGREGATORS_PATTERN.search(stripped)
+            if match:
+                num_aggregators = int(match.group("value"))
+                continue
+
+            match = _GROUP_LINE_PATTERN.match(stripped)
+            if match:
+                group, entry = _build_group_entry(match)
+                port_channels[group] = entry
+                current_group = group
+                continue
+
+            if current_group is not None and _CONTINUATION_PORT_PATTERN.match(line):
+                _add_continuation_ports(port_channels, current_group, stripped)
+
+        groups, aggregators = _validate_required_fields(
+            num_channel_groups, num_aggregators
+        )
+
+        return ShowEtherchannelSummaryResult(
+            num_channel_groups=groups,
+            num_aggregators=aggregators,
+            port_channels=port_channels,
+        )

--- a/tests/parsers/ios/show_etherchannel_summary/001_basic/expected.json
+++ b/tests/parsers/ios/show_etherchannel_summary/001_basic/expected.json
@@ -22,7 +22,7 @@
                     "status": "P"
                 }
             },
-            "port_channel": "Po1",
+            "port_channel": "Port-channel1",
             "port_channel_status": "in-use",
             "protocol": "LACP"
         },
@@ -34,7 +34,7 @@
                     "status": "P"
                 }
             },
-            "port_channel": "Po13",
+            "port_channel": "Port-channel13",
             "port_channel_status": "in-use",
             "protocol": "LACP"
         },
@@ -46,7 +46,7 @@
                     "status": "P"
                 }
             },
-            "port_channel": "Po14",
+            "port_channel": "Port-channel14",
             "port_channel_status": "in-use",
             "protocol": "LACP"
         },
@@ -62,7 +62,7 @@
                     "status": "P"
                 }
             },
-            "port_channel": "Po3",
+            "port_channel": "Port-channel3",
             "port_channel_status": "in-use",
             "protocol": "LACP"
         },
@@ -78,7 +78,7 @@
                     "status": "P"
                 }
             },
-            "port_channel": "Po51",
+            "port_channel": "Port-channel51",
             "port_channel_status": "in-use",
             "protocol": "LACP"
         },
@@ -94,7 +94,7 @@
                     "status": "P"
                 }
             },
-            "port_channel": "Po7",
+            "port_channel": "Port-channel7",
             "port_channel_status": "in-use",
             "protocol": "LACP"
         }

--- a/tests/parsers/ios/show_etherchannel_summary/001_basic/expected.json
+++ b/tests/parsers/ios/show_etherchannel_summary/001_basic/expected.json
@@ -1,0 +1,102 @@
+{
+    "num_aggregators": 6,
+    "num_channel_groups": 6,
+    "port_channels": {
+        "1": {
+            "layer": "Layer2",
+            "members": {
+                "TenGigabitEthernet3/5": {
+                    "interface": "TenGigabitEthernet3/5",
+                    "status": "P"
+                },
+                "TenGigabitEthernet5/5": {
+                    "interface": "TenGigabitEthernet5/5",
+                    "status": "P"
+                },
+                "TenGigabitEthernet6/4": {
+                    "interface": "TenGigabitEthernet6/4",
+                    "status": "P"
+                },
+                "TenGigabitEthernet9/4": {
+                    "interface": "TenGigabitEthernet9/4",
+                    "status": "P"
+                }
+            },
+            "port_channel": "Po1",
+            "port_channel_status": "in-use",
+            "protocol": "LACP"
+        },
+        "13": {
+            "layer": "Layer2",
+            "members": {
+                "TenGigabitEthernet2/8": {
+                    "interface": "TenGigabitEthernet2/8",
+                    "status": "P"
+                }
+            },
+            "port_channel": "Po13",
+            "port_channel_status": "in-use",
+            "protocol": "LACP"
+        },
+        "14": {
+            "layer": "Layer2",
+            "members": {
+                "TenGigabitEthernet1/8": {
+                    "interface": "TenGigabitEthernet1/8",
+                    "status": "P"
+                }
+            },
+            "port_channel": "Po14",
+            "port_channel_status": "in-use",
+            "protocol": "LACP"
+        },
+        "3": {
+            "layer": "Layer2",
+            "members": {
+                "TenGigabitEthernet2/2": {
+                    "interface": "TenGigabitEthernet2/2",
+                    "status": "P"
+                },
+                "TenGigabitEthernet4/2": {
+                    "interface": "TenGigabitEthernet4/2",
+                    "status": "P"
+                }
+            },
+            "port_channel": "Po3",
+            "port_channel_status": "in-use",
+            "protocol": "LACP"
+        },
+        "51": {
+            "layer": "Layer2",
+            "members": {
+                "TenGigabitEthernet2/10": {
+                    "interface": "TenGigabitEthernet2/10",
+                    "status": "P"
+                },
+                "TenGigabitEthernet4/10": {
+                    "interface": "TenGigabitEthernet4/10",
+                    "status": "P"
+                }
+            },
+            "port_channel": "Po51",
+            "port_channel_status": "in-use",
+            "protocol": "LACP"
+        },
+        "7": {
+            "layer": "Layer2",
+            "members": {
+                "TenGigabitEthernet1/3": {
+                    "interface": "TenGigabitEthernet1/3",
+                    "status": "P"
+                },
+                "TenGigabitEthernet3/3": {
+                    "interface": "TenGigabitEthernet3/3",
+                    "status": "P"
+                }
+            },
+            "port_channel": "Po7",
+            "port_channel_status": "in-use",
+            "protocol": "LACP"
+        }
+    }
+}

--- a/tests/parsers/ios/show_etherchannel_summary/001_basic/input.txt
+++ b/tests/parsers/ios/show_etherchannel_summary/001_basic/input.txt
@@ -1,0 +1,25 @@
+Flags:  D - down        P - bundled in port-channel
+        I - stand-alone s - suspended
+        H - Hot-standby (LACP only)
+        R - Layer3      S - Layer2
+        U - in use      N - not in use, no aggregation
+        f - failed to allocate aggregator
+
+        M - not in use, no aggregation due to minimum links not met
+        m - not in use, port not aggregated due to minimum links not met
+        u - unsuitable for bundling
+        d - default port
+
+        w - waiting to be aggregated
+Number of channel-groups in use: 6
+Number of aggregators:           6
+
+Group  Port-channel  Protocol    Ports
+------+-------------+-----------+-----------------------------------------------
+1      Po1(SU)         LACP      Te6/4(P)       Te3/5(P)       Te9/4(P)
+                                 Te5/5(P)
+3      Po3(SU)         LACP      Te4/2(P)       Te2/2(P)
+7      Po7(SU)         LACP      Te3/3(P)       Te1/3(P)
+13     Po13(SU)        LACP      Te2/8(P)
+14     Po14(SU)        LACP      Te1/8(P)
+51     Po51(SU)        LACP      Te2/10(P)      Te4/10(P)

--- a/tests/parsers/ios/show_etherchannel_summary/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_etherchannel_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple port-channels with LACP, including multi-line member ports
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_etherchannel_summary/002_no_members/expected.json
+++ b/tests/parsers/ios/show_etherchannel_summary/002_no_members/expected.json
@@ -1,0 +1,11 @@
+{
+    "num_aggregators": 1,
+    "num_channel_groups": 1,
+    "port_channels": {
+        "2": {
+            "layer": "Layer3",
+            "port_channel": "Po2",
+            "port_channel_status": "in-use"
+        }
+    }
+}

--- a/tests/parsers/ios/show_etherchannel_summary/002_no_members/expected.json
+++ b/tests/parsers/ios/show_etherchannel_summary/002_no_members/expected.json
@@ -4,7 +4,7 @@
     "port_channels": {
         "2": {
             "layer": "Layer3",
-            "port_channel": "Po2",
+            "port_channel": "Port-channel2",
             "port_channel_status": "in-use"
         }
     }

--- a/tests/parsers/ios/show_etherchannel_summary/002_no_members/input.txt
+++ b/tests/parsers/ios/show_etherchannel_summary/002_no_members/input.txt
@@ -1,0 +1,19 @@
+csr1000v-1#show etherchannel summary
+Flags:  D - down        P/bndl - bundled in port-channel
+        I - stand-alone s/susp - suspended
+        H - Hot-standby (LACP only)
+        R - Layer3      S - Layer2
+        U - in use      f - failed to allocate aggregator
+
+        M - not in use, minimum links not met
+        u - unsuitable for bundling
+        w - waiting to be aggregated
+        d - default port
+
+
+Number of channel-groups in use: 1
+Number of aggregators:           1
+
+Group  Port-channel  Protocol    Ports
+------+-------------+-----------+-----------------------------------------------
+2	Po2(RU)		-

--- a/tests/parsers/ios/show_etherchannel_summary/002_no_members/metadata.yaml
+++ b/tests/parsers/ios/show_etherchannel_summary/002_no_members/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single port-channel with no member ports and no protocol
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add new parser for `show etherchannel summary` on Cisco IOS
- Extracts port-channel groups with protocol, layer, status, and member ports
- Handles multi-line continuation ports and groups with no members
- Includes interface name canonicalization via `canonical_interface_name`

## Test plan

- [x] Test case 001_basic: Multiple LACP port-channels with multi-line member ports
- [x] Test case 002_no_members: Single port-channel with no protocol and no member ports
- [x] All ruff lint/format checks pass
- [x] Xenon complexity check passes (max-absolute B)
- [x] Pre-commit hooks pass

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)