### PR TITLE
feat: add parser for 'show vrrp detail' on IOS-XE

### DIFF
--- a/changes/372.parser_added
+++ b/changes/372.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show vrrp detail' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vrrp_all.py
+++ b/src/muninn/parsers/iosxe/show_vrrp_all.py
@@ -1,4 +1,4 @@
-"""Parser for 'show vrrp all' command on IOS-XE."""
+"""Parser for 'show vrrp all' and 'show vrrp detail' commands on IOS-XE."""
 
 import re
 from typing import NotRequired, TypedDict
@@ -262,6 +262,7 @@ _FIELD_DISPATCH: dict[str, _FieldApplier] = {
 
 
 @register(OS.CISCO_IOSXE, "show vrrp all")
+@register(OS.CISCO_IOSXE, "show vrrp detail")
 class ShowVrrpAllParser(BaseParser[ShowVrrpAllResult]):
     """Parser for 'show vrrp all' command.
 

--- a/tests/parsers/iosxe/show_vrrp_detail/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vrrp_detail/001_basic/expected.json
@@ -1,0 +1,38 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/0/6.101": {
+            "1": {
+                "address_family": "IPv4",
+                "advertisement_interval_secs": 1.0,
+                "flags": "0/1",
+                "master_advertisement_interval_secs": 1.0,
+                "master_down_expires_secs": 3066.0,
+                "master_down_interval_secs": 3.218,
+                "master_router_ip": "192.105.105.91",
+                "master_router_priority": 220,
+                "preemption": "enabled",
+                "priority": 200,
+                "state": "BACKUP",
+                "virtual_ip_address": "192.105.105.201",
+                "virtual_mac_address": "0000.5E00.0101"
+            }
+        },
+        "GigabitEthernet0/0/6.102": {
+            "2": {
+                "address_family": "IPv4",
+                "advertisement_interval_secs": 3.0,
+                "flags": "1/1",
+                "master_advertisement_expires_msec": 1304,
+                "master_advertisement_interval_secs": 3.0,
+                "master_router_ip": "192.105.105.102",
+                "master_router_is_local": true,
+                "master_router_priority": 100,
+                "preemption": "enabled",
+                "priority": 100,
+                "state": "MASTER",
+                "virtual_ip_address": "192.105.105.202",
+                "virtual_mac_address": "0000.5E00.0102"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vrrp_detail/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vrrp_detail/001_basic/input.txt
@@ -1,0 +1,63 @@
+GigabitEthernet0/0/6.101 - Group 1 - Address-Family IPv4
+  State is BACKUP
+  State duration 5 hours 41 mins 27 secs
+  Virtual IP address is 192.105.105.201
+  Virtual MAC address is 0000.5E00.0101
+  Advertisement interval is 1000 msec
+  Preemption enabled
+  Priority is 200
+  State change reason is VRRP_PREEMPT
+  Tloc preference not configured, value 0
+  Master Router is 192.105.105.91, priority is 220
+  Master Advertisement interval is 1000 msec (learned)
+  Master Down interval is 3218 msec (expires in 3066 msec)
+  FLAGS: 0/1
+  VRRPv3 Advertisements: sent 23 (errors 0) - rcvd 26331
+  VRRPv2 Advertisements: sent 23 (errors 0) - rcvd 2
+  Group Discarded Packets: 26361
+    VRRPv2 incompatibility: 26329
+    IP Address Owner conflicts: 0
+    Invalid address count: 0
+    IP address configuration mismatch : 0
+    Invalid Advert Interval: 0
+    Adverts received in Init state: 32
+    Invalid group other reason: 0
+  Group State transition:
+    Init to master: 0
+    Init to backup: 2 (Last change Tue Feb 15 07:17:16.662)
+    Backup to master: 2 (Last change Tue Feb 15 07:17:19.881)
+    Master to backup: 1 (Last change Tue Feb 15 07:17:37.384)
+    Master to init: 1 (Last change Tue Feb 15 07:12:56.285)
+    Backup to init: 0
+GigabitEthernet0/0/6.102 - Group 2 - Address-Family IPv4
+  State is MASTER
+  State duration 5 hours 41 mins 37 secs
+  Virtual IP address is 192.105.105.202
+  Virtual MAC address is 0000.5E00.0102
+  Advertisement interval is 3000 msec
+  Preemption enabled
+  Priority is 100
+  State change reason is VRRP_MASTER_NO_RESP
+  Tloc preference not configured, value 0
+    Track object omp state UP shutdown
+  Master Router is 192.105.105.102 (local), priority is 100
+  Master Advertisement interval is 3000 msec (expires in 1304 msec)
+  Master Down interval is unknown
+  FLAGS: 1/1
+  VRRPv3 Advertisements: sent 7598 (errors 0) - rcvd 3592
+  VRRPv2 Advertisements: sent 7598 (errors 0) - rcvd 1
+  Group Discarded Packets: 3623
+    VRRPv2 incompatibility: 3591
+    IP Address Owner conflicts: 0
+    Invalid address count: 0
+    IP address configuration mismatch : 3593
+    Invalid Advert Interval: 0
+    Adverts received in Init state: 32
+    Invalid group other reason: 0
+  Group State transition:
+    Init to master: 0
+    Init to backup: 2 (Last change Tue Feb 15 07:17:16.663)
+    Backup to master: 2 (Last change Tue Feb 15 07:17:27.491)
+    Master to backup: 0
+    Master to init: 1 (Last change Tue Feb 15 07:12:56.286)
+    Backup to init: 0

--- a/tests/parsers/iosxe/show_vrrp_detail/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vrrp_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic VRRP detail output with master and backup states
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_vrrp_detail/002_init_state/expected.json
+++ b/tests/parsers/iosxe/show_vrrp_detail/002_init_state/expected.json
@@ -1,0 +1,16 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/0/2.150": {
+            "2": {
+                "address_family": "IPv4",
+                "advertisement_interval_secs": 1.0,
+                "flags": "1/0",
+                "preemption": "enabled",
+                "priority": 250,
+                "state": "INIT",
+                "virtual_ip_address": "no address",
+                "virtual_mac_address": "0000.5E00.0102"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vrrp_detail/002_init_state/input.txt
+++ b/tests/parsers/iosxe/show_vrrp_detail/002_init_state/input.txt
@@ -1,0 +1,31 @@
+GigabitEthernet0/0/2.150 - Group 2 - Address-Family IPv4
+  State is INIT (No layer3 interface address)
+  State duration 6 hours 40 mins 47 secs
+  Virtual IP address is no address
+  Virtual MAC address is 0000.5E00.0102
+  Advertisement interval is 1000 msec
+  Preemption enabled
+  Priority is 250
+  State change reason is VRRP_INIT
+  Tloc preference not configured, value 0
+  Master Router is unknown, priority is unknown
+  Master Advertisement interval is unknown
+  Master Down interval is unknown
+  FLAGS: 1/0
+  VRRPv3 Advertisements: sent 0 (errors 0) - rcvd 0
+  VRRPv2 Advertisements: sent 0 (errors 0) - rcvd 0
+  Group Discarded Packets: 0
+    VRRPv2 incompatibility: 0
+    IP Address Owner conflicts: 0
+    Invalid address count: 0
+    IP address configuration mismatch : 0
+    Invalid Advert Interval: 0
+    Adverts received in Init state: 0
+    Invalid group other reason: 0
+  Group State transition:
+    Init to master: 0
+    Init to backup: 0
+    Backup to master: 0
+    Master to backup: 0
+    Master to init: 0
+    Backup to init: 0

--- a/tests/parsers/iosxe/show_vrrp_detail/002_init_state/metadata.yaml
+++ b/tests/parsers/iosxe/show_vrrp_detail/002_init_state/metadata.yaml
@@ -1,0 +1,3 @@
+description: VRRP group in INIT state with no virtual IP address configured
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Register `show vrrp detail` as an alias on the existing `ShowVrrpAllParser` in `show_vrrp_all.py`, since both commands produce identical output format
- Add two test cases: basic multi-group output (BACKUP + MASTER states) and INIT state with no virtual IP address configured
- Test data sourced from Genie parser test suite

Closes #118

## Test plan

- [x] `uv run pytest tests/parsers/test_parsers.py -k show_vrrp_detail -v` — 2 tests pass
- [x] `uv run ruff check src/muninn/parsers/iosxe/show_vrrp_all.py` — clean
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_vrrp_all.py` — passes
- [x] `uv run pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)