### PR TITLE
feat: add parser for 'show bgp all summary' on IOS-XE

### DIFF
--- a/changes/387.parser_added
+++ b/changes/387.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bgp all summary' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_bgp_all_summary.py
+++ b/src/muninn/parsers/iosxe/show_bgp_all_summary.py
@@ -1,0 +1,63 @@
+"""Parser for 'show bgp all summary' command on IOS-XE.
+
+This command produces output identical in format to 'show ip bgp summary'
+with multiple address-family sections.  We reuse the existing parsing
+logic and register it under the additional command name.
+"""
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.parsers.ios.show_ip_bgp_summary import (
+    AddressFamilyEntry,
+    ShowIpBgpSummaryResult,
+    _parse_address_family,
+    _split_address_families,
+    _strip_prompt_lines,
+)
+from muninn.registry import register
+
+__all__ = ["ShowBgpAllSummaryParser"]
+
+
+@register(OS.CISCO_IOSXE, "show bgp all summary")
+class ShowBgpAllSummaryParser(BaseParser["ShowIpBgpSummaryResult"]):
+    """Parser for 'show bgp all summary' command on IOS-XE.
+
+    Example output::
+
+        For address family: IPv4 Unicast
+        BGP router identifier 192.168.111.1, local AS number 100
+        BGP table version is 28, main routing table version 28
+        ...
+        Neighbor  V  AS MsgRcvd MsgSent TblVer InQ OutQ Up/Down State/PfxRcd
+        192.168.111.1  4  100  0  0  1  0  0 01:07:38 Idle
+
+    The output format is identical to 'show ip bgp summary'; parsing logic
+    is reused from that parser.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpBgpSummaryResult:
+        """Parse 'show bgp all summary' output.
+
+        Args:
+            output: Raw CLI output from 'show bgp all summary' command.
+
+        Returns:
+            Parsed data with neighbors grouped by address family.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        raw_lines = output.splitlines()
+        lines = _strip_prompt_lines(raw_lines)
+
+        sections = _split_address_families(lines)
+        address_families: dict[str, AddressFamilyEntry] = {}
+
+        for af_name, af_lines in sections:
+            parsed = _parse_address_family(af_lines, af_name)
+            if parsed is not None:
+                address_families[af_name] = parsed
+
+        return {"address_families": address_families}

--- a/tests/parsers/iosxe/show_bgp_all_summary/001_multi_af_idle_neighbors/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_summary/001_multi_af_idle_neighbors/expected.json
@@ -1,0 +1,191 @@
+{
+    "address_families": {
+        "IPv4 Unicast": {
+            "activity": {
+                "paths_current": 66,
+                "paths_total": 39,
+                "prefixes_current": 47,
+                "prefixes_total": 20,
+                "scan_interval_secs": 60
+            },
+            "local_as": "100",
+            "main_routing_table_version": 28,
+            "memory": {
+                "filter_list_cache_entries": {
+                    "bytes": 0,
+                    "count": 0
+                },
+                "network_entries": {
+                    "bytes": 6696,
+                    "count": 27
+                },
+                "path_attribute_entries": {
+                    "bestpath_count": 1,
+                    "bytes": 280,
+                    "count": 1
+                },
+                "path_entries": {
+                    "bytes": 3672,
+                    "count": 27
+                },
+                "route_map_cache_entries": {
+                    "bytes": 0,
+                    "count": 0
+                },
+                "total_bytes": 10648
+            },
+            "neighbors": {
+                "192.168.111.1": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "01:07:38",
+                    "version": 4
+                },
+                "192.168.19.2": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "300",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "01:07:38",
+                    "version": 4
+                },
+                "192.168.4.1": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "never",
+                    "version": 4
+                },
+                "192.168.51.1": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "01:07:38",
+                    "version": 4
+                },
+                "192.168.70.4": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "200",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "never",
+                    "version": 4
+                }
+            },
+            "router_id": "192.168.111.1",
+            "table_version": 28
+        },
+        "IPv6 Unicast": {
+            "local_as": "100",
+            "main_routing_table_version": 1,
+            "memory": {},
+            "neighbors": {
+                "2001::14:4": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "200",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "never",
+                    "version": 4
+                },
+                "2001::26:2": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "300",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "01:07:38",
+                    "version": 4
+                },
+                "2001:db8:400::1:1": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "01:07:38",
+                    "version": 4
+                },
+                "2001:db8:400::4:1": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "01:07:38",
+                    "version": 4
+                }
+            },
+            "router_id": "192.168.111.1",
+            "table_version": 1
+        },
+        "VPNv4 Unicast": {
+            "local_as": "100",
+            "main_routing_table_version": 1,
+            "memory": {},
+            "neighbors": {
+                "10.36.3.3": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "never",
+                    "version": 4
+                }
+            },
+            "router_id": "192.168.111.1",
+            "table_version": 1
+        },
+        "VPNv6 Unicast": {
+            "local_as": "100",
+            "main_routing_table_version": 1,
+            "memory": {},
+            "neighbors": {
+                "10.36.3.3": {
+                    "in_queue": 0,
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "Idle",
+                    "tbl_ver": 1,
+                    "up_down": "never",
+                    "version": 4
+                }
+            },
+            "router_id": "192.168.111.1",
+            "table_version": 1
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_all_summary/001_multi_af_idle_neighbors/input.txt
+++ b/tests/parsers/iosxe/show_bgp_all_summary/001_multi_af_idle_neighbors/input.txt
@@ -1,0 +1,42 @@
+Router#show bgp all summary
+For address family: IPv4 Unicast
+BGP router identifier 192.168.111.1, local AS number 100
+BGP table version is 28, main routing table version 28
+27 network entries using 6696 bytes of memory
+27 path entries using 3672 bytes of memory
+1/1 BGP path/bestpath attribute entries using 280 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 10648 total bytes of memory
+BGP activity 47/20 prefixes, 66/39 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.111.1       4          100       0       0        1    0    0 01:07:38 Idle
+192.168.4.1       4          100       0       0        1    0    0 never    Idle
+192.168.51.1       4          100       0       0        1    0    0 01:07:38 Idle
+192.168.70.4      4          200       0       0        1    0    0 never    Idle
+192.168.19.2      4          300       0       0        1    0    0 01:07:38 Idle
+
+For address family: IPv6 Unicast
+BGP router identifier 192.168.111.1, local AS number 100
+BGP table version is 1, main routing table version 1
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+2001:db8:400::1:1       4          100       0       0        1    0    0 01:07:38 Idle
+2001:db8:400::4:1       4          100       0       0        1    0    0 01:07:38 Idle
+2001::14:4      4          200       0       0        1    0    0 never    Idle
+2001::26:2      4          300       0       0        1    0    0 01:07:38 Idle
+
+For address family: VPNv4 Unicast
+BGP router identifier 192.168.111.1, local AS number 100
+BGP table version is 1, main routing table version 1
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.36.3.3         4          100       0       0        1    0    0 never    Idle
+
+For address family: VPNv6 Unicast
+BGP router identifier 192.168.111.1, local AS number 100
+BGP table version is 1, main routing table version 1
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.36.3.3         4          100       0       0        1    0    0 never    Idle

--- a/tests/parsers/iosxe/show_bgp_all_summary/001_multi_af_idle_neighbors/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_all_summary/001_multi_af_idle_neighbors/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple address families (IPv4, IPv6, VPNv4, VPNv6) with all neighbors in Idle state
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_bgp_all_summary/002_vpnv4_vpnv6_with_prefixes/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_summary/002_vpnv4_vpnv6_with_prefixes/expected.json
@@ -1,0 +1,194 @@
+{
+    "address_families": {
+        "VPNv4 Unicast": {
+            "activity": {
+                "paths_current": 120,
+                "paths_total": 30,
+                "prefixes_current": 85,
+                "prefixes_total": 25,
+                "scan_interval_secs": 60
+            },
+            "local_as": "100",
+            "main_routing_table_version": 56,
+            "memory": {
+                "as_path_entries": {
+                    "bytes": 120,
+                    "count": 3
+                },
+                "extended_community_entries": {
+                    "bytes": 96,
+                    "count": 4
+                },
+                "filter_list_cache_entries": {
+                    "bytes": 0,
+                    "count": 0
+                },
+                "network_entries": {
+                    "bytes": 4560,
+                    "count": 30
+                },
+                "path_attribute_entries": {
+                    "bestpath_count": 4,
+                    "bytes": 960,
+                    "count": 6
+                },
+                "path_entries": {
+                    "bytes": 3600,
+                    "count": 45
+                },
+                "route_map_cache_entries": {
+                    "bytes": 0,
+                    "count": 0
+                },
+                "rrinfo_entries": {
+                    "bytes": 48,
+                    "count": 2
+                },
+                "total_bytes": 9384
+            },
+            "neighbors": {
+                "10.16.2.2": {
+                    "in_queue": 0,
+                    "msg_rcvd": 82,
+                    "msg_sent": 88,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "10",
+                    "tbl_ver": 56,
+                    "up_down": "01:12:00",
+                    "version": 4
+                },
+                "10.36.3.3": {
+                    "in_queue": 0,
+                    "msg_rcvd": 82,
+                    "msg_sent": 89,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "10",
+                    "tbl_ver": 56,
+                    "up_down": "01:12:06",
+                    "version": 4
+                },
+                "10.4.6.6": {
+                    "in_queue": 0,
+                    "msg_rcvd": 68,
+                    "msg_sent": 75,
+                    "out_queue": 0,
+                    "remote_as": "300",
+                    "state_pfxrcd": "5",
+                    "tbl_ver": 56,
+                    "up_down": "01:03:23",
+                    "version": 4
+                },
+                "10.66.6.6": {
+                    "in_queue": 0,
+                    "msg_rcvd": 67,
+                    "msg_sent": 72,
+                    "out_queue": 0,
+                    "remote_as": "400",
+                    "state_pfxrcd": "5",
+                    "tbl_ver": 56,
+                    "up_down": "01:03:14",
+                    "version": 4
+                }
+            },
+            "router_id": "10.64.4.4",
+            "table_version": 56
+        },
+        "VPNv6 Unicast": {
+            "activity": {
+                "paths_current": 120,
+                "paths_total": 30,
+                "prefixes_current": 85,
+                "prefixes_total": 25,
+                "scan_interval_secs": 60
+            },
+            "local_as": "100",
+            "main_routing_table_version": 66,
+            "memory": {
+                "as_path_entries": {
+                    "bytes": 120,
+                    "count": 3
+                },
+                "extended_community_entries": {
+                    "bytes": 96,
+                    "count": 4
+                },
+                "filter_list_cache_entries": {
+                    "bytes": 0,
+                    "count": 0
+                },
+                "network_entries": {
+                    "bytes": 5280,
+                    "count": 30
+                },
+                "path_attribute_entries": {
+                    "bestpath_count": 4,
+                    "bytes": 960,
+                    "count": 6
+                },
+                "path_entries": {
+                    "bytes": 4860,
+                    "count": 45
+                },
+                "route_map_cache_entries": {
+                    "bytes": 0,
+                    "count": 0
+                },
+                "rrinfo_entries": {
+                    "bytes": 48,
+                    "count": 2
+                },
+                "total_bytes": 11364
+            },
+            "neighbors": {
+                "10.16.2.2": {
+                    "in_queue": 0,
+                    "msg_rcvd": 82,
+                    "msg_sent": 88,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "10",
+                    "tbl_ver": 66,
+                    "up_down": "01:12:00",
+                    "version": 4
+                },
+                "10.36.3.3": {
+                    "in_queue": 0,
+                    "msg_rcvd": 82,
+                    "msg_sent": 89,
+                    "out_queue": 0,
+                    "remote_as": "100",
+                    "state_pfxrcd": "10",
+                    "tbl_ver": 66,
+                    "up_down": "01:12:06",
+                    "version": 4
+                },
+                "2001:DB8:20:4:6::6": {
+                    "in_queue": 0,
+                    "msg_rcvd": 67,
+                    "msg_sent": 73,
+                    "out_queue": 0,
+                    "remote_as": "400",
+                    "state_pfxrcd": "5",
+                    "tbl_ver": 66,
+                    "up_down": "01:03:11",
+                    "version": 4
+                },
+                "2001:DB8:4:6::6": {
+                    "in_queue": 0,
+                    "msg_rcvd": 67,
+                    "msg_sent": 75,
+                    "out_queue": 0,
+                    "remote_as": "300",
+                    "state_pfxrcd": "5",
+                    "tbl_ver": 66,
+                    "up_down": "01:03:19",
+                    "version": 4
+                }
+            },
+            "router_id": "10.64.4.4",
+            "table_version": 66
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_all_summary/002_vpnv4_vpnv6_with_prefixes/input.txt
+++ b/tests/parsers/iosxe/show_bgp_all_summary/002_vpnv4_vpnv6_with_prefixes/input.txt
@@ -1,0 +1,41 @@
+Router#show bgp all summary
+For address family: VPNv4 Unicast
+BGP router identifier 10.64.4.4, local AS number 100
+BGP table version is 56, main routing table version 56
+30 network entries using 4560 bytes of memory
+45 path entries using 3600 bytes of memory
+6/4 BGP path/bestpath attribute entries using 960 bytes of memory
+2 BGP rrinfo entries using 48 bytes of memory
+3 BGP AS-PATH entries using 120 bytes of memory
+4 BGP extended community entries using 96 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 9384 total bytes of memory
+BGP activity 85/25 prefixes, 120/30 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.16.2.2         4          100      82      88       56    0    0 01:12:00       10
+10.36.3.3         4          100      82      89       56    0    0 01:12:06       10
+10.4.6.6        4          300      68      75       56    0    0 01:03:23        5
+10.66.6.6        4          400      67      72       56    0    0 01:03:14        5
+
+For address family: VPNv6 Unicast
+BGP router identifier 10.64.4.4, local AS number 100
+BGP table version is 66, main routing table version 66
+30 network entries using 5280 bytes of memory
+45 path entries using 4860 bytes of memory
+6/4 BGP path/bestpath attribute entries using 960 bytes of memory
+2 BGP rrinfo entries using 48 bytes of memory
+3 BGP AS-PATH entries using 120 bytes of memory
+4 BGP extended community entries using 96 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 11364 total bytes of memory
+BGP activity 85/25 prefixes, 120/30 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+10.16.2.2         4          100      82      88       66    0    0 01:12:00       10
+10.36.3.3         4          100      82      89       66    0    0 01:12:06       10
+2001:DB8:4:6::6 4          300      67      75       66    0    0 01:03:19        5
+2001:DB8:20:4:6::6
+                4          400      67      73       66    0    0 01:03:11        5

--- a/tests/parsers/iosxe/show_bgp_all_summary/002_vpnv4_vpnv6_with_prefixes/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_all_summary/002_vpnv4_vpnv6_with_prefixes/metadata.yaml
@@ -1,0 +1,3 @@
+description: VPNv4 and VPNv6 address families with active neighbors reporting prefix counts and a wrapped IPv6 address
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show bgp all summary` on IOS-XE, reusing the existing `show ip bgp summary` parsing logic since the output format is identical
- Register a new `ShowBgpAllSummaryParser` class that delegates to the shared address-family/neighbor parsing functions
- Include two test cases from Genie parser test data covering multi-AF idle neighbors and VPNv4/VPNv6 with active prefix counts (including wrapped IPv6 neighbor addresses)

Closes #136

## Test plan
- [x] Both test cases pass: `uv run pytest tests/parsers/iosxe/show_bgp_all_summary/ -v`
- [x] Ruff check and format pass
- [x] Xenon complexity check passes (max-absolute B)
- [x] All pre-commit hooks pass
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)