### PR TITLE
feat: add parser for 'show power available' on IOS

### DIFF
--- a/changes/376.parser_added
+++ b/changes/376.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show power available' on IOS.

--- a/src/muninn/parsers/ios/show_power_available.py
+++ b/src/muninn/parsers/ios/show_power_available.py
@@ -1,0 +1,170 @@
+"""Parser for 'show power available' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PowerSummaryEntry(TypedDict):
+    """Schema for a power summary row."""
+
+    used: int
+    available: int
+
+
+class PowerMeasurementEntry(TypedDict):
+    """Schema for a power measurement row."""
+
+    watts: int
+
+
+class ShowPowerAvailableResult(TypedDict):
+    """Schema for 'show power available' parsed output."""
+
+    system_power: PowerSummaryEntry
+    inline_power: PowerSummaryEntry
+    backplane_power: PowerSummaryEntry
+    total_used: int
+    total_maximum_available: int
+    measurements: NotRequired[dict[str, PowerMeasurementEntry]]
+    measurement_total: NotRequired[int]
+
+
+# Power Summary rows: "System Power (12V)        971        1360"
+_SUMMARY_ROW_RE = re.compile(
+    r"^(System Power|Inline Power|Backplane Power)\s+\([^)]+\)\s+(\d+)\s+(\d+)\s*$"
+)
+
+# Total row with max: "Total  1694 (not to exceed Total Maximum Available = 4200)"
+_TOTAL_WITH_MAX_RE = re.compile(
+    r"^Total\s+(\d+)\s+\(not to exceed Total Maximum Available\s*=\s*(\d+)\)\s*$"
+)
+
+# Total row (simple): "Total                     575         750"
+_TOTAL_SIMPLE_RE = re.compile(r"^Total\s+(\d+)\s+(\d+)\s*$")
+
+# Measurement row: "PS1                         250"
+_MEASUREMENT_ROW_RE = re.compile(r"^(PS\d+)\s+(\d+)\s*$")
+
+# Measurement total: "Total                       350"
+_MEASUREMENT_TOTAL_RE = re.compile(r"^Total\s+(\d+)\s*$")
+
+# Section header for Power Measurement
+_MEASUREMENT_HEADER_RE = re.compile(r"^Power Measurement", re.IGNORECASE)
+
+_SUMMARY_KEY_MAP: dict[str, str] = {
+    "System Power": "system_power",
+    "Inline Power": "inline_power",
+    "Backplane Power": "backplane_power",
+}
+
+
+def _is_skip_line(line: str) -> bool:
+    """Return True if the line is a header, separator, or blank."""
+    if not line:
+        return True
+    if line.startswith("---") or line.startswith("--"):
+        return True
+    if line.startswith("Power Summary") or line.startswith("(in Watts)"):
+        return True
+    return False
+
+
+@register(OS.CISCO_IOS, "show power available")
+class ShowPowerAvailableParser(BaseParser[ShowPowerAvailableResult]):
+    """Parser for 'show power available' command.
+
+    Example output:
+        Power Summary                      Maximum
+         (in Watts)              Used     Available
+        ----------------------   ----     ---------
+        System Power (12V)        971        1360
+        Inline Power (-50V)       683        3189
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPowerAvailableResult:
+        """Parse 'show power available' output.
+
+        Args:
+            output: Raw CLI output from 'show power available' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        result: dict = {}
+        measurements: dict[str, PowerMeasurementEntry] = {}
+        in_measurement_section = False
+
+        for line in output.splitlines():
+            line = line.strip()
+            if _is_skip_line(line):
+                continue
+
+            if _MEASUREMENT_HEADER_RE.match(line):
+                in_measurement_section = True
+                continue
+
+            if in_measurement_section:
+                cls._parse_measurement_line(line, measurements, result)
+            else:
+                cls._parse_summary_line(line, result)
+
+        missing = [
+            f
+            for f in ("system_power", "inline_power", "backplane_power", "total_used")
+            if f not in result
+        ]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        if measurements:
+            result["measurements"] = measurements
+
+        return result  # type: ignore[return-value]
+
+    @classmethod
+    def _parse_summary_line(cls, line: str, result: dict) -> None:
+        """Parse a line from the Power Summary section."""
+        m = _SUMMARY_ROW_RE.match(line)
+        if m:
+            key = _SUMMARY_KEY_MAP[m.group(1)]
+            result[key] = PowerSummaryEntry(
+                used=int(m.group(2)), available=int(m.group(3))
+            )
+            return
+
+        m = _TOTAL_WITH_MAX_RE.match(line)
+        if m:
+            result["total_used"] = int(m.group(1))
+            result["total_maximum_available"] = int(m.group(2))
+            return
+
+        m = _TOTAL_SIMPLE_RE.match(line)
+        if m:
+            result["total_used"] = int(m.group(1))
+            result["total_maximum_available"] = int(m.group(2))
+
+    @classmethod
+    def _parse_measurement_line(
+        cls,
+        line: str,
+        measurements: dict[str, PowerMeasurementEntry],
+        result: dict,
+    ) -> None:
+        """Parse a line from the Power Measurement section."""
+        m = _MEASUREMENT_ROW_RE.match(line)
+        if m:
+            measurements[m.group(1)] = PowerMeasurementEntry(watts=int(m.group(2)))
+            return
+
+        m = _MEASUREMENT_TOTAL_RE.match(line)
+        if m:
+            result["measurement_total"] = int(m.group(1))

--- a/tests/parsers/ios/show_power_available/001_basic/expected.json
+++ b/tests/parsers/ios/show_power_available/001_basic/expected.json
@@ -1,0 +1,25 @@
+{
+    "backplane_power": {
+        "available": 40,
+        "used": 40
+    },
+    "inline_power": {
+        "available": 3189,
+        "used": 683
+    },
+    "measurement_total": 350,
+    "measurements": {
+        "PS1": {
+            "watts": 250
+        },
+        "PS2": {
+            "watts": 100
+        }
+    },
+    "system_power": {
+        "available": 1360,
+        "used": 971
+    },
+    "total_maximum_available": 4200,
+    "total_used": 1694
+}

--- a/tests/parsers/ios/show_power_available/001_basic/input.txt
+++ b/tests/parsers/ios/show_power_available/001_basic/input.txt
@@ -1,0 +1,16 @@
+Power Summary                      Maximum
+ (in Watts)              Used     Available
+----------------------   ----     ---------
+System Power (12V)        971        1360
+Inline Power (-50V)       683        3189
+Backplane Power (3.3V)     40          40
+----------------------   ----     ---------
+Total                    1694 (not to exceed Total Maximum Available = 4200)
+
+Power Measurement    Inline Power (-50V)
+(in Watts)             (+/- 50Watts)
+------------------   -------------------
+PS1                         250
+PS2                         100
+------------------   -------------------
+Total                       350

--- a/tests/parsers/ios/show_power_available/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_power_available/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Full output with power summary and measurement sections
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_power_available/002_no_measurement_section/expected.json
+++ b/tests/parsers/ios/show_power_available/002_no_measurement_section/expected.json
@@ -1,0 +1,16 @@
+{
+    "backplane_power": {
+        "available": 0,
+        "used": 0
+    },
+    "inline_power": {
+        "available": 0,
+        "used": 0
+    },
+    "system_power": {
+        "available": 750,
+        "used": 575
+    },
+    "total_maximum_available": 750,
+    "total_used": 575
+}

--- a/tests/parsers/ios/show_power_available/002_no_measurement_section/input.txt
+++ b/tests/parsers/ios/show_power_available/002_no_measurement_section/input.txt
@@ -1,0 +1,8 @@
+Power Summary                      Maximum
+ (in Watts)              Used     Available
+----------------------   ----     ---------
+System Power (12V)        575         750
+Inline Power (-50V)         0           0
+Backplane Power (3.3V)      0           0
+----------------------   ----     ---------
+Total                     575         750

--- a/tests/parsers/ios/show_power_available/002_no_measurement_section/metadata.yaml
+++ b/tests/parsers/ios/show_power_available/002_no_measurement_section/metadata.yaml
@@ -1,0 +1,3 @@
+description: Power summary only without measurement section
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show power available` command on Cisco IOS
- Parses power summary section (system, inline, backplane power with used/available watts)
- Parses optional power measurement section (per-PSU wattage readings)
- Includes 2 test cases: full output with measurements, and summary-only output

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_power_available -v` — 2 tests pass
- [x] `uv run ruff check` — no lint issues
- [x] `uv run xenon --max-absolute B` — complexity within limits
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)