### PR TITLE
feat: add parser for 'show bgp all neighbors' on IOS-XE

### DIFF
--- a/changes/386.parser_added
+++ b/changes/386.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bgp all neighbors' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_bgp_neighbors.py
+++ b/src/muninn/parsers/iosxe/show_ip_bgp_neighbors.py
@@ -557,6 +557,7 @@ def _parse_neighbor_block(lines: list[str]) -> NeighborEntry:
 
 @register(OS.CISCO_IOSXE, "show ip bgp neighbors")
 @register(OS.CISCO_IOSXE, "show bgp neighbors")
+@register(OS.CISCO_IOSXE, "show bgp all neighbors")
 class ShowIpBgpNeighborsParser(BaseParser["ShowIpBgpNeighborsResult"]):
     """Parser for 'show ip bgp neighbors' on IOS-XE.
 

--- a/tests/parsers/iosxe/show_bgp_all_neighbors/001_single_neighbor/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_neighbors/001_single_neighbor/expected.json
@@ -1,0 +1,33 @@
+{
+    "neighbors": {
+        "10.16.2.2": {
+            "address_families": {},
+            "bgp_state": "Established",
+            "bgp_version": 4,
+            "connections_dropped": 0,
+            "connections_established": 1,
+            "hold_time": 180,
+            "keepalive_interval": 60,
+            "last_read": "00:00:04",
+            "last_write": "00:00:09",
+            "link_type": "internal",
+            "message_stats": {
+                "keepalives_rcvd": 74,
+                "keepalives_sent": 75,
+                "notifications_rcvd": 0,
+                "notifications_sent": 0,
+                "opens_rcvd": 1,
+                "opens_sent": 1,
+                "route_refresh_rcvd": 0,
+                "route_refresh_sent": 0,
+                "total_rcvd": 81,
+                "total_sent": 87,
+                "updates_rcvd": 6,
+                "updates_sent": 11
+            },
+            "remote_as": 100,
+            "router_id": "10.16.2.2",
+            "state_duration": "01:10:35"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_all_neighbors/001_single_neighbor/input.txt
+++ b/tests/parsers/iosxe/show_bgp_all_neighbors/001_single_neighbor/input.txt
@@ -1,0 +1,41 @@
+For address family: IPv4 Unicast
+
+For address family: IPv6 Unicast
+
+For address family: VPNv4 Unicast
+BGP neighbor is 10.16.2.2,  remote AS 100, internal link
+  BGP version 4, remote router ID 10.16.2.2
+  BGP state = Established, up for 01:10:35
+  Last read 00:00:04, last write 00:00:09, hold time is 180, keepalive interval is 60 seconds
+  Neighbor sessions:
+    1 active, is not multisession capable (disabled)
+  Neighbor capabilities:
+    Route refresh: advertised and received(new)
+    Four-octets ASN Capability: advertised and received
+    Address family VPNv4 Unicast: advertised and received
+    Address family VPNv6 Unicast: advertised and received
+    Enhanced Refresh Capability: advertised
+    Multisession Capability:
+    Stateful switchover support enabled: NO for session 1
+  Message statistics:
+    InQ depth is 0
+    OutQ depth is 0
+
+                             Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:               11          6
+    Keepalives:            75         74
+    Route Refresh:          0          0
+    Total:                 87         81
+  Default minimum time between advertisement runs is 0 seconds
+
+  Address tracking is enabled, the RIB does have a route to 10.16.2.2
+  Connections established 1; dropped 0
+  Last reset never
+  Transport(tcp) path-mtu-discovery is enabled
+  Graceful-Restart is disabled
+Connection state is ESTAB, I/O status: 1, unread input bytes: 0
+Connection is ECN Disabled, Mininum incoming TTL 0, Outgoing TTL 255
+Local host: 10.64.4.4, Local port: 35281
+Foreign host: 10.16.2.2, Foreign port: 179

--- a/tests/parsers/iosxe/show_bgp_all_neighbors/001_single_neighbor/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_all_neighbors/001_single_neighbor/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single external BGP neighbor with IPv4 Unicast address family
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_bgp_all_neighbors/002_multiple_neighbors_with_vrfs/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_neighbors/002_multiple_neighbors_with_vrfs/expected.json
@@ -1,0 +1,74 @@
+{
+    "neighbors": {
+        "10.16.2.2": {
+            "address_families": {},
+            "bgp_state": "Established",
+            "bgp_version": 4,
+            "connections_dropped": 0,
+            "connections_established": 1,
+            "description": "router2222222",
+            "hold_time": 180,
+            "keepalive_interval": 60,
+            "last_read": "00:00:04",
+            "last_write": "00:00:09",
+            "link_type": "internal",
+            "message_stats": {
+                "keepalives_rcvd": 74,
+                "keepalives_sent": 75,
+                "notifications_rcvd": 0,
+                "notifications_sent": 0,
+                "opens_rcvd": 1,
+                "opens_sent": 1,
+                "route_refresh_rcvd": 0,
+                "route_refresh_sent": 0,
+                "total_rcvd": 81,
+                "total_sent": 87,
+                "updates_rcvd": 6,
+                "updates_sent": 11
+            },
+            "remote_as": 100,
+            "router_id": "10.16.2.2",
+            "state_duration": "01:10:35"
+        },
+        "10.4.6.6": {
+            "address_families": {
+                "IPv4 Multicast": {
+                    "neighbor_version": 0,
+                    "table_version": 0
+                },
+                "VPNv6 Multicast": {
+                    "neighbor_version": 0,
+                    "table_version": 0
+                }
+            },
+            "bgp_state": "Established",
+            "bgp_version": 4,
+            "connections_dropped": 1,
+            "connections_established": 2,
+            "hold_time": 180,
+            "keepalive_interval": 60,
+            "last_read": "00:00:33",
+            "last_reset": "01:02:11, due to Peer closed the session of session 1",
+            "last_write": "00:00:30",
+            "link_type": "external",
+            "message_stats": {
+                "keepalives_rcvd": 64,
+                "keepalives_sent": 69,
+                "notifications_rcvd": 0,
+                "notifications_sent": 0,
+                "opens_rcvd": 1,
+                "opens_sent": 1,
+                "route_refresh_rcvd": 0,
+                "route_refresh_sent": 0,
+                "total_rcvd": 66,
+                "total_sent": 73,
+                "updates_rcvd": 1,
+                "updates_sent": 3
+            },
+            "remote_as": 300,
+            "router_id": "10.4.6.6",
+            "state_duration": "01:01:59",
+            "vrf": "VRF1"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_all_neighbors/002_multiple_neighbors_with_vrfs/input.txt
+++ b/tests/parsers/iosxe/show_bgp_all_neighbors/002_multiple_neighbors_with_vrfs/input.txt
@@ -1,0 +1,55 @@
+For address family: IPv4 Unicast
+
+For address family: VPNv4 Unicast
+BGP neighbor is 10.16.2.2,  remote AS 100, internal link
+  Description: router2222222
+  BGP version 4, remote router ID 10.16.2.2
+  BGP state = Established, up for 01:10:35
+  Last read 00:00:04, last write 00:00:09, hold time is 180, keepalive interval is 60 seconds
+  Neighbor sessions:
+    1 active, is not multisession capable (disabled)
+  Message statistics:
+    InQ depth is 0
+    OutQ depth is 0
+
+                             Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:               11          6
+    Keepalives:            75         74
+    Route Refresh:          0          0
+    Total:                 87         81
+  Default minimum time between advertisement runs is 0 seconds
+
+  Connections established 1; dropped 0
+  Last reset never
+Local host: 10.64.4.4, Local port: 35281
+Foreign host: 10.16.2.2, Foreign port: 179
+
+BGP neighbor is 10.4.6.6,  vrf VRF1,  remote AS 300, external link
+  BGP version 4, remote router ID 10.4.6.6
+  BGP state = Established, up for 01:01:59
+  Last read 00:00:33, last write 00:00:30, hold time is 180, keepalive interval is 60 seconds
+  Neighbor sessions:
+    1 active, is not multisession capable (disabled)
+  Message statistics:
+    InQ depth is 0
+    OutQ depth is 0
+
+                             Sent       Rcvd
+    Opens:                  1          1
+    Notifications:          0          0
+    Updates:                3          1
+    Keepalives:            69         64
+    Route Refresh:          0          0
+    Total:                 73         66
+  Default minimum time between advertisement runs is 0 seconds
+
+  Connections established 2; dropped 1
+  Last reset 01:02:11, due to Peer closed the session of session 1
+Local host: 10.4.6.4, Local port: 179
+Foreign host: 10.4.6.6, Foreign port: 11010
+
+For address family: IPv4 Multicast
+
+For address family: VPNv6 Multicast

--- a/tests/parsers/iosxe/show_bgp_all_neighbors/002_multiple_neighbors_with_vrfs/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_all_neighbors/002_multiple_neighbors_with_vrfs/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple BGP neighbors across VRFs with description and last reset
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Register `show bgp all neighbors` command with the existing `show_ip_bgp_neighbors` parser on IOS-XE, since the output format is identical to `show ip bgp neighbors` / `show bgp neighbors`
- Add 2 test cases: single neighbor and multiple neighbors with VRFs

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_bgp_all_neighbors" -v` passes (2 tests)
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)