### PR TITLE
feat: add parser for 'show route-map' on NX-OS

### DIFF
--- a/changes/371.parser_added
+++ b/changes/371.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show route-map' on NX-OS.

--- a/src/muninn/parsers/nxos/show_route_map.py
+++ b/src/muninn/parsers/nxos/show_route_map.py
@@ -1,0 +1,146 @@
+"""Parser for 'show route-map' command on NX-OS."""
+
+import re
+from dataclasses import dataclass, field
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class RouteMapSequenceEntry(TypedDict):
+    """Schema for a single route-map sequence."""
+
+    action: str
+    match_clauses: list[str]
+    set_clauses: list[str]
+    description: NotRequired[str]
+
+
+class RouteMapEntry(TypedDict):
+    """Schema for a single route-map with all its sequences."""
+
+    sequences: dict[str, RouteMapSequenceEntry]
+
+
+class ShowRouteMapResult(TypedDict):
+    """Schema for 'show route-map' parsed output."""
+
+    route_maps: dict[str, RouteMapEntry]
+
+
+_HEADER_PATTERN = re.compile(
+    r"^route-map\s+(?P<name>\S+),\s+(?P<action>permit|deny),"
+    r"\s+sequence\s+(?P<seq>\d+)",
+    re.IGNORECASE,
+)
+_MATCH_HEADER = re.compile(r"^\s*Match clauses:\s*$")
+_SET_HEADER = re.compile(r"^\s*Set clauses:\s*$")
+_CLAUSE_INDENT = "    "
+
+
+@dataclass
+class _ParseState:
+    """Mutable state for the route-map parser."""
+
+    route_maps: dict[str, RouteMapEntry] = field(default_factory=dict)
+    name: str | None = None
+    seq: str | None = None
+    action: str | None = None
+    section: str | None = None
+    match_clauses: list[str] = field(default_factory=list)
+    set_clauses: list[str] = field(default_factory=list)
+
+    def flush(self) -> None:
+        """Save current sequence into route_maps and reset."""
+        if self.name is None or self.seq is None or self.action is None:
+            return
+        if self.name not in self.route_maps:
+            self.route_maps[self.name] = RouteMapEntry(sequences={})
+        self.route_maps[self.name]["sequences"][self.seq] = RouteMapSequenceEntry(
+            action=self.action,
+            match_clauses=list(self.match_clauses),
+            set_clauses=list(self.set_clauses),
+        )
+
+    def start_new(self, name: str, seq: str, action: str) -> None:
+        """Begin a new route-map sequence, flushing the previous one."""
+        self.flush()
+        self.name = name
+        self.seq = seq
+        self.action = action
+        self.match_clauses = []
+        self.set_clauses = []
+        self.section = None
+
+
+def _is_clause_line(line: str) -> bool:
+    """Check if a line is an indented clause value."""
+    return line.startswith(_CLAUSE_INDENT) and bool(line.strip())
+
+
+def _process_line(line: str, state: _ParseState) -> None:
+    """Process a single line of route-map output and update state."""
+    stripped = line.strip()
+
+    header = _HEADER_PATTERN.match(stripped)
+    if header:
+        state.start_new(
+            header.group("name"),
+            header.group("seq"),
+            header.group("action"),
+        )
+        return
+
+    if _MATCH_HEADER.match(line):
+        state.section = "match"
+        return
+
+    if _SET_HEADER.match(line):
+        state.section = "set"
+        return
+
+    if _is_clause_line(line) and state.section:
+        if state.section == "match":
+            state.match_clauses.append(stripped)
+        else:
+            state.set_clauses.append(stripped)
+
+
+@register(OS.CISCO_NXOS, "show route-map")
+class ShowRouteMapParser(BaseParser[ShowRouteMapResult]):
+    """Parser for 'show route-map' command.
+
+    Example output:
+        route-map RM-TEST-OUT, permit, sequence 10
+          Match clauses:
+            as-path (as-path filter): AS-TEST
+          Set clauses:
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteMapResult:
+        """Parse 'show route-map' output.
+
+        Args:
+            output: Raw CLI output from 'show route-map' command.
+
+        Returns:
+            Parsed route-map data keyed by route-map name.
+
+        Raises:
+            ValueError: If no route-maps found in output.
+        """
+        state = _ParseState()
+
+        for line in output.splitlines():
+            _process_line(line, state)
+
+        state.flush()
+
+        if not state.route_maps:
+            msg = "No route-maps found in output"
+            raise ValueError(msg)
+
+        return ShowRouteMapResult(route_maps=state.route_maps)

--- a/tests/parsers/nxos/show_route-map/001_basic/expected.json
+++ b/tests/parsers/nxos/show_route-map/001_basic/expected.json
@@ -1,0 +1,79 @@
+{
+    "route_maps": {
+        "RM-BGP-TO-OSPF": {
+            "sequences": {
+                "10": {
+                    "action": "deny",
+                    "match_clauses": [
+                        "tag: 12345"
+                    ],
+                    "set_clauses": []
+                },
+                "20": {
+                    "action": "permit",
+                    "match_clauses": [],
+                    "set_clauses": []
+                }
+            }
+        },
+        "RM-ISP1-IN": {
+            "sequences": {
+                "1000": {
+                    "action": "permit",
+                    "match_clauses": [],
+                    "set_clauses": [
+                        "local-preference 300"
+                    ]
+                }
+            }
+        },
+        "RM-ISP1-OUT": {
+            "sequences": {
+                "1000": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "as-path (as-path filter): AS-ISP2"
+                    ],
+                    "set_clauses": []
+                }
+            }
+        },
+        "RM-N3K1-TO-N3K2": {
+            "sequences": {
+                "10": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "ip address prefix-lists: PF-N3K1-TO-N3K2"
+                    ],
+                    "set_clauses": [
+                        "extcommunity RT:100:1"
+                    ]
+                }
+            }
+        },
+        "RM-TEST-OUT": {
+            "sequences": {
+                "10": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "as-path (as-path filter): AS-TEST"
+                    ],
+                    "set_clauses": []
+                }
+            }
+        },
+        "TEST_THIS": {
+            "sequences": {
+                "10": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "ip address (access-lists): AL_TEST_TEST"
+                    ],
+                    "set_clauses": [
+                        "ip next-hop 2.2.2.2"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_route-map/001_basic/input.txt
+++ b/tests/parsers/nxos/show_route-map/001_basic/input.txt
@@ -1,0 +1,29 @@
+route-map RM-TEST-OUT, permit, sequence 10
+  Match clauses:
+    as-path (as-path filter): AS-TEST
+  Set clauses:
+route-map RM-BGP-TO-OSPF, deny, sequence 10
+  Match clauses:
+    tag: 12345
+  Set clauses:
+route-map RM-BGP-TO-OSPF, permit, sequence 20
+  Match clauses:
+  Set clauses:
+route-map RM-ISP1-IN, permit, sequence 1000
+  Match clauses:
+  Set clauses:
+    local-preference 300
+route-map RM-ISP1-OUT, permit, sequence 1000
+  Match clauses:
+    as-path (as-path filter): AS-ISP2
+  Set clauses:
+route-map TEST_THIS, permit, sequence 10
+  Match clauses:
+    ip address (access-lists): AL_TEST_TEST
+  Set clauses:
+    ip next-hop 2.2.2.2
+route-map RM-N3K1-TO-N3K2, permit, sequence 10
+  Match clauses:
+    ip address prefix-lists: PF-N3K1-TO-N3K2
+  Set clauses:
+    extcommunity RT:100:1

--- a/tests/parsers/nxos/show_route-map/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_route-map/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple route-maps with various match and set clauses
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_route-map/002_single_entry/expected.json
+++ b/tests/parsers/nxos/show_route-map/002_single_entry/expected.json
@@ -1,0 +1,17 @@
+{
+    "route_maps": {
+        "RM-SIMPLE": {
+            "sequences": {
+                "10": {
+                    "action": "permit",
+                    "match_clauses": [
+                        "ip address prefix-lists: PF-DEFAULT"
+                    ],
+                    "set_clauses": [
+                        "local-preference 200"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_route-map/002_single_entry/input.txt
+++ b/tests/parsers/nxos/show_route-map/002_single_entry/input.txt
@@ -1,0 +1,5 @@
+route-map RM-SIMPLE, permit, sequence 10
+  Match clauses:
+    ip address prefix-lists: PF-DEFAULT
+  Set clauses:
+    local-preference 200

--- a/tests/parsers/nxos/show_route-map/002_single_entry/metadata.yaml
+++ b/tests/parsers/nxos/show_route-map/002_single_entry/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single route-map with one sequence
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for `show route-map` on Cisco NX-OS
- Parses route-map names, sequences (with action permit/deny), match clauses, and set clauses
- Includes 2 test cases: multi-entry and single-entry scenarios

Closes #122

## Test plan
- [x] `uv run pytest tests/parsers/nxos/show_route-map/ -v` -- 2 tests pass
- [x] `uv run ruff check` -- no issues
- [x] `uv run xenon --max-absolute B` -- complexity within limits
- [x] `uv run pre-commit run --all-files` -- all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)