### PR TITLE
feat: add parser for 'show standby' on IOS

### DIFF
--- a/changes/363.parser_added
+++ b/changes/363.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show standby' on IOS.

--- a/src/muninn/parsers/ios/show_standby.py
+++ b/src/muninn/parsers/ios/show_standby.py
@@ -166,12 +166,12 @@ def _match_track_line(stripped: str) -> TrackEntry | None:
 
     match = _TRACK_INTERFACE_RE.match(stripped)
     if match:
-        entry = {"type": "interface", "name": match.group("name")}
+        iface_entry: TrackEntry = {"type": "interface", "name": match.group("name")}
         if match.group("state"):
-            entry["state"] = match.group("state")
+            iface_entry["state"] = match.group("state")
         if match.group("decrement"):
-            entry["decrement"] = int(match.group("decrement"))
-        return entry
+            iface_entry["decrement"] = int(match.group("decrement"))
+        return iface_entry
 
     return None
 

--- a/src/muninn/parsers/ios/show_standby.py
+++ b/src/muninn/parsers/ios/show_standby.py
@@ -51,10 +51,16 @@ class StandbyGroupEntry(TypedDict):
     tracks: NotRequired[list[TrackEntry]]
 
 
+class StandbyInterfaceEntry(TypedDict):
+    """Schema for HSRP groups under a single interface."""
+
+    groups: dict[str, StandbyGroupEntry]
+
+
 class ShowStandbyResult(TypedDict):
     """Schema for 'show standby' parsed output."""
 
-    groups: dict[str, StandbyGroupEntry]
+    interfaces: dict[str, StandbyInterfaceEntry]
 
 
 # Block header: "Vlan50 - Group 50 (version 2)" or "Vlan50 - Group 50"
@@ -178,15 +184,14 @@ def _match_track_line(stripped: str) -> TrackEntry | None:
 
 def _parse_block(
     header: re.Match[str], lines: list[str]
-) -> tuple[str, StandbyGroupEntry]:
+) -> tuple[str, str, StandbyGroupEntry]:
     """Parse a single interface/group block into a StandbyGroupEntry."""
     interface = canonical_interface_name(header.group("interface"), os=OS.CISCO_IOS)
-    group = int(header.group("group"))
-    key = f"{interface}|{group}"
+    group = header.group("group")
 
     entry: dict[str, object] = {
         "interface": interface,
-        "group": group,
+        "group": int(group),
     }
 
     if header.group("version"):
@@ -194,7 +199,18 @@ def _parse_block(
 
     _extract_fields(lines, entry)
 
-    return key, entry  # type: ignore[return-value]
+    return interface, group, entry  # type: ignore[return-value]
+
+
+def _store_group(
+    interfaces: dict[str, StandbyInterfaceEntry],
+    interface: str,
+    group: str,
+    entry: StandbyGroupEntry,
+) -> None:
+    """Store a parsed standby group underneath its interface."""
+    interface_entry = interfaces.setdefault(interface, StandbyInterfaceEntry(groups={}))
+    interface_entry["groups"][group] = entry
 
 
 @dataclass
@@ -416,9 +432,9 @@ class ShowStandbyParser(BaseParser[ShowStandbyResult]):
             msg = "No HSRP standby groups found in output"
             raise ValueError(msg)
 
-        groups: dict[str, StandbyGroupEntry] = {}
+        interfaces: dict[str, StandbyInterfaceEntry] = {}
         for header, lines in blocks:
-            key, entry = _parse_block(header, lines)
-            groups[key] = entry
+            interface, group, entry = _parse_block(header, lines)
+            _store_group(interfaces, interface, group, entry)
 
-        return {"groups": groups}
+        return {"interfaces": interfaces}

--- a/src/muninn/parsers/ios/show_standby.py
+++ b/src/muninn/parsers/ios/show_standby.py
@@ -1,0 +1,424 @@
+"""Parser for 'show standby' command on IOS."""
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class TrackEntry(TypedDict):
+    """Schema for a tracked object or interface."""
+
+    type: str
+    name: str
+    state: NotRequired[str]
+    decrement: NotRequired[int]
+
+
+class StandbyGroupEntry(TypedDict):
+    """Schema for a single HSRP standby group."""
+
+    interface: str
+    group: int
+    version: NotRequired[int]
+    state: str
+    state_changes: int
+    last_state_change: str
+    virtual_ip: str
+    secondary_virtual_ips: NotRequired[list[str]]
+    active_virtual_mac: str
+    local_virtual_mac: str
+    hello_time_sec: int
+    hold_time_sec: int
+    authentication_type: NotRequired[str]
+    authentication_string: NotRequired[str]
+    preemption: bool
+    preemption_delay_min_sec: NotRequired[int]
+    preemption_delay_reload_sec: NotRequired[int]
+    active_router: str
+    active_router_priority: NotRequired[int]
+    active_router_mac: NotRequired[str]
+    standby_router: str
+    standby_router_priority: NotRequired[int]
+    priority: int
+    configured_priority: int
+    group_name: NotRequired[str]
+    tracks: NotRequired[list[TrackEntry]]
+
+
+class ShowStandbyResult(TypedDict):
+    """Schema for 'show standby' parsed output."""
+
+    groups: dict[str, StandbyGroupEntry]
+
+
+# Block header: "Vlan50 - Group 50 (version 2)" or "Vlan50 - Group 50"
+_BLOCK_HEADER_RE = re.compile(
+    r"^(?P<interface>\S+)\s+-\s+Group\s+(?P<group>\d+)"
+    r"(?:\s+\(version\s+(?P<version>\d+)\))?\s*$"
+)
+
+_STATE_RE = re.compile(r"^State\s+is\s+(?P<state>\S+)")
+_STATE_CHANGE_RE = re.compile(
+    r"^(?P<count>\d+)\s+state\s+changes?,"
+    r"\s+last\s+state\s+change\s+(?P<duration>\S+)"
+)
+_VIRTUAL_IP_RE = re.compile(r"^Virtual\s+IP\s+address\s+is\s+(?P<ip>\S+)")
+_SECONDARY_IP_RE = re.compile(r"^Secondary\s+virtual\s+IP\s+address\s+(?P<ip>\S+)")
+_ACTIVE_MAC_RE = re.compile(r"^Active\s+virtual\s+MAC\s+address\s+is\s+(?P<mac>\S+)")
+_LOCAL_MAC_RE = re.compile(r"^Local\s+virtual\s+MAC\s+address\s+is\s+(?P<mac>\S+)")
+_HELLO_HOLD_RE = re.compile(
+    r"^Hello\s+time\s+(?P<hello>\d+)\s+sec,\s+hold\s+time\s+(?P<hold>\d+)\s+sec"
+)
+_AUTH_RE = re.compile(
+    r"^Authentication\s+(?P<type>\S+),"
+    r"\s+(?:key-chain\s+\"(?P<keychain>[^\"]+)\""
+    r"|key-string"
+    r"|string\s+\"(?P<string>[^\"]+)\")"
+)
+_PREEMPT_RE = re.compile(
+    r"^Preemption\s+(?P<enabled>enabled|disabled)"
+    r"(?:,\s+delay\s+min\s+(?P<min>\d+)\s+secs?)?"
+    r"(?:,\s+reload\s+(?P<reload>\d+)\s+secs?)?"
+)
+_ACTIVE_ROUTER_RE = re.compile(
+    r"^Active\s+router\s+is\s+(?P<router>\S+?)(?:,\s+priority\s+(?P<priority>\d+))?"
+    r"(?:\s+\(expires\s+in\s+\S+\s+sec\))?\s*$"
+)
+_ACTIVE_ROUTER_MAC_RE = re.compile(r"^MAC\s+address\s+is\s+(?P<mac>\S+)")
+_STANDBY_ROUTER_RE = re.compile(
+    r"^Standby\s+router\s+is\s+(?P<router>\S+?)(?:,\s+priority\s+(?P<priority>\d+))?"
+    r"(?:\s+\(expires\s+in\s+\S+\s+sec\))?\s*$"
+)
+_PRIORITY_RE = re.compile(
+    r"^Priority\s+(?P<priority>\d+)\s+\(configured\s+(?P<configured>\d+)\)"
+)
+_GROUP_NAME_RE = re.compile(
+    r"^(?:Group\s+name|IP\s+redundancy\s+name)\s+is\s+\"(?P<name>[^\"]+)\""
+)
+_TRACK_OBJECT_RE = re.compile(
+    r"^Track\s+object\s+(?P<name>\S+)"
+    r"(?:\s+state\s+(?P<state>\S+))?"
+    r"(?:\s+decrement\s+(?P<decrement>\d+))?"
+    r"(?:\s+\((?P<note>[^)]+)\))?"
+)
+_TRACK_INTERFACE_RE = re.compile(
+    r"^Track\s+interface\s+(?P<name>\S+)"
+    r"\s+state\s+(?P<state>\S+)"
+    r"(?:\s+decrement\s+(?P<decrement>\d+))?"
+)
+
+
+def _split_blocks(output: str) -> list[tuple[re.Match[str], list[str]]]:
+    """Split output into blocks, each starting with an interface/group header."""
+    blocks: list[tuple[re.Match[str], list[str]]] = []
+    current_match: re.Match[str] | None = None
+    current_lines: list[str] = []
+
+    for line in output.splitlines():
+        header = _BLOCK_HEADER_RE.match(line.strip())
+        if header:
+            if current_match is not None:
+                blocks.append((current_match, current_lines))
+            current_match = header
+            current_lines = []
+        elif current_match is not None:
+            current_lines.append(line)
+
+    if current_match is not None:
+        blocks.append((current_match, current_lines))
+
+    return blocks
+
+
+def _parse_tracks(lines: list[str], start_idx: int) -> list[TrackEntry]:
+    """Parse track lines from a block starting at the given index."""
+    tracks: list[TrackEntry] = []
+    for line in lines[start_idx:]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        track = _match_track_line(stripped)
+        if track:
+            tracks.append(track)
+    return tracks
+
+
+def _match_track_line(stripped: str) -> TrackEntry | None:
+    """Match a single track line and return a TrackEntry or None."""
+    match = _TRACK_OBJECT_RE.match(stripped)
+    if match:
+        entry: TrackEntry = {"type": "object", "name": match.group("name")}
+        state = match.group("state")
+        note = match.group("note")
+        if state:
+            entry["state"] = state
+        elif note:
+            entry["state"] = note
+        if match.group("decrement"):
+            entry["decrement"] = int(match.group("decrement"))
+        return entry
+
+    match = _TRACK_INTERFACE_RE.match(stripped)
+    if match:
+        entry = {"type": "interface", "name": match.group("name")}
+        if match.group("state"):
+            entry["state"] = match.group("state")
+        if match.group("decrement"):
+            entry["decrement"] = int(match.group("decrement"))
+        return entry
+
+    return None
+
+
+def _parse_block(
+    header: re.Match[str], lines: list[str]
+) -> tuple[str, StandbyGroupEntry]:
+    """Parse a single interface/group block into a StandbyGroupEntry."""
+    interface = canonical_interface_name(header.group("interface"), os=OS.CISCO_IOS)
+    group = int(header.group("group"))
+    key = f"{interface}|{group}"
+
+    entry: dict[str, object] = {
+        "interface": interface,
+        "group": group,
+    }
+
+    if header.group("version"):
+        entry["version"] = int(header.group("version"))
+
+    _extract_fields(lines, entry)
+
+    return key, entry  # type: ignore[return-value]
+
+
+@dataclass
+class _FieldContext:
+    """Mutable context for collecting list-type fields during parsing."""
+
+    secondary_ips: list[str] = field(default_factory=list)
+    tracks: list[TrackEntry] = field(default_factory=list)
+
+
+def _extract_fields(lines: list[str], entry: dict[str, object]) -> None:
+    """Extract all fields from the body lines of a block."""
+    ctx = _FieldContext()
+    expect_active_mac = False
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if _try_simple_fields(stripped, entry):
+            expect_active_mac = False
+            continue
+
+        if expect_active_mac:
+            mac_match = _ACTIVE_ROUTER_MAC_RE.match(stripped)
+            if mac_match:
+                entry["active_router_mac"] = mac_match.group("mac")
+                expect_active_mac = False
+                continue
+
+        expect_active_mac = _try_remaining_fields(stripped, entry, ctx)
+
+    if ctx.secondary_ips:
+        entry["secondary_virtual_ips"] = ctx.secondary_ips
+    if ctx.tracks:
+        entry["tracks"] = ctx.tracks
+
+
+def _try_simple_fields(stripped: str, entry: dict[str, object]) -> bool:
+    """Try to match simple single-line fields. Returns True if matched."""
+    match = _STATE_RE.match(stripped)
+    if match:
+        entry["state"] = match.group("state")
+        return True
+
+    match = _STATE_CHANGE_RE.match(stripped)
+    if match:
+        entry["state_changes"] = int(match.group("count"))
+        entry["last_state_change"] = match.group("duration")
+        return True
+
+    match = _VIRTUAL_IP_RE.match(stripped)
+    if match:
+        entry["virtual_ip"] = match.group("ip")
+        return True
+
+    match = _ACTIVE_MAC_RE.match(stripped)
+    if match:
+        entry["active_virtual_mac"] = match.group("mac")
+        return True
+
+    match = _LOCAL_MAC_RE.match(stripped)
+    if match:
+        entry["local_virtual_mac"] = match.group("mac")
+        return True
+
+    match = _HELLO_HOLD_RE.match(stripped)
+    if match:
+        entry["hello_time_sec"] = int(match.group("hello"))
+        entry["hold_time_sec"] = int(match.group("hold"))
+        return True
+
+    return False
+
+
+def _apply_secondary_ip(
+    match: re.Match[str],
+    _entry: dict[str, object],
+    ctx: _FieldContext,
+) -> bool:
+    """Handle secondary virtual IP match."""
+    ctx.secondary_ips.append(match.group("ip"))
+    return False
+
+
+def _apply_auth(
+    match: re.Match[str],
+    entry: dict[str, object],
+    _ctx: _FieldContext,
+) -> bool:
+    """Handle authentication match."""
+    entry["authentication_type"] = match.group("type")
+    auth_str = match.group("keychain") or match.group("string")
+    if auth_str:
+        entry["authentication_string"] = auth_str
+    return False
+
+
+def _apply_preempt(
+    match: re.Match[str],
+    entry: dict[str, object],
+    _ctx: _FieldContext,
+) -> bool:
+    """Handle preemption match."""
+    entry["preemption"] = match.group("enabled") == "enabled"
+    if match.group("min"):
+        entry["preemption_delay_min_sec"] = int(match.group("min"))
+    if match.group("reload"):
+        entry["preemption_delay_reload_sec"] = int(match.group("reload"))
+    return False
+
+
+def _apply_active_router(
+    match: re.Match[str],
+    entry: dict[str, object],
+    _ctx: _FieldContext,
+) -> bool:
+    """Handle active router match. Returns True to signal MAC line follows."""
+    entry["active_router"] = match.group("router")
+    if match.group("priority"):
+        entry["active_router_priority"] = int(match.group("priority"))
+    return True
+
+
+def _apply_standby_router(
+    match: re.Match[str],
+    entry: dict[str, object],
+    _ctx: _FieldContext,
+) -> bool:
+    """Handle standby router match."""
+    entry["standby_router"] = match.group("router")
+    if match.group("priority"):
+        entry["standby_router_priority"] = int(match.group("priority"))
+    return False
+
+
+def _apply_priority(
+    match: re.Match[str],
+    entry: dict[str, object],
+    _ctx: _FieldContext,
+) -> bool:
+    """Handle priority match."""
+    entry["priority"] = int(match.group("priority"))
+    entry["configured_priority"] = int(match.group("configured"))
+    return False
+
+
+def _apply_group_name(
+    match: re.Match[str],
+    entry: dict[str, object],
+    _ctx: _FieldContext,
+) -> bool:
+    """Handle group name match."""
+    entry["group_name"] = match.group("name")
+    return False
+
+
+# Type alias for handler functions
+_Handler = Callable[[re.Match[str], dict[str, object], "_FieldContext"], bool]
+
+# Pattern table: (compiled regex, handler function)
+_FIELD_HANDLERS: tuple[tuple[re.Pattern[str], _Handler], ...] = (
+    (_SECONDARY_IP_RE, _apply_secondary_ip),
+    (_AUTH_RE, _apply_auth),
+    (_PREEMPT_RE, _apply_preempt),
+    (_ACTIVE_ROUTER_RE, _apply_active_router),
+    (_STANDBY_ROUTER_RE, _apply_standby_router),
+    (_PRIORITY_RE, _apply_priority),
+    (_GROUP_NAME_RE, _apply_group_name),
+)
+
+
+def _try_remaining_fields(
+    stripped: str,
+    entry: dict[str, object],
+    ctx: _FieldContext,
+) -> bool:
+    """Try remaining field patterns. Returns True if active router matched."""
+    for pattern, handler in _FIELD_HANDLERS:
+        match = pattern.match(stripped)
+        if match:
+            return handler(match, entry, ctx)
+
+    track = _match_track_line(stripped)
+    if track:
+        ctx.tracks.append(track)
+
+    return False
+
+
+@register(OS.CISCO_IOS, "show standby")
+class ShowStandbyParser(BaseParser[ShowStandbyResult]):
+    """Parser for 'show standby' command.
+
+    Example output:
+        Vlan50 - Group 50 (version 2)
+          State is Standby
+            1 state change, last state change 10w3d
+          Virtual IP address is 10.0.52.161
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowStandbyResult:
+        """Parse 'show standby' output.
+
+        Args:
+            output: Raw CLI output from 'show standby' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        blocks = _split_blocks(output)
+
+        if not blocks:
+            msg = "No HSRP standby groups found in output"
+            raise ValueError(msg)
+
+        groups: dict[str, StandbyGroupEntry] = {}
+        for header, lines in blocks:
+            key, entry = _parse_block(header, lines)
+            groups[key] = entry
+
+        return {"groups": groups}

--- a/tests/parsers/ios/show_standby/001_basic/expected.json
+++ b/tests/parsers/ios/show_standby/001_basic/expected.json
@@ -1,0 +1,27 @@
+{
+    "groups": {
+        "Vlan50|50": {
+            "active_router": "10.0.52.163",
+            "active_router_mac": "6073.5c43.63b7",
+            "active_router_priority": 110,
+            "active_virtual_mac": "0000.0c9f.f032",
+            "authentication_type": "MD5",
+            "configured_priority": 90,
+            "group": 50,
+            "group_name": "hsrp-Vl50-50",
+            "hello_time_sec": 3,
+            "hold_time_sec": 10,
+            "interface": "Vlan50",
+            "last_state_change": "10w3d",
+            "local_virtual_mac": "0000.0c9f.f032",
+            "preemption": true,
+            "preemption_delay_min_sec": 120,
+            "priority": 90,
+            "standby_router": "local",
+            "state": "Standby",
+            "state_changes": 1,
+            "version": 2,
+            "virtual_ip": "10.0.52.161"
+        }
+    }
+}

--- a/tests/parsers/ios/show_standby/001_basic/expected.json
+++ b/tests/parsers/ios/show_standby/001_basic/expected.json
@@ -1,27 +1,31 @@
 {
-    "groups": {
-        "Vlan50|50": {
-            "active_router": "10.0.52.163",
-            "active_router_mac": "6073.5c43.63b7",
-            "active_router_priority": 110,
-            "active_virtual_mac": "0000.0c9f.f032",
-            "authentication_type": "MD5",
-            "configured_priority": 90,
-            "group": 50,
-            "group_name": "hsrp-Vl50-50",
-            "hello_time_sec": 3,
-            "hold_time_sec": 10,
-            "interface": "Vlan50",
-            "last_state_change": "10w3d",
-            "local_virtual_mac": "0000.0c9f.f032",
-            "preemption": true,
-            "preemption_delay_min_sec": 120,
-            "priority": 90,
-            "standby_router": "local",
-            "state": "Standby",
-            "state_changes": 1,
-            "version": 2,
-            "virtual_ip": "10.0.52.161"
+    "interfaces": {
+        "Vlan50": {
+            "groups": {
+                "50": {
+                    "active_router": "10.0.52.163",
+                    "active_router_mac": "6073.5c43.63b7",
+                    "active_router_priority": 110,
+                    "active_virtual_mac": "0000.0c9f.f032",
+                    "authentication_type": "MD5",
+                    "configured_priority": 90,
+                    "group": 50,
+                    "group_name": "hsrp-Vl50-50",
+                    "hello_time_sec": 3,
+                    "hold_time_sec": 10,
+                    "interface": "Vlan50",
+                    "last_state_change": "10w3d",
+                    "local_virtual_mac": "0000.0c9f.f032",
+                    "preemption": true,
+                    "preemption_delay_min_sec": 120,
+                    "priority": 90,
+                    "standby_router": "local",
+                    "state": "Standby",
+                    "state_changes": 1,
+                    "version": 2,
+                    "virtual_ip": "10.0.52.161"
+                }
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_standby/001_basic/input.txt
+++ b/tests/parsers/ios/show_standby/001_basic/input.txt
@@ -1,0 +1,15 @@
+Vlan50 - Group 50 (version 2)
+  State is Standby
+    1 state change, last state change 10w3d
+  Virtual IP address is 10.0.52.161
+  Active virtual MAC address is 0000.0c9f.f032 (MAC Not In Use)
+    Local virtual MAC address is 0000.0c9f.f032 (v2 default)
+  Hello time 3 sec, hold time 10 sec
+    Next hello sent in 2.512 secs
+  Authentication MD5, key-string
+  Preemption enabled, delay min 120 secs
+  Active router is 10.0.52.163, priority 110 (expires in 10.464 sec)
+    MAC address is 6073.5c43.63b7
+  Standby router is local
+  Priority 90 (configured 90)
+  Group name is "hsrp-Vl50-50" (default)

--- a/tests/parsers/ios/show_standby/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_standby/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single HSRP group in standby state with MD5 authentication and preemption delay
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/expected.json
+++ b/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/expected.json
@@ -1,0 +1,114 @@
+{
+    "groups": {
+        "BDI10|1": {
+            "active_router": "local",
+            "active_virtual_mac": "0000.0c07.ac01",
+            "configured_priority": 240,
+            "group": 1,
+            "group_name": "hsrp-BD10-1",
+            "hello_time_sec": 3,
+            "hold_time_sec": 10,
+            "interface": "BDI10",
+            "last_state_change": "17w6d",
+            "local_virtual_mac": "0000.0c07.ac01",
+            "preemption": true,
+            "preemption_delay_min_sec": 180,
+            "priority": 240,
+            "standby_router": "203.57.147.3",
+            "standby_router_priority": 230,
+            "state": "Active",
+            "state_changes": 14,
+            "tracks": [
+                {
+                    "name": "1",
+                    "state": "Up",
+                    "type": "object"
+                }
+            ],
+            "virtual_ip": "203.57.147.1"
+        },
+        "GigabitEthernet0/1.2951|1": {
+            "active_router": "local",
+            "active_virtual_mac": "0000.0c9f.f001",
+            "configured_priority": 255,
+            "group": 1,
+            "group_name": "hsrp-Gi0/1.2951-1",
+            "hello_time_sec": 3,
+            "hold_time_sec": 10,
+            "interface": "GigabitEthernet0/1.2951",
+            "last_state_change": "3y37w",
+            "local_virtual_mac": "0000.0c9f.f001",
+            "preemption": true,
+            "preemption_delay_min_sec": 180,
+            "preemption_delay_reload_sec": 300,
+            "priority": 255,
+            "standby_router": "unknown",
+            "state": "Active",
+            "state_changes": 2,
+            "tracks": [
+                {
+                    "name": "1",
+                    "state": "unknown",
+                    "type": "object"
+                }
+            ],
+            "version": 2,
+            "virtual_ip": "111.222.230.17"
+        },
+        "Vlan111|1": {
+            "active_router": "192.168.77.60",
+            "active_router_priority": 255,
+            "active_virtual_mac": "0000.0c07.ac01",
+            "configured_priority": 255,
+            "group": 1,
+            "group_name": "hsrp-Vl111-1",
+            "hello_time_sec": 3,
+            "hold_time_sec": 10,
+            "interface": "Vlan111",
+            "last_state_change": "26w2d",
+            "local_virtual_mac": "0000.0c07.ac01",
+            "preemption": true,
+            "preemption_delay_min_sec": 180,
+            "priority": 255,
+            "standby_router": "local",
+            "state": "Standby",
+            "state_changes": 1,
+            "tracks": [
+                {
+                    "decrement": 60,
+                    "name": "1",
+                    "state": "Up",
+                    "type": "object"
+                }
+            ],
+            "virtual_ip": "192.168.77.62"
+        },
+        "Vlan703|4": {
+            "active_router": "local",
+            "active_virtual_mac": "0000.0c07.ac04",
+            "configured_priority": 200,
+            "group": 4,
+            "group_name": "hsrp-Vl703-4",
+            "hello_time_sec": 3,
+            "hold_time_sec": 10,
+            "interface": "Vlan703",
+            "last_state_change": "5d14h",
+            "local_virtual_mac": "0000.0c07.ac04",
+            "preemption": true,
+            "preemption_delay_min_sec": 180,
+            "priority": 200,
+            "standby_router": "unknown",
+            "state": "Active",
+            "state_changes": 11,
+            "tracks": [
+                {
+                    "decrement": 10,
+                    "name": "Dialer0",
+                    "state": "Up",
+                    "type": "interface"
+                }
+            ],
+            "virtual_ip": "172.23.40.9"
+        }
+    }
+}

--- a/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/expected.json
+++ b/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/expected.json
@@ -1,114 +1,130 @@
 {
-    "groups": {
-        "BDI10|1": {
-            "active_router": "local",
-            "active_virtual_mac": "0000.0c07.ac01",
-            "configured_priority": 240,
-            "group": 1,
-            "group_name": "hsrp-BD10-1",
-            "hello_time_sec": 3,
-            "hold_time_sec": 10,
-            "interface": "BDI10",
-            "last_state_change": "17w6d",
-            "local_virtual_mac": "0000.0c07.ac01",
-            "preemption": true,
-            "preemption_delay_min_sec": 180,
-            "priority": 240,
-            "standby_router": "203.57.147.3",
-            "standby_router_priority": 230,
-            "state": "Active",
-            "state_changes": 14,
-            "tracks": [
-                {
-                    "name": "1",
-                    "state": "Up",
-                    "type": "object"
+    "interfaces": {
+        "BDI10": {
+            "groups": {
+                "1": {
+                    "active_router": "local",
+                    "active_virtual_mac": "0000.0c07.ac01",
+                    "configured_priority": 240,
+                    "group": 1,
+                    "group_name": "hsrp-BD10-1",
+                    "hello_time_sec": 3,
+                    "hold_time_sec": 10,
+                    "interface": "BDI10",
+                    "last_state_change": "17w6d",
+                    "local_virtual_mac": "0000.0c07.ac01",
+                    "preemption": true,
+                    "preemption_delay_min_sec": 180,
+                    "priority": 240,
+                    "standby_router": "203.57.147.3",
+                    "standby_router_priority": 230,
+                    "state": "Active",
+                    "state_changes": 14,
+                    "tracks": [
+                        {
+                            "name": "1",
+                            "state": "Up",
+                            "type": "object"
+                        }
+                    ],
+                    "virtual_ip": "203.57.147.1"
                 }
-            ],
-            "virtual_ip": "203.57.147.1"
+            }
         },
-        "GigabitEthernet0/1.2951|1": {
-            "active_router": "local",
-            "active_virtual_mac": "0000.0c9f.f001",
-            "configured_priority": 255,
-            "group": 1,
-            "group_name": "hsrp-Gi0/1.2951-1",
-            "hello_time_sec": 3,
-            "hold_time_sec": 10,
-            "interface": "GigabitEthernet0/1.2951",
-            "last_state_change": "3y37w",
-            "local_virtual_mac": "0000.0c9f.f001",
-            "preemption": true,
-            "preemption_delay_min_sec": 180,
-            "preemption_delay_reload_sec": 300,
-            "priority": 255,
-            "standby_router": "unknown",
-            "state": "Active",
-            "state_changes": 2,
-            "tracks": [
-                {
-                    "name": "1",
-                    "state": "unknown",
-                    "type": "object"
+        "GigabitEthernet0/1.2951": {
+            "groups": {
+                "1": {
+                    "active_router": "local",
+                    "active_virtual_mac": "0000.0c9f.f001",
+                    "configured_priority": 255,
+                    "group": 1,
+                    "group_name": "hsrp-Gi0/1.2951-1",
+                    "hello_time_sec": 3,
+                    "hold_time_sec": 10,
+                    "interface": "GigabitEthernet0/1.2951",
+                    "last_state_change": "3y37w",
+                    "local_virtual_mac": "0000.0c9f.f001",
+                    "preemption": true,
+                    "preemption_delay_min_sec": 180,
+                    "preemption_delay_reload_sec": 300,
+                    "priority": 255,
+                    "standby_router": "unknown",
+                    "state": "Active",
+                    "state_changes": 2,
+                    "tracks": [
+                        {
+                            "name": "1",
+                            "state": "unknown",
+                            "type": "object"
+                        }
+                    ],
+                    "version": 2,
+                    "virtual_ip": "111.222.230.17"
                 }
-            ],
-            "version": 2,
-            "virtual_ip": "111.222.230.17"
+            }
         },
-        "Vlan111|1": {
-            "active_router": "192.168.77.60",
-            "active_router_priority": 255,
-            "active_virtual_mac": "0000.0c07.ac01",
-            "configured_priority": 255,
-            "group": 1,
-            "group_name": "hsrp-Vl111-1",
-            "hello_time_sec": 3,
-            "hold_time_sec": 10,
-            "interface": "Vlan111",
-            "last_state_change": "26w2d",
-            "local_virtual_mac": "0000.0c07.ac01",
-            "preemption": true,
-            "preemption_delay_min_sec": 180,
-            "priority": 255,
-            "standby_router": "local",
-            "state": "Standby",
-            "state_changes": 1,
-            "tracks": [
-                {
-                    "decrement": 60,
-                    "name": "1",
-                    "state": "Up",
-                    "type": "object"
+        "Vlan111": {
+            "groups": {
+                "1": {
+                    "active_router": "192.168.77.60",
+                    "active_router_priority": 255,
+                    "active_virtual_mac": "0000.0c07.ac01",
+                    "configured_priority": 255,
+                    "group": 1,
+                    "group_name": "hsrp-Vl111-1",
+                    "hello_time_sec": 3,
+                    "hold_time_sec": 10,
+                    "interface": "Vlan111",
+                    "last_state_change": "26w2d",
+                    "local_virtual_mac": "0000.0c07.ac01",
+                    "preemption": true,
+                    "preemption_delay_min_sec": 180,
+                    "priority": 255,
+                    "standby_router": "local",
+                    "state": "Standby",
+                    "state_changes": 1,
+                    "tracks": [
+                        {
+                            "decrement": 60,
+                            "name": "1",
+                            "state": "Up",
+                            "type": "object"
+                        }
+                    ],
+                    "virtual_ip": "192.168.77.62"
                 }
-            ],
-            "virtual_ip": "192.168.77.62"
+            }
         },
-        "Vlan703|4": {
-            "active_router": "local",
-            "active_virtual_mac": "0000.0c07.ac04",
-            "configured_priority": 200,
-            "group": 4,
-            "group_name": "hsrp-Vl703-4",
-            "hello_time_sec": 3,
-            "hold_time_sec": 10,
-            "interface": "Vlan703",
-            "last_state_change": "5d14h",
-            "local_virtual_mac": "0000.0c07.ac04",
-            "preemption": true,
-            "preemption_delay_min_sec": 180,
-            "priority": 200,
-            "standby_router": "unknown",
-            "state": "Active",
-            "state_changes": 11,
-            "tracks": [
-                {
-                    "decrement": 10,
-                    "name": "Dialer0",
-                    "state": "Up",
-                    "type": "interface"
+        "Vlan703": {
+            "groups": {
+                "4": {
+                    "active_router": "local",
+                    "active_virtual_mac": "0000.0c07.ac04",
+                    "configured_priority": 200,
+                    "group": 4,
+                    "group_name": "hsrp-Vl703-4",
+                    "hello_time_sec": 3,
+                    "hold_time_sec": 10,
+                    "interface": "Vlan703",
+                    "last_state_change": "5d14h",
+                    "local_virtual_mac": "0000.0c07.ac04",
+                    "preemption": true,
+                    "preemption_delay_min_sec": 180,
+                    "priority": 200,
+                    "standby_router": "unknown",
+                    "state": "Active",
+                    "state_changes": 11,
+                    "tracks": [
+                        {
+                            "decrement": 10,
+                            "name": "Dialer0",
+                            "state": "Up",
+                            "type": "interface"
+                        }
+                    ],
+                    "virtual_ip": "172.23.40.9"
                 }
-            ],
-            "virtual_ip": "172.23.40.9"
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/input.txt
+++ b/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/input.txt
@@ -1,0 +1,57 @@
+Vlan111 - Group 1
+  State is Standby
+    1 state change, last state change 26w2d
+  Virtual IP address is 192.168.77.62
+  Active virtual MAC address is 0000.0c07.ac01
+    Local virtual MAC address is 0000.0c07.ac01 (v1 default)
+  Hello time 3 sec, hold time 10 sec
+    Next hello sent in 0.704 secs
+  Preemption enabled, delay min 180 secs
+  Active router is 192.168.77.60, priority 255 (expires in 10.416 sec)
+  Standby router is local
+  Priority 255 (configured 255)
+    Track object 1 state Up decrement 60
+  Group name is "hsrp-Vl111-1" (default)
+BDI10 - Group 1
+  State is Active
+    14 state changes, last state change 17w6d
+    Track object 1 state Up
+  Virtual IP address is 203.57.147.1
+  Active virtual MAC address is 0000.0c07.ac01 (MAC In Use)
+    Local virtual MAC address is 0000.0c07.ac01 (v1 default)
+  Hello time 3 sec, hold time 10 sec
+    Next hello sent in 1.040 secs
+  Preemption enabled, delay min 180 secs
+  Active router is local
+  Standby router is 203.57.147.3, priority 230 (expires in 10.240 sec)
+  Priority 240 (configured 240)
+  Group name is "hsrp-BD10-1" (default)
+  FLAGS: 1/1
+Vlan703 - Group 4
+  State is Active
+    11 state changes, last state change 5d14h
+  Virtual IP address is 172.23.40.9
+  Active virtual MAC address is 0000.0c07.ac04
+    Local virtual MAC address is 0000.0c07.ac04 (v1 default)
+  Hello time 3 sec, hold time 10 sec
+    Next hello sent in 0.340 secs
+  Preemption enabled, delay min 180 secs
+  Active router is local
+  Standby router is unknown
+  Priority 200 (configured 200)
+    Track interface Dialer0 state Up decrement 10
+  IP redundancy name is "hsrp-Vl703-4" (default)
+GigabitEthernet0/1.2951 - Group 1 (version 2)
+  State is Active
+    2 state changes, last state change 3y37w
+  Virtual IP address is 111.222.230.17
+  Active virtual MAC address is 0000.0c9f.f001
+    Local virtual MAC address is 0000.0c9f.f001 (v2 default)
+  Hello time 3 sec, hold time 10 sec
+    Next hello sent in 2.720 secs
+  Preemption enabled, delay min 180 secs, reload 300 secs
+  Active router is local
+  Standby router is unknown
+  Priority 255 (configured 255)
+    Track object 1 (unknown)
+  Group name is "hsrp-Gi0/1.2951-1" (default)

--- a/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/metadata.yaml
+++ b/tests/parsers/ios/show_standby/002_multiple_groups_with_tracks/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple HSRP groups across different interfaces with track objects and track interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add new parser for `show standby` command on Cisco IOS (`OS.CISCO_IOS`)
- Parses HSRP standby group details including interface, group, version, state, virtual/active/standby IPs and MACs, hello/hold timers, authentication, preemption settings, priority, track objects/interfaces, and group names
- Includes 2 test cases: basic single group and multiple groups with track objects/interfaces

## Test plan

- [x] `uv run pytest tests/parsers/ios/show_standby/ -v` -- 2 tests pass
- [x] `uv run ruff check` -- no lint errors
- [x] `uv run ruff format` -- properly formatted
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` -- complexity within limits
- [x] `uv run pre-commit run --all-files` -- all hooks pass

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)