### PR TITLE
feat: add parser for 'show standby internal' on IOS-XE

### DIFF
--- a/changes/367.parser_added
+++ b/changes/367.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show standby internal' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_standby_internal.py
+++ b/src/muninn/parsers/iosxe/show_standby_internal.py
@@ -6,6 +6,7 @@ from typing import NotRequired, TypedDict
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class VirtualIpEntry(TypedDict):
@@ -136,7 +137,7 @@ def _parse_vip_section(
         if m:
             entries[m.group("hash")] = {
                 "ip": m.group("ip"),
-                "interface": m.group("intf"),
+                "interface": canonical_interface_name(m.group("intf")),
                 "group": int(m.group("group")),
             }
             idx += 1
@@ -153,9 +154,7 @@ def _parse_mac_section(
     Returns the new line index and the entries dict.
     """
     entries: dict[str, MacAddressEntry] = {}
-    pending_hash: str | None = None
-    pending_intf: str | None = None
-    pending_mac: str | None = None
+    pending: tuple[str, str, str] | None = None
 
     while idx < len(lines):
         line = lines[idx].strip()
@@ -165,22 +164,23 @@ def _parse_mac_section(
 
         m = _MAC_HASH_ROW.match(line)
         if m:
-            pending_hash = m.group("hash")
-            pending_intf = m.group("intf")
-            pending_mac = m.group("mac")
+            pending = (
+                m.group("hash"),
+                canonical_interface_name(m.group("intf")),
+                m.group("mac"),
+            )
             idx += 1
             continue
 
         m = _MAC_GRP_ROW.match(line)
-        if m and pending_hash is not None:
-            entries[pending_hash] = {
-                "interface": pending_intf,  # type: ignore[typeddict-item]
-                "mac_address": pending_mac,  # type: ignore[typeddict-item]
+        if m and pending is not None:
+            hash_id, intf, mac = pending
+            entries[hash_id] = {
+                "interface": intf,
+                "mac_address": mac,
                 "group": int(m.group("group")),
             }
-            pending_hash = None
-            pending_intf = None
-            pending_mac = None
+            pending = None
             idx += 1
             continue
 
@@ -206,7 +206,7 @@ def _parse_table_sections(
             af_key = "ipv6" if af.upper() == "IPV6" else "ipv4"
             idx, entries = _parse_vip_section(lines, idx + 1, af_key)
             if entries:
-                vip_table[af_key] = entries  # type: ignore[literal-required]
+                vip_table[af_key] = entries
             continue
 
         if _MAC_SECTION_HEADER.match(line):

--- a/src/muninn/parsers/iosxe/show_standby_internal.py
+++ b/src/muninn/parsers/iosxe/show_standby_internal.py
@@ -1,0 +1,274 @@
+"""Parser for 'show standby internal' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class VirtualIpEntry(TypedDict):
+    """Schema for a virtual IP hash table entry."""
+
+    ip: str
+    interface: str
+    group: int
+
+
+class MacAddressEntry(TypedDict):
+    """Schema for a MAC address table entry."""
+
+    interface: str
+    mac_address: str
+    group: int
+
+
+class VirtualIpHashTable(TypedDict):
+    """Schema for the virtual IP hash tables."""
+
+    ipv4: NotRequired[dict[str, VirtualIpEntry]]
+    ipv6: NotRequired[dict[str, VirtualIpEntry]]
+
+
+class ShowStandbyInternalResult(TypedDict):
+    """Schema for 'show standby internal' parsed output."""
+
+    hsrp_common_process_state: str
+    msgq_size: int
+    msgq_max_size: int
+    hsrp_ipv4_process_state: str
+    hsrp_ipv6_process_state: str
+    hsrp_timer_wheel_state: str
+    hsrp_ha_state: str
+    v3_to_v4_transform: str
+    virtual_ip_hash_table: NotRequired[VirtualIpHashTable]
+    mac_address_table: NotRequired[dict[str, MacAddressEntry]]
+
+
+_COMMON_PROCESS = re.compile(
+    r"^HSRP\s+common\s+process\s+(?P<state>.+)$", re.IGNORECASE
+)
+_MSGQ = re.compile(
+    r"^MsgQ\s+size\s+(?P<size>\d+),\s*max\s+(?P<max>\d+)$", re.IGNORECASE
+)
+_IPV4_PROCESS = re.compile(r"^HSRP\s+IPv4\s+process\s+(?P<state>.+)$", re.IGNORECASE)
+_IPV6_PROCESS = re.compile(r"^HSRP\s+IPv6\s+process\s+(?P<state>.+)$", re.IGNORECASE)
+_TIMER_WHEEL = re.compile(r"^HSRP\s+Timer\s+wheel\s+(?P<state>.+)$", re.IGNORECASE)
+_HA_LINE = re.compile(
+    r"^HSRP\s+HA\s+(?P<ha_state>\S+),\s*v3\s+to\s+v4\s+transform\s+(?P<transform>\S+)$",
+    re.IGNORECASE,
+)
+_VIP_SECTION_HEADER = re.compile(
+    r"^HSRP\s+virtual\s+(?P<af>IPv6|IP)\s+Hash\s+Table", re.IGNORECASE
+)
+_VIP_ROW = re.compile(
+    r"^(?P<hash>\d+)\s+(?P<ip>\S+)\s+(?P<intf>\S+)\s+Grp\s+(?P<group>\d+)$"
+)
+_MAC_SECTION_HEADER = re.compile(r"^HSRP\s+MAC\s+Address\s+Table$", re.IGNORECASE)
+_MAC_HASH_ROW = re.compile(
+    r"^(?P<hash>\d+)\s+(?P<intf>\S+)\s+(?P<mac>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})$"
+)
+_MAC_GRP_ROW = re.compile(r"^\S+\s+Grp\s+(?P<group>\d+)$")
+
+
+_STATUS_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_COMMON_PROCESS, "hsrp_common_process_state"),
+    (_IPV4_PROCESS, "hsrp_ipv4_process_state"),
+    (_IPV6_PROCESS, "hsrp_ipv6_process_state"),
+    (_TIMER_WHEEL, "hsrp_timer_wheel_state"),
+)
+
+
+def _parse_status_lines(lines: list[str], idx: int, result: dict[str, object]) -> int:
+    """Parse the process-status and MsgQ header lines.
+
+    Returns the new line index.
+    """
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line:
+            idx += 1
+            continue
+
+        matched = False
+        for pattern, field in _STATUS_PATTERNS:
+            m = pattern.match(line)
+            if m:
+                result[field] = m.group("state")
+                idx += 1
+                matched = True
+                break
+
+        if matched:
+            continue
+
+        if m := _MSGQ.match(line):
+            result["msgq_size"] = int(m.group("size"))
+            result["msgq_max_size"] = int(m.group("max"))
+            idx += 1
+            continue
+
+        if m := _HA_LINE.match(line):
+            result["hsrp_ha_state"] = m.group("ha_state")
+            result["v3_to_v4_transform"] = m.group("transform")
+            idx += 1
+            continue
+
+        break
+    return idx
+
+
+def _parse_vip_section(
+    lines: list[str], idx: int, af_key: str
+) -> tuple[int, dict[str, VirtualIpEntry]]:
+    """Parse a virtual IP hash table section.
+
+    Returns the new line index and the entries dict.
+    """
+    entries: dict[str, VirtualIpEntry] = {}
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line:
+            idx += 1
+            continue
+        m = _VIP_ROW.match(line)
+        if m:
+            entries[m.group("hash")] = {
+                "ip": m.group("ip"),
+                "interface": m.group("intf"),
+                "group": int(m.group("group")),
+            }
+            idx += 1
+            continue
+        break
+    return idx, entries
+
+
+def _parse_mac_section(
+    lines: list[str], idx: int
+) -> tuple[int, dict[str, MacAddressEntry]]:
+    """Parse the MAC address table section.
+
+    Returns the new line index and the entries dict.
+    """
+    entries: dict[str, MacAddressEntry] = {}
+    pending_hash: str | None = None
+    pending_intf: str | None = None
+    pending_mac: str | None = None
+
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line:
+            idx += 1
+            continue
+
+        m = _MAC_HASH_ROW.match(line)
+        if m:
+            pending_hash = m.group("hash")
+            pending_intf = m.group("intf")
+            pending_mac = m.group("mac")
+            idx += 1
+            continue
+
+        m = _MAC_GRP_ROW.match(line)
+        if m and pending_hash is not None:
+            entries[pending_hash] = {
+                "interface": pending_intf,  # type: ignore[typeddict-item]
+                "mac_address": pending_mac,  # type: ignore[typeddict-item]
+                "group": int(m.group("group")),
+            }
+            pending_hash = None
+            pending_intf = None
+            pending_mac = None
+            idx += 1
+            continue
+
+        break
+    return idx, entries
+
+
+def _parse_table_sections(
+    lines: list[str], idx: int, result: dict[str, object]
+) -> None:
+    """Parse virtual IP hash table and MAC address table sections."""
+    vip_table: VirtualIpHashTable = {}
+
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line:
+            idx += 1
+            continue
+
+        m = _VIP_SECTION_HEADER.match(line)
+        if m:
+            af = m.group("af")
+            af_key = "ipv6" if af.upper() == "IPV6" else "ipv4"
+            idx, entries = _parse_vip_section(lines, idx + 1, af_key)
+            if entries:
+                vip_table[af_key] = entries  # type: ignore[literal-required]
+            continue
+
+        if _MAC_SECTION_HEADER.match(line):
+            idx, mac_entries = _parse_mac_section(lines, idx + 1)
+            if mac_entries:
+                result["mac_address_table"] = mac_entries
+            continue
+
+        idx += 1
+
+    if vip_table:
+        result["virtual_ip_hash_table"] = vip_table
+
+
+_REQUIRED_FIELDS = (
+    "hsrp_common_process_state",
+    "hsrp_ipv4_process_state",
+    "hsrp_ipv6_process_state",
+    "hsrp_timer_wheel_state",
+    "hsrp_ha_state",
+    "v3_to_v4_transform",
+)
+
+
+def _validate_result(result: dict[str, object]) -> None:
+    """Raise ValueError if any required fields are missing."""
+    missing = [f for f in _REQUIRED_FIELDS if f not in result]
+    if missing:
+        msg = f"Missing required fields: {', '.join(missing)}"
+        raise ValueError(msg)
+
+
+@register(OS.CISCO_IOSXE, "show standby internal")
+class ShowStandbyInternalParser(BaseParser[ShowStandbyInternalResult]):
+    """Parser for 'show standby internal' command.
+
+    Example output:
+        HSRP common process not running
+          MsgQ size 0, max 0
+        HSRP IPv4 process not running
+        HSRP Timer wheel running
+        HSRP HA capable, v3 to v4 transform disabled
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowStandbyInternalResult:
+        """Parse 'show standby internal' output.
+
+        Args:
+            output: Raw CLI output from 'show standby internal' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+        result: dict[str, object] = {}
+
+        idx = _parse_status_lines(lines, 0, result)
+        _parse_table_sections(lines, idx, result)
+        _validate_result(result)
+
+        return result  # type: ignore[return-value]

--- a/tests/parsers/iosxe/show_standby_internal/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_standby_internal/001_basic/expected.json
@@ -1,0 +1,53 @@
+{
+    "hsrp_common_process_state": "not running",
+    "hsrp_ha_state": "capable",
+    "hsrp_ipv4_process_state": "not running",
+    "hsrp_ipv6_process_state": "not running",
+    "hsrp_timer_wheel_state": "running",
+    "mac_address_table": {
+        "166": {
+            "group": 10,
+            "interface": "Gi2/0/3",
+            "mac_address": "0000.0cff.b311"
+        },
+        "169": {
+            "group": 5,
+            "interface": "Gi1/0/1",
+            "mac_address": "0000.0cff.b30c"
+        },
+        "172": {
+            "group": 0,
+            "interface": "Gi2/0/3",
+            "mac_address": "0000.0cff.b307"
+        },
+        "173": {
+            "group": 1,
+            "interface": "Gi2/0/3",
+            "mac_address": "0000.0cff.b308"
+        }
+    },
+    "msgq_max_size": 0,
+    "msgq_size": 0,
+    "v3_to_v4_transform": "disabled",
+    "virtual_ip_hash_table": {
+        "ipv4": {
+            "103": {
+                "group": 0,
+                "interface": "Gi1/0/1",
+                "ip": "192.168.1.254"
+            },
+            "106": {
+                "group": 10,
+                "interface": "Gi1/0/2",
+                "ip": "192.168.2.254"
+            }
+        },
+        "ipv6": {
+            "78": {
+                "group": 20,
+                "interface": "Gi1",
+                "ip": "2001:DB8:10:1:1::254"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_standby_internal/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_standby_internal/001_basic/expected.json
@@ -7,22 +7,22 @@
     "mac_address_table": {
         "166": {
             "group": 10,
-            "interface": "Gi2/0/3",
+            "interface": "GigabitEthernet2/0/3",
             "mac_address": "0000.0cff.b311"
         },
         "169": {
             "group": 5,
-            "interface": "Gi1/0/1",
+            "interface": "GigabitEthernet1/0/1",
             "mac_address": "0000.0cff.b30c"
         },
         "172": {
             "group": 0,
-            "interface": "Gi2/0/3",
+            "interface": "GigabitEthernet2/0/3",
             "mac_address": "0000.0cff.b307"
         },
         "173": {
             "group": 1,
-            "interface": "Gi2/0/3",
+            "interface": "GigabitEthernet2/0/3",
             "mac_address": "0000.0cff.b308"
         }
     },
@@ -33,19 +33,19 @@
         "ipv4": {
             "103": {
                 "group": 0,
-                "interface": "Gi1/0/1",
+                "interface": "GigabitEthernet1/0/1",
                 "ip": "192.168.1.254"
             },
             "106": {
                 "group": 10,
-                "interface": "Gi1/0/2",
+                "interface": "GigabitEthernet1/0/2",
                 "ip": "192.168.2.254"
             }
         },
         "ipv6": {
             "78": {
                 "group": 20,
-                "interface": "Gi1",
+                "interface": "GigabitEthernet1",
                 "ip": "2001:DB8:10:1:1::254"
             }
         }

--- a/tests/parsers/iosxe/show_standby_internal/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_standby_internal/001_basic/input.txt
@@ -1,0 +1,24 @@
+
+HSRP common process not running
+  MsgQ size 0, max 0
+HSRP IPv4 process not running
+HSRP IPv6 process not running
+HSRP Timer wheel running
+HSRP HA capable, v3 to v4 transform disabled
+
+HSRP virtual IP Hash Table (global)
+103 192.168.1.254                    Gi1/0/1    Grp 0
+106 192.168.2.254                    Gi1/0/2    Grp 10
+
+HSRP virtual IPv6 Hash Table (global)
+78  2001:DB8:10:1:1::254             Gi1        Grp 20
+
+HSRP MAC Address Table
+169 Gi1/0/1 0000.0cff.b30c
+    Gi1/0/1 Grp 5
+166 Gi2/0/3 0000.0cff.b311
+    Gi2/0/3 Grp 10
+172 Gi2/0/3 0000.0cff.b307
+    Gi2/0/3 Grp 0
+173 Gi2/0/3 0000.0cff.b308
+    Gi2/0/3 Grp 1

--- a/tests/parsers/iosxe/show_standby_internal/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_standby_internal/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Full output with IPv4/IPv6 virtual IP tables and MAC address table
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_standby_internal/002_no_virtual_ip_or_mac/expected.json
+++ b/tests/parsers/iosxe/show_standby_internal/002_no_virtual_ip_or_mac/expected.json
@@ -1,0 +1,10 @@
+{
+    "hsrp_common_process_state": "running",
+    "hsrp_ha_state": "capable",
+    "hsrp_ipv4_process_state": "running",
+    "hsrp_ipv6_process_state": "running",
+    "hsrp_timer_wheel_state": "running",
+    "msgq_max_size": 128,
+    "msgq_size": 5,
+    "v3_to_v4_transform": "enabled"
+}

--- a/tests/parsers/iosxe/show_standby_internal/002_no_virtual_ip_or_mac/input.txt
+++ b/tests/parsers/iosxe/show_standby_internal/002_no_virtual_ip_or_mac/input.txt
@@ -1,0 +1,6 @@
+HSRP common process running
+  MsgQ size 5, max 128
+HSRP IPv4 process running
+HSRP IPv6 process running
+HSRP Timer wheel running
+HSRP HA capable, v3 to v4 transform enabled

--- a/tests/parsers/iosxe/show_standby_internal/002_no_virtual_ip_or_mac/metadata.yaml
+++ b/tests/parsers/iosxe/show_standby_internal/002_no_virtual_ip_or_mac/metadata.yaml
@@ -1,0 +1,3 @@
+description: Minimal output with only process status lines and no tables
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show standby internal` command on IOS-XE (cisco_iosxe)
- Parses HSRP process status, MsgQ stats, virtual IP hash tables (IPv4/IPv6), and MAC address table
- Includes 2 test cases: full output with all sections, and minimal output with status lines only

## Test plan
- [x] `uv run pytest tests/parsers/iosxe/show_standby_internal/ -v` — 2 tests pass
- [x] `uv run ruff check` — no issues
- [x] `uv run xenon --max-absolute B` — complexity within limits
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)