### PR TITLE
feat: add parser for 'show ip bgp all' on IOS-XE

### DIFF
--- a/changes/385.parser_added
+++ b/changes/385.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip bgp all' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_bgp_all.py
+++ b/src/muninn/parsers/iosxe/show_bgp_all.py
@@ -477,6 +477,7 @@ def _finalize_rd(
 
 
 @register(OS.CISCO_IOSXE, "show bgp all")
+@register(OS.CISCO_IOSXE, "show ip bgp all")
 class ShowBgpAllParser(BaseParser["ShowBgpAllResult"]):
     """Parser for 'show bgp all' command on IOS-XE.
 

--- a/tests/parsers/iosxe/show_ip_bgp_all/001_vpnv4_with_wrapped_prefix/expected.json
+++ b/tests/parsers/iosxe/show_ip_bgp_all/001_vpnv4_with_wrapped_prefix/expected.json
@@ -1,0 +1,69 @@
+{
+    "address_families": {
+        "VPNv4 Unicast": {
+            "route_distinguishers": {
+                "5918:50": {
+                    "default_vrf": "L3VPN-0050",
+                    "rd": "5918:50",
+                    "routes": {
+                        "172.16.200.1/32": {
+                            "paths": [
+                                {
+                                    "as_path": "60000",
+                                    "locprf": 100,
+                                    "next_hop": "10.13.202.64",
+                                    "origin": "i",
+                                    "path_type": "i",
+                                    "status_codes": "*>",
+                                    "weight": 0
+                                }
+                            ]
+                        },
+                        "172.16.200.2/32": {
+                            "paths": [
+                                {
+                                    "as_path": "60000",
+                                    "locprf": 100,
+                                    "next_hop": "10.13.202.64",
+                                    "origin": "i",
+                                    "path_type": "i",
+                                    "status_codes": "*>",
+                                    "weight": 0
+                                }
+                            ]
+                        },
+                        "172.16.200.3/32": {
+                            "paths": [
+                                {
+                                    "as_path": "60000",
+                                    "locprf": 100,
+                                    "next_hop": "10.13.202.64",
+                                    "origin": "i",
+                                    "path_type": "i",
+                                    "status_codes": "*>",
+                                    "weight": 0
+                                }
+                            ]
+                        },
+                        "172.16.200.99/32": {
+                            "paths": [
+                                {
+                                    "as_path": "60000",
+                                    "locprf": 100,
+                                    "next_hop": "10.13.202.64",
+                                    "origin": "i",
+                                    "path_type": "i",
+                                    "status_codes": "*>",
+                                    "weight": 0
+                                }
+                            ]
+                        }
+                    },
+                    "vrf_router_id": "192.168.10.254"
+                }
+            },
+            "router_id": "10.169.197.254",
+            "table_version": 27013588
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_bgp_all/001_vpnv4_with_wrapped_prefix/input.txt
+++ b/tests/parsers/iosxe/show_ip_bgp_all/001_vpnv4_with_wrapped_prefix/input.txt
@@ -1,0 +1,22 @@
+Router#show ip bgp all
+Load for five secs: 4%/0%; one minute: 5%; five minutes: 4%
+Time source is NTP, 09:44:45.434 EST Tue Jun 8 2016
+For address family: IPv4 Unicast
+
+
+For address family: VPNv4 Unicast
+
+BGP table version is 27013588, local router ID is 10.169.197.254
+Status codes: s suppressed, d damped, h history, * valid, > best, i - internal,
+              r RIB-failure, S Stale, m multipath, b backup-path, f RT-Filter,
+              x best-external, a additional-path, c RIB-compressed,
+Origin codes: i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
+
+     Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 5918:50 (default for vrf L3VPN-0050) VRF Router ID 192.168.10.254
+ *>i 172.16.200.1/32  10.13.202.64                  100      0 60000 i
+ *>i 172.16.200.2/32  10.13.202.64                  100      0 60000 i
+ *>i 172.16.200.3/32  10.13.202.64                  100      0 60000 i
+ *>i 172.16.200.99/32
+                   10.13.202.64                  100      0 60000 i

--- a/tests/parsers/iosxe/show_ip_bgp_all/001_vpnv4_with_wrapped_prefix/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_bgp_all/001_vpnv4_with_wrapped_prefix/metadata.yaml
@@ -1,0 +1,3 @@
+description: VPNv4 Unicast with wrapped network prefix and VRF Router ID
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_ip_bgp_all/002_multiple_address_families/expected.json
+++ b/tests/parsers/iosxe/show_ip_bgp_all/002_multiple_address_families/expected.json
@@ -1,0 +1,101 @@
+{
+    "address_families": {
+        "L2VPN E-VPN": {
+            "route_distinguishers": {
+                "65535:1": {
+                    "default_vrf": "evpn1",
+                    "rd": "65535:1",
+                    "routes": {
+                        "[5][65535:1][0][24][10.1.1.0]/17": {
+                            "paths": [
+                                {
+                                    "as_path": "",
+                                    "metric": 0,
+                                    "next_hop": "0.0.0.0",
+                                    "origin": "?",
+                                    "path_type": "",
+                                    "status_codes": "*>",
+                                    "weight": 32768
+                                }
+                            ]
+                        },
+                        "[5][65535:1][0][24][10.36.3.0]/17": {
+                            "paths": [
+                                {
+                                    "as_path": "",
+                                    "metric": 0,
+                                    "next_hop": "0.0.0.0",
+                                    "origin": "?",
+                                    "path_type": "",
+                                    "status_codes": "*>",
+                                    "weight": 32768
+                                },
+                                {
+                                    "as_path": "65530",
+                                    "locprf": 0,
+                                    "next_hop": "10.36.3.254",
+                                    "origin": "?",
+                                    "path_type": "",
+                                    "status_codes": "*",
+                                    "weight": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "router_id": "10.21.33.33",
+            "table_version": 4
+        },
+        "VPNv4 Unicast": {
+            "route_distinguishers": {
+                "65535:1": {
+                    "af_private_import_to_af": "L2VPN E-VPN",
+                    "default_vrf": "evpn1",
+                    "pfx_count": 2,
+                    "pfx_limit": 1000,
+                    "rd": "65535:1",
+                    "routes": {
+                        "10.1.1.0/24": {
+                            "paths": [
+                                {
+                                    "as_path": "",
+                                    "metric": 0,
+                                    "next_hop": "0.0.0.0",
+                                    "origin": "?",
+                                    "path_type": "",
+                                    "status_codes": "*>",
+                                    "weight": 32768
+                                }
+                            ]
+                        },
+                        "10.36.3.0/24": {
+                            "paths": [
+                                {
+                                    "as_path": "65530",
+                                    "locprf": 0,
+                                    "next_hop": "10.36.3.254",
+                                    "origin": "?",
+                                    "path_type": "",
+                                    "status_codes": "*",
+                                    "weight": 0
+                                },
+                                {
+                                    "as_path": "",
+                                    "metric": 0,
+                                    "next_hop": "0.0.0.0",
+                                    "origin": "?",
+                                    "path_type": "",
+                                    "status_codes": "*>",
+                                    "weight": 32768
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "router_id": "10.21.33.33",
+            "table_version": 5
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_bgp_all/002_multiple_address_families/input.txt
+++ b/tests/parsers/iosxe/show_ip_bgp_all/002_multiple_address_families/input.txt
@@ -1,0 +1,55 @@
+R1_CE#show ip bgp all
+For address family: IPv4 Unicast
+
+
+For address family: IPv6 Unicast
+
+
+For address family: VPNv4 Unicast
+
+BGP table version is 5, local router ID is 10.21.33.33
+Status codes: s suppressed, d damped, h history, * valid, > best, i - internal,
+              r RIB-failure, S Stale, m multipath, b backup-path, f RT-Filter,
+              x best-external, a additional-path, c RIB-compressed,
+              t secondary path,
+Origin codes: i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
+
+     Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 65535:1 (default for vrf evpn1)
+AF-Private Import to Address-Family: L2VPN E-VPN, Pfx Count/Limit: 2/1000
+ *    10.36.3.0/24       10.36.3.254                0             0 65530 ?
+ *>                    0.0.0.0                  0         32768 ?
+ *>   10.1.1.0/24     0.0.0.0                  0         32768 ?
+
+For address family: IPv4 Multicast
+
+For address family: L2VPN E-VPN
+
+BGP table version is 4, local router ID is 10.21.33.33
+Status codes: s suppressed, d damped, h history, * valid, > best, i - internal,
+              r RIB-failure, S Stale, m multipath, b backup-path, f RT-Filter,
+              x best-external, a additional-path, c RIB-compressed,
+              t secondary path,
+Origin codes: i - IGP, e - EGP, ? - incomplete
+RPKI validation codes: V valid, I invalid, N Not found
+
+     Network          Next Hop            Metric LocPrf Weight Path
+Route Distinguisher: 65535:1 (default for vrf evpn1)
+ *>   [5][65535:1][0][24][10.36.3.0]/17
+                      0.0.0.0                  0         32768 ?
+ *                     10.36.3.254                0             0 65530 ?
+ *>   [5][65535:1][0][24][10.1.1.0]/17
+                      0.0.0.0                  0         32768 ?
+
+
+For address family: VPNv4 Multicast
+
+
+For address family: MVPNv4 Unicast
+
+
+For address family: MVPNv6 Unicast
+
+
+For address family: VPNv4 Flowspec

--- a/tests/parsers/iosxe/show_ip_bgp_all/002_multiple_address_families/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_bgp_all/002_multiple_address_families/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple address families with VPNv4 and L2VPN E-VPN data
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added `@register(OS.CISCO_IOSXE, "show ip bgp all")` decorator to the existing `ShowBgpAllParser` since `show ip bgp all` produces identical output to `show bgp all` on IOS-XE
- Added 2 test cases: VPNv4 with wrapped network prefixes, and multiple address families (VPNv4 + L2VPN E-VPN)

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k "show_ip_bgp_all" -v` — 2 tests pass
- [x] `uv run ruff check` and `uv run ruff format` — clean
- [x] `uv run xenon --max-absolute B` — passes
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)