### PR TITLE
feat: add parser for 'show vrrp' on IOS-XE

### DIFF
--- a/changes/357.parser_added
+++ b/changes/357.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show vrrp' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vrrp.py
+++ b/src/muninn/parsers/iosxe/show_vrrp.py
@@ -1,0 +1,386 @@
+"""Parser for 'show vrrp' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class TrackObjectEntry(TypedDict):
+    """Schema for a tracked object."""
+
+    state: str
+    decrement: int
+
+
+class VrrpGroupEntry(TypedDict):
+    """Schema for a single VRRP group entry."""
+
+    state: str
+    virtual_ip_address: str
+    virtual_mac_address: str
+    advertisement_interval_secs: float
+    preemption: str
+    priority: int
+    configured_priority: NotRequired[int]
+    master_router_ip: NotRequired[str]
+    master_router_is_local: NotRequired[bool]
+    master_router_priority: NotRequired[int]
+    master_advertisement_interval_secs: NotRequired[float]
+    master_down_interval_secs: NotRequired[float]
+    master_down_expires_secs: NotRequired[float]
+    master_advertisement_expires_msec: NotRequired[int]
+    track_objects: NotRequired[dict[str, TrackObjectEntry]]
+    address_family: NotRequired[str]
+    description: NotRequired[str]
+    flags: NotRequired[str]
+    authentication: NotRequired[str]
+    state_duration_secs: NotRequired[float]
+    vrrs_group_name: NotRequired[str]
+    state_change_reason: NotRequired[str]
+
+
+class ShowVrrpResult(TypedDict):
+    """Schema for 'show vrrp' parsed output."""
+
+    interfaces: dict[str, dict[str, VrrpGroupEntry]]
+
+
+# Header: "GigabitEthernet3.420 - Group 10" or with address family
+_HEADER_PATTERN = re.compile(
+    r"^(?P<interface>\S+)\s+-\s+Group\s+(?P<group>\d+)"
+    r"(?:\s+-\s+Address-Family\s+(?P<af>\S+))?",
+)
+
+_STATE_PATTERN = re.compile(
+    r"^State\s+is\s+(?P<state>\S+)",
+)
+
+_VIRTUAL_IP_PATTERN = re.compile(
+    r"^Virtual\s+IP\s+address\s+is\s+(?P<ip>.+)$",
+)
+
+_VIRTUAL_MAC_PATTERN = re.compile(
+    r"^Virtual\s+MAC\s+address\s+is\s+(?P<mac>\S+)",
+)
+
+_ADV_INTERVAL_PATTERN = re.compile(
+    r"^Advertisement\s+interval\s+is\s+(?P<value>[\d.]+)\s+(?P<unit>sec|msec)",
+)
+
+_PREEMPTION_PATTERN = re.compile(
+    r"^Preemption\s+(?P<preemption>\S+)",
+)
+
+_PRIORITY_PATTERN = re.compile(
+    r"^Priority\s+is\s+(?P<priority>\d+)"
+    r"(?:\s+\((?:cfgd|Configured)\s+(?P<configured>\d+)\))?",
+)
+
+_TRACK_PATTERN = re.compile(
+    r"^Track\s+object\s+(?P<id>\d+)\s+state\s+(?P<state>\S+)"
+    r"\s+decrement\s+(?P<dec>\d+)",
+)
+
+_MASTER_ROUTER_PATTERN = re.compile(
+    r"^Master\s+Router\s+is\s+(?P<ip>\S+?)(?:\s+\((?P<local>local)\))?"
+    r",\s+priority\s+is\s+(?P<priority>\S+)",
+)
+
+_MASTER_ADV_PATTERN = re.compile(
+    r"^Master\s+Advertisement\s+interval\s+is\s+"
+    r"(?P<value>[\d.]+)\s+(?P<unit>sec|msec)"
+    r"(?:\s+\((?:expires\s+in\s+(?P<expires>[\d.]+)\s+(?P<exp_unit>sec|msec)"
+    r"|learned)\))?",
+)
+
+_MASTER_DOWN_PATTERN = re.compile(
+    r"^Master\s+Down\s+interval\s+is\s+"
+    r"(?:(?P<value>[\d.]+)\s+(?P<unit>sec|msec)"
+    r"(?:\s+\(expires\s+in\s+(?P<expires>[\d.]+)\s+(?P<exp_unit>sec|msec)\))?"
+    r"|(?P<unknown>unknown))",
+)
+
+_FLAGS_PATTERN = re.compile(r"^FLAGS:\s+(?P<flags>\S+)")
+
+_AUTH_PATTERN = re.compile(r"^Authentication\s+(?P<auth>.+)$")
+
+_DESCRIPTION_PATTERN = re.compile(r'^Description\s+is\s+"(?P<desc>[^"]+)"')
+
+_STATE_DURATION_PATTERN = re.compile(
+    r"^State\s+duration\s+"
+    r"(?:(?P<weeks>\d+)\s+weeks?\s+)?"
+    r"(?:(?P<days>\d+)\s+days?\s+)?"
+    r"(?:(?P<hours>\d+)\s+hours?)?"
+    r"(?:(?P<mins>\d+)\s+mins?\s+)?"
+    r"(?P<secs>[\d.]+)\s+secs?",
+)
+
+_VRRS_PATTERN = re.compile(r"^VRRS\s+Group\s+name\s+(?P<name>\S+)")
+
+_STATE_CHANGE_REASON_PATTERN = re.compile(
+    r"^State\s+change\s+reason\s+is\s+(?P<reason>\S+)",
+)
+
+_FIELD_PARSERS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_STATE_PATTERN, "state"),
+    (_VIRTUAL_IP_PATTERN, "virtual_ip"),
+    (_VIRTUAL_MAC_PATTERN, "virtual_mac"),
+    (_ADV_INTERVAL_PATTERN, "adv_interval"),
+    (_PREEMPTION_PATTERN, "preemption"),
+    (_PRIORITY_PATTERN, "priority"),
+    (_TRACK_PATTERN, "track"),
+    (_MASTER_ROUTER_PATTERN, "master_router"),
+    (_MASTER_ADV_PATTERN, "master_adv"),
+    (_MASTER_DOWN_PATTERN, "master_down"),
+    (_FLAGS_PATTERN, "flags"),
+    (_AUTH_PATTERN, "auth"),
+    (_DESCRIPTION_PATTERN, "description"),
+    (_STATE_DURATION_PATTERN, "state_duration"),
+    (_VRRS_PATTERN, "vrrs"),
+    (_STATE_CHANGE_REASON_PATTERN, "state_change_reason"),
+)
+
+
+def _interval_to_secs(value: str, unit: str) -> float:
+    """Convert an interval value and unit to seconds."""
+    num = float(value)
+    if unit == "msec":
+        return num / 1000.0
+    return num
+
+
+def _apply_state(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply state match."""
+    entry["state"] = match.group("state")
+
+
+def _apply_virtual_ip(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply virtual IP match."""
+    entry["virtual_ip_address"] = match.group("ip").strip()
+
+
+def _apply_virtual_mac(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply virtual MAC match."""
+    entry["virtual_mac_address"] = match.group("mac")
+
+
+def _apply_adv_interval(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply advertisement interval match."""
+    entry["advertisement_interval_secs"] = _interval_to_secs(
+        match.group("value"), match.group("unit")
+    )
+
+
+def _apply_preemption(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply preemption match."""
+    entry["preemption"] = match.group("preemption")
+
+
+def _apply_flags(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply flags match."""
+    entry["flags"] = match.group("flags")
+
+
+def _apply_auth(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply authentication match."""
+    entry["authentication"] = match.group("auth").strip()
+
+
+def _apply_description(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply description match."""
+    entry["description"] = match.group("desc")
+
+
+def _apply_priority(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply priority match to entry."""
+    entry["priority"] = int(match.group("priority"))
+    configured = match.group("configured")
+    if configured:
+        entry["configured_priority"] = int(configured)
+
+
+def _apply_track(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply track object match to entry."""
+    track_id = match.group("id")
+    track_entry: TrackObjectEntry = {
+        "state": match.group("state"),
+        "decrement": int(match.group("dec")),
+    }
+    if "track_objects" not in entry:
+        entry["track_objects"] = {}
+    entry["track_objects"][track_id] = track_entry
+
+
+def _apply_master_router(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply master router match to entry."""
+    ip = match.group("ip")
+    if ip != "unknown":
+        entry["master_router_ip"] = ip
+    if match.group("local"):
+        entry["master_router_is_local"] = True
+    priority = match.group("priority")
+    if priority != "unknown":
+        entry["master_router_priority"] = int(priority)
+
+
+def _apply_master_adv(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply master advertisement interval match to entry."""
+    entry["master_advertisement_interval_secs"] = _interval_to_secs(
+        match.group("value"), match.group("unit")
+    )
+    expires = match.group("expires")
+    if expires:
+        exp_unit = match.group("exp_unit")
+        ms = int(float(expires) * (1 if exp_unit == "msec" else 1000))
+        entry["master_advertisement_expires_msec"] = ms
+
+
+def _apply_master_down(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply master down interval match to entry."""
+    if match.group("unknown"):
+        return
+    value = match.group("value")
+    unit = match.group("unit")
+    entry["master_down_interval_secs"] = _interval_to_secs(value, unit)
+    expires = match.group("expires")
+    if expires:
+        exp_unit = match.group("exp_unit")
+        entry["master_down_expires_secs"] = _interval_to_secs(expires, exp_unit)
+
+
+def _apply_state_duration(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply state duration match to entry."""
+    weeks = int(match.group("weeks")) if match.group("weeks") else 0
+    days = int(match.group("days")) if match.group("days") else 0
+    hours = int(match.group("hours")) if match.group("hours") else 0
+    mins = int(match.group("mins")) if match.group("mins") else 0
+    secs = float(match.group("secs"))
+    entry["state_duration_secs"] = round(
+        weeks * 604800.0 + days * 86400.0 + hours * 3600.0 + mins * 60.0 + secs, 3
+    )
+
+
+def _apply_vrrs(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply VRRS group name match."""
+    entry["vrrs_group_name"] = match.group("name")
+
+
+def _apply_state_change_reason(entry: VrrpGroupEntry, match: re.Match[str]) -> None:
+    """Apply state change reason match."""
+    entry["state_change_reason"] = match.group("reason")
+
+
+_FieldApplier = type(_apply_state)
+
+_FIELD_DISPATCH: dict[str, _FieldApplier] = {
+    "state": _apply_state,
+    "virtual_ip": _apply_virtual_ip,
+    "virtual_mac": _apply_virtual_mac,
+    "adv_interval": _apply_adv_interval,
+    "preemption": _apply_preemption,
+    "priority": _apply_priority,
+    "track": _apply_track,
+    "master_router": _apply_master_router,
+    "master_adv": _apply_master_adv,
+    "master_down": _apply_master_down,
+    "flags": _apply_flags,
+    "auth": _apply_auth,
+    "description": _apply_description,
+    "state_duration": _apply_state_duration,
+    "vrrs": _apply_vrrs,
+    "state_change_reason": _apply_state_change_reason,
+}
+
+
+@register(OS.CISCO_IOSXE, "show vrrp")
+class ShowVrrpParser(BaseParser[ShowVrrpResult]):
+    """Parser for 'show vrrp' command.
+
+    Example output:
+        GigabitEthernet3.420 - Group 10
+          State is Master
+          Virtual IP address is 10.13.120.254
+          Virtual MAC address is 0000.5eff.010a
+          Advertisement interval is 1.000 sec
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVrrpResult:
+        """Parse 'show vrrp' output.
+
+        Args:
+            output: Raw CLI output from 'show vrrp' command.
+
+        Returns:
+            Parsed VRRP data keyed by interface and group number.
+
+        Raises:
+            ValueError: If no VRRP entries found in output.
+        """
+        interfaces: dict[str, dict[str, VrrpGroupEntry]] = {}
+        current_entry: VrrpGroupEntry | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            header_match = _HEADER_PATTERN.match(stripped)
+            if header_match:
+                current_entry = _start_new_entry(interfaces, header_match)
+                continue
+
+            if current_entry is None:
+                continue
+
+            _parse_field_line(stripped, current_entry)
+
+        if not interfaces:
+            msg = "No VRRP entries found in output"
+            raise ValueError(msg)
+
+        return ShowVrrpResult(interfaces=interfaces)
+
+
+def _start_new_entry(
+    interfaces: dict[str, dict[str, VrrpGroupEntry]],
+    match: re.Match[str],
+) -> VrrpGroupEntry:
+    """Create a new VRRP group entry from a header match."""
+    raw_intf = match.group("interface")
+    interface = canonical_interface_name(raw_intf, os=OS.CISCO_IOSXE)
+    group = match.group("group")
+    af = match.group("af")
+
+    entry = VrrpGroupEntry(
+        state="",
+        virtual_ip_address="",
+        virtual_mac_address="",
+        advertisement_interval_secs=0.0,
+        preemption="",
+        priority=0,
+    )
+
+    if af:
+        entry["address_family"] = af
+
+    # Use "group/AF" as key when address family is present to avoid collisions
+    key = f"{group}/{af}" if af else group
+
+    if interface not in interfaces:
+        interfaces[interface] = {}
+    interfaces[interface][key] = entry
+    return entry
+
+
+def _parse_field_line(line: str, entry: VrrpGroupEntry) -> None:
+    """Parse a single field line and apply it to the entry."""
+    for pattern, field in _FIELD_PARSERS:
+        match = pattern.match(line)
+        if match:
+            _FIELD_DISPATCH[field](entry, match)
+            return

--- a/src/muninn/parsers/iosxe/show_vrrp.py
+++ b/src/muninn/parsers/iosxe/show_vrrp.py
@@ -43,10 +43,22 @@ class VrrpGroupEntry(TypedDict):
     state_change_reason: NotRequired[str]
 
 
+class VrrpGroupContainer(TypedDict):
+    """Schema for VRRP address families under a group."""
+
+    address_families: dict[str, VrrpGroupEntry]
+
+
+class VrrpInterfaceEntry(TypedDict):
+    """Schema for VRRP groups under an interface."""
+
+    groups: dict[str, VrrpGroupContainer]
+
+
 class ShowVrrpResult(TypedDict):
     """Schema for 'show vrrp' parsed output."""
 
-    interfaces: dict[str, dict[str, VrrpGroupEntry]]
+    interfaces: dict[str, VrrpInterfaceEntry]
 
 
 # Header: "GigabitEthernet3.420 - Group 10" or with address family
@@ -316,12 +328,12 @@ class ShowVrrpParser(BaseParser[ShowVrrpResult]):
             output: Raw CLI output from 'show vrrp' command.
 
         Returns:
-            Parsed VRRP data keyed by interface and group number.
+            Parsed VRRP data keyed by interface, group, and address family.
 
         Raises:
             ValueError: If no VRRP entries found in output.
         """
-        interfaces: dict[str, dict[str, VrrpGroupEntry]] = {}
+        interfaces: dict[str, VrrpInterfaceEntry] = {}
         current_entry: VrrpGroupEntry | None = None
 
         for line in output.splitlines():
@@ -347,14 +359,14 @@ class ShowVrrpParser(BaseParser[ShowVrrpResult]):
 
 
 def _start_new_entry(
-    interfaces: dict[str, dict[str, VrrpGroupEntry]],
+    interfaces: dict[str, VrrpInterfaceEntry],
     match: re.Match[str],
 ) -> VrrpGroupEntry:
     """Create a new VRRP group entry from a header match."""
     raw_intf = match.group("interface")
     interface = canonical_interface_name(raw_intf, os=OS.CISCO_IOSXE)
     group = match.group("group")
-    af = match.group("af")
+    af = match.group("af") or "IPv4"
 
     entry = VrrpGroupEntry(
         state="",
@@ -365,15 +377,13 @@ def _start_new_entry(
         priority=0,
     )
 
-    if af:
-        entry["address_family"] = af
-
-    # Use "group/AF" as key when address family is present to avoid collisions
-    key = f"{group}/{af}" if af else group
+    entry["address_family"] = af
 
     if interface not in interfaces:
-        interfaces[interface] = {}
-    interfaces[interface][key] = entry
+        interfaces[interface] = VrrpInterfaceEntry(groups={})
+    if group not in interfaces[interface]["groups"]:
+        interfaces[interface]["groups"][group] = VrrpGroupContainer(address_families={})
+    interfaces[interface]["groups"][group]["address_families"][af] = entry
     return entry
 
 

--- a/tests/parsers/iosxe/show_vrrp/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vrrp/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "interfaces": {
+        "GigabitEthernet3.420": {
+            "10": {
+                "advertisement_interval_secs": 1.0,
+                "flags": "1/1",
+                "master_advertisement_interval_secs": 1.0,
+                "master_down_interval_secs": 3.609,
+                "master_router_ip": "10.13.120.1",
+                "master_router_is_local": true,
+                "master_router_priority": 100,
+                "preemption": "enabled",
+                "priority": 100,
+                "state": "Master",
+                "track_objects": {
+                    "1": {
+                        "decrement": 15,
+                        "state": "Up"
+                    }
+                },
+                "virtual_ip_address": "10.13.120.254",
+                "virtual_mac_address": "0000.5eff.010a"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vrrp/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vrrp/001_basic/expected.json
@@ -1,25 +1,32 @@
 {
     "interfaces": {
         "GigabitEthernet3.420": {
-            "10": {
-                "advertisement_interval_secs": 1.0,
-                "flags": "1/1",
-                "master_advertisement_interval_secs": 1.0,
-                "master_down_interval_secs": 3.609,
-                "master_router_ip": "10.13.120.1",
-                "master_router_is_local": true,
-                "master_router_priority": 100,
-                "preemption": "enabled",
-                "priority": 100,
-                "state": "Master",
-                "track_objects": {
-                    "1": {
-                        "decrement": 15,
-                        "state": "Up"
+            "groups": {
+                "10": {
+                    "address_families": {
+                        "IPv4": {
+                            "address_family": "IPv4",
+                            "advertisement_interval_secs": 1.0,
+                            "flags": "1/1",
+                            "master_advertisement_interval_secs": 1.0,
+                            "master_down_interval_secs": 3.609,
+                            "master_router_ip": "10.13.120.1",
+                            "master_router_is_local": true,
+                            "master_router_priority": 100,
+                            "preemption": "enabled",
+                            "priority": 100,
+                            "state": "Master",
+                            "track_objects": {
+                                "1": {
+                                    "decrement": 15,
+                                    "state": "Up"
+                                }
+                            },
+                            "virtual_ip_address": "10.13.120.254",
+                            "virtual_mac_address": "0000.5eff.010a"
+                        }
                     }
-                },
-                "virtual_ip_address": "10.13.120.254",
-                "virtual_mac_address": "0000.5eff.010a"
+                }
             }
         }
     }

--- a/tests/parsers/iosxe/show_vrrp/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vrrp/001_basic/input.txt
@@ -1,0 +1,12 @@
+GigabitEthernet3.420 - Group 10
+  State is Master
+  Virtual IP address is 10.13.120.254
+  Virtual MAC address is 0000.5eff.010a
+  Advertisement interval is 1.000 sec
+  Preemption enabled
+  Priority is 100
+    Track object 1 state Up decrement 15
+  Master Router is 10.13.120.1 (local), priority is 100
+  Master Advertisement interval is 1.000 sec
+  Master Down interval is 3.609 sec
+  FLAGS: 1/1

--- a/tests/parsers/iosxe/show_vrrp/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vrrp/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic VRRP output with single group, tracking, and authentication
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/expected.json
+++ b/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/expected.json
@@ -1,0 +1,52 @@
+{
+    "interfaces": {
+        "Vlan33": {
+            "10/IPv4": {
+                "address_family": "IPv4",
+                "advertisement_interval_secs": 1.0,
+                "description": "WORKING-VRRP",
+                "flags": "1/1",
+                "master_advertisement_expires_msec": 46,
+                "master_advertisement_interval_secs": 1.0,
+                "master_router_ip": "17.0.0.1",
+                "master_router_is_local": true,
+                "master_router_priority": 150,
+                "preemption": "enabled",
+                "priority": 150,
+                "state": "MASTER",
+                "state_duration_secs": 520.214,
+                "track_objects": {
+                    "1": {
+                        "decrement": 70,
+                        "state": "UP"
+                    }
+                },
+                "virtual_ip_address": "17.0.0.154",
+                "virtual_mac_address": "0000.5E00.010A"
+            },
+            "10/IPv6": {
+                "address_family": "IPv6",
+                "advertisement_interval_secs": 1.0,
+                "description": "WORKING-VRRP",
+                "flags": "1/1",
+                "master_advertisement_expires_msec": 441,
+                "master_advertisement_interval_secs": 1.0,
+                "master_router_ip": "FE80::2A3:D1FF:FE45:BEC5",
+                "master_router_is_local": true,
+                "master_router_priority": 150,
+                "preemption": "enabled",
+                "priority": 150,
+                "state": "MASTER",
+                "state_duration_secs": 520.213,
+                "track_objects": {
+                    "1": {
+                        "decrement": 70,
+                        "state": "UP"
+                    }
+                },
+                "virtual_ip_address": "FE80::1",
+                "virtual_mac_address": "0000.5E00.020A"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/expected.json
+++ b/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/expected.json
@@ -1,51 +1,57 @@
 {
     "interfaces": {
         "Vlan33": {
-            "10/IPv4": {
-                "address_family": "IPv4",
-                "advertisement_interval_secs": 1.0,
-                "description": "WORKING-VRRP",
-                "flags": "1/1",
-                "master_advertisement_expires_msec": 46,
-                "master_advertisement_interval_secs": 1.0,
-                "master_router_ip": "17.0.0.1",
-                "master_router_is_local": true,
-                "master_router_priority": 150,
-                "preemption": "enabled",
-                "priority": 150,
-                "state": "MASTER",
-                "state_duration_secs": 520.214,
-                "track_objects": {
-                    "1": {
-                        "decrement": 70,
-                        "state": "UP"
+            "groups": {
+                "10": {
+                    "address_families": {
+                        "IPv4": {
+                            "address_family": "IPv4",
+                            "advertisement_interval_secs": 1.0,
+                            "description": "WORKING-VRRP",
+                            "flags": "1/1",
+                            "master_advertisement_expires_msec": 46,
+                            "master_advertisement_interval_secs": 1.0,
+                            "master_router_ip": "17.0.0.1",
+                            "master_router_is_local": true,
+                            "master_router_priority": 150,
+                            "preemption": "enabled",
+                            "priority": 150,
+                            "state": "MASTER",
+                            "state_duration_secs": 520.214,
+                            "track_objects": {
+                                "1": {
+                                    "decrement": 70,
+                                    "state": "UP"
+                                }
+                            },
+                            "virtual_ip_address": "17.0.0.154",
+                            "virtual_mac_address": "0000.5E00.010A"
+                        },
+                        "IPv6": {
+                            "address_family": "IPv6",
+                            "advertisement_interval_secs": 1.0,
+                            "description": "WORKING-VRRP",
+                            "flags": "1/1",
+                            "master_advertisement_expires_msec": 441,
+                            "master_advertisement_interval_secs": 1.0,
+                            "master_router_ip": "FE80::2A3:D1FF:FE45:BEC5",
+                            "master_router_is_local": true,
+                            "master_router_priority": 150,
+                            "preemption": "enabled",
+                            "priority": 150,
+                            "state": "MASTER",
+                            "state_duration_secs": 520.213,
+                            "track_objects": {
+                                "1": {
+                                    "decrement": 70,
+                                    "state": "UP"
+                                }
+                            },
+                            "virtual_ip_address": "FE80::1",
+                            "virtual_mac_address": "0000.5E00.020A"
+                        }
                     }
-                },
-                "virtual_ip_address": "17.0.0.154",
-                "virtual_mac_address": "0000.5E00.010A"
-            },
-            "10/IPv6": {
-                "address_family": "IPv6",
-                "advertisement_interval_secs": 1.0,
-                "description": "WORKING-VRRP",
-                "flags": "1/1",
-                "master_advertisement_expires_msec": 441,
-                "master_advertisement_interval_secs": 1.0,
-                "master_router_ip": "FE80::2A3:D1FF:FE45:BEC5",
-                "master_router_is_local": true,
-                "master_router_priority": 150,
-                "preemption": "enabled",
-                "priority": 150,
-                "state": "MASTER",
-                "state_duration_secs": 520.213,
-                "track_objects": {
-                    "1": {
-                        "decrement": 70,
-                        "state": "UP"
-                    }
-                },
-                "virtual_ip_address": "FE80::1",
-                "virtual_mac_address": "0000.5E00.020A"
+                }
             }
         }
     }

--- a/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/input.txt
+++ b/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/input.txt
@@ -1,0 +1,31 @@
+Vlan33 - Group 10 - Address-Family IPv4
+  Description is "WORKING-VRRP"
+  State is MASTER
+  State duration 8 mins 40.214 secs
+  Virtual IP address is 17.0.0.154
+  Virtual MAC address is 0000.5E00.010A
+  Advertisement interval is 1000 msec
+  Preemption enabled
+  Priority is 150
+    Track object 1 state UP decrement 70
+  Master Router is 17.0.0.1 (local), priority is 150
+  Master Advertisement interval is 1000 msec (expires in 46 msec)
+  Master Down interval is unknown
+  FLAGS: 1/1
+
+Vlan33 - Group 10 - Address-Family IPv6
+  Description is "WORKING-VRRP"
+  State is MASTER
+  State duration 8 mins 40.213 secs
+  Virtual IP address is FE80::1
+  Virtual secondary IP addresses:
+    17::154/64
+  Virtual MAC address is 0000.5E00.020A
+  Advertisement interval is 1000 msec
+  Preemption enabled
+  Priority is 150
+    Track object 1 state UP decrement 70
+  Master Router is FE80::2A3:D1FF:FE45:BEC5 (local), priority is 150
+  Master Advertisement interval is 1000 msec (expires in 441 msec)
+  Master Down interval is unknown
+  FLAGS: 1/1

--- a/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/metadata.yaml
+++ b/tests/parsers/iosxe/show_vrrp/002_multiple_groups_ipv4_ipv6/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRRP groups with IPv4 and IPv6 address families on same interface
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show vrrp` command on Cisco IOS-XE devices
- Supports single and multiple VRRP groups, IPv4/IPv6 address families, tracking objects, VRRS groups, authentication, state duration, and state change reasons
- Includes 2 test cases: basic single-group output and multi-group IPv4/IPv6 output

## Test plan
- [x] `uv run pytest tests/parsers/iosxe/show_vrrp/ -v` passes (2 test cases)
- [x] `uv run ruff check` and `uv run ruff format` pass
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)