### PR TITLE
feat: add parser for 'show snmp community' on IOS

### DIFF
--- a/changes/382.parser_added
+++ b/changes/382.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show snmp community' on IOS.

--- a/src/muninn/parsers/ios/show_snmp_community.py
+++ b/src/muninn/parsers/ios/show_snmp_community.py
@@ -1,0 +1,110 @@
+"""Parser for 'show snmp community' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class SnmpCommunityEntry(TypedDict):
+    """Schema for a single SNMP community entry."""
+
+    index: str
+    security_name: str
+    storage_type: str
+    access_list: NotRequired[str]
+
+
+class ShowSnmpCommunityResult(TypedDict):
+    """Schema for 'show snmp community' parsed output."""
+
+    communities: dict[str, SnmpCommunityEntry]
+
+
+_NAME_PATTERN = re.compile(r"^Community\s+name:\s+(?P<name>\S+)$")
+_INDEX_PATTERN = re.compile(r"^Community\s+Index:\s+(?P<index>\S+)$")
+_SECURITY_PATTERN = re.compile(r"^Community\s+SecurityName:\s+(?P<security_name>\S+)$")
+_STORAGE_PATTERN = re.compile(
+    r"^storage-type:\s+(?P<storage_type>\S+)\s+active"
+    r"(?:\s+access-list:\s+(?P<access_list>\S+))?$"
+)
+
+_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_NAME_PATTERN, "name"),
+    (_INDEX_PATTERN, "index"),
+    (_SECURITY_PATTERN, "security_name"),
+)
+
+
+def _parse_block(block: str) -> tuple[str, SnmpCommunityEntry] | None:
+    """Parse a single community block into a (name, entry) tuple."""
+    fields: dict[str, str] = {}
+    storage_match: re.Match[str] | None = None
+
+    for line in block.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        for pattern, field in _FIELD_PATTERNS:
+            if match := pattern.match(line):
+                fields[field] = match.group(field)
+                break
+        else:
+            storage_match = _STORAGE_PATTERN.match(line)
+
+    if not all(k in fields for k in ("name", "index", "security_name")):
+        return None
+    if storage_match is None:
+        return None
+
+    entry = SnmpCommunityEntry(
+        index=fields["index"],
+        security_name=fields["security_name"],
+        storage_type=storage_match.group("storage_type"),
+    )
+    access_list = storage_match.group("access_list")
+    if access_list:
+        entry["access_list"] = access_list
+    return fields["name"], entry
+
+
+@register(OS.CISCO_IOS, "show snmp community")
+class ShowSnmpCommunityParser(BaseParser[ShowSnmpCommunityResult]):
+    """Parser for 'show snmp community' command.
+
+    Example output:
+        Community name: public
+        Community Index: cisco1
+        Community SecurityName: public
+        storage-type: nonvolatile        active
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSnmpCommunityResult:
+        """Parse 'show snmp community' output.
+
+        Args:
+            output: Raw CLI output from 'show snmp community' command.
+
+        Returns:
+            Parsed data keyed by community name.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        communities: dict[str, SnmpCommunityEntry] = {}
+        blocks = re.split(r"\n\s*\n", output)
+
+        for block in blocks:
+            result = _parse_block(block)
+            if result is not None:
+                name, entry = result
+                communities[name] = entry
+
+        if not communities:
+            msg = "No SNMP community entries found in output"
+            raise ValueError(msg)
+
+        return ShowSnmpCommunityResult(communities=communities)

--- a/tests/parsers/ios/show_snmp_community/001_basic/expected.json
+++ b/tests/parsers/ios/show_snmp_community/001_basic/expected.json
@@ -1,0 +1,19 @@
+{
+    "communities": {
+        "ILMI": {
+            "index": "cisco0",
+            "security_name": "ILMI",
+            "storage_type": "read-only"
+        },
+        "private": {
+            "index": "cisco2",
+            "security_name": "private",
+            "storage_type": "nonvolatile"
+        },
+        "public": {
+            "index": "cisco1",
+            "security_name": "public",
+            "storage_type": "nonvolatile"
+        }
+    }
+}

--- a/tests/parsers/ios/show_snmp_community/001_basic/input.txt
+++ b/tests/parsers/ios/show_snmp_community/001_basic/input.txt
@@ -1,0 +1,16 @@
+Community name: ILMI
+Community Index: cisco0
+Community SecurityName: ILMI
+storage-type: read-only  active
+
+
+Community name: public
+Community Index: cisco1
+Community SecurityName: public
+storage-type: nonvolatile        active
+
+
+Community name: private
+Community Index: cisco2
+Community SecurityName: private
+storage-type: nonvolatile        active

--- a/tests/parsers/ios/show_snmp_community/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_snmp_community/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with multiple SNMP communities
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_snmp_community/002_with_access_list/expected.json
+++ b/tests/parsers/ios/show_snmp_community/002_with_access_list/expected.json
@@ -1,0 +1,15 @@
+{
+    "communities": {
+        "Monitoring": {
+            "access_list": "33",
+            "index": "cisco1",
+            "security_name": "Monitoring",
+            "storage_type": "nonvolatile"
+        },
+        "public": {
+            "index": "cisco1",
+            "security_name": "public",
+            "storage_type": "nonvolatile"
+        }
+    }
+}

--- a/tests/parsers/ios/show_snmp_community/002_with_access_list/input.txt
+++ b/tests/parsers/ios/show_snmp_community/002_with_access_list/input.txt
@@ -1,0 +1,10 @@
+Community name: public
+Community Index: cisco1
+Community SecurityName: public
+storage-type: nonvolatile        active
+
+
+Community name: Monitoring
+Community Index: cisco1
+Community SecurityName: Monitoring
+storage-type: nonvolatile	 active	access-list: 33

--- a/tests/parsers/ios/show_snmp_community/002_with_access_list/metadata.yaml
+++ b/tests/parsers/ios/show_snmp_community/002_with_access_list/metadata.yaml
@@ -1,0 +1,3 @@
+description: Community with access list configured
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for `show snmp community` on Cisco IOS
- Parses community entries into structured data keyed by community name
- Handles optional `access-list` field when present

## Test plan
- [x] `001_basic` — Multiple communities without access lists
- [x] `002_with_access_list` — Community with access-list configured
- [x] All pre-commit hooks pass
- [x] xenon complexity check passes (max-absolute B)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)