### PR TITLE
feat: add parser for 'show processes' on NX-OS

### DIFF
--- a/changes/370.parser_added
+++ b/changes/370.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show processes' on NX-OS.

--- a/src/muninn/parsers/nxos/show_processes.py
+++ b/src/muninn/parsers/nxos/show_processes.py
@@ -1,0 +1,99 @@
+"""Parser for 'show processes' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single process entry."""
+
+    state: str
+    type: str
+    start_cnt: int
+    pid: NotRequired[int]
+    pc: NotRequired[str]
+    tty: NotRequired[int]
+
+
+class ShowProcessesResult(TypedDict):
+    """Schema for 'show processes' parsed output."""
+
+    processes: dict[str, ProcessEntry]
+
+
+_RUNNING_PATTERN = re.compile(
+    r"^\s*(?P<pid>\d+)\s+(?P<state>\S+)\s+(?P<pc>\S+)\s+"
+    r"(?P<start_cnt>\d+)\s+(?P<tty>\S+)\s+(?P<type>\S+)\s+(?P<process>\S+)\s*$"
+)
+
+_NOT_RUNNING_PATTERN = re.compile(
+    r"^\s*-\s+(?P<state>\S+)\s+(?:-)\s+"
+    r"(?P<start_cnt>\d+)\s+(?P<tty>\S+)\s+(?P<type>\S+)\s+(?P<process>\S+)\s*$"
+)
+
+
+@register(OS.CISCO_NXOS, "show processes")
+class ShowProcessesParser(BaseParser[ShowProcessesResult]):
+    """Parser for 'show processes' command.
+
+    Example output:
+        PID    State  PC        Start_cnt    TTY   Type  Process
+        -----  -----  --------  -----------  ----  ----  -------------
+            1      S  b8dffed3            1     -     O  init
+            -     NR         -            0     -     X  ldap
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowProcessesResult:
+        """Parse 'show processes' output.
+
+        Args:
+            output: Raw CLI output from 'show processes' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        processes: dict[str, ProcessEntry] = {}
+
+        for line in output.splitlines():
+            match = _RUNNING_PATTERN.match(line)
+            if match:
+                name = match.group("process")
+                entry = ProcessEntry(
+                    state=match.group("state"),
+                    type=match.group("type"),
+                    start_cnt=int(match.group("start_cnt")),
+                    pid=int(match.group("pid")),
+                    pc=match.group("pc"),
+                )
+                tty = match.group("tty")
+                if tty != "-":
+                    entry["tty"] = int(tty)
+                processes[name] = entry
+                continue
+
+            match = _NOT_RUNNING_PATTERN.match(line)
+            if match:
+                name = match.group("process")
+                entry = ProcessEntry(
+                    state=match.group("state"),
+                    type=match.group("type"),
+                    start_cnt=int(match.group("start_cnt")),
+                )
+                tty = match.group("tty")
+                if tty != "-":
+                    entry["tty"] = int(tty)
+                processes[name] = entry
+
+        if not processes:
+            msg = "No process entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowProcessesResult, {"processes": processes})

--- a/tests/parsers/nxos/show_processes/001_basic/expected.json
+++ b/tests/parsers/nxos/show_processes/001_basic/expected.json
@@ -1,0 +1,52 @@
+{
+    "processes": {
+        "agetty": {
+            "pc": "e4385a40",
+            "pid": 26687,
+            "start_cnt": 1,
+            "state": "S",
+            "tty": 0,
+            "type": "O"
+        },
+        "dbus-daemon": {
+            "pc": "9c608843",
+            "pid": 26675,
+            "start_cnt": 1,
+            "state": "S",
+            "type": "O"
+        },
+        "init": {
+            "pc": "b8dffed3",
+            "pid": 1,
+            "start_cnt": 1,
+            "state": "S",
+            "type": "O"
+        },
+        "ksoftirqd/1": {
+            "pc": "0",
+            "pid": 10,
+            "start_cnt": 1,
+            "state": "S",
+            "type": "O"
+        },
+        "kworker/0:0": {
+            "pc": "0",
+            "pid": 4,
+            "start_cnt": 1,
+            "state": "S",
+            "type": "O"
+        },
+        "ldap": {
+            "start_cnt": 0,
+            "state": "NR",
+            "type": "X"
+        },
+        "rsyslogd": {
+            "pc": "cbdcd9b3",
+            "pid": 26668,
+            "start_cnt": 1,
+            "state": "S",
+            "type": "O"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_processes/001_basic/input.txt
+++ b/tests/parsers/nxos/show_processes/001_basic/input.txt
@@ -1,0 +1,18 @@
+
+N95_1# show processes
+
+PID    State  PC        Start_cnt    TTY   Type  Process
+-----  -----  --------  -----------  ----  ----  -------------
+    1      S  b8dffed3            1     -     O  init
+    4      S         0            1     -     O  kworker/0:0
+   10      S         0            1     -     O  ksoftirqd/1
+26668      S  cbdcd9b3            1     -     O  rsyslogd
+26675      S  9c608843            1     -     O  dbus-daemon
+26687      S  e4385a40            1     0     O  agetty
+    -     NR         -            0     -     X  ldap
+
+State: R(runnable), S(sleeping), Z(defunct)
+
+Type:  U(unknown), O(non sysmgr)
+       VL(vdc-local), VG(vdc-global), VU(vdc-unaware)
+       NR(not running), ER(terminated etc)

--- a/tests/parsers/nxos/show_processes/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_processes/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard output with multiple running processes and one not-running process
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_processes/002_not_running_process/expected.json
+++ b/tests/parsers/nxos/show_processes/002_not_running_process/expected.json
@@ -1,0 +1,14 @@
+{
+    "processes": {
+        "ldap": {
+            "start_cnt": 0,
+            "state": "NR",
+            "type": "X"
+        },
+        "radius": {
+            "start_cnt": 0,
+            "state": "NR",
+            "type": "X"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_processes/002_not_running_process/input.txt
+++ b/tests/parsers/nxos/show_processes/002_not_running_process/input.txt
@@ -1,0 +1,4 @@
+PID    State  PC        Start_cnt    TTY   Type  Process
+-----  -----  --------  -----------  ----  ----  -------------
+    -     NR         -            0     -     X  ldap
+    -     NR         -            0     -     X  radius

--- a/tests/parsers/nxos/show_processes/002_not_running_process/metadata.yaml
+++ b/tests/parsers/nxos/show_processes/002_not_running_process/metadata.yaml
@@ -1,0 +1,3 @@
+description: Output with only not-running processes
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show processes` command on Cisco NX-OS
- Parses process table entries including PID, state, PC, start count, TTY, and type
- Handles both running processes (with PID) and not-running processes (PID shown as `-`)
- Includes 2 test cases: standard output with mixed process states and not-running-only output

Closes #121

## Test plan
- [x] Parser tests pass (`uv run pytest tests/parsers/test_parsers.py -k show_processes -v`)
- [x] Ruff check and format pass
- [x] Xenon complexity check passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)