### PR TITLE
feat: add parser for 'show ip prefix-list' on IOS

### DIFF
--- a/changes/375.parser_added
+++ b/changes/375.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip prefix-list' on IOS.

--- a/src/muninn/parsers/ios/show_ip_prefix_list.py
+++ b/src/muninn/parsers/ios/show_ip_prefix_list.py
@@ -1,0 +1,105 @@
+"""Parser for 'show ip prefix-list' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PrefixEntry(TypedDict):
+    """Schema for a single prefix-list entry."""
+
+    seq: int
+    action: str
+    network: str
+    ge: NotRequired[int]
+    le: NotRequired[int]
+
+
+class PrefixListInfo(TypedDict):
+    """Schema for a single prefix-list."""
+
+    count: int
+    entries: dict[str, PrefixEntry]
+
+
+class ShowIpPrefixListResult(TypedDict):
+    """Schema for 'show ip prefix-list' parsed output."""
+
+    prefix_lists: dict[str, PrefixListInfo]
+
+
+@register(OS.CISCO_IOS, "show ip prefix-list")
+class ShowIpPrefixListParser(BaseParser[ShowIpPrefixListResult]):
+    """Parser for 'show ip prefix-list' command.
+
+    Example output:
+        ip prefix-list OSPF_Redist: 2 entries
+           seq 5 deny 10.0.0.0/24
+           seq 10 permit 0.0.0.0/0 le 32
+    """
+
+    _HEADER_PATTERN = re.compile(
+        r"^ip\s+prefix-list\s+(?P<name>\S+):\s+(?P<count>\d+)\s+entr",
+    )
+
+    _ENTRY_PATTERN = re.compile(
+        r"^\s*seq\s+(?P<seq>\d+)\s+(?P<action>permit|deny)\s+"
+        r"(?P<network>\S+)"
+        r"(?:\s+ge\s+(?P<ge>\d+))?"
+        r"(?:\s+le\s+(?P<le>\d+))?",
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpPrefixListResult:
+        """Parse 'show ip prefix-list' output.
+
+        Args:
+            output: Raw CLI output from 'show ip prefix-list' command.
+
+        Returns:
+            Parsed prefix-list data keyed by list name.
+
+        Raises:
+            ValueError: If no prefix-list data found in output.
+        """
+        prefix_lists: dict[str, PrefixListInfo] = {}
+        current_name: str | None = None
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            header_match = cls._HEADER_PATTERN.match(line)
+            if header_match:
+                current_name = header_match.group("name")
+                count = int(header_match.group("count"))
+                prefix_lists[current_name] = PrefixListInfo(
+                    count=count,
+                    entries={},
+                )
+                continue
+
+            entry_match = cls._ENTRY_PATTERN.match(line)
+            if entry_match and current_name is not None:
+                seq = int(entry_match.group("seq"))
+                entry: PrefixEntry = {
+                    "seq": seq,
+                    "action": entry_match.group("action"),
+                    "network": entry_match.group("network"),
+                }
+
+                if entry_match.group("ge"):
+                    entry["ge"] = int(entry_match.group("ge"))
+                if entry_match.group("le"):
+                    entry["le"] = int(entry_match.group("le"))
+
+                prefix_lists[current_name]["entries"][str(seq)] = entry
+
+        if not prefix_lists:
+            msg = "No prefix-list data found in output"
+            raise ValueError(msg)
+
+        return ShowIpPrefixListResult(prefix_lists=prefix_lists)

--- a/tests/parsers/ios/show_ip_prefix-list/001_basic/expected.json
+++ b/tests/parsers/ios/show_ip_prefix-list/001_basic/expected.json
@@ -1,0 +1,27 @@
+{
+    "prefix_lists": {
+        "OSPF_Redist": {
+            "count": 2,
+            "entries": {
+                "5": {
+                    "action": "deny",
+                    "network": "10.0.0.0/24",
+                    "seq": 5
+                },
+                "10": {
+                    "action": "permit",
+                    "le": 32,
+                    "network": "0.0.0.0/0",
+                    "seq": 10
+                },
+                "15": {
+                    "action": "deny",
+                    "ge": 10,
+                    "le": 20,
+                    "network": "10.0.0.0/8",
+                    "seq": 15
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_prefix-list/001_basic/input.txt
+++ b/tests/parsers/ios/show_ip_prefix-list/001_basic/input.txt
@@ -1,0 +1,4 @@
+ip prefix-list OSPF_Redist: 2 entries
+   seq 5 deny 10.0.0.0/24
+   seq 10 permit 0.0.0.0/0 le 32
+   seq 15 deny 10.0.0.0/8 ge 10 le 20

--- a/tests/parsers/ios/show_ip_prefix-list/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ip_prefix-list/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single prefix-list with permit, deny, and ge/le entries
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_ip_prefix-list/002_multiple_lists/expected.json
+++ b/tests/parsers/ios/show_ip_prefix-list/002_multiple_lists/expected.json
@@ -1,0 +1,38 @@
+{
+    "prefix_lists": {
+        "INBOUND": {
+            "count": 3,
+            "entries": {
+                "5": {
+                    "action": "permit",
+                    "network": "192.168.1.0/24",
+                    "seq": 5
+                },
+                "10": {
+                    "action": "permit",
+                    "le": 24,
+                    "network": "172.16.0.0/12",
+                    "seq": 10
+                },
+                "15": {
+                    "action": "deny",
+                    "le": 32,
+                    "network": "0.0.0.0/0",
+                    "seq": 15
+                }
+            }
+        },
+        "OUTBOUND": {
+            "count": 1,
+            "entries": {
+                "10": {
+                    "action": "permit",
+                    "ge": 16,
+                    "le": 24,
+                    "network": "10.0.0.0/8",
+                    "seq": 10
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_prefix-list/002_multiple_lists/input.txt
+++ b/tests/parsers/ios/show_ip_prefix-list/002_multiple_lists/input.txt
@@ -1,0 +1,6 @@
+ip prefix-list INBOUND: 3 entries
+   seq 5 permit 192.168.1.0/24
+   seq 10 permit 172.16.0.0/12 le 24
+   seq 15 deny 0.0.0.0/0 le 32
+ip prefix-list OUTBOUND: 1 entries
+   seq 10 permit 10.0.0.0/8 ge 16 le 24

--- a/tests/parsers/ios/show_ip_prefix-list/002_multiple_lists/metadata.yaml
+++ b/tests/parsers/ios/show_ip_prefix-list/002_multiple_lists/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple prefix-lists with varying entry counts
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ip prefix-list` command on Cisco IOS
- Parses prefix-list entries with sequence number, action, network/mask, and optional ge/le constraints
- Supports multiple prefix-lists in a single output

## Test plan
- [x] 001_basic: Single prefix-list with permit, deny, and ge/le entries
- [x] 002_multiple_lists: Multiple prefix-lists with varying entry counts
- [x] All quality checks pass (ruff, xenon, pre-commit)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)