### PR TITLE
feat: add parser for 'show access-list' on IOS

### DIFF
--- a/changes/356.parser_added
+++ b/changes/356.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show access-list' on IOS.

--- a/src/muninn/parsers/ios/show_access_list.py
+++ b/src/muninn/parsers/ios/show_access_list.py
@@ -1,0 +1,142 @@
+"""Parser for 'show access-list' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class AccessListEntry(TypedDict):
+    """Schema for a single access control entry (ACE)."""
+
+    sequence: int
+    action: str
+    line: str
+    matches: NotRequired[int]
+
+
+class AccessList(TypedDict):
+    """Schema for a single access list."""
+
+    type: str
+    entries: dict[str, AccessListEntry]
+
+
+class ShowAccessListResult(TypedDict):
+    """Schema for 'show access-list' parsed output."""
+
+    access_lists: dict[str, AccessList]
+
+
+# Header pattern: "Extended IP access list <name>" or "Standard IP access list <name>"
+_HEADER_PATTERN = re.compile(
+    r"^(?P<type>(?:Extended|Standard)\s+IP\s+access\s+list)\s+(?P<name>\S+)$"
+)
+
+# ACE pattern: sequence, action, rest of line, optional match count
+_ACE_PATTERN = re.compile(
+    r"^(?P<sequence>\d+)\s+(?P<action>permit|deny)\s+(?P<rest>.+)$"
+)
+
+# Match count at end of line: (NNN matches)
+_MATCH_COUNT_PATTERN = re.compile(r"\((\d+)\s+matches?\)$")
+
+
+def _parse_ace_line(line: str) -> AccessListEntry | None:
+    """Parse a single ACE line into an entry dict.
+
+    Args:
+        line: Stripped line from CLI output.
+
+    Returns:
+        Parsed ACE entry, or None if line does not match.
+    """
+    match = _ACE_PATTERN.match(line)
+    if not match:
+        return None
+
+    sequence = int(match.group("sequence"))
+    action = match.group("action")
+    rest = match.group("rest").strip()
+
+    # Build the full action + rest as the line content
+    full_line = f"{action} {rest}"
+
+    # Check for match count and strip it from line
+    match_count_match = _MATCH_COUNT_PATTERN.search(full_line)
+    if match_count_match:
+        matches = int(match_count_match.group(1))
+        full_line = full_line[: match_count_match.start()].rstrip()
+        entry: AccessListEntry = {
+            "sequence": sequence,
+            "action": action,
+            "line": full_line,
+            "matches": matches,
+        }
+        return entry
+
+    return {
+        "sequence": sequence,
+        "action": action,
+        "line": full_line,
+    }
+
+
+@register(OS.CISCO_IOS, "show access-list")
+class ShowAccessListParser(BaseParser[ShowAccessListResult]):
+    """Parser for 'show access-list' command.
+
+    Example output:
+        Extended IP access list 102
+            10 permit tcp any host 192.168.1.100 eq ftp
+            20 permit tcp any host 192.168.1.100 gt 1024
+        Standard IP access list 1
+            10 permit 10.1.2.3 log
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowAccessListResult:
+        """Parse 'show access-list' output.
+
+        Args:
+            output: Raw CLI output from 'show access-list' command.
+
+        Returns:
+            Parsed data with access lists keyed by name.
+
+        Raises:
+            ValueError: If no access lists found in output.
+        """
+        access_lists: dict[str, AccessList] = {}
+        current_name: str | None = None
+        current_type: str | None = None
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            header_match = _HEADER_PATTERN.match(line)
+            if header_match:
+                current_name = header_match.group("name")
+                current_type = header_match.group("type")
+                access_lists[current_name] = {
+                    "type": current_type,
+                    "entries": {},
+                }
+                continue
+
+            if current_name is None:
+                continue
+
+            entry = _parse_ace_line(line)
+            if entry:
+                access_lists[current_name]["entries"][str(entry["sequence"])] = entry
+
+        if not access_lists:
+            msg = "No access lists found in output"
+            raise ValueError(msg)
+
+        return ShowAccessListResult(access_lists=access_lists)

--- a/tests/parsers/ios/show_access-list/001_basic/expected.json
+++ b/tests/parsers/ios/show_access-list/001_basic/expected.json
@@ -1,0 +1,70 @@
+{
+    "access_lists": {
+        "1": {
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "line": "permit 10.1.2.3 log",
+                    "sequence": 10
+                },
+                "20": {
+                    "action": "deny",
+                    "line": "deny 10.1.1.1",
+                    "sequence": 20
+                },
+                "30": {
+                    "action": "deny",
+                    "line": "deny 192.168.1.0, wildcard bits 0.0.0.255",
+                    "sequence": 30
+                },
+                "40": {
+                    "action": "deny",
+                    "line": "deny any log",
+                    "sequence": 40
+                }
+            },
+            "type": "Standard IP access list"
+        },
+        "10": {
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "line": "permit 192.168.1.0, wildcard bits 0.0.0.255",
+                    "matches": 5177,
+                    "sequence": 10
+                }
+            },
+            "type": "Standard IP access list"
+        },
+        "102": {
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "line": "permit tcp any host 192.168.1.100 eq ftp",
+                    "sequence": 10
+                },
+                "20": {
+                    "action": "permit",
+                    "line": "permit tcp any host 192.168.1.100 gt 1024",
+                    "sequence": 20
+                }
+            },
+            "type": "Extended IP access list"
+        },
+        "VLAN-TEST": {
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "line": "permit ip any any",
+                    "sequence": 10
+                },
+                "20": {
+                    "action": "deny",
+                    "line": "deny ip any any",
+                    "sequence": 20
+                }
+            },
+            "type": "Extended IP access list"
+        }
+    }
+}

--- a/tests/parsers/ios/show_access-list/001_basic/input.txt
+++ b/tests/parsers/ios/show_access-list/001_basic/input.txt
@@ -1,0 +1,13 @@
+Extended IP access list 102
+    10 permit tcp any host 192.168.1.100 eq ftp
+    20 permit tcp any host 192.168.1.100 gt 1024
+Extended IP access list VLAN-TEST
+    10 permit ip any any
+    20 deny ip any any
+Standard IP access list 1
+    10 permit 10.1.2.3 log
+    20 deny   10.1.1.1
+    30 deny   192.168.1.0, wildcard bits 0.0.0.255
+    40 deny   any log
+Standard IP access list 10
+    10 permit 192.168.1.0, wildcard bits 0.0.0.255 (5177 matches)

--- a/tests/parsers/ios/show_access-list/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_access-list/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed standard and extended access lists with match counts
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_access-list/002_standard_only/expected.json
+++ b/tests/parsers/ios/show_access-list/002_standard_only/expected.json
@@ -1,0 +1,36 @@
+{
+    "access_lists": {
+        "1": {
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "line": "permit 4.5.6.0 log",
+                    "sequence": 10
+                },
+                "20": {
+                    "action": "permit",
+                    "line": "permit any",
+                    "sequence": 20
+                }
+            },
+            "type": "Standard IP access list"
+        },
+        "2": {
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "line": "permit 0.0.0.0, wildcard bits 255.255.255.252 log",
+                    "matches": 4556,
+                    "sequence": 10
+                },
+                "20": {
+                    "action": "permit",
+                    "line": "permit any",
+                    "matches": 11665,
+                    "sequence": 20
+                }
+            },
+            "type": "Standard IP access list"
+        }
+    }
+}

--- a/tests/parsers/ios/show_access-list/002_standard_only/input.txt
+++ b/tests/parsers/ios/show_access-list/002_standard_only/input.txt
@@ -1,0 +1,6 @@
+Standard IP access list 1
+10 permit 4.5.6.0 log
+20 permit any
+Standard IP access list 2
+10 permit 0.0.0.0, wildcard bits 255.255.255.252 log (4556 matches)
+20 permit any (11665 matches)

--- a/tests/parsers/ios/show_access-list/002_standard_only/metadata.yaml
+++ b/tests/parsers/ios/show_access-list/002_standard_only/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard access lists only with match counts
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add a new parser for the `show access-list` command on Cisco IOS
- Supports both Standard and Extended IP access lists
- Extracts sequence numbers, actions, ACE content, and optional match counts
- Includes two test cases covering mixed ACL types and standard-only output

Closes #104

## Test plan

- [x] Parser handles Extended IP access lists
- [x] Parser handles Standard IP access lists
- [x] Parser extracts match counts when present
- [x] Parser handles named and numbered ACLs
- [x] All pre-commit hooks pass (ruff, xenon, pretty-format-json)
- [x] `uv run pytest tests/parsers/ -k access -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)