### PR TITLE
feat: add parser for 'show power supplies' on IOS

### DIFF
--- a/changes/379.parser_added
+++ b/changes/379.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show power supplies' on IOS.

--- a/src/muninn/parsers/ios/show_power_supplies.py
+++ b/src/muninn/parsers/ios/show_power_supplies.py
@@ -1,0 +1,78 @@
+"""Parser for 'show power supplies' command on IOS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ShowPowerSuppliesResult(TypedDict):
+    """Schema for 'show power supplies' parsed output."""
+
+    needed: int
+    available: int
+
+
+_NEEDED_RE = re.compile(
+    r"^Power\s+supplies\s+needed\s+by\s+system\s*:\s*(?P<value>\d+)$"
+)
+_AVAILABLE_RE = re.compile(
+    r"^Power\s+supplies\s+currently\s+available\s*:\s*(?P<value>\d+)$"
+)
+
+_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_NEEDED_RE, "needed"),
+    (_AVAILABLE_RE, "available"),
+)
+
+
+def _match_field(line: str, result: dict[str, int]) -> None:
+    """Try to match a line against known field patterns and update result."""
+    for pattern, field in _FIELD_PATTERNS:
+        match = pattern.match(line)
+        if match:
+            result[field] = int(match.group("value"))
+            return
+
+
+@register(OS.CISCO_IOS, "show power supplies")
+class ShowPowerSuppliesParser(BaseParser[ShowPowerSuppliesResult]):
+    """Parser for 'show power supplies' command.
+
+    Example output:
+        Power supplies needed by system    : 1
+        Power supplies currently available : 2
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPowerSuppliesResult:
+        """Parse 'show power supplies' output.
+
+        Args:
+            output: Raw CLI output from 'show power supplies' command.
+
+        Returns:
+            Parsed data with needed and available power supply counts.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        result: dict[str, int] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            _match_field(line, result)
+
+        missing = [f for f in ("needed", "available") if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return ShowPowerSuppliesResult(
+            needed=result["needed"],
+            available=result["available"],
+        )

--- a/tests/parsers/ios/show_power_supplies/001_single_supply/expected.json
+++ b/tests/parsers/ios/show_power_supplies/001_single_supply/expected.json
@@ -1,0 +1,4 @@
+{
+    "available": 1,
+    "needed": 1
+}

--- a/tests/parsers/ios/show_power_supplies/001_single_supply/input.txt
+++ b/tests/parsers/ios/show_power_supplies/001_single_supply/input.txt
@@ -1,0 +1,2 @@
+Power supplies needed by system    : 1
+Power supplies currently available : 1

--- a/tests/parsers/ios/show_power_supplies/001_single_supply/metadata.yaml
+++ b/tests/parsers/ios/show_power_supplies/001_single_supply/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single power supply needed and available
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_power_supplies/002_redundant_supplies/expected.json
+++ b/tests/parsers/ios/show_power_supplies/002_redundant_supplies/expected.json
@@ -1,0 +1,4 @@
+{
+    "available": 2,
+    "needed": 1
+}

--- a/tests/parsers/ios/show_power_supplies/002_redundant_supplies/input.txt
+++ b/tests/parsers/ios/show_power_supplies/002_redundant_supplies/input.txt
@@ -1,0 +1,2 @@
+Power supplies needed by system    : 1
+Power supplies currently available : 2

--- a/tests/parsers/ios/show_power_supplies/002_redundant_supplies/metadata.yaml
+++ b/tests/parsers/ios/show_power_supplies/002_redundant_supplies/metadata.yaml
@@ -1,0 +1,3 @@
+description: Redundant power supplies with two available
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show power supplies` command on Cisco IOS
- Parses power supply needed/available counts into structured data
- Includes 2 test cases: single supply and redundant supplies

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_power_supplies -v` — 2 tests pass
- [x] `uv run ruff check` — no issues
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` — passes
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)