### PR TITLE
feat: add parser for 'show environment temperature' on IOS

### DIFF
--- a/changes/374.parser_added
+++ b/changes/374.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show environment temperature' on IOS.

--- a/src/muninn/parsers/ios/show_environment_temperature.py
+++ b/src/muninn/parsers/ios/show_environment_temperature.py
@@ -1,0 +1,172 @@
+"""Parser for 'show environment temperature' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class TemperatureSensorEntry(TypedDict):
+    """Schema for a single temperature sensor reading."""
+
+    temperature_value: int
+    temperature_state: str
+    yellow_threshold: int
+    red_threshold: int
+
+
+class SwitchTemperatureEntry(TypedDict):
+    """Schema for a single switch temperature entry."""
+
+    system_temperature: str
+    inlet: NotRequired[TemperatureSensorEntry]
+    hotspot: NotRequired[TemperatureSensorEntry]
+
+
+class ShowEnvironmentTemperatureResult(TypedDict):
+    """Schema for 'show environment temperature' parsed output."""
+
+    switches: dict[str, SwitchTemperatureEntry]
+
+
+_SWITCH_HEADER = re.compile(
+    r"^Switch\s+(?P<switch_id>\d+):\s+SYSTEM TEMPERATURE is\s+(?P<status>\S+)"
+)
+_SENSOR_VALUE = re.compile(
+    r"^(?P<sensor>Inlet|Hotspot)\s+Temperature\s+Value:\s+(?P<value>\d+)"
+)
+_TEMP_STATE = re.compile(r"^Temperature\s+State:\s+(?P<state>\S+)")
+_YELLOW_THRESHOLD = re.compile(r"^Yellow\s+Threshold\s*:\s+(?P<value>\d+)")
+_RED_THRESHOLD = re.compile(r"^Red\s+Threshold\s*:\s+(?P<value>\d+)")
+
+
+def _parse_sensor(lines: list[str], idx: int) -> tuple[TemperatureSensorEntry, int]:
+    """Parse a sensor block (value, state, yellow threshold, red threshold).
+
+    Args:
+        lines: List of stripped lines from output.
+        idx: Index of the sensor value line (already matched).
+
+    Returns:
+        Tuple of (sensor entry, next line index).
+
+    Raises:
+        ValueError: If expected follow-on lines are missing.
+    """
+    value_match = _SENSOR_VALUE.match(lines[idx])
+    if not value_match:
+        msg = f"Expected sensor value line at index {idx}"
+        raise ValueError(msg)
+    temp_value = int(value_match.group("value"))
+    idx += 1
+
+    state = _extract_field(_TEMP_STATE, lines, idx, "Temperature State")
+    idx += 1
+
+    yellow = int(_extract_field(_YELLOW_THRESHOLD, lines, idx, "Yellow Threshold"))
+    idx += 1
+
+    red = int(_extract_field(_RED_THRESHOLD, lines, idx, "Red Threshold"))
+    idx += 1
+
+    entry: TemperatureSensorEntry = {
+        "temperature_value": temp_value,
+        "temperature_state": state,
+        "yellow_threshold": yellow,
+        "red_threshold": red,
+    }
+    return entry, idx
+
+
+def _extract_field(
+    pattern: re.Pattern[str], lines: list[str], idx: int, field_name: str
+) -> str:
+    """Extract a single field value from the expected line position.
+
+    Args:
+        pattern: Compiled regex with a named group to extract.
+        lines: List of stripped lines.
+        idx: Current line index.
+        field_name: Human-readable field name for error messages.
+
+    Returns:
+        The matched group value.
+
+    Raises:
+        ValueError: If the line doesn't match the expected pattern.
+    """
+    if idx >= len(lines):
+        msg = f"Unexpected end of output while looking for {field_name}"
+        raise ValueError(msg)
+    match = pattern.match(lines[idx])
+    if not match:
+        msg = f"Expected {field_name} at line: {lines[idx]!r}"
+        raise ValueError(msg)
+    return match.group(1)
+
+
+@register(OS.CISCO_IOS, "show environment temperature")
+class ShowEnvironmentTemperatureParser(
+    BaseParser[ShowEnvironmentTemperatureResult],
+):
+    """Parser for 'show environment temperature' command.
+
+    Example output:
+        Switch 1: SYSTEM TEMPERATURE is OK
+        Inlet Temperature Value: 29 Degree Celsius
+        Temperature State: GREEN
+        Yellow Threshold : 46 Degree Celsius
+        Red Threshold    : 56 Degree Celsius
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEnvironmentTemperatureResult:
+        """Parse 'show environment temperature' output.
+
+        Args:
+            output: Raw CLI output from 'show environment temperature' command.
+
+        Returns:
+            Parsed data keyed by switch number.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        raw_lines = output.splitlines()
+        lines = [line.strip() for line in raw_lines]
+
+        switches: dict[str, SwitchTemperatureEntry] = {}
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx]
+            if not line:
+                idx += 1
+                continue
+
+            header_match = _SWITCH_HEADER.match(line)
+            if header_match:
+                switch_id = header_match.group("switch_id")
+                status = header_match.group("status")
+                entry: SwitchTemperatureEntry = {"system_temperature": status}
+                switches[switch_id] = entry
+                idx += 1
+                continue
+
+            sensor_match = _SENSOR_VALUE.match(line)
+            if sensor_match and switches:
+                sensor_type = sensor_match.group("sensor").lower()
+                current_switch = list(switches.values())[-1]
+                sensor_entry, idx = _parse_sensor(lines, idx)
+                current_switch[sensor_type] = sensor_entry  # type: ignore[literal-required]
+                continue
+
+            idx += 1
+
+        if not switches:
+            msg = "No switch temperature data found in output"
+            raise ValueError(msg)
+
+        return {"switches": switches}

--- a/tests/parsers/ios/show_environment_temperature/001_basic/expected.json
+++ b/tests/parsers/ios/show_environment_temperature/001_basic/expected.json
@@ -1,0 +1,34 @@
+{
+    "switches": {
+        "1": {
+            "hotspot": {
+                "red_threshold": 125,
+                "temperature_state": "GREEN",
+                "temperature_value": 67,
+                "yellow_threshold": 105
+            },
+            "inlet": {
+                "red_threshold": 56,
+                "temperature_state": "GREEN",
+                "temperature_value": 29,
+                "yellow_threshold": 46
+            },
+            "system_temperature": "OK"
+        },
+        "2": {
+            "hotspot": {
+                "red_threshold": 125,
+                "temperature_state": "GREEN",
+                "temperature_value": 69,
+                "yellow_threshold": 105
+            },
+            "inlet": {
+                "red_threshold": 56,
+                "temperature_state": "GREEN",
+                "temperature_value": 28,
+                "yellow_threshold": 46
+            },
+            "system_temperature": "OK"
+        }
+    }
+}

--- a/tests/parsers/ios/show_environment_temperature/001_basic/input.txt
+++ b/tests/parsers/ios/show_environment_temperature/001_basic/input.txt
@@ -1,0 +1,20 @@
+Switch 1: SYSTEM TEMPERATURE is OK
+Inlet Temperature Value: 29 Degree Celsius
+Temperature State: GREEN
+Yellow Threshold : 46 Degree Celsius
+Red Threshold    : 56 Degree Celsius
+
+Hotspot Temperature Value: 67 Degree Celsius
+Temperature State: GREEN
+Yellow Threshold : 105 Degree Celsius
+Red Threshold    : 125 Degree Celsius
+Switch 2: SYSTEM TEMPERATURE is OK
+Inlet Temperature Value: 28 Degree Celsius
+Temperature State: GREEN
+Yellow Threshold : 46 Degree Celsius
+Red Threshold    : 56 Degree Celsius
+
+Hotspot Temperature Value: 69 Degree Celsius
+Temperature State: GREEN
+Yellow Threshold : 105 Degree Celsius
+Red Threshold    : 125 Degree Celsius

--- a/tests/parsers/ios/show_environment_temperature/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_environment_temperature/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Stack with two switches showing inlet and hotspot temperatures
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_environment_temperature/002_single_switch/expected.json
+++ b/tests/parsers/ios/show_environment_temperature/002_single_switch/expected.json
@@ -1,0 +1,13 @@
+{
+    "switches": {
+        "1": {
+            "inlet": {
+                "red_threshold": 56,
+                "temperature_state": "YELLOW",
+                "temperature_value": 32,
+                "yellow_threshold": 46
+            },
+            "system_temperature": "OK"
+        }
+    }
+}

--- a/tests/parsers/ios/show_environment_temperature/002_single_switch/input.txt
+++ b/tests/parsers/ios/show_environment_temperature/002_single_switch/input.txt
@@ -1,0 +1,5 @@
+Switch 1: SYSTEM TEMPERATURE is OK
+Inlet Temperature Value: 32 Degree Celsius
+Temperature State: YELLOW
+Yellow Threshold : 46 Degree Celsius
+Red Threshold    : 56 Degree Celsius

--- a/tests/parsers/ios/show_environment_temperature/002_single_switch/metadata.yaml
+++ b/tests/parsers/ios/show_environment_temperature/002_single_switch/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single switch with only inlet temperature sensor
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show environment temperature` on Cisco IOS
- Parses per-switch temperature data including inlet and hotspot sensors with values, states, and thresholds
- Includes 2 test cases: multi-switch stack and single switch with one sensor

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_environment_temperature -v` passes (2 tests)
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)