### PR TITLE
feat: add parser for 'show module' on NX-OS

### DIFF
--- a/changes/373.parser_added
+++ b/changes/373.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show module' on NX-OS.

--- a/src/muninn/parsers/nxos/show_module.py
+++ b/src/muninn/parsers/nxos/show_module.py
@@ -1,0 +1,375 @@
+"""Parser for 'show module' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ModuleEntry(TypedDict):
+    """Schema for a single module entry."""
+
+    module_number: int
+    ports: int
+    module_type: str
+    status: str
+    model: NotRequired[str]
+    software_version: NotRequired[str]
+    hardware_version: NotRequired[str]
+    slot: NotRequired[str]
+    mac_address_range: NotRequired[str]
+    serial_number: NotRequired[str]
+    online_diag_status: NotRequired[str]
+    world_wide_name: NotRequired[str]
+
+
+class ShowModuleResult(TypedDict):
+    """Schema for 'show module' parsed output."""
+
+    modules: dict[str, ModuleEntry]
+    xbar_modules: NotRequired[dict[str, ModuleEntry]]
+    fabric_modules: NotRequired[dict[str, ModuleEntry]]
+
+
+# Section header patterns
+_MOD_HEADER = re.compile(
+    r"^(?:Mod|Lem|LFM|Xbar)\s+Ports\s+Module-Type\s+Model\s+Status",
+    re.IGNORECASE,
+)
+_SW_HW_HEADER = re.compile(
+    r"^(?:Mod|Xbar|Lem)\s+Sw\s+Hw",
+    re.IGNORECASE,
+)
+_MAC_HEADER = re.compile(
+    r"^(?:Mod|Xbar|Lem|LFM)\s+MAC-Address",
+    re.IGNORECASE,
+)
+_DIAG_HEADER = re.compile(
+    r"^(?:Mod|Xbar|Lem|LFM)\s+Online Diag Status",
+    re.IGNORECASE,
+)
+_POWER_HEADER = re.compile(r"^Mod\s+Power-Status\s+Reason", re.IGNORECASE)
+_SEPARATOR = re.compile(r"^[-\s]+$")
+_DASH_GROUP = re.compile(r"-+")
+
+# Data row patterns for non-column-position sections
+_SW_HW_ROW = re.compile(
+    r"^(?P<mod>\d+)\s+(?P<sw>\S+)\s+(?P<hw>\S+)"
+    r"(?:\s+(?P<extra>.+))?$",
+)
+_MAC_ROW = re.compile(
+    r"^(?P<mod>\d+)\s+(?P<mac>\S+(?:\s+to\s+\S+)?)\s+(?P<serial>\S+)$",
+)
+_DIAG_ROW = re.compile(r"^(?P<mod>\d+)\s+(?P<status>\S+)$")
+
+_SENTINEL_VALUES = frozenset({"--", "N/A", "NA", ""})
+
+
+def _normalize(value: str | None) -> str | None:
+    """Normalize sentinel values to None."""
+    if value is None:
+        return None
+    value = value.strip()
+    if value in _SENTINEL_VALUES:
+        return None
+    return value
+
+
+def _detect_section_type(line: str) -> str:
+    """Detect the section type prefix from a header line."""
+    lower = line.lower()
+    if lower.startswith("xbar"):
+        return "xbar"
+    if lower.startswith("lfm"):
+        return "lfm"
+    if lower.startswith("lem"):
+        return "lem"
+    return "mod"
+
+
+def _parse_separator_columns(sep_line: str) -> list[tuple[int, int]]:
+    """Parse a separator line to find column boundaries.
+
+    Returns a list of (start, end) tuples for each column.
+    """
+    return [(m.start(), m.end()) for m in _DASH_GROUP.finditer(sep_line)]
+
+
+def _col_field(line: str, start: int, end: int) -> str:
+    """Extract and strip a column-position field from a line."""
+    return line[start:end].strip() if len(line) > start else ""
+
+
+def _parse_mod_rows(
+    lines: list[str],
+    start: int,
+    columns: list[tuple[int, int]],
+    modules: dict[str, ModuleEntry],
+) -> int:
+    """Parse module table rows using column positions. Returns next line index."""
+    if len(columns) < 5:
+        return start
+
+    idx = start
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+        if not stripped or _SEPARATOR.match(stripped):
+            idx += 1
+            continue
+        mod_str = _col_field(line, columns[0][0], columns[1][0])
+        if not mod_str or not mod_str.isdigit():
+            break
+        entry = _build_mod_entry(line, mod_str, columns)
+        modules[mod_str] = entry
+        idx += 1
+    return idx
+
+
+def _build_mod_entry(
+    line: str,
+    mod_str: str,
+    columns: list[tuple[int, int]],
+) -> ModuleEntry:
+    """Build a ModuleEntry from a module table row using column positions."""
+    ports_str = _col_field(line, columns[1][0], columns[2][0])
+    module_type = _col_field(line, columns[2][0], columns[3][0])
+    model = _col_field(line, columns[3][0], columns[4][0])
+    status = _col_field(line, columns[4][0], len(line)).rstrip(" *")
+
+    entry: ModuleEntry = {
+        "module_number": int(mod_str),
+        "ports": int(ports_str) if ports_str.isdigit() else 0,
+        "module_type": module_type,
+        "status": status,
+    }
+    model_normalized = _normalize(model)
+    if model_normalized:
+        entry["model"] = model_normalized
+    return entry
+
+
+def _parse_sw_hw_rows(
+    lines: list[str],
+    start: int,
+    modules: dict[str, ModuleEntry],
+) -> int:
+    """Parse software/hardware table rows. Returns next line index."""
+    idx = start
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line or _SEPARATOR.match(line):
+            idx += 1
+            continue
+        match = _SW_HW_ROW.match(line)
+        if not match:
+            break
+        mod = match.group("mod")
+        entry = modules.get(mod)
+        if entry is not None:
+            _apply_sw_hw(entry, match)
+        idx += 1
+    return idx
+
+
+def _apply_sw_hw(entry: ModuleEntry, match: re.Match[str]) -> None:
+    """Apply software/hardware fields to an entry."""
+    sw = _normalize(match.group("sw"))
+    hw = _normalize(match.group("hw"))
+    if sw:
+        entry["software_version"] = sw
+    if hw:
+        entry["hardware_version"] = hw
+    extra = _normalize(match.group("extra"))
+    if extra:
+        _apply_sw_extra(entry, extra)
+
+
+def _apply_sw_extra(entry: ModuleEntry, extra: str) -> None:
+    """Apply extra fields from the sw/hw row (WWN or Slot)."""
+    if ":" in extra and len(extra) > 10:
+        entry["world_wide_name"] = extra
+    else:
+        entry["slot"] = extra
+
+
+def _parse_mac_rows(
+    lines: list[str],
+    start: int,
+    modules: dict[str, ModuleEntry],
+) -> int:
+    """Parse MAC address table rows. Returns next line index."""
+    idx = start
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line or _SEPARATOR.match(line):
+            idx += 1
+            continue
+        match = _MAC_ROW.match(line)
+        if not match:
+            break
+        mod = match.group("mod")
+        entry = modules.get(mod)
+        if entry is not None:
+            mac = _normalize(match.group("mac"))
+            serial = _normalize(match.group("serial"))
+            if mac:
+                entry["mac_address_range"] = mac
+            if serial:
+                entry["serial_number"] = serial
+        idx += 1
+    return idx
+
+
+def _parse_diag_rows(
+    lines: list[str],
+    start: int,
+    modules: dict[str, ModuleEntry],
+) -> int:
+    """Parse online diag status rows. Returns next line index."""
+    idx = start
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line or _SEPARATOR.match(line):
+            idx += 1
+            continue
+        match = _DIAG_ROW.match(line)
+        if not match:
+            break
+        mod = match.group("mod")
+        entry = modules.get(mod)
+        if entry is not None:
+            entry["online_diag_status"] = match.group("status")
+        idx += 1
+    return idx
+
+
+def _skip_section(lines: list[str], start: int) -> int:
+    """Skip an unrecognized section. Returns next line index."""
+    idx = start
+    while idx < len(lines):
+        line = lines[idx].strip()
+        if not line or _SEPARATOR.match(line):
+            idx += 1
+            continue
+        if _is_any_header(line):
+            break
+        idx += 1
+    return idx
+
+
+def _is_any_header(line: str) -> bool:
+    """Check if a line matches any known section header."""
+    return bool(
+        _MOD_HEADER.match(line)
+        or _SW_HW_HEADER.match(line)
+        or _MAC_HEADER.match(line)
+        or _DIAG_HEADER.match(line)
+        or _POWER_HEADER.match(line)
+    )
+
+
+def _skip_to_data(lines: list[str], idx: int) -> tuple[int, str]:
+    """Skip the separator line after a header. Returns (next_index, sep_line)."""
+    idx += 1
+    sep_line = ""
+    if idx < len(lines) and _SEPARATOR.match(lines[idx].strip()):
+        sep_line = lines[idx]
+        idx += 1
+    return idx, sep_line
+
+
+def _get_target_dict(
+    section_type: str,
+    modules: dict[str, ModuleEntry],
+    xbar: dict[str, ModuleEntry],
+    fabric: dict[str, ModuleEntry],
+) -> dict[str, ModuleEntry]:
+    """Return the correct dict for the current section type."""
+    if section_type == "xbar":
+        return xbar
+    if section_type in ("lfm", "lem"):
+        return fabric
+    return modules
+
+
+def _process_header(
+    lines: list[str],
+    idx: int,
+    line: str,
+    modules: dict[str, ModuleEntry],
+    xbar: dict[str, ModuleEntry],
+    fabric: dict[str, ModuleEntry],
+) -> int:
+    """Dispatch parsing based on the header type. Returns next line index."""
+    section_type = _detect_section_type(line)
+    target = _get_target_dict(section_type, modules, xbar, fabric)
+    data_idx, sep_line = _skip_to_data(lines, idx)
+
+    if _MOD_HEADER.match(line):
+        columns = _parse_separator_columns(sep_line) if sep_line else []
+        return _parse_mod_rows(lines, data_idx, columns, target)
+    if _SW_HW_HEADER.match(line):
+        return _parse_sw_hw_rows(lines, data_idx, target)
+    if _MAC_HEADER.match(line):
+        return _parse_mac_rows(lines, data_idx, target)
+    if _DIAG_HEADER.match(line):
+        return _parse_diag_rows(lines, data_idx, target)
+    if _POWER_HEADER.match(line):
+        return _skip_section(lines, data_idx)
+    return idx + 1
+
+
+@register(OS.CISCO_NXOS, "show module")
+class ShowModuleParser(BaseParser[ShowModuleResult]):
+    """Parser for 'show module' command.
+
+    Example output:
+        Mod  Ports  Module-Type                         Model              Status
+        ---  -----  ----------------------------------- ------------------ ----------
+        1    0      Supervisor Module-2                 N7K-SUP2           active *
+        3    48     1/10 Gbps Ethernet Module           N7K-F248XP-25E     ok
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowModuleResult:
+        """Parse 'show module' output.
+
+        Args:
+            output: Raw CLI output from 'show module' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+        modules: dict[str, ModuleEntry] = {}
+        xbar: dict[str, ModuleEntry] = {}
+        fabric: dict[str, ModuleEntry] = {}
+
+        idx = 0
+        while idx < len(lines):
+            line = lines[idx].strip()
+            if not line or _SEPARATOR.match(line):
+                idx += 1
+                continue
+            if _is_any_header(line):
+                idx = _process_header(lines, idx, line, modules, xbar, fabric)
+            else:
+                idx += 1
+
+        if not modules:
+            msg = "No module entries found in output"
+            raise ValueError(msg)
+
+        result: ShowModuleResult = {"modules": modules}
+        if xbar:
+            result["xbar_modules"] = xbar
+        if fabric:
+            result["fabric_modules"] = fabric
+
+        return result

--- a/tests/parsers/nxos/show_module/001_basic/expected.json
+++ b/tests/parsers/nxos/show_module/001_basic/expected.json
@@ -1,0 +1,45 @@
+{
+    "modules": {
+        "1": {
+            "hardware_version": "0.0",
+            "mac_address_range": "2c-c2-60-17-d7-60 to 2c-c2-60-17-df-5f",
+            "model": "N7K-SUP1",
+            "module_number": 1,
+            "module_type": "NX-OSv Supervisor Module",
+            "ports": 0,
+            "serial_number": "TM6017D760B",
+            "software_version": "7.3(1)D1(0.10)",
+            "status": "active"
+        },
+        "2": {
+            "hardware_version": "0.0",
+            "mac_address_range": "02-00-0c-00-02-00 to 02-00-0c-00-02-7f",
+            "model": "N7K-F248XP-25",
+            "module_number": 2,
+            "module_type": "NX-OSv Ethernet Module",
+            "ports": 48,
+            "serial_number": "TM6017D760C",
+            "status": "ok"
+        },
+        "3": {
+            "hardware_version": "0.0",
+            "mac_address_range": "02-00-0c-00-03-00 to 02-00-0c-00-03-7f",
+            "model": "N7K-F248XP-25",
+            "module_number": 3,
+            "module_type": "NX-OSv Ethernet Module",
+            "ports": 48,
+            "serial_number": "TM6017D760D",
+            "status": "ok"
+        },
+        "4": {
+            "hardware_version": "0.0",
+            "mac_address_range": "02-00-0c-00-04-00 to 02-00-0c-00-04-7f",
+            "model": "N7K-F248XP-25",
+            "module_number": 4,
+            "module_type": "NX-OSv Ethernet Module",
+            "ports": 48,
+            "serial_number": "TM6017D760E",
+            "status": "ok"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_module/001_basic/input.txt
+++ b/tests/parsers/nxos/show_module/001_basic/input.txt
@@ -1,0 +1,23 @@
+Mod  Ports  Module-Type                         Model              Status
+---  -----  ----------------------------------- ------------------ ----------
+1    0      NX-OSv Supervisor Module            N7K-SUP1           active *
+2    48     NX-OSv Ethernet Module              N7K-F248XP-25      ok
+3    48     NX-OSv Ethernet Module              N7K-F248XP-25      ok
+4    48     NX-OSv Ethernet Module              N7K-F248XP-25      ok
+
+Mod  Sw               Hw      World-Wide-Name(s) (WWN)
+---  ---------------  ------  --------------------------------------------------
+1    7.3(1)D1(0.10)   0.0     --
+2    NA               0.0     --
+3    NA               0.0     --
+4    NA               0.0     --
+
+
+Mod  MAC-Address(es)                         Serial-Num
+---  --------------------------------------  ----------
+1    2c-c2-60-17-d7-60 to 2c-c2-60-17-df-5f  TM6017D760B
+2    02-00-0c-00-02-00 to 02-00-0c-00-02-7f  TM6017D760C
+3    02-00-0c-00-03-00 to 02-00-0c-00-03-7f  TM6017D760D
+4    02-00-0c-00-04-00 to 02-00-0c-00-04-7f  TM6017D760E
+
+* this terminal session

--- a/tests/parsers/nxos/show_module/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_module/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic NX-OSv output with supervisor and ethernet modules
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_module/002_xbar_and_fabric/expected.json
+++ b/tests/parsers/nxos/show_module/002_xbar_and_fabric/expected.json
@@ -1,0 +1,135 @@
+{
+    "modules": {
+        "1": {
+            "hardware_version": "1.0",
+            "mac_address_range": "84-78-ac-ff-d3-dc to 84-78-ac-ff-d3-ee",
+            "model": "N7K-SUP2",
+            "module_number": 1,
+            "module_type": "Supervisor Module-2",
+            "online_diag_status": "Pass",
+            "ports": 0,
+            "serial_number": "JAF1708AGTH",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "active"
+        },
+        "2": {
+            "hardware_version": "1.0",
+            "mac_address_range": "84-78-ac-ff-c8-0f to 84-78-ac-ff-c8-21",
+            "model": "N7K-SUP2",
+            "module_number": 2,
+            "module_type": "Supervisor Module-2",
+            "online_diag_status": "Pass",
+            "ports": 0,
+            "serial_number": "JAF1708AGQH",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "ha-standby"
+        },
+        "3": {
+            "hardware_version": "1.0",
+            "mac_address_range": "84-78-ac-ff-f5-48 to 84-78-ac-ff-f5-7b",
+            "model": "N7K-F248XP-25E",
+            "module_number": 3,
+            "module_type": "1/10 Gbps Ethernet Module",
+            "online_diag_status": "Pass",
+            "ports": 48,
+            "serial_number": "JAF1717AAND",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "ok"
+        },
+        "4": {
+            "hardware_version": "1.0",
+            "mac_address_range": "54-4a-00-ff-c6-ed to 54-4a-00-ff-c6-29",
+            "model": "N7K-F312FQ-25",
+            "module_number": 4,
+            "module_type": "10/40 Gbps Ethernet Module",
+            "online_diag_status": "Pass",
+            "ports": 12,
+            "serial_number": "JAE18120FLU",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "ok"
+        },
+        "6": {
+            "hardware_version": "2.0",
+            "mac_address_range": "bc-16-65-ff-04-b8 to bc-16-65-ff-04-db",
+            "model": "N7K-M132XP-12L",
+            "module_number": 6,
+            "module_type": "10 Gbps Ethernet XL Module",
+            "online_diag_status": "Pass",
+            "ports": 32,
+            "serial_number": "JAF1719AHMB",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "ok"
+        },
+        "7": {
+            "hardware_version": "1.0",
+            "mac_address_range": "d8-67-d9-ff-9f-d6 to d8-67-d9-ff-9f-f1",
+            "model": "N7K-M224XP-23L",
+            "module_number": 7,
+            "module_type": "10 Gbps Ethernet Module",
+            "online_diag_status": "Pass",
+            "ports": 24,
+            "serial_number": "JAF1641APPF",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "ok"
+        },
+        "8": {
+            "hardware_version": "2.1",
+            "mac_address_range": "bc-16-65-ff-f2-0b to bc-16-65-ff-f3-3d",
+            "model": "N7K-M148GT-11L",
+            "module_number": 8,
+            "module_type": "10/100/1000 Mbps Ethernet XL Module",
+            "online_diag_status": "Pass",
+            "ports": 48,
+            "serial_number": "JAF1717BEAT",
+            "software_version": "8.3(0)CV(0.658)",
+            "status": "ok"
+        }
+    },
+    "xbar_modules": {
+        "1": {
+            "hardware_version": "3.1",
+            "model": "N7K-C7009-FAB-2",
+            "module_number": 1,
+            "module_type": "Fabric Module 2",
+            "ports": 0,
+            "serial_number": "JAF1705AEEF",
+            "status": "ok"
+        },
+        "2": {
+            "hardware_version": "3.1",
+            "model": "N7K-C7009-FAB-2",
+            "module_number": 2,
+            "module_type": "Fabric Module 2",
+            "ports": 0,
+            "serial_number": "JAF1705BFBM",
+            "status": "ok"
+        },
+        "3": {
+            "hardware_version": "3.1",
+            "model": "N7K-C7009-FAB-2",
+            "module_number": 3,
+            "module_type": "Fabric Module 2",
+            "ports": 0,
+            "serial_number": "JAF1705AELK",
+            "status": "ok"
+        },
+        "4": {
+            "hardware_version": "3.1",
+            "model": "N7K-C7009-FAB-2",
+            "module_number": 4,
+            "module_type": "Fabric Module 2",
+            "ports": 0,
+            "serial_number": "JAF1705BFCF",
+            "status": "ok"
+        },
+        "5": {
+            "hardware_version": "3.1",
+            "model": "N7K-C7009-FAB-2",
+            "module_number": 5,
+            "module_type": "Fabric Module 2",
+            "ports": 0,
+            "serial_number": "JAF1704APQH",
+            "status": "ok"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_module/002_xbar_and_fabric/input.txt
+++ b/tests/parsers/nxos/show_module/002_xbar_and_fabric/input.txt
@@ -1,0 +1,69 @@
+Mod  Ports  Module-Type                         Model              Status
+---  -----  ----------------------------------- ------------------ ----------
+1    0      Supervisor Module-2                 N7K-SUP2           active *
+2    0      Supervisor Module-2                 N7K-SUP2           ha-standby
+3    48     1/10 Gbps Ethernet Module           N7K-F248XP-25E     ok
+4    12     10/40 Gbps Ethernet Module          N7K-F312FQ-25      ok
+6    32     10 Gbps Ethernet XL Module          N7K-M132XP-12L     ok
+7    24     10 Gbps Ethernet Module             N7K-M224XP-23L     ok
+8    48     10/100/1000 Mbps Ethernet XL Module N7K-M148GT-11L     ok
+
+Mod  Sw               Hw
+---  ---------------  ------
+1    8.3(0)CV(0.658)  1.0
+2    8.3(0)CV(0.658)  1.0
+3    8.3(0)CV(0.658)  1.0
+4    8.3(0)CV(0.658)  1.0
+6    8.3(0)CV(0.658)  2.0
+7    8.3(0)CV(0.658)  1.0
+8    8.3(0)CV(0.658)  2.1
+
+
+
+Mod  MAC-Address(es)                         Serial-Num
+---  --------------------------------------  ----------
+1    84-78-ac-ff-d3-dc to 84-78-ac-ff-d3-ee  JAF1708AGTH
+2    84-78-ac-ff-c8-0f to 84-78-ac-ff-c8-21  JAF1708AGQH
+3    84-78-ac-ff-f5-48 to 84-78-ac-ff-f5-7b  JAF1717AAND
+4    54-4a-00-ff-c6-ed to 54-4a-00-ff-c6-29  JAE18120FLU
+6    bc-16-65-ff-04-b8 to bc-16-65-ff-04-db  JAF1719AHMB
+7    d8-67-d9-ff-9f-d6 to d8-67-d9-ff-9f-f1  JAF1641APPF
+8    bc-16-65-ff-f2-0b to bc-16-65-ff-f3-3d  JAF1717BEAT
+
+Mod  Online Diag Status
+---  ------------------
+1    Pass
+2    Pass
+3    Pass
+4    Pass
+6    Pass
+7    Pass
+8    Pass
+
+Xbar Ports  Module-Type                         Model              Status
+---  -----  ----------------------------------- ------------------ ----------
+1    0      Fabric Module 2                     N7K-C7009-FAB-2    ok
+2    0      Fabric Module 2                     N7K-C7009-FAB-2    ok
+3    0      Fabric Module 2                     N7K-C7009-FAB-2    ok
+4    0      Fabric Module 2                     N7K-C7009-FAB-2    ok
+5    0      Fabric Module 2                     N7K-C7009-FAB-2    ok
+
+Xbar Sw               Hw
+---  ---------------  ------
+1    NA               3.1
+2    NA               3.1
+3    NA               3.1
+4    NA               3.1
+5    NA               3.1
+
+
+
+Xbar MAC-Address(es)                         Serial-Num
+---  --------------------------------------  ----------
+1    NA                                      JAF1705AEEF
+2    NA                                      JAF1705BFBM
+3    NA                                      JAF1705AELK
+4    NA                                      JAF1705BFCF
+5    NA                                      JAF1704APQH
+
+* this terminal session

--- a/tests/parsers/nxos/show_module/002_xbar_and_fabric/metadata.yaml
+++ b/tests/parsers/nxos/show_module/002_xbar_and_fabric/metadata.yaml
@@ -1,0 +1,3 @@
+description: N7K output with multiple module types, xbar fabric modules, and online diag
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show module` command on NX-OS (cisco_nxos)
- Handles multiple section types: Mod, Xbar, Lem, and LFM module tables
- Uses column-position-based parsing derived from separator lines for reliable field extraction across different NX-OS output formats (N7K, N9K, N9800)
- Includes 2 test cases: basic NX-OSv output and N7K with xbar fabric modules

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_module -v` — 2 NX-OS test cases pass
- [x] `uv run ruff check` and `uv run ruff format` — no issues
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` — complexity within limits
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)