### PR TITLE
feat: add parser for 'show module submodule' on IOS

### DIFF
--- a/changes/378.parser_added
+++ b/changes/378.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show module submodule' on IOS.

--- a/src/muninn/parsers/ios/show_module_submodule.py
+++ b/src/muninn/parsers/ios/show_module_submodule.py
@@ -1,0 +1,90 @@
+"""Parser for 'show module submodule' command on IOS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class SubmoduleEntry(TypedDict):
+    """Schema for a single sub-module entry."""
+
+    sub_module: str
+    model: str
+    serial: str
+    hw_ver: str
+    status: str
+
+
+class ShowModuleSubmoduleResult(TypedDict):
+    """Schema for 'show module submodule' parsed output."""
+
+    submodules: dict[str, list[SubmoduleEntry]]
+
+
+@register(OS.CISCO_IOS, "show module submodule")
+class ShowModuleSubmoduleParser(BaseParser[ShowModuleSubmoduleResult]):
+    """Parser for 'show module submodule' command.
+
+    Example output:
+        Mod Sub-Module                  Model           Serial           Hw     Status
+        --- --------------------------- --------------- --------------- ------- -------
+          1 Policy Feature Card 2       WS-F6K-PFC2     SAD062802AV      3.2    Ok
+          1 Cat6k MSFC 2 daughterboard  WS-F6K-MSFC2    SAD062803TX      2.5    Ok
+    """
+
+    _HEADER_PATTERN = re.compile(
+        r"^Mod\s+Sub-Module\s+Model\s+Serial\s+Hw\s+Status",
+    )
+    _SEPARATOR_PATTERN = re.compile(r"^-+(\s+-+)+$")
+    _ROW_PATTERN = re.compile(
+        r"^\s*(?P<mod>\d+)\s+"
+        r"(?P<sub_module>.+?)\s+"
+        r"(?P<model>\S+)\s+"
+        r"(?P<serial>\S+)\s+"
+        r"(?P<hw_ver>\S+)\s+"
+        r"(?P<status>\S+)\s*$",
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowModuleSubmoduleResult:
+        """Parse 'show module submodule' output.
+
+        Args:
+            output: Raw CLI output from 'show module submodule' command.
+
+        Returns:
+            Parsed data with sub-module entries keyed by module number.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        submodules: dict[str, list[SubmoduleEntry]] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if cls._HEADER_PATTERN.match(line) or cls._SEPARATOR_PATTERN.match(line):
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if match:
+                mod = match.group("mod")
+                entry = SubmoduleEntry(
+                    sub_module=match.group("sub_module").strip(),
+                    model=match.group("model"),
+                    serial=match.group("serial"),
+                    hw_ver=match.group("hw_ver"),
+                    status=match.group("status"),
+                )
+                submodules.setdefault(mod, []).append(entry)
+
+        if not submodules:
+            msg = "No sub-module entries found in output"
+            raise ValueError(msg)
+
+        return ShowModuleSubmoduleResult(submodules=submodules)

--- a/src/muninn/parsers/ios/show_module_submodule.py
+++ b/src/muninn/parsers/ios/show_module_submodule.py
@@ -8,10 +8,9 @@ from muninn.parser import BaseParser
 from muninn.registry import register
 
 
-class SubmoduleEntry(TypedDict):
-    """Schema for a single sub-module entry."""
+class SubmoduleDetails(TypedDict):
+    """Schema for a single sub-module's details."""
 
-    sub_module: str
     model: str
     serial: str
     hw_ver: str
@@ -21,7 +20,7 @@ class SubmoduleEntry(TypedDict):
 class ShowModuleSubmoduleResult(TypedDict):
     """Schema for 'show module submodule' parsed output."""
 
-    submodules: dict[str, list[SubmoduleEntry]]
+    submodules: dict[str, dict[str, SubmoduleDetails]]
 
 
 @register(OS.CISCO_IOS, "show module submodule")
@@ -61,7 +60,7 @@ class ShowModuleSubmoduleParser(BaseParser[ShowModuleSubmoduleResult]):
         Raises:
             ValueError: If the output cannot be parsed.
         """
-        submodules: dict[str, list[SubmoduleEntry]] = {}
+        submodules: dict[str, dict[str, SubmoduleDetails]] = {}
 
         for line in output.splitlines():
             line = line.strip()
@@ -74,14 +73,14 @@ class ShowModuleSubmoduleParser(BaseParser[ShowModuleSubmoduleResult]):
             match = cls._ROW_PATTERN.match(line)
             if match:
                 mod = match.group("mod")
-                entry = SubmoduleEntry(
-                    sub_module=match.group("sub_module").strip(),
+                sub_module = match.group("sub_module").strip()
+                entry = SubmoduleDetails(
                     model=match.group("model"),
                     serial=match.group("serial"),
                     hw_ver=match.group("hw_ver"),
                     status=match.group("status"),
                 )
-                submodules.setdefault(mod, []).append(entry)
+                submodules.setdefault(mod, {})[sub_module] = entry
 
         if not submodules:
             msg = "No sub-module entries found in output"

--- a/tests/parsers/ios/show_module_submodule/001_basic/expected.json
+++ b/tests/parsers/ios/show_module_submodule/001_basic/expected.json
@@ -1,0 +1,54 @@
+{
+    "submodules": {
+        "1": [
+            {
+                "hw_ver": "3.2",
+                "model": "WS-F6K-PFC2",
+                "serial": "SAD062802AV",
+                "status": "Ok",
+                "sub_module": "Policy Feature Card 2"
+            },
+            {
+                "hw_ver": "2.5",
+                "model": "WS-F6K-MSFC2",
+                "serial": "SAD062803TX",
+                "status": "Ok",
+                "sub_module": "Cat6k MSFC 2 daughterboard"
+            }
+        ],
+        "3": [
+            {
+                "hw_ver": "2.1",
+                "model": "WS-F6K-DFC",
+                "serial": "SAL06121A19",
+                "status": "Ok",
+                "sub_module": "Distributed Forwarding Card"
+            }
+        ],
+        "4": [
+            {
+                "hw_ver": "2.1",
+                "model": "WS-F6K-DFC",
+                "serial": "SAL06121A46",
+                "status": "Ok",
+                "sub_module": "Distributed Forwarding Card"
+            }
+        ],
+        "6": [
+            {
+                "hw_ver": "2.3",
+                "model": "WS-F6K-DFC",
+                "serial": "SAL06261R0A",
+                "status": "Ok",
+                "sub_module": "Distributed Forwarding Card"
+            },
+            {
+                "hw_ver": "1.1",
+                "model": "WS-G6488",
+                "serial": "SAD062201BN",
+                "status": "Ok",
+                "sub_module": "10GBASE-LR Serial 1310nm lo"
+            }
+        ]
+    }
+}

--- a/tests/parsers/ios/show_module_submodule/001_basic/expected.json
+++ b/tests/parsers/ios/show_module_submodule/001_basic/expected.json
@@ -1,54 +1,48 @@
 {
     "submodules": {
-        "1": [
-            {
+        "1": {
+            "Policy Feature Card 2": {
                 "hw_ver": "3.2",
                 "model": "WS-F6K-PFC2",
                 "serial": "SAD062802AV",
-                "status": "Ok",
-                "sub_module": "Policy Feature Card 2"
+                "status": "Ok"
             },
-            {
+            "Cat6k MSFC 2 daughterboard": {
                 "hw_ver": "2.5",
                 "model": "WS-F6K-MSFC2",
                 "serial": "SAD062803TX",
-                "status": "Ok",
-                "sub_module": "Cat6k MSFC 2 daughterboard"
+                "status": "Ok"
             }
-        ],
-        "3": [
-            {
+        },
+        "3": {
+            "Distributed Forwarding Card": {
                 "hw_ver": "2.1",
                 "model": "WS-F6K-DFC",
                 "serial": "SAL06121A19",
-                "status": "Ok",
-                "sub_module": "Distributed Forwarding Card"
+                "status": "Ok"
             }
-        ],
-        "4": [
-            {
+        },
+        "4": {
+            "Distributed Forwarding Card": {
                 "hw_ver": "2.1",
                 "model": "WS-F6K-DFC",
                 "serial": "SAL06121A46",
-                "status": "Ok",
-                "sub_module": "Distributed Forwarding Card"
+                "status": "Ok"
             }
-        ],
-        "6": [
-            {
+        },
+        "6": {
+            "Distributed Forwarding Card": {
                 "hw_ver": "2.3",
                 "model": "WS-F6K-DFC",
                 "serial": "SAL06261R0A",
-                "status": "Ok",
-                "sub_module": "Distributed Forwarding Card"
+                "status": "Ok"
             },
-            {
+            "10GBASE-LR Serial 1310nm lo": {
                 "hw_ver": "1.1",
                 "model": "WS-G6488",
                 "serial": "SAD062201BN",
-                "status": "Ok",
-                "sub_module": "10GBASE-LR Serial 1310nm lo"
+                "status": "Ok"
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/ios/show_module_submodule/001_basic/input.txt
+++ b/tests/parsers/ios/show_module_submodule/001_basic/input.txt
@@ -1,0 +1,8 @@
+Mod Sub-Module                  Model           Serial           Hw     Status
+--- --------------------------- --------------- --------------- ------- -------
+  1 Policy Feature Card 2       WS-F6K-PFC2     SAD062802AV      3.2    Ok
+  1 Cat6k MSFC 2 daughterboard  WS-F6K-MSFC2    SAD062803TX      2.5    Ok
+  3 Distributed Forwarding Card WS-F6K-DFC      SAL06121A19      2.1    Ok
+  4 Distributed Forwarding Card WS-F6K-DFC      SAL06121A46      2.1    Ok
+  6 Distributed Forwarding Card WS-F6K-DFC      SAL06261R0A      2.3    Ok
+  6 10GBASE-LR Serial 1310nm lo WS-G6488        SAD062201BN      1.1    Ok

--- a/tests/parsers/ios/show_module_submodule/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_module_submodule/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple sub-modules across several module slots
+platform: Catalyst 6500
+software_version: Unknown

--- a/tests/parsers/ios/show_module_submodule/002_single_module/expected.json
+++ b/tests/parsers/ios/show_module_submodule/002_single_module/expected.json
@@ -1,0 +1,20 @@
+{
+    "submodules": {
+        "5": [
+            {
+                "hw_ver": "2.1",
+                "model": "WS-F6K-PFC3B",
+                "serial": "SAL1011G1VS",
+                "status": "Ok",
+                "sub_module": "Policy Feature Card 3"
+            },
+            {
+                "hw_ver": "3.0",
+                "model": "WS-F6K-MSFC2A",
+                "serial": "SAL1011G0BT",
+                "status": "Ok",
+                "sub_module": "Cat6k MSFC 2A daughterboard"
+            }
+        ]
+    }
+}

--- a/tests/parsers/ios/show_module_submodule/002_single_module/expected.json
+++ b/tests/parsers/ios/show_module_submodule/002_single_module/expected.json
@@ -1,20 +1,18 @@
 {
     "submodules": {
-        "5": [
-            {
+        "5": {
+            "Policy Feature Card 3": {
                 "hw_ver": "2.1",
                 "model": "WS-F6K-PFC3B",
                 "serial": "SAL1011G1VS",
-                "status": "Ok",
-                "sub_module": "Policy Feature Card 3"
+                "status": "Ok"
             },
-            {
+            "Cat6k MSFC 2A daughterboard": {
                 "hw_ver": "3.0",
                 "model": "WS-F6K-MSFC2A",
                 "serial": "SAL1011G0BT",
-                "status": "Ok",
-                "sub_module": "Cat6k MSFC 2A daughterboard"
+                "status": "Ok"
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/ios/show_module_submodule/002_single_module/input.txt
+++ b/tests/parsers/ios/show_module_submodule/002_single_module/input.txt
@@ -1,0 +1,4 @@
+Mod  Sub-Module                  Model              Serial       Hw     Status
+---- --------------------------- ------------------ ----------- ------- -------
+5  Policy Feature Card 3       WS-F6K-PFC3B          SAL1011G1VS  2.1    Ok
+5  Cat6k MSFC 2A daughterboard WS-F6K-MSFC2A        SAL1011G0BT  3.0    Ok

--- a/tests/parsers/ios/show_module_submodule/002_single_module/metadata.yaml
+++ b/tests/parsers/ios/show_module_submodule/002_single_module/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single module slot with PFC and MSFC sub-modules
+platform: Catalyst 6500
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show module submodule` command on Cisco IOS (Catalyst 6500/6000 series)
- Parses sub-module entries (PFC, MSFC, DFC, optics) into structured data keyed by module slot number
- Includes 2 test cases: multi-module output and single-module output

## Test plan
- [x] `uv run pytest tests/ -k show_module_submodule -v` passes (2 tests)
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)