### PR TITLE
feat: add parser for 'show ip arp detail vrf all' on NX-OS

### DIFF
--- a/changes/358.parser_added
+++ b/changes/358.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip arp detail vrf all' on NX-OS.

--- a/src/muninn/parsers/nxos/show_ip_arp_detail_vrf_all.py
+++ b/src/muninn/parsers/nxos/show_ip_arp_detail_vrf_all.py
@@ -1,0 +1,108 @@
+"""Parser for 'show ip arp detail vrf all' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class ArpDetailEntry(TypedDict):
+    """Schema for a single detailed ARP entry."""
+
+    interface: str
+    physical_interface: str
+    age: NotRequired[str]
+    mac_address: NotRequired[str]
+    flags: NotRequired[str]
+    vrf: NotRequired[str]
+
+
+class ShowIpArpDetailVrfAllResult(TypedDict):
+    """Schema for 'show ip arp detail vrf all' parsed output."""
+
+    arp_entries: dict[str, ArpDetailEntry]
+
+
+_ARP_DETAIL_PATTERN = re.compile(
+    r"^(?P<address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+    r"(?P<age>-|\d{2}:\d{2}:\d{2})\s+"
+    r"(?P<mac>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}|INCOMPLETE)\s+"
+    r"(?P<interface>\S+)\s+"
+    r"(?P<physical_interface>\S+)"
+    r"(?:\s+(?P<flags>[\*\+\#]+|CP|PS|RO))?"
+    r"(?:\s+(?P<vrf>\S+))?$"
+)
+
+
+def _build_entry(match: re.Match[str]) -> ArpDetailEntry:
+    """Build an ARP detail entry from a regex match."""
+    entry: ArpDetailEntry = {
+        "interface": canonical_interface_name(
+            match.group("interface"), os=OS.CISCO_NXOS
+        ),
+        "physical_interface": canonical_interface_name(
+            match.group("physical_interface"), os=OS.CISCO_NXOS
+        ),
+    }
+
+    age_str = match.group("age")
+    if age_str != "-":
+        entry["age"] = age_str
+
+    mac = match.group("mac")
+    if mac.upper() != "INCOMPLETE":
+        entry["mac_address"] = mac.lower()
+
+    flags = match.group("flags")
+    if flags:
+        entry["flags"] = flags
+
+    vrf = match.group("vrf")
+    if vrf:
+        entry["vrf"] = vrf
+
+    return entry
+
+
+@register(OS.CISCO_NXOS, "show ip arp detail vrf all")
+class ShowIpArpDetailVrfAllParser(BaseParser[ShowIpArpDetailVrfAllResult]):
+    """Parser for 'show ip arp detail vrf all' command on NX-OS.
+
+    Example output:
+        10.1.7.1       00:17:15  0012.7fff.04d7  mgmt0    mgmt0
+        10.1.3.5          -      aaaa.bbff.8888  Eth1/1   Eth1/1
+        192.168.240.59 00:02:40  0cc4.7aee.9c2e  Vlan240  Po1000  +
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpArpDetailVrfAllResult:
+        """Parse 'show ip arp detail vrf all' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed ARP detail entries keyed by IP address.
+
+        Raises:
+            ValueError: If no ARP entries found.
+        """
+        arp_entries: dict[str, ArpDetailEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = _ARP_DETAIL_PATTERN.match(line)
+            if match:
+                arp_entries[match.group("address")] = _build_entry(match)
+
+        if not arp_entries:
+            msg = "No ARP entries found in output"
+            raise ValueError(msg)
+
+        return ShowIpArpDetailVrfAllResult(arp_entries=arp_entries)

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/001_basic/expected.json
@@ -1,0 +1,54 @@
+{
+    "arp_entries": {
+        "10.48.3.254": {
+            "age": "00:00:05",
+            "interface": "mgmt0",
+            "mac_address": "0000.5e00.0101",
+            "physical_interface": "mgmt0",
+            "vrf": "management"
+        },
+        "172.20.12.16": {
+            "age": "00:03:13",
+            "interface": "Ethernet1/54",
+            "mac_address": "10b3.d6dc.0293",
+            "physical_interface": "Ethernet1/54",
+            "vrf": "default"
+        },
+        "172.20.12.18": {
+            "age": "00:01:53",
+            "interface": "Vlan3622",
+            "mac_address": "7c21.0e12.3627",
+            "physical_interface": "Port-channel1000",
+            "vrf": "default"
+        },
+        "172.24.8.85": {
+            "age": "00:16:58",
+            "interface": "Port-channel1100.3623",
+            "mac_address": "7c21.0e12.3627",
+            "physical_interface": "Port-channel1100.3623",
+            "vrf": "VRFTEST"
+        },
+        "172.24.8.89": {
+            "age": "00:17:00",
+            "interface": "Port-channel1100.3624",
+            "mac_address": "7c21.0e12.3627",
+            "physical_interface": "Port-channel1100.3624",
+            "vrf": "VRFBORDER"
+        },
+        "192.168.240.59": {
+            "age": "00:02:40",
+            "flags": "+",
+            "interface": "Vlan240",
+            "mac_address": "0cc4.7aee.9c2e",
+            "physical_interface": "Port-channel1000",
+            "vrf": "VRFTEST"
+        },
+        "192.168.240.62": {
+            "age": "00:12:56",
+            "interface": "Vlan240",
+            "mac_address": "a2b6.9300.0003",
+            "physical_interface": "Ethernet163/1/47",
+            "vrf": "VRFTEST"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/001_basic/input.txt
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/001_basic/input.txt
@@ -1,0 +1,19 @@
+LEAF_6# show ip arp detail vrf all
+
+Flags: * - Adjacencies learnt on non-active FHRP router
+       + - Adjacencies synced via CFSoE
+       # - Adjacencies Throttled for Glean
+       CP - Added via L2RIB, Control plane Adjacencies
+       PS - Added via L2RIB, Peer Sync
+       RO - Re-Originated Peer Sync Entry
+
+IP ARP Table for all contexts
+Total number of entries: 7
+Address         Age       MAC Address     Interface        Physical Interface  Flags    VRF Name
+10.48.3.254     00:00:05  0000.5e00.0101  mgmt0            mgmt0                        management
+172.20.12.16    00:03:13  10b3.d6dc.0293  Ethernet1/54     Ethernet1/54                 default
+172.20.12.18    00:01:53  7c21.0e12.3627  Vlan3622         port-channel1000             default
+172.24.8.85     00:16:58  7c21.0e12.3627  port-channel1100.3623 port-channel1100.3623         VRFTEST
+172.24.8.89     00:17:00  7c21.0e12.3627  port-channel1100.3624 port-channel1100.3624         VRFBORDER
+192.168.240.59  00:02:40  0cc4.7aee.9c2e  Vlan240          port-channel1000    +        VRFTEST
+192.168.240.62  00:12:56  a2b6.9300.0003  Vlan240          Ethernet163/1/47             VRFTEST

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with flags and various interface types
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json
@@ -1,0 +1,27 @@
+{
+    "arp_entries": {
+        "172.16.8.178": {
+            "age": "00:00:04",
+            "interface": "Vlan392",
+            "physical_interface": "Vlan392"
+        },
+        "172.16.8.183": {
+            "age": "00:13:47",
+            "interface": "Vlan392",
+            "mac_address": "0050.56ff.ece6",
+            "physical_interface": "Port-channel105"
+        },
+        "172.16.8.185": {
+            "age": "00:08:55",
+            "flags": "+",
+            "interface": "Vlan392",
+            "mac_address": "0050.56ff.c11c",
+            "physical_interface": "Port-channel110"
+        },
+        "172.16.10.1": {
+            "interface": "Vlan393",
+            "mac_address": "0000.0cff.9129",
+            "physical_interface": "-"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/input.txt
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/input.txt
@@ -1,0 +1,17 @@
+show ip arp detail vrf all
+
+
+Flags: * - Adjacencies learnt on non-active FHRP router
+	   + - Adjacencies synced via CFSoE
+	   # - Adjacencies Throttled for Glean
+	   CP - Added via L2RIB, Control plane Adjacencies
+	   PS - Added via L2RIB, Peer Sync
+	   RO - Re-Originated Peer Sync Entry
+
+IP ARP Table for all contexts
+Total number of entries: 4
+Address         Age       MAC Address     Interface        Physical Interface  Flags
+172.16.8.178    00:00:04  INCOMPLETE      Vlan392          Vlan392
+172.16.8.183    00:13:47  0050.56ff.ece6  Vlan392          port-channel105
+172.16.8.185    00:08:55  0050.56ff.c11c  Vlan392          port-channel110     +
+172.16.10.1        -      0000.0cff.9129  Vlan393          -

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/metadata.yaml
@@ -1,0 +1,3 @@
+description: Entries with INCOMPLETE MAC and static ARP entries
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add new parser for `show ip arp detail vrf all` on Cisco NX-OS
- Parses ARP detail entries including interface, physical interface, MAC address, age, flags, and VRF name
- Handles edge cases: INCOMPLETE MACs (omitted from output), static entries (age `-`), missing physical interface (`-`), and optional VRF/flags columns

## Test plan

- [x] 001_basic: Multiple VRFs with flags and various interface types (7 entries)
- [x] 002_incomplete_and_static: INCOMPLETE MAC addresses, static entries, CFSoE flag
- [x] All pre-commit hooks pass
- [x] Xenon complexity check passes

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)