### PR TITLE
feat: add parser for 'show route-map' on IOS

### DIFF
--- a/changes/355.parser_added
+++ b/changes/355.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show route-map' on IOS.

--- a/src/muninn/parsers/ios/show_route_map.py
+++ b/src/muninn/parsers/ios/show_route_map.py
@@ -1,6 +1,7 @@
 """Parser for 'show route-map' command on IOS."""
 
 import re
+from dataclasses import dataclass, field
 from typing import NotRequired, TypedDict
 
 from muninn.os import OS
@@ -8,16 +9,20 @@ from muninn.parser import BaseParser
 from muninn.registry import register
 
 
-class RouteMapEntry(TypedDict):
+class RouteMapSequenceEntry(TypedDict):
     """Schema for a single route-map sequence entry."""
 
-    name: str
     action: str
-    sequence: int
     match_clauses: list[str]
     set_clauses: list[str]
     policy_routing_packets: NotRequired[int]
     policy_routing_bytes: NotRequired[int]
+
+
+class RouteMapEntry(TypedDict):
+    """Schema for a single route-map with all its sequences."""
+
+    sequences: dict[str, RouteMapSequenceEntry]
 
 
 class ShowRouteMapResult(TypedDict):
@@ -44,6 +49,51 @@ _DYNAMIC_COUNT = re.compile(
 
 _MATCH_HEADER = re.compile(r"^\s*Match\s+clauses:\s*$")
 _SET_HEADER = re.compile(r"^\s*Set\s+clauses:\s*$")
+
+
+@dataclass
+class _ParseState:
+    """Mutable parser state for the current route-map sequence."""
+
+    route_maps: dict[str, RouteMapEntry] = field(default_factory=dict)
+    name: str | None = None
+    sequence: str | None = None
+    action: str | None = None
+    match_clauses: list[str] = field(default_factory=list)
+    set_clauses: list[str] = field(default_factory=list)
+    policy_routing_packets: int | None = None
+    policy_routing_bytes: int | None = None
+
+    def flush(self) -> None:
+        """Save the current route-map sequence into the result."""
+        if self.name is None or self.sequence is None or self.action is None:
+            return
+
+        if self.name not in self.route_maps:
+            self.route_maps[self.name] = RouteMapEntry(sequences={})
+
+        sequence_entry: RouteMapSequenceEntry = {
+            "action": self.action,
+            "match_clauses": list(self.match_clauses),
+            "set_clauses": list(self.set_clauses),
+        }
+        if self.policy_routing_packets is not None:
+            sequence_entry["policy_routing_packets"] = self.policy_routing_packets
+        if self.policy_routing_bytes is not None:
+            sequence_entry["policy_routing_bytes"] = self.policy_routing_bytes
+
+        self.route_maps[self.name]["sequences"][self.sequence] = sequence_entry
+
+    def start_new(self, name: str, sequence: str, action: str) -> None:
+        """Begin a new route-map sequence, flushing any current one."""
+        self.flush()
+        self.name = name
+        self.sequence = sequence
+        self.action = action
+        self.match_clauses = []
+        self.set_clauses = []
+        self.policy_routing_packets = None
+        self.policy_routing_bytes = None
 
 
 def _is_noise_line(line: str) -> bool:
@@ -114,7 +164,7 @@ class ShowRouteMapParser(BaseParser[ShowRouteMapResult]):
             ValueError: If the output cannot be parsed.
         """
         lines = output.splitlines()
-        route_maps: dict[str, RouteMapEntry] = {}
+        state = _ParseState()
         idx = 0
 
         while idx < len(lines):
@@ -130,27 +180,24 @@ class ShowRouteMapParser(BaseParser[ShowRouteMapResult]):
                 idx += 1
                 continue
 
-            entry: RouteMapEntry = {
-                "name": header_match.group("name"),
-                "action": header_match.group("action"),
-                "sequence": int(header_match.group("sequence")),
-                "match_clauses": [],
-                "set_clauses": [],
-            }
+            state.start_new(
+                name=header_match.group("name"),
+                sequence=header_match.group("sequence"),
+                action=header_match.group("action"),
+            )
             idx += 1
-            idx = _parse_entry_body(lines, idx, entry)
+            idx = _parse_entry_body(lines, idx, state)
 
-            key = f"{entry['name']}:{entry['sequence']}"
-            route_maps[key] = entry
+        state.flush()
 
-        if not route_maps:
+        if not state.route_maps:
             msg = "No route-map entries found in output"
             raise ValueError(msg)
 
-        return {"route_maps": route_maps}
+        return {"route_maps": state.route_maps}
 
 
-def _parse_entry_body(lines: list[str], idx: int, entry: RouteMapEntry) -> int:
+def _parse_entry_body(lines: list[str], idx: int, state: _ParseState) -> int:
     """Parse match clauses, set clauses, and policy routing for one entry."""
     while idx < len(lines):
         line = lines[idx]
@@ -169,19 +216,19 @@ def _parse_entry_body(lines: list[str], idx: int, entry: RouteMapEntry) -> int:
         if _MATCH_HEADER.match(line):
             idx += 1
             clauses, idx = _parse_clause_lines(lines, idx)
-            entry["match_clauses"] = clauses
+            state.match_clauses = clauses
             continue
 
         if _SET_HEADER.match(line):
             idx += 1
             clauses, idx = _parse_clause_lines(lines, idx)
-            entry["set_clauses"] = clauses
+            state.set_clauses = clauses
             continue
 
         policy_match = _POLICY_ROUTING.match(line)
         if policy_match:
-            entry["policy_routing_packets"] = int(policy_match.group("packets"))
-            entry["policy_routing_bytes"] = int(policy_match.group("bytes"))
+            state.policy_routing_packets = int(policy_match.group("packets"))
+            state.policy_routing_bytes = int(policy_match.group("bytes"))
             idx += 1
             break
 

--- a/src/muninn/parsers/ios/show_route_map.py
+++ b/src/muninn/parsers/ios/show_route_map.py
@@ -1,0 +1,190 @@
+"""Parser for 'show route-map' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class RouteMapEntry(TypedDict):
+    """Schema for a single route-map sequence entry."""
+
+    name: str
+    action: str
+    sequence: int
+    match_clauses: list[str]
+    set_clauses: list[str]
+    policy_routing_packets: NotRequired[int]
+    policy_routing_bytes: NotRequired[int]
+
+
+class ShowRouteMapResult(TypedDict):
+    """Schema for 'show route-map' parsed output."""
+
+    route_maps: dict[str, RouteMapEntry]
+
+
+_ROUTE_MAP_HEADER = re.compile(
+    r"^route-map\s+(?P<name>\S+),\s+(?P<action>permit|deny),\s+"
+    r"sequence\s+(?P<sequence>\d+)\s*$"
+)
+
+_POLICY_ROUTING = re.compile(
+    r"^\s*Policy\s+routing\s+matches:\s+(?P<packets>\d+)\s+packets?,\s+"
+    r"(?P<bytes>\d+)\s+bytes?\s*$"
+)
+
+_SECTION_HEADER = re.compile(r"^\s*(?:STATIC|DYNAMIC)\s+routemaps\s*$", re.IGNORECASE)
+
+_DYNAMIC_COUNT = re.compile(
+    r"^\s*Current\s+active\s+dynamic\s+routemaps\s*=", re.IGNORECASE
+)
+
+_MATCH_HEADER = re.compile(r"^\s*Match\s+clauses:\s*$")
+_SET_HEADER = re.compile(r"^\s*Set\s+clauses:\s*$")
+
+
+def _is_noise_line(line: str) -> bool:
+    """Check if a line should be skipped during parsing."""
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if _SECTION_HEADER.match(stripped):
+        return True
+    return bool(_DYNAMIC_COUNT.match(stripped))
+
+
+def _parse_clause_lines(lines: list[str], start: int) -> tuple[list[str], int]:
+    """Parse indented clause lines starting from the given index.
+
+    Returns the list of clause strings and the next line index to process.
+    """
+    clauses: list[str] = []
+    idx = start
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped:
+            idx += 1
+            continue
+        # Stop if we hit a non-indented line or a known section boundary
+        if _ROUTE_MAP_HEADER.match(stripped):
+            break
+        if _MATCH_HEADER.match(line):
+            break
+        if _SET_HEADER.match(line):
+            break
+        if _POLICY_ROUTING.match(line):
+            break
+        if _SECTION_HEADER.match(stripped):
+            break
+        if _DYNAMIC_COUNT.match(stripped):
+            break
+        clauses.append(stripped)
+        idx += 1
+    return clauses, idx
+
+
+@register(OS.CISCO_IOS, "show route-map")
+class ShowRouteMapParser(BaseParser[ShowRouteMapResult]):
+    """Parser for 'show route-map' command.
+
+    Example output:
+        route-map equal, permit, sequence 10
+          Match clauses:
+            length 150 200
+          Set clauses:
+            ip next-hop 10.10.11.254
+          Policy routing matches: 0 packets, 0 bytes
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteMapResult:
+        """Parse 'show route-map' output.
+
+        Args:
+            output: Raw CLI output from 'show route-map' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+        route_maps: dict[str, RouteMapEntry] = {}
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx]
+            stripped = line.strip()
+
+            if _is_noise_line(stripped):
+                idx += 1
+                continue
+
+            header_match = _ROUTE_MAP_HEADER.match(stripped)
+            if not header_match:
+                idx += 1
+                continue
+
+            entry: RouteMapEntry = {
+                "name": header_match.group("name"),
+                "action": header_match.group("action"),
+                "sequence": int(header_match.group("sequence")),
+                "match_clauses": [],
+                "set_clauses": [],
+            }
+            idx += 1
+            idx = _parse_entry_body(lines, idx, entry)
+
+            key = f"{entry['name']}:{entry['sequence']}"
+            route_maps[key] = entry
+
+        if not route_maps:
+            msg = "No route-map entries found in output"
+            raise ValueError(msg)
+
+        return {"route_maps": route_maps}
+
+
+def _parse_entry_body(lines: list[str], idx: int, entry: RouteMapEntry) -> int:
+    """Parse match clauses, set clauses, and policy routing for one entry."""
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+
+        if not stripped:
+            idx += 1
+            continue
+
+        if _ROUTE_MAP_HEADER.match(stripped):
+            break
+
+        if _SECTION_HEADER.match(stripped) or _DYNAMIC_COUNT.match(stripped):
+            break
+
+        if _MATCH_HEADER.match(line):
+            idx += 1
+            clauses, idx = _parse_clause_lines(lines, idx)
+            entry["match_clauses"] = clauses
+            continue
+
+        if _SET_HEADER.match(line):
+            idx += 1
+            clauses, idx = _parse_clause_lines(lines, idx)
+            entry["set_clauses"] = clauses
+            continue
+
+        policy_match = _POLICY_ROUTING.match(line)
+        if policy_match:
+            entry["policy_routing_packets"] = int(policy_match.group("packets"))
+            entry["policy_routing_bytes"] = int(policy_match.group("bytes"))
+            idx += 1
+            break
+
+        idx += 1
+
+    return idx

--- a/tests/parsers/ios/show_route-map/001_basic/expected.json
+++ b/tests/parsers/ios/show_route-map/001_basic/expected.json
@@ -1,31 +1,31 @@
 {
     "route_maps": {
-        "equal:10": {
-            "action": "permit",
-            "match_clauses": [
-                "length 150 200"
-            ],
-            "name": "equal",
-            "policy_routing_bytes": 0,
-            "policy_routing_packets": 0,
-            "sequence": 10,
-            "set_clauses": [
-                "ip next-hop 10.10.11.254"
-            ]
-        },
-        "equal:20": {
-            "action": "permit",
-            "match_clauses": [
-                "ip address prefix-lists: PFX",
-                "ip address (access-lists): 101"
-            ],
-            "name": "equal",
-            "policy_routing_bytes": 15190,
-            "policy_routing_packets": 144,
-            "sequence": 20,
-            "set_clauses": [
-                "ip next-hop 10.10.11.14"
-            ]
+        "equal": {
+            "sequences": {
+                "10": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "length 150 200"
+                    ],
+                    "policy_routing_bytes": 0,
+                    "policy_routing_packets": 0,
+                    "set_clauses": [
+                        "ip next-hop 10.10.11.254"
+                    ]
+                },
+                "20": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "ip address prefix-lists: PFX",
+                        "ip address (access-lists): 101"
+                    ],
+                    "policy_routing_bytes": 15190,
+                    "policy_routing_packets": 144,
+                    "set_clauses": [
+                        "ip next-hop 10.10.11.14"
+                    ]
+                }
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_route-map/001_basic/expected.json
+++ b/tests/parsers/ios/show_route-map/001_basic/expected.json
@@ -1,0 +1,31 @@
+{
+    "route_maps": {
+        "equal:10": {
+            "action": "permit",
+            "match_clauses": [
+                "length 150 200"
+            ],
+            "name": "equal",
+            "policy_routing_bytes": 0,
+            "policy_routing_packets": 0,
+            "sequence": 10,
+            "set_clauses": [
+                "ip next-hop 10.10.11.254"
+            ]
+        },
+        "equal:20": {
+            "action": "permit",
+            "match_clauses": [
+                "ip address prefix-lists: PFX",
+                "ip address (access-lists): 101"
+            ],
+            "name": "equal",
+            "policy_routing_bytes": 15190,
+            "policy_routing_packets": 144,
+            "sequence": 20,
+            "set_clauses": [
+                "ip next-hop 10.10.11.14"
+            ]
+        }
+    }
+}

--- a/tests/parsers/ios/show_route-map/001_basic/input.txt
+++ b/tests/parsers/ios/show_route-map/001_basic/input.txt
@@ -1,0 +1,13 @@
+route-map equal, permit, sequence 10
+   Match clauses:
+     length 150 200
+   Set clauses:
+     ip next-hop 10.10.11.254
+   Policy routing matches: 0 packets, 0 bytes
+route-map equal, permit, sequence 20
+  Match clauses:
+    ip address prefix-lists: PFX
+    ip address (access-lists): 101
+  Set clauses:
+    ip next-hop 10.10.11.14
+  Policy routing matches: 144 packets, 15190 bytes

--- a/tests/parsers/ios/show_route-map/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_route-map/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic route-map with two sequences showing match and set clauses
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/expected.json
+++ b/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/expected.json
@@ -1,37 +1,39 @@
 {
     "route_maps": {
-        "RM-FILTER-REDISTRIBUTED-DMVPN-ROUTES-IN:20": {
-            "action": "permit",
-            "match_clauses": [],
-            "name": "RM-FILTER-REDISTRIBUTED-DMVPN-ROUTES-IN",
-            "policy_routing_bytes": 0,
-            "policy_routing_packets": 0,
-            "sequence": 20,
-            "set_clauses": []
+        "RM-FILTER-REDISTRIBUTED-DMVPN-ROUTES-IN": {
+            "sequences": {
+                "20": {
+                    "action": "permit",
+                    "match_clauses": [],
+                    "policy_routing_bytes": 0,
+                    "policy_routing_packets": 0,
+                    "set_clauses": []
+                }
+            }
         },
-        "RM-PBR_APPS_TO_MPLS:10": {
-            "action": "permit",
-            "match_clauses": [
-                "ip address (access-lists): ACL-APPLICATION-SAP-DC"
-            ],
-            "name": "RM-PBR_APPS_TO_MPLS",
-            "policy_routing_bytes": 0,
-            "policy_routing_packets": 0,
-            "sequence": 10,
-            "set_clauses": [
-                "ip next-hop 172.16.154.94 172.16.154.102"
-            ]
-        },
-        "RM-PBR_APPS_TO_MPLS:5": {
-            "action": "deny",
-            "match_clauses": [
-                "ip address (access-lists): PBR-EXCLUSION-SITE-SUBNET"
-            ],
-            "name": "RM-PBR_APPS_TO_MPLS",
-            "policy_routing_bytes": 0,
-            "policy_routing_packets": 0,
-            "sequence": 5,
-            "set_clauses": []
+        "RM-PBR_APPS_TO_MPLS": {
+            "sequences": {
+                "10": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "ip address (access-lists): ACL-APPLICATION-SAP-DC"
+                    ],
+                    "policy_routing_bytes": 0,
+                    "policy_routing_packets": 0,
+                    "set_clauses": [
+                        "ip next-hop 172.16.154.94 172.16.154.102"
+                    ]
+                },
+                "5": {
+                    "action": "deny",
+                    "match_clauses": [
+                        "ip address (access-lists): PBR-EXCLUSION-SITE-SUBNET"
+                    ],
+                    "policy_routing_bytes": 0,
+                    "policy_routing_packets": 0,
+                    "set_clauses": []
+                }
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/expected.json
+++ b/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/expected.json
@@ -1,0 +1,37 @@
+{
+    "route_maps": {
+        "RM-FILTER-REDISTRIBUTED-DMVPN-ROUTES-IN:20": {
+            "action": "permit",
+            "match_clauses": [],
+            "name": "RM-FILTER-REDISTRIBUTED-DMVPN-ROUTES-IN",
+            "policy_routing_bytes": 0,
+            "policy_routing_packets": 0,
+            "sequence": 20,
+            "set_clauses": []
+        },
+        "RM-PBR_APPS_TO_MPLS:10": {
+            "action": "permit",
+            "match_clauses": [
+                "ip address (access-lists): ACL-APPLICATION-SAP-DC"
+            ],
+            "name": "RM-PBR_APPS_TO_MPLS",
+            "policy_routing_bytes": 0,
+            "policy_routing_packets": 0,
+            "sequence": 10,
+            "set_clauses": [
+                "ip next-hop 172.16.154.94 172.16.154.102"
+            ]
+        },
+        "RM-PBR_APPS_TO_MPLS:5": {
+            "action": "deny",
+            "match_clauses": [
+                "ip address (access-lists): PBR-EXCLUSION-SITE-SUBNET"
+            ],
+            "name": "RM-PBR_APPS_TO_MPLS",
+            "policy_routing_bytes": 0,
+            "policy_routing_packets": 0,
+            "sequence": 5,
+            "set_clauses": []
+        }
+    }
+}

--- a/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/input.txt
+++ b/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/input.txt
@@ -1,0 +1,18 @@
+STATIC routemaps
+route-map RM-PBR_APPS_TO_MPLS, deny, sequence 5
+  Match clauses:
+    ip address (access-lists): PBR-EXCLUSION-SITE-SUBNET
+  Set clauses:
+  Policy routing matches: 0 packets, 0 bytes
+route-map RM-PBR_APPS_TO_MPLS, permit, sequence 10
+  Match clauses:
+    ip address (access-lists): ACL-APPLICATION-SAP-DC
+  Set clauses:
+    ip next-hop 172.16.154.94 172.16.154.102
+  Policy routing matches: 0 packets, 0 bytes
+route-map RM-FILTER-REDISTRIBUTED-DMVPN-ROUTES-IN, permit, sequence 20
+  Match clauses:
+  Set clauses:
+  Policy routing matches: 0 packets, 0 bytes
+DYNAMIC routemaps
+Current active dynamic routemaps = 0

--- a/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/metadata.yaml
+++ b/tests/parsers/ios/show_route-map/002_deny_and_empty_clauses/metadata.yaml
@@ -1,0 +1,3 @@
+description: Route-maps with deny action, empty clauses, and STATIC/DYNAMIC headers
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add a section-based parser for the `show route-map` command on Cisco IOS
- Extracts route-map entries keyed by `<name>:<sequence>` with match clauses, set clauses, action (permit/deny), and policy routing statistics
- Handles STATIC/DYNAMIC routemaps headers, empty clauses, and multiple sequences per route-map name

Closes #107

## Test plan

- [x] `001_basic` - Two permit sequences with match/set clauses and policy routing counters
- [x] `002_deny_and_empty_clauses` - Deny action, empty match/set clauses, STATIC/DYNAMIC headers
- [x] All ruff, xenon, and pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)