### PR TITLE
feat: add parser for 'show route-map all' on IOS-XE

### DIFF
--- a/changes/365.parser_added
+++ b/changes/365.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show route-map all' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_route_map_all.py
+++ b/src/muninn/parsers/iosxe/show_route_map_all.py
@@ -1,0 +1,199 @@
+"""Parser for 'show route-map all' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class RouteMapClauseEntry(TypedDict):
+    """Schema for a single route-map sequence entry."""
+
+    action: str
+    sequence: int
+    match_clauses: NotRequired[list[str]]
+    set_clauses: NotRequired[list[str]]
+    policy_routing_packets: NotRequired[int]
+    policy_routing_bytes: NotRequired[int]
+
+
+class ShowRouteMapAllResult(TypedDict):
+    """Schema for 'show route-map all' parsed output.
+
+    Keyed by route-map name, each containing a dict of sequence numbers
+    mapped to their clause entries.
+    """
+
+    route_maps: dict[str, dict[str, RouteMapClauseEntry]]
+
+
+# Route-map header: route-map NAME, permit/deny, sequence N
+_HEADER_PATTERN = re.compile(
+    r"^route-map\s+(?P<name>\S+),\s+(?P<action>permit|deny),\s+"
+    r"sequence\s+(?P<seq>\d+)"
+)
+
+# Section headers within a route-map entry
+_MATCH_HEADER = re.compile(r"^Match\s+clauses:$")
+_SET_HEADER = re.compile(r"^Set\s+clauses:$")
+
+# Policy routing matches line
+_POLICY_ROUTING = re.compile(
+    r"^Policy\s+routing\s+matches:\s+(?P<packets>\d+)\s+packets,"
+    r"\s+(?P<bytes>\d+)\s+bytes"
+)
+
+# Patterns that signal the end of a clause block
+_SECTION_BOUNDARIES: tuple[re.Pattern[str], ...] = (
+    _MATCH_HEADER,
+    _SET_HEADER,
+    _POLICY_ROUTING,
+    _HEADER_PATTERN,
+)
+
+
+def _is_clause_line(raw: str, stripped: str) -> bool:
+    """Return True if the line is an indented clause line, not a boundary."""
+    if not raw.startswith("    ") and not raw.startswith("\t"):
+        return False
+    return not any(p.match(stripped) for p in _SECTION_BOUNDARIES)
+
+
+def _parse_clauses(lines: list[str], idx: int) -> tuple[list[str], int]:
+    """Parse indented clause lines following a Match/Set header.
+
+    Returns a tuple of (clause_list, next_line_index).
+    """
+    clauses: list[str] = []
+    while idx < len(lines):
+        raw = lines[idx]
+        stripped = raw.strip()
+        if not stripped:
+            idx += 1
+            continue
+        if not _is_clause_line(raw, stripped):
+            break
+        clauses.append(stripped)
+        idx += 1
+    return clauses, idx
+
+
+def _apply_policy_routing(entry: RouteMapClauseEntry, match: re.Match[str]) -> None:
+    """Apply policy routing match data to an entry."""
+    entry["policy_routing_packets"] = int(match.group("packets"))
+    entry["policy_routing_bytes"] = int(match.group("bytes"))
+
+
+def _handle_section(
+    stripped: str,
+    lines: list[str],
+    idx: int,
+    entry: RouteMapClauseEntry,
+) -> tuple[bool, int]:
+    """Handle a section line (Match/Set/Policy). Returns (handled, next_idx)."""
+    if _MATCH_HEADER.match(stripped):
+        clauses, new_idx = _parse_clauses(lines, idx + 1)
+        if clauses:
+            entry["match_clauses"] = clauses
+        return True, new_idx
+
+    if _SET_HEADER.match(stripped):
+        clauses, new_idx = _parse_clauses(lines, idx + 1)
+        if clauses:
+            entry["set_clauses"] = clauses
+        return True, new_idx
+
+    policy_match = _POLICY_ROUTING.match(stripped)
+    if policy_match:
+        _apply_policy_routing(entry, policy_match)
+        return True, idx + 1
+
+    return False, idx
+
+
+def _parse_entry(
+    lines: list[str],
+    idx: int,
+    header_match: re.Match[str],
+) -> tuple[RouteMapClauseEntry, int]:
+    """Parse a single route-map entry after the header line.
+
+    Returns (entry, next_line_index).
+    """
+    entry = RouteMapClauseEntry(
+        action=header_match.group("action"),
+        sequence=int(header_match.group("seq")),
+    )
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped:
+            idx += 1
+            continue
+
+        if _HEADER_PATTERN.match(stripped):
+            break
+
+        handled, idx = _handle_section(stripped, lines, idx, entry)
+        if not handled:
+            idx += 1
+
+    return entry, idx
+
+
+@register(OS.CISCO_IOSXE, "show route-map all")
+class ShowRouteMapAllParser(BaseParser[ShowRouteMapAllResult]):
+    """Parser for 'show route-map all' command.
+
+    Example output:
+        route-map RM_BGP_IN, permit, sequence 10
+          Match clauses:
+            ip address (access-lists): AL_BGP_IN
+          Set clauses:
+            local-preference 200
+          Policy routing matches: 0 packets, 0 bytes
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteMapAllResult:
+        """Parse 'show route-map all' output.
+
+        Args:
+            output: Raw CLI output from 'show route-map all' command.
+
+        Returns:
+            Parsed route-map data keyed by route-map name and sequence number.
+
+        Raises:
+            ValueError: If no route-map entries found in output.
+        """
+        route_maps: dict[str, dict[str, RouteMapClauseEntry]] = {}
+        lines = output.splitlines()
+        idx = 0
+
+        while idx < len(lines):
+            stripped = lines[idx].strip()
+            if not stripped:
+                idx += 1
+                continue
+
+            header_match = _HEADER_PATTERN.match(stripped)
+            if not header_match:
+                idx += 1
+                continue
+
+            name = header_match.group("name")
+            seq = header_match.group("seq")
+            entry, idx = _parse_entry(lines, idx + 1, header_match)
+
+            if name not in route_maps:
+                route_maps[name] = {}
+            route_maps[name][seq] = entry
+
+        if not route_maps:
+            msg = "No route-map entries found in output"
+            raise ValueError(msg)
+
+        return ShowRouteMapAllResult(route_maps=route_maps)

--- a/tests/parsers/iosxe/show_route-map_all/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_route-map_all/001_basic/expected.json
@@ -1,0 +1,29 @@
+{
+    "route_maps": {
+        "RM_BGP_IN": {
+            "10": {
+                "action": "permit",
+                "match_clauses": [
+                    "ip address (access-lists): AL_BGP_IN"
+                ],
+                "policy_routing_bytes": 0,
+                "policy_routing_packets": 0,
+                "sequence": 10,
+                "set_clauses": [
+                    "local-preference 200"
+                ]
+            }
+        },
+        "RM_BGP_OUT": {
+            "10": {
+                "action": "deny",
+                "match_clauses": [
+                    "ip address prefix-lists: PL_DEFAULT"
+                ],
+                "policy_routing_bytes": 0,
+                "policy_routing_packets": 0,
+                "sequence": 10
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_route-map_all/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_route-map_all/001_basic/input.txt
@@ -1,0 +1,11 @@
+route-map RM_BGP_IN, permit, sequence 10
+  Match clauses:
+    ip address (access-lists): AL_BGP_IN
+  Set clauses:
+    local-preference 200
+  Policy routing matches: 0 packets, 0 bytes
+route-map RM_BGP_OUT, deny, sequence 10
+  Match clauses:
+    ip address prefix-lists: PL_DEFAULT
+  Set clauses:
+  Policy routing matches: 0 packets, 0 bytes

--- a/tests/parsers/iosxe/show_route-map_all/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_route-map_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with two route-maps each having a single sequence
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_route-map_all/002_multiple_sequences/expected.json
+++ b/tests/parsers/iosxe/show_route-map_all/002_multiple_sequences/expected.json
@@ -1,0 +1,40 @@
+{
+    "route_maps": {
+        "RM_OSPF_REDISTRIBUTE": {
+            "10": {
+                "action": "permit",
+                "match_clauses": [
+                    "ip address prefix-lists: PL_CONNECTED",
+                    "route-type: external type 1"
+                ],
+                "policy_routing_bytes": 567890,
+                "policy_routing_packets": 1234,
+                "sequence": 10,
+                "set_clauses": [
+                    "metric 100",
+                    "metric-type type-1",
+                    "tag 65000"
+                ]
+            },
+            "20": {
+                "action": "permit",
+                "match_clauses": [
+                    "ip address prefix-lists: PL_STATIC"
+                ],
+                "policy_routing_bytes": 0,
+                "policy_routing_packets": 0,
+                "sequence": 20,
+                "set_clauses": [
+                    "metric 200",
+                    "metric-type type-2"
+                ]
+            },
+            "30": {
+                "action": "deny",
+                "policy_routing_bytes": 0,
+                "policy_routing_packets": 0,
+                "sequence": 30
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_route-map_all/002_multiple_sequences/input.txt
+++ b/tests/parsers/iosxe/show_route-map_all/002_multiple_sequences/input.txt
@@ -1,0 +1,20 @@
+route-map RM_OSPF_REDISTRIBUTE, permit, sequence 10
+  Match clauses:
+    ip address prefix-lists: PL_CONNECTED
+    route-type: external type 1
+  Set clauses:
+    metric 100
+    metric-type type-1
+    tag 65000
+  Policy routing matches: 1234 packets, 567890 bytes
+route-map RM_OSPF_REDISTRIBUTE, permit, sequence 20
+  Match clauses:
+    ip address prefix-lists: PL_STATIC
+  Set clauses:
+    metric 200
+    metric-type type-2
+  Policy routing matches: 0 packets, 0 bytes
+route-map RM_OSPF_REDISTRIBUTE, deny, sequence 30
+  Match clauses:
+  Set clauses:
+  Policy routing matches: 0 packets, 0 bytes

--- a/tests/parsers/iosxe/show_route-map_all/002_multiple_sequences/metadata.yaml
+++ b/tests/parsers/iosxe/show_route-map_all/002_multiple_sequences/metadata.yaml
@@ -1,0 +1,3 @@
+description: Route-map with multiple sequences and various match/set clauses
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new section-based parser for `show route-map all` on Cisco IOS-XE
- Extracts route-map name, action (permit/deny), sequence number, match clauses, set clauses, and policy routing statistics
- Includes 2 test cases: basic output with two route-maps, and a single route-map with multiple sequences

## Test plan
- [x] `uv run pytest tests/parsers/iosxe/show_route-map_all/ -v` — 2 tests pass
- [x] `uv run ruff check` — no lint issues
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` — complexity within limits
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)