### PR TITLE
feat: add parser for 'show bgp neighbors' on IOS-XE

### DIFF
--- a/changes/359.parser_added
+++ b/changes/359.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bgp neighbors' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_bgp_neighbors.py
+++ b/src/muninn/parsers/iosxe/show_ip_bgp_neighbors.py
@@ -556,6 +556,7 @@ def _parse_neighbor_block(lines: list[str]) -> NeighborEntry:
 
 
 @register(OS.CISCO_IOSXE, "show ip bgp neighbors")
+@register(OS.CISCO_IOSXE, "show bgp neighbors")
 class ShowIpBgpNeighborsParser(BaseParser["ShowIpBgpNeighborsResult"]):
     """Parser for 'show ip bgp neighbors' on IOS-XE.
 

--- a/tests/parsers/iosxe/show_bgp_neighbors/001_two_internal_neighbors/expected.json
+++ b/tests/parsers/iosxe/show_bgp_neighbors/001_two_internal_neighbors/expected.json
@@ -1,0 +1,136 @@
+{
+    "neighbors": {
+        "10.1.1.1": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbor_version": 1,
+                    "prefix_activity": {
+                        "explicit_withdraw_rcvd": 0,
+                        "explicit_withdraw_sent": 0,
+                        "implicit_withdraw_rcvd": 0,
+                        "implicit_withdraw_sent": 0,
+                        "prefixes_current_rcvd": 0,
+                        "prefixes_current_sent": 0,
+                        "prefixes_total_rcvd": 0,
+                        "prefixes_total_sent": 0,
+                        "used_as_bestpath": 0,
+                        "used_as_multipath": 0
+                    },
+                    "table_version": 1
+                },
+                "VPNv4 Unicast": {
+                    "neighbor_version": 21,
+                    "prefix_activity": {
+                        "explicit_withdraw_rcvd": 0,
+                        "explicit_withdraw_sent": 0,
+                        "implicit_withdraw_rcvd": 0,
+                        "implicit_withdraw_sent": 4,
+                        "prefixes_current_rcvd": 4,
+                        "prefixes_current_sent": 4,
+                        "prefixes_total_rcvd": 4,
+                        "prefixes_total_sent": 8,
+                        "used_as_bestpath": 4,
+                        "used_as_multipath": 0
+                    },
+                    "table_version": 21
+                }
+            },
+            "bgp_state": "Established",
+            "bgp_version": 4,
+            "connections_dropped": 0,
+            "connections_established": 1,
+            "foreign_host": "10.1.1.1",
+            "foreign_port": 44730,
+            "hold_time": 180,
+            "keepalive_interval": 60,
+            "last_read": "00:00:46",
+            "last_write": "00:00:33",
+            "link_type": "internal",
+            "local_host": "10.5.5.5",
+            "local_port": 179,
+            "message_stats": {
+                "keepalives_rcvd": 6147,
+                "keepalives_sent": 6146,
+                "notifications_rcvd": 0,
+                "notifications_sent": 0,
+                "opens_rcvd": 1,
+                "opens_sent": 1,
+                "route_refresh_rcvd": 0,
+                "route_refresh_sent": 0,
+                "total_rcvd": 6162,
+                "total_sent": 6157,
+                "updates_rcvd": 14,
+                "updates_sent": 10
+            },
+            "remote_as": 65000,
+            "router_id": "10.1.1.1",
+            "state_duration": "3d21h"
+        },
+        "10.2.2.2": {
+            "address_families": {
+                "IPv4 Unicast": {
+                    "neighbor_version": 1,
+                    "prefix_activity": {
+                        "explicit_withdraw_rcvd": 0,
+                        "explicit_withdraw_sent": 0,
+                        "implicit_withdraw_rcvd": 0,
+                        "implicit_withdraw_sent": 0,
+                        "prefixes_current_rcvd": 0,
+                        "prefixes_current_sent": 0,
+                        "prefixes_total_rcvd": 0,
+                        "prefixes_total_sent": 0,
+                        "used_as_bestpath": 0,
+                        "used_as_multipath": 0
+                    },
+                    "table_version": 1
+                },
+                "VPNv4 Unicast": {
+                    "neighbor_version": 21,
+                    "prefix_activity": {
+                        "explicit_withdraw_rcvd": 0,
+                        "explicit_withdraw_sent": 0,
+                        "implicit_withdraw_rcvd": 0,
+                        "implicit_withdraw_sent": 4,
+                        "prefixes_current_rcvd": 4,
+                        "prefixes_current_sent": 4,
+                        "prefixes_total_rcvd": 4,
+                        "prefixes_total_sent": 8,
+                        "used_as_bestpath": 0,
+                        "used_as_multipath": 0
+                    },
+                    "table_version": 21
+                }
+            },
+            "bgp_state": "Established",
+            "bgp_version": 4,
+            "connections_dropped": 0,
+            "connections_established": 1,
+            "foreign_host": "10.2.2.2",
+            "foreign_port": 43047,
+            "hold_time": 180,
+            "keepalive_interval": 60,
+            "last_read": "00:00:04",
+            "last_write": "00:00:28",
+            "link_type": "internal",
+            "local_host": "10.5.5.5",
+            "local_port": 179,
+            "message_stats": {
+                "keepalives_rcvd": 6139,
+                "keepalives_sent": 6134,
+                "notifications_rcvd": 0,
+                "notifications_sent": 0,
+                "opens_rcvd": 1,
+                "opens_sent": 1,
+                "route_refresh_rcvd": 0,
+                "route_refresh_sent": 0,
+                "total_rcvd": 6154,
+                "total_sent": 6145,
+                "updates_rcvd": 14,
+                "updates_sent": 10
+            },
+            "remote_as": 65000,
+            "router_id": "10.2.2.2",
+            "state_duration": "3d21h"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_neighbors/001_two_internal_neighbors/input.txt
+++ b/tests/parsers/iosxe/show_bgp_neighbors/001_two_internal_neighbors/input.txt
@@ -1,0 +1,229 @@
+BGP neighbor is 10.1.1.1,  remote AS 65000, internal link
+  BGP version 4, remote router ID 10.1.1.1
+  BGP state = Established, up for 3d21h
+  Last read 00:00:46, last write 00:00:33, hold time is 180, keepalive interval is 60 seconds
+  Neighbor sessions:
+    1 active, is not multisession capable (disabled)
+  Neighbor capabilities:
+    Route refresh: advertised and received(new)
+    Four-octets ASN Capability: advertised and received
+    Address family IPv4 Unicast: advertised and received
+    Address family VPNv4 Unicast: advertised and received
+    Enhanced Refresh Capability: advertised and received
+    Multisession Capability:
+    Stateful switchover support enabled: NO for session 1
+  Message statistics:
+    InQ depth is 0
+    OutQ depth is 0
+
+                             Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:               10         14
+    Keepalives:          6146       6147
+    Route Refresh:          0          0
+    Total:               6157       6162
+  Do log neighbor state changes (via global configuration)
+  Default minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv4 Unicast
+  Session: 10.1.1.1
+  BGP table version 1, neighbor version 1/0
+  Output queue size : 0
+  Index 1, Advertise bit 0
+  1 update-group member
+  Slow-peer detection is disabled
+  Slow-peer split-update-group dynamic is disabled
+                                     Sent       Rcvd
+  Prefix activity:               ----       ----
+    Prefixes Current:               0          0
+    Prefixes Total:                 0          0
+    Implicit Withdraw:              0          0
+    Explicit Withdraw:              0          0
+    Used as bestpath:             n/a          0
+    Used as multipath:            n/a          0
+    Used as secondary:            n/a          0
+
+                                       Outbound    Inbound
+  Local Policy Denied Prefixes:    --------    -------
+    Total:                                0          0
+  Number of NLRIs in the update sent: max 0, min 0
+  Last detected as dynamic slow peer: never
+  Dynamic slow peer recovered: never
+  Refresh Epoch: 1
+  Last Sent Refresh Start-of-rib: never
+  Last Sent Refresh End-of-rib: never
+  Last Received Refresh Start-of-rib: never
+  Last Received Refresh End-of-rib: never
+                           Sent   Rcvd
+    Refresh activity:          ----   ----
+      Refresh Start-of-RIB          0          0
+      Refresh End-of-RIB            0          0
+
+ For address family: VPNv4 Unicast
+  Session: 10.1.1.1
+  BGP table version 21, neighbor version 21/0
+  Output queue size : 0
+  Index 3, Advertise bit 1
+  3 update-group member
+  Extended-community attribute sent to this neighbor
+  Slow-peer detection is disabled
+  Slow-peer split-update-group dynamic is disabled
+                                     Sent       Rcvd
+  Prefix activity:               ----       ----
+    Prefixes Current:               4          4 (Consumes 544 bytes)
+    Prefixes Total:                 8          4
+    Implicit Withdraw:              4          0
+    Explicit Withdraw:              0          0
+    Used as bestpath:             n/a          4
+    Used as multipath:            n/a          0
+    Used as secondary:            n/a          0
+
+                                       Outbound    Inbound
+  Local Policy Denied Prefixes:    --------    -------
+    ORIGINATOR loop:                    n/a          8
+    Bestpath from this peer:              4        n/a
+    Bestpath from iBGP peer:              4        n/a
+    AF Permit Check:                      4        n/a
+    Total:                               12          8
+  Number of NLRIs in the update sent: max 1, min 0
+  Last detected as dynamic slow peer: never
+  Dynamic slow peer recovered: never
+  Refresh Epoch: 1
+  Last Sent Refresh Start-of-rib: never
+  Last Sent Refresh End-of-rib: never
+  Last Received Refresh Start-of-rib: never
+  Last Received Refresh End-of-rib: never
+                           Sent   Rcvd
+    Refresh activity:          ----   ----
+      Refresh Start-of-RIB          0          0
+      Refresh End-of-RIB            0          0
+
+  Address tracking is enabled, the RIB does have a route to 10.1.1.1
+  Route to peer address reachability Up: 2; Down: 1
+    Last notification 3d20h
+  Connections established 1; dropped 0
+  Last reset never
+  Interface associated: (none) (peering address NOT in same link)
+  Transport(tcp) path-mtu-discovery is enabled
+  Graceful-Restart is disabled
+  SSO is disabled
+Connection state is ESTAB, I/O status: 1, unread input bytes: 0
+Connection is ECN Disabled, Mininum incoming TTL 0, Outgoing TTL 255
+Local host: 10.5.5.5, Local port: 179
+Foreign host: 10.1.1.1, Foreign port: 44730
+
+BGP neighbor is 10.2.2.2,  remote AS 65000, internal link
+  BGP version 4, remote router ID 10.2.2.2
+  BGP state = Established, up for 3d21h
+  Last read 00:00:04, last write 00:00:28, hold time is 180, keepalive interval is 60 seconds
+  Neighbor sessions:
+    1 active, is not multisession capable (disabled)
+  Neighbor capabilities:
+    Route refresh: advertised and received(new)
+    Four-octets ASN Capability: advertised and received
+    Address family IPv4 Unicast: advertised and received
+    Address family VPNv4 Unicast: advertised and received
+    Enhanced Refresh Capability: advertised and received
+    Multisession Capability:
+    Stateful switchover support enabled: NO for session 1
+  Message statistics:
+    InQ depth is 0
+    OutQ depth is 0
+
+                             Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:               10         14
+    Keepalives:          6134       6139
+    Route Refresh:          0          0
+    Total:               6145       6154
+  Do log neighbor state changes (via global configuration)
+  Default minimum time between advertisement runs is 0 seconds
+
+ For address family: IPv4 Unicast
+  Session: 10.2.2.2
+  BGP table version 1, neighbor version 1/0
+  Output queue size : 0
+  Index 1, Advertise bit 0
+  1 update-group member
+  Slow-peer detection is disabled
+  Slow-peer split-update-group dynamic is disabled
+                                     Sent       Rcvd
+  Prefix activity:               ----       ----
+    Prefixes Current:               0          0
+    Prefixes Total:                 0          0
+    Implicit Withdraw:              0          0
+    Explicit Withdraw:              0          0
+    Used as bestpath:             n/a          0
+    Used as multipath:            n/a          0
+    Used as secondary:            n/a          0
+
+                                       Outbound    Inbound
+  Local Policy Denied Prefixes:    --------    -------
+    Total:                                0          0
+  Number of NLRIs in the update sent: max 0, min 0
+  Last detected as dynamic slow peer: never
+  Dynamic slow peer recovered: never
+  Refresh Epoch: 1
+  Last Sent Refresh Start-of-rib: never
+  Last Sent Refresh End-of-rib: never
+  Last Received Refresh Start-of-rib: never
+  Last Received Refresh End-of-rib: never
+                           Sent   Rcvd
+    Refresh activity:          ----   ----
+      Refresh Start-of-RIB          0          0
+      Refresh End-of-RIB            0          0
+
+ For address family: VPNv4 Unicast
+  Session: 10.2.2.2
+  BGP table version 21, neighbor version 21/0
+  Output queue size : 0
+  Index 3, Advertise bit 1
+  3 update-group member
+  Extended-community attribute sent to this neighbor
+  Slow-peer detection is disabled
+  Slow-peer split-update-group dynamic is disabled
+                                     Sent       Rcvd
+  Prefix activity:               ----       ----
+    Prefixes Current:               4          4 (Consumes 544 bytes)
+    Prefixes Total:                 8          4
+    Implicit Withdraw:              4          0
+    Explicit Withdraw:              0          0
+    Used as bestpath:             n/a          0
+    Used as multipath:            n/a          0
+    Used as secondary:            n/a          0
+
+                                       Outbound    Inbound
+  Local Policy Denied Prefixes:    --------    -------
+    ORIGINATOR loop:                    n/a          8
+    Bestpath from this peer:              4        n/a
+    Bestpath from iBGP peer:              4        n/a
+    AF Permit Check:                      4        n/a
+    Total:                               12          8
+  Number of NLRIs in the update sent: max 1, min 0
+  Last detected as dynamic slow peer: never
+  Dynamic slow peer recovered: never
+  Refresh Epoch: 1
+  Last Sent Refresh Start-of-rib: never
+  Last Sent Refresh End-of-rib: never
+  Last Received Refresh Start-of-rib: never
+  Last Received Refresh End-of-rib: never
+                           Sent   Rcvd
+    Refresh activity:          ----   ----
+      Refresh Start-of-RIB          0          0
+      Refresh End-of-RIB            0          0
+
+  Address tracking is enabled, the RIB does have a route to 10.2.2.2
+  Route to peer address reachability Up: 2; Down: 1
+    Last notification 3d20h
+  Connections established 1; dropped 0
+  Last reset never
+  Interface associated: (none) (peering address NOT in same link)
+  Transport(tcp) path-mtu-discovery is enabled
+  Graceful-Restart is disabled
+  SSO is disabled
+Connection state is ESTAB, I/O status: 1, unread input bytes: 0
+Connection is ECN Disabled, Mininum incoming TTL 0, Outgoing TTL 255
+Local host: 10.5.5.5, Local port: 179
+Foreign host: 10.2.2.2, Foreign port: 43047

--- a/tests/parsers/iosxe/show_bgp_neighbors/001_two_internal_neighbors/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_neighbors/001_two_internal_neighbors/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two internal iBGP neighbors with IPv4 and VPNv4 address families
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_bgp_neighbors/002_single_external_neighbor_with_vrf/expected.json
+++ b/tests/parsers/iosxe/show_bgp_neighbors/002_single_external_neighbor_with_vrf/expected.json
@@ -1,0 +1,55 @@
+{
+    "neighbors": {
+        "172.17.211.2": {
+            "address_families": {
+                "VPNv4 Unicast": {
+                    "neighbor_version": 21,
+                    "prefix_activity": {
+                        "explicit_withdraw_rcvd": 0,
+                        "explicit_withdraw_sent": 0,
+                        "implicit_withdraw_rcvd": 0,
+                        "implicit_withdraw_sent": 3,
+                        "prefixes_current_rcvd": 1,
+                        "prefixes_current_sent": 3,
+                        "prefixes_total_rcvd": 1,
+                        "prefixes_total_sent": 6,
+                        "used_as_bestpath": 1,
+                        "used_as_multipath": 0
+                    },
+                    "table_version": 21
+                }
+            },
+            "bgp_state": "Established",
+            "bgp_version": 4,
+            "connections_dropped": 0,
+            "connections_established": 1,
+            "foreign_host": "172.17.211.2",
+            "foreign_port": 179,
+            "hold_time": 180,
+            "keepalive_interval": 60,
+            "last_read": "00:00:39",
+            "last_write": "00:00:39",
+            "link_type": "external",
+            "local_host": "172.17.211.1",
+            "local_port": 48585,
+            "message_stats": {
+                "keepalives_rcvd": 7772,
+                "keepalives_sent": 7779,
+                "notifications_rcvd": 0,
+                "notifications_sent": 0,
+                "opens_rcvd": 1,
+                "opens_sent": 1,
+                "route_refresh_rcvd": 0,
+                "route_refresh_sent": 0,
+                "total_rcvd": 7775,
+                "total_sent": 7787,
+                "updates_rcvd": 2,
+                "updates_sent": 7
+            },
+            "remote_as": 65001,
+            "router_id": "172.16.1.156",
+            "state_duration": "4d21h",
+            "vrf": "VRF200"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_neighbors/002_single_external_neighbor_with_vrf/input.txt
+++ b/tests/parsers/iosxe/show_bgp_neighbors/002_single_external_neighbor_with_vrf/input.txt
@@ -1,0 +1,78 @@
+BGP neighbor is 172.17.211.2,  vrf VRF200,  remote AS 65001, external link
+  BGP version 4, remote router ID 172.16.1.156
+  BGP state = Established, up for 4d21h
+  Last read 00:00:39, last write 00:00:39, hold time is 180, keepalive interval is 60 seconds
+  Neighbor sessions:
+    1 active, is not multisession capable (disabled)
+  Neighbor capabilities:
+    Route refresh: advertised and received(new)
+    Four-octets ASN Capability: advertised and received
+    Address family IPv4 Unicast: advertised and received
+    Enhanced Refresh Capability: advertised and received
+    Multisession Capability:
+    Stateful switchover support enabled: NO for session 1
+  Message statistics:
+    InQ depth is 0
+    OutQ depth is 0
+
+                             Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:                7          2
+    Keepalives:          7779       7772
+    Route Refresh:          0          0
+    Total:               7787       7775
+  Do log neighbor state changes (via global configuration)
+  Default minimum time between advertisement runs is 0 seconds
+
+ For address family: VPNv4 Unicast
+  Translates address family IPv4 Unicast for VRF VRF200
+  Session: 172.17.211.2
+  BGP table version 21, neighbor version 21/0
+  Output queue size : 0
+  Index 2, Advertise bit 0
+  2 update-group member
+  Overrides the neighbor AS with my AS before sending updates
+  Slow-peer detection is disabled
+  Slow-peer split-update-group dynamic is disabled
+                                     Sent       Rcvd
+  Prefix activity:               ----       ----
+    Prefixes Current:               3          1 (Consumes 136 bytes)
+    Prefixes Total:                 6          1
+    Implicit Withdraw:              3          0
+    Explicit Withdraw:              0          0
+    Used as bestpath:             n/a          1
+    Used as multipath:            n/a          0
+    Used as secondary:            n/a          0
+
+                                       Outbound    Inbound
+  Local Policy Denied Prefixes:    --------    -------
+    Bestpath from this peer:              2        n/a
+    Total:                                2          0
+  Number of NLRIs in the update sent: max 1, min 0
+  Last detected as dynamic slow peer: never
+  Dynamic slow peer recovered: never
+  Refresh Epoch: 1
+  Last Sent Refresh Start-of-rib: never
+  Last Sent Refresh End-of-rib: never
+  Last Received Refresh Start-of-rib: never
+  Last Received Refresh End-of-rib: never
+                           Sent   Rcvd
+    Refresh activity:          ----   ----
+      Refresh Start-of-RIB          0          0
+      Refresh End-of-RIB            0          0
+
+  Address tracking is enabled, the RIB does have a route to 172.17.211.2
+  Route to peer address reachability Up: 1; Down: 0
+    Last notification 4d21h
+  Connections established 1; dropped 0
+  Last reset never
+  External BGP neighbor configured for connected checks (single-hop no-disable-connected-check)
+  Interface associated: GigabitEthernet3.200 (peering address in same link)
+  Transport(tcp) path-mtu-discovery is enabled
+  Graceful-Restart is disabled
+  SSO is disabled
+Connection state is ESTAB, I/O status: 1, unread input bytes: 0
+Connection is ECN Disabled, Mininum incoming TTL 0, Outgoing TTL 1
+Local host: 172.17.211.1, Local port: 48585
+Foreign host: 172.17.211.2, Foreign port: 179

--- a/tests/parsers/iosxe/show_bgp_neighbors/002_single_external_neighbor_with_vrf/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_neighbors/002_single_external_neighbor_with_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single external eBGP neighbor in VRF with VPNv4 address family
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Registers `show bgp neighbors` as an alias on the existing `show ip bgp neighbors` parser for IOS-XE, since the CLI output format is identical
- Adds two test cases sourced from Genie parser test data: one with two internal iBGP neighbors (IPv4 + VPNv4 AFs) and one with a single external eBGP neighbor in a VRF

## Test plan

- [x] Both test cases pass: `uv run pytest tests/parsers/test_parsers.py -k show_bgp_neighbors -v`
- [x] Ruff check and format pass
- [x] Xenon complexity check passes
- [x] All pre-commit hooks pass

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)