### PR TITLE
feat: add parser for 'show snmp group' on IOS

### DIFF
--- a/changes/383.parser_added
+++ b/changes/383.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show snmp group' on IOS.

--- a/src/muninn/parsers/ios/show_snmp_group.py
+++ b/src/muninn/parsers/ios/show_snmp_group.py
@@ -1,0 +1,169 @@
+"""Parser for 'show snmp group' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class SnmpGroupEntry(TypedDict):
+    """Schema for a single SNMP group entry."""
+
+    group_name: str
+    security_model: str
+    context_name: NotRequired[str]
+    storage_type: str
+    read_view: NotRequired[str]
+    write_view: NotRequired[str]
+    notify_view: NotRequired[str]
+    row_status: str
+    access_list: NotRequired[str]
+
+
+class ShowSnmpGroupResult(TypedDict):
+    """Schema for 'show snmp group' parsed output."""
+
+    groups: dict[str, SnmpGroupEntry]
+
+
+_SEPARATOR_PATTERN = re.compile(r"^\s*$")
+_GROUPNAME_PATTERN = re.compile(
+    r"^groupname:\s*(\S+)\s+security model:(.+)$", re.MULTILINE
+)
+_CONTEXT_PATTERN = re.compile(r"contextname:\s*(.+?)\s{2,}storage-type:\s*(\S+)")
+_READVIEW_PATTERN = re.compile(r"readview\s*:\s*(.+?)\s{2,}writeview:\s*(.*)")
+_NOTIFYVIEW_PATTERN = re.compile(r"notifyview:\s*(.*)")
+_ROWSTATUS_PATTERN = re.compile(r"row status:\s*(\S+)(?:\s+access-list:\s*(\S+))?")
+
+_NO_VALUE_MARKERS = frozenset(
+    {
+        "<no context specified>",
+        "<no writeview specified>",
+        "<no notifyview specified>",
+        "<no readview specified>",
+    }
+)
+
+
+def _normalize_view(value: str | None) -> str | None:
+    """Return None for sentinel/empty view values, stripped string otherwise."""
+    if value is None:
+        return None
+    value = value.strip()
+    if not value or value in _NO_VALUE_MARKERS:
+        return None
+    return value
+
+
+def _set_optional(entry: SnmpGroupEntry, field: str, value: str | None) -> None:
+    """Set an optional field on the entry if the value is not None."""
+    if value is not None:
+        entry[field] = value  # type: ignore[literal-required]
+
+
+def _extract_views(text: str) -> tuple[str | None, str | None, str | None]:
+    """Extract read, write, and notify views from block text.
+
+    Returns:
+        Tuple of (read_view, write_view, notify_view), each None if absent.
+    """
+    read_view_match = _READVIEW_PATTERN.search(text)
+    read_view = _normalize_view(read_view_match.group(1)) if read_view_match else None
+    write_view = _normalize_view(read_view_match.group(2)) if read_view_match else None
+
+    notify_match = _NOTIFYVIEW_PATTERN.search(text)
+    notify_view = _normalize_view(notify_match.group(1)) if notify_match else None
+
+    return read_view, write_view, notify_view
+
+
+def _parse_block(lines: list[str]) -> SnmpGroupEntry | None:
+    """Parse a single SNMP group block into an entry.
+
+    Args:
+        lines: Lines comprising one group block.
+
+    Returns:
+        Parsed entry, or None if the block is not a valid group.
+    """
+    text = "\n".join(lines)
+
+    group_match = _GROUPNAME_PATTERN.search(text)
+    if not group_match:
+        return None
+
+    context_match = _CONTEXT_PATTERN.search(text)
+    row_match = _ROWSTATUS_PATTERN.search(text)
+    read_view, write_view, notify_view = _extract_views(text)
+
+    entry: SnmpGroupEntry = {
+        "group_name": group_match.group(1),
+        "security_model": group_match.group(2).strip(),
+        "storage_type": context_match.group(2) if context_match else "unknown",
+        "row_status": row_match.group(1) if row_match else "unknown",
+    }
+
+    context_name = _normalize_view(context_match.group(1)) if context_match else None
+    access_list = row_match.group(2) if row_match and row_match.group(2) else None
+
+    _set_optional(entry, "context_name", context_name)
+    _set_optional(entry, "read_view", read_view)
+    _set_optional(entry, "write_view", write_view)
+    _set_optional(entry, "notify_view", notify_view)
+    _set_optional(entry, "access_list", access_list)
+
+    return entry
+
+
+@register(OS.CISCO_IOS, "show snmp group")
+class ShowSnmpGroupParser(BaseParser[ShowSnmpGroupResult]):
+    """Parser for 'show snmp group' command.
+
+    Example output:
+        groupname: GROUP1                           security model:v3 priv
+        contextname: <no context specified>         storage-type: nonvolatile
+        readview : g1readview                       writeview: <no writeview specified>
+        notifyview: g1notifyview
+        row status: active      access-list: snmp-acl-name
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSnmpGroupResult:
+        """Parse 'show snmp group' output.
+
+        Args:
+            output: Raw CLI output from 'show snmp group' command.
+
+        Returns:
+            Parsed data with groups keyed by 'group_name:security_model'.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        groups: dict[str, SnmpGroupEntry] = {}
+        current_block: list[str] = []
+
+        for line in output.splitlines():
+            if _SEPARATOR_PATTERN.match(line) and current_block:
+                entry = _parse_block(current_block)
+                if entry is not None:
+                    key = f"{entry['group_name']}:{entry['security_model']}"
+                    groups[key] = entry
+                current_block = []
+            else:
+                current_block.append(line)
+
+        # Process the last block
+        if current_block:
+            entry = _parse_block(current_block)
+            if entry is not None:
+                key = f"{entry['group_name']}:{entry['security_model']}"
+                groups[key] = entry
+
+        if not groups:
+            msg = "No SNMP group entries found in output"
+            raise ValueError(msg)
+
+        return ShowSnmpGroupResult(groups=groups)

--- a/src/muninn/parsers/ios/show_snmp_group.py
+++ b/src/muninn/parsers/ios/show_snmp_group.py
@@ -25,7 +25,7 @@ class SnmpGroupEntry(TypedDict):
 class ShowSnmpGroupResult(TypedDict):
     """Schema for 'show snmp group' parsed output."""
 
-    groups: dict[str, SnmpGroupEntry]
+    groups: dict[str, dict[str, SnmpGroupEntry]]
 
 
 _SEPARATOR_PATTERN = re.compile(r"^\s*$")
@@ -137,20 +137,20 @@ class ShowSnmpGroupParser(BaseParser[ShowSnmpGroupResult]):
             output: Raw CLI output from 'show snmp group' command.
 
         Returns:
-            Parsed data with groups keyed by 'group_name:security_model'.
+            Parsed data with groups keyed by group name, then security model.
 
         Raises:
             ValueError: If the output cannot be parsed.
         """
-        groups: dict[str, SnmpGroupEntry] = {}
+        groups: dict[str, dict[str, SnmpGroupEntry]] = {}
         current_block: list[str] = []
 
         for line in output.splitlines():
             if _SEPARATOR_PATTERN.match(line) and current_block:
                 entry = _parse_block(current_block)
                 if entry is not None:
-                    key = f"{entry['group_name']}:{entry['security_model']}"
-                    groups[key] = entry
+                    group_entries = groups.setdefault(entry["group_name"], {})
+                    group_entries[entry["security_model"]] = entry
                 current_block = []
             else:
                 current_block.append(line)
@@ -159,8 +159,8 @@ class ShowSnmpGroupParser(BaseParser[ShowSnmpGroupResult]):
         if current_block:
             entry = _parse_block(current_block)
             if entry is not None:
-                key = f"{entry['group_name']}:{entry['security_model']}"
-                groups[key] = entry
+                group_entries = groups.setdefault(entry["group_name"], {})
+                group_entries[entry["security_model"]] = entry
 
         if not groups:
             msg = "No SNMP group entries found in output"

--- a/tests/parsers/ios/show_snmp_group/001_basic/expected.json
+++ b/tests/parsers/ios/show_snmp_group/001_basic/expected.json
@@ -1,0 +1,61 @@
+{
+    "groups": {
+        "GROUP1:v3 priv": {
+            "access_list": "snmp-acl-name",
+            "group_name": "GROUP1",
+            "notify_view": "g1notifyview",
+            "read_view": "g1readview",
+            "row_status": "active",
+            "security_model": "v3 priv",
+            "storage_type": "nonvolatile"
+        },
+        "GROUP2:v1": {
+            "access_list": "snmp-acl-name",
+            "group_name": "GROUP2",
+            "read_view": "v1default",
+            "row_status": "active",
+            "security_model": "v1",
+            "storage_type": "nonvolatile"
+        },
+        "GROUP2:v2c": {
+            "access_list": "snmp-acl-name",
+            "group_name": "GROUP2",
+            "read_view": "v1default",
+            "row_status": "active",
+            "security_model": "v2c",
+            "storage_type": "nonvolatile"
+        },
+        "GROUP3:v1": {
+            "access_list": "snmp-acl-name",
+            "group_name": "GROUP3",
+            "read_view": "v1default",
+            "row_status": "active",
+            "security_model": "v1",
+            "storage_type": "nonvolatile"
+        },
+        "GROUP3:v2c": {
+            "access_list": "snmp-acl-name",
+            "group_name": "GROUP3",
+            "read_view": "v1default",
+            "row_status": "active",
+            "security_model": "v2c",
+            "storage_type": "nonvolatile"
+        },
+        "ILMI:v1": {
+            "group_name": "ILMI",
+            "read_view": "*ilmi",
+            "row_status": "active",
+            "security_model": "v1",
+            "storage_type": "permanent",
+            "write_view": "*ilmi"
+        },
+        "ILMI:v2c": {
+            "group_name": "ILMI",
+            "read_view": "*ilmi",
+            "row_status": "active",
+            "security_model": "v2c",
+            "storage_type": "permanent",
+            "write_view": "*ilmi"
+        }
+    }
+}

--- a/tests/parsers/ios/show_snmp_group/001_basic/expected.json
+++ b/tests/parsers/ios/show_snmp_group/001_basic/expected.json
@@ -1,61 +1,69 @@
 {
     "groups": {
-        "GROUP1:v3 priv": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP1",
-            "notify_view": "g1notifyview",
-            "read_view": "g1readview",
-            "row_status": "active",
-            "security_model": "v3 priv",
-            "storage_type": "nonvolatile"
+        "GROUP1": {
+            "v3 priv": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP1",
+                "notify_view": "g1notifyview",
+                "read_view": "g1readview",
+                "row_status": "active",
+                "security_model": "v3 priv",
+                "storage_type": "nonvolatile"
+            }
         },
-        "GROUP2:v1": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP2",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v1",
-            "storage_type": "nonvolatile"
+        "GROUP2": {
+            "v1": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP2",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v1",
+                "storage_type": "nonvolatile"
+            },
+            "v2c": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP2",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v2c",
+                "storage_type": "nonvolatile"
+            }
         },
-        "GROUP2:v2c": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP2",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v2c",
-            "storage_type": "nonvolatile"
+        "GROUP3": {
+            "v1": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP3",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v1",
+                "storage_type": "nonvolatile"
+            },
+            "v2c": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP3",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v2c",
+                "storage_type": "nonvolatile"
+            }
         },
-        "GROUP3:v1": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP3",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v1",
-            "storage_type": "nonvolatile"
-        },
-        "GROUP3:v2c": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP3",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v2c",
-            "storage_type": "nonvolatile"
-        },
-        "ILMI:v1": {
-            "group_name": "ILMI",
-            "read_view": "*ilmi",
-            "row_status": "active",
-            "security_model": "v1",
-            "storage_type": "permanent",
-            "write_view": "*ilmi"
-        },
-        "ILMI:v2c": {
-            "group_name": "ILMI",
-            "read_view": "*ilmi",
-            "row_status": "active",
-            "security_model": "v2c",
-            "storage_type": "permanent",
-            "write_view": "*ilmi"
+        "ILMI": {
+            "v1": {
+                "group_name": "ILMI",
+                "read_view": "*ilmi",
+                "row_status": "active",
+                "security_model": "v1",
+                "storage_type": "permanent",
+                "write_view": "*ilmi"
+            },
+            "v2c": {
+                "group_name": "ILMI",
+                "read_view": "*ilmi",
+                "row_status": "active",
+                "security_model": "v2c",
+                "storage_type": "permanent",
+                "write_view": "*ilmi"
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_snmp_group/001_basic/input.txt
+++ b/tests/parsers/ios/show_snmp_group/001_basic/input.txt
@@ -1,0 +1,41 @@
+groupname: GROUP1                           security model:v3 priv
+contextname: <no context specified>         storage-type: nonvolatile
+readview : g1readview                       writeview: <no writeview specified>
+notifyview: g1notifyview
+row status: active      access-list: snmp-acl-name
+
+groupname: ILMI                             security model:v1
+contextname: <no context specified>         storage-type: permanent
+readview : *ilmi                            writeview: *ilmi
+notifyview: <no notifyview specified>
+row status: active
+
+groupname: ILMI                             security model:v2c
+contextname: <no context specified>         storage-type: permanent
+readview : *ilmi                            writeview: *ilmi
+notifyview: <no notifyview specified>
+row status: active
+
+groupname: GROUP2                           security model:v1
+contextname: <no context specified>         storage-type: nonvolatile
+readview : v1default                        writeview: <no writeview specified>
+notifyview: <no notifyview specified>
+row status: active      access-list: snmp-acl-name
+
+groupname: GROUP2                           security model:v2c
+contextname: <no context specified>         storage-type: nonvolatile
+readview : v1default                        writeview: <no writeview specified>
+notifyview: <no notifyview specified>
+row status: active      access-list: snmp-acl-name
+
+groupname: GROUP3                           security model:v1
+contextname: <no context specified>         storage-type: nonvolatile
+readview : v1default                        writeview: <no writeview specified>
+notifyview: <no notifyview specified>
+row status: active      access-list: snmp-acl-name
+
+groupname: GROUP3                           security model:v2c
+contextname: <no context specified>         storage-type: nonvolatile
+readview : v1default                        writeview: <no writeview specified>
+notifyview: <no notifyview specified>
+row status: active      access-list: snmp-acl-name

--- a/tests/parsers/ios/show_snmp_group/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_snmp_group/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple SNMP groups with v1, v2c, and v3 security models
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_snmp_group/002_single_group/expected.json
+++ b/tests/parsers/ios/show_snmp_group/002_single_group/expected.json
@@ -1,0 +1,13 @@
+{
+    "groups": {
+        "NETADMIN:v3 auth": {
+            "group_name": "NETADMIN",
+            "notify_view": "fullview",
+            "read_view": "fullview",
+            "row_status": "active",
+            "security_model": "v3 auth",
+            "storage_type": "nonvolatile",
+            "write_view": "fullview"
+        }
+    }
+}

--- a/tests/parsers/ios/show_snmp_group/002_single_group/expected.json
+++ b/tests/parsers/ios/show_snmp_group/002_single_group/expected.json
@@ -1,13 +1,15 @@
 {
     "groups": {
-        "NETADMIN:v3 auth": {
-            "group_name": "NETADMIN",
-            "notify_view": "fullview",
-            "read_view": "fullview",
-            "row_status": "active",
-            "security_model": "v3 auth",
-            "storage_type": "nonvolatile",
-            "write_view": "fullview"
+        "NETADMIN": {
+            "v3 auth": {
+                "group_name": "NETADMIN",
+                "notify_view": "fullview",
+                "read_view": "fullview",
+                "row_status": "active",
+                "security_model": "v3 auth",
+                "storage_type": "nonvolatile",
+                "write_view": "fullview"
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_snmp_group/002_single_group/input.txt
+++ b/tests/parsers/ios/show_snmp_group/002_single_group/input.txt
@@ -1,0 +1,5 @@
+groupname: NETADMIN                         security model:v3 auth
+contextname: <no context specified>         storage-type: nonvolatile
+readview : fullview                         writeview: fullview
+notifyview: fullview
+row status: active

--- a/tests/parsers/ios/show_snmp_group/002_single_group/metadata.yaml
+++ b/tests/parsers/ios/show_snmp_group/002_single_group/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single SNMP group with v3 authentication
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add block-based parser for `show snmp group` on Cisco IOS
- Groups keyed by `group_name:security_model` to handle same group name with different security models (e.g., ILMI with v1 and v2c)
- Optional fields (context_name, read_view, write_view, notify_view, access_list) omitted when not present or set to sentinel values

## Test plan
- [x] 001_basic: Multiple groups with v1, v2c, and v3 security models, access lists, mixed views
- [x] 002_single_group: Single group with v3 auth security model and all views populated
- [x] All pre-commit hooks pass
- [x] Xenon complexity check passes (max-absolute B)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)