### PR TITLE
feat: add parser for 'show bgp summary' on IOS-XE

### DIFF
--- a/changes/361.parser_added
+++ b/changes/361.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bgp summary' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_bgp_summary.py
+++ b/src/muninn/parsers/iosxe/show_bgp_summary.py
@@ -1,0 +1,195 @@
+"""Parser for 'show bgp summary' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class NeighborEntry(TypedDict):
+    """Schema for a single BGP neighbor in the summary table."""
+
+    version: int
+    remote_as: int
+    msg_rcvd: int
+    msg_sent: int
+    table_version: int
+    in_queue: int
+    out_queue: int
+    up_down: str
+    state: NotRequired[str]
+    prefixes_received: NotRequired[int]
+
+
+class ShowBgpSummaryResult(TypedDict):
+    """Schema for 'show bgp summary' parsed output."""
+
+    router_id: str
+    local_as: int
+    neighbors: dict[str, NeighborEntry]
+
+
+def _parse_local_as(raw: str) -> int:
+    """Parse local AS number, handling asdot notation (e.g., '304.304')."""
+    if "." in raw:
+        high, low = raw.split(".", 1)
+        return int(high) * 65536 + int(low)
+    return int(raw)
+
+
+def _is_noise_line(line: str) -> bool:
+    """Return True if the line is a prompt, load, or time source line."""
+    if not line:
+        return True
+    if line.endswith("#") or "#show " in line.lower():
+        return True
+    return line.startswith("Load for ") or line.startswith("Time source ")
+
+
+def _parse_state_pfxrcd(value: str) -> tuple[str | None, int | None]:
+    """Parse the State/PfxRcd field into state and prefix count.
+
+    If the value is a plain integer, it represents prefixes received.
+    Otherwise, it is a state string (e.g., 'Idle', 'Active', 'Connect').
+    """
+    try:
+        return (None, int(value))
+    except ValueError:
+        return (value, None)
+
+
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<neighbor>\S+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<remote_as>\S+)\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<tbl_ver>\d+)\s+"
+    r"(?P<in_q>\d+)\s+"
+    r"(?P<out_q>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfxrcd>\S+)\s*$"
+)
+
+
+_ROUTER_ID_PATTERN = re.compile(
+    r"BGP\s+router\s+identifier\s+(?P<router_id>\S+),\s+"
+    r"local\s+AS\s+number\s+(?P<local_as>\S+)"
+)
+
+_HEADER_PATTERN = re.compile(r"^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent")
+
+
+def _build_neighbor_entry(
+    match: re.Match[str],
+) -> tuple[str, NeighborEntry]:
+    """Build a NeighborEntry from a regex match on a neighbor row."""
+    neighbor = match.group("neighbor")
+    state, prefixes = _parse_state_pfxrcd(match.group("state_pfxrcd"))
+
+    entry: NeighborEntry = {
+        "version": int(match.group("version")),
+        "remote_as": _parse_local_as(match.group("remote_as")),
+        "msg_rcvd": int(match.group("msg_rcvd")),
+        "msg_sent": int(match.group("msg_sent")),
+        "table_version": int(match.group("tbl_ver")),
+        "in_queue": int(match.group("in_q")),
+        "out_queue": int(match.group("out_q")),
+        "up_down": match.group("up_down"),
+    }
+
+    if state is not None:
+        entry["state"] = state
+    if prefixes is not None:
+        entry["prefixes_received"] = prefixes
+
+    return (neighbor, entry)
+
+
+def _find_router_id(
+    lines: list[str],
+) -> tuple[str | None, int | None]:
+    """Find the first BGP router identifier line and extract ID and AS."""
+    for line in lines:
+        stripped = line.strip()
+        if _is_noise_line(stripped):
+            continue
+        id_match = _ROUTER_ID_PATTERN.search(stripped)
+        if id_match:
+            rid = id_match.group("router_id")
+            las = _parse_local_as(id_match.group("local_as"))
+            return (rid, las)
+    return (None, None)
+
+
+def _parse_neighbors(
+    lines: list[str],
+) -> dict[str, NeighborEntry]:
+    """Parse neighbor rows from lines following the table header."""
+    neighbors: dict[str, NeighborEntry] = {}
+    in_table = False
+
+    for line in lines:
+        stripped = line.strip()
+        if _is_noise_line(stripped):
+            continue
+
+        if _HEADER_PATTERN.match(stripped):
+            in_table = True
+            continue
+
+        if not in_table:
+            continue
+
+        match = _NEIGHBOR_PATTERN.match(stripped)
+        if match:
+            key, entry = _build_neighbor_entry(match)
+            neighbors[key] = entry
+
+    return neighbors
+
+
+@register(OS.CISCO_IOSXE, "show bgp summary")
+class ShowBgpSummaryParser(BaseParser["ShowBgpSummaryResult"]):
+    """Parser for 'show bgp summary' command.
+
+    Example output::
+
+        BGP router identifier 192.168.111.1, local AS number 100
+        Neighbor   V    AS MsgRcvd MsgSent TblVer InQ OutQ Up/Down State/PfxRcd
+        192.168.111.1  4  100    0    0     1   0   0 01:07:38 Idle
+        10.5.17.1      4  150  220  217    60   0   0 03:08:19   15
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowBgpSummaryResult:
+        """Parse 'show bgp summary' output.
+
+        Args:
+            output: Raw CLI output from 'show bgp summary' command.
+
+        Returns:
+            Parsed data with neighbors keyed by neighbor address.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+
+        router_id, local_as = _find_router_id(lines)
+        if router_id is None or local_as is None:
+            msg = "Could not find BGP router identifier in output"
+            raise ValueError(msg)
+
+        neighbors = _parse_neighbors(lines)
+        if not neighbors:
+            msg = "No BGP neighbors found in output"
+            raise ValueError(msg)
+
+        return ShowBgpSummaryResult(
+            router_id=router_id,
+            local_as=local_as,
+            neighbors=neighbors,
+        )

--- a/tests/parsers/iosxe/show_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_bgp_summary/001_basic/expected.json
@@ -1,0 +1,50 @@
+{
+    "local_as": 65100,
+    "neighbors": {
+        "10.5.17.1": {
+            "in_queue": 0,
+            "msg_rcvd": 220,
+            "msg_sent": 217,
+            "out_queue": 0,
+            "prefixes_received": 15,
+            "remote_as": 150,
+            "table_version": 60,
+            "up_down": "03:08:19",
+            "version": 4
+        },
+        "10.5.18.1": {
+            "in_queue": 0,
+            "msg_rcvd": 220,
+            "msg_sent": 217,
+            "out_queue": 0,
+            "prefixes_received": 15,
+            "remote_as": 150,
+            "table_version": 60,
+            "up_down": "03:09:00",
+            "version": 4
+        },
+        "10.5.27.1": {
+            "in_queue": 0,
+            "msg_rcvd": 219,
+            "msg_sent": 223,
+            "out_queue": 0,
+            "prefixes_received": 15,
+            "remote_as": 150,
+            "table_version": 60,
+            "up_down": "03:08:20",
+            "version": 4
+        },
+        "10.5.28.1": {
+            "in_queue": 0,
+            "msg_rcvd": 219,
+            "msg_sent": 224,
+            "out_queue": 0,
+            "prefixes_received": 15,
+            "remote_as": 150,
+            "table_version": 60,
+            "up_down": "03:08:56",
+            "version": 4
+        }
+    },
+    "router_id": "30.1.107.78"
+}

--- a/tests/parsers/iosxe/show_bgp_summary/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_bgp_summary/001_basic/input.txt
@@ -1,0 +1,19 @@
+BGP router identifier 30.1.107.78, local AS number 65100
+BGP table version is 60, main routing table version 60
+17 network entries using 4216 bytes of memory
+62 path entries using 8432 bytes of memory
+15 multipath network entries and 56 multipath paths
+4/4 BGP path/bestpath attribute entries using 1184 bytes of memory
+4 BGP AS-PATH entries using 128 bytes of memory
+103 BGP extended community entries using 4540 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 18500 total bytes of memory
+BGP activity 13646/1790 prefixes, 34178/7652 paths, scan interval 60 secs
+17 networks peaked at 09:18:03 Dec 8 2021 PDT (03:09:01.606 ago)
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.5.17.1       4          150     220     217       60    0    0 03:08:19       15
+10.5.18.1       4          150     220     217       60    0    0 03:09:00       15
+10.5.27.1       4          150     219     223       60    0    0 03:08:20       15
+10.5.28.1       4          150     219     224       60    0    0 03:08:56       15

--- a/tests/parsers/iosxe/show_bgp_summary/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with multiple established neighbors showing prefix counts
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_bgp_summary/002_neighbors_in_state/expected.json
+++ b/tests/parsers/iosxe/show_bgp_summary/002_neighbors_in_state/expected.json
@@ -1,0 +1,61 @@
+{
+    "local_as": 100,
+    "neighbors": {
+        "192.168.111.1": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 100,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "01:07:38",
+            "version": 4
+        },
+        "192.168.19.2": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 300,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "01:07:38",
+            "version": 4
+        },
+        "192.168.4.1": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 100,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "192.168.51.1": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 100,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "01:07:38",
+            "version": 4
+        },
+        "192.168.70.4": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 200,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        }
+    },
+    "router_id": "192.168.111.1"
+}

--- a/tests/parsers/iosxe/show_bgp_summary/002_neighbors_in_state/input.txt
+++ b/tests/parsers/iosxe/show_bgp_summary/002_neighbors_in_state/input.txt
@@ -1,0 +1,20 @@
+Router#show bgp summary
+Load for five secs: 12%/0%; one minute: 8%; five minutes: 6%
+Time source is NTP, 16:14:07.495 EST Tue Jun 8 2016
+BGP router identifier 192.168.111.1, local AS number 100
+BGP table version is 28, main routing table version 28
+27 network entries using 6696 bytes of memory
+27 path entries using 3672 bytes of memory
+1/1 BGP path/bestpath attribute entries using 280 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 10648 total bytes of memory
+BGP activity 47/20 prefixes, 66/39 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.111.1       4          100       0       0        1    0    0 01:07:38 Idle
+192.168.4.1       4          100       0       0        1    0    0 never    Idle
+192.168.51.1       4          100       0       0        1    0    0 01:07:38 Idle
+192.168.70.4      4          200       0       0        1    0    0 never    Idle
+192.168.19.2      4          300       0       0        1    0    0 01:07:38 Idle
+Router#

--- a/tests/parsers/iosxe/show_bgp_summary/002_neighbors_in_state/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_summary/002_neighbors_in_state/metadata.yaml
@@ -1,0 +1,3 @@
+description: Neighbors in Idle state with no prefixes received
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add a new parser for `show bgp summary` on Cisco IOS-XE that extracts the BGP router identifier, local AS number, and neighbor table entries
- Each neighbor entry includes version, remote AS, message counts, queue depths, uptime, and either state or prefix count
- Handles asdot AS notation, noise/prompt lines, and both established and non-established neighbor states
- Includes two test cases: basic output with established neighbors and edge case with all neighbors in Idle state

Closes #111

## Test plan

- [x] `001_basic` - Four established neighbors with prefix counts
- [x] `002_neighbors_in_state` - Five neighbors in Idle state with prompt/load noise lines
- [x] `uv run ruff check` passes
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)