### PR TITLE
feat: add parser for 'show bgp all detail' on IOS-XE

### DIFF
--- a/changes/388.parser_added
+++ b/changes/388.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bgp all detail' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_bgp_all_detail.py
+++ b/src/muninn/parsers/iosxe/show_bgp_all_detail.py
@@ -597,19 +597,12 @@ def _merge_address_family_entry(
             **new.get("routes", {}),
         }
 
-    merged_rds = {
-        rd: {
-            **rd_entry,
-            "routes": dict(rd_entry["routes"]),
-        }
-        for rd, rd_entry in current.get("route_distinguishers", {}).items()
-    }
+    merged_rds: dict[str, RouteDistinguisherEntry] = {}
+    for rd, rd_entry in current.get("route_distinguishers", {}).items():
+        merged_rds[rd] = _copy_rd_entry(rd_entry)
     for rd, rd_entry in new.get("route_distinguishers", {}).items():
         if rd not in merged_rds:
-            merged_rds[rd] = {
-                **rd_entry,
-                "routes": dict(rd_entry["routes"]),
-            }
+            merged_rds[rd] = _copy_rd_entry(rd_entry)
             continue
         if "default_vrf" in rd_entry:
             merged_rds[rd]["default_vrf"] = rd_entry["default_vrf"]
@@ -619,6 +612,14 @@ def _merge_address_family_entry(
         merged["route_distinguishers"] = merged_rds
 
     return merged
+
+
+def _copy_rd_entry(rd_entry: RouteDistinguisherEntry) -> RouteDistinguisherEntry:
+    """Return a copy of a Route Distinguisher entry."""
+    copied: RouteDistinguisherEntry = {"routes": dict(rd_entry["routes"])}
+    if "default_vrf" in rd_entry:
+        copied["default_vrf"] = rd_entry["default_vrf"]
+    return copied
 
 
 @register(OS.CISCO_IOSXE, "show bgp all detail")

--- a/src/muninn/parsers/iosxe/show_bgp_all_detail.py
+++ b/src/muninn/parsers/iosxe/show_bgp_all_detail.py
@@ -1,0 +1,602 @@
+"""Parser for 'show bgp all detail' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PathEntry(TypedDict):
+    """Schema for a single BGP path within a route."""
+
+    as_path: str
+    origin: str
+    next_hop: str
+    from_peer: str
+    router_id: str
+    metric: NotRequired[int]
+    localpref: NotRequired[int]
+    weight: NotRequired[int]
+    valid: bool
+    best: bool
+    internal: NotRequired[bool]
+    sourced: NotRequired[bool]
+    multipath: NotRequired[bool]
+    refresh_epoch: NotRequired[int]
+    rx_pathid: NotRequired[str]
+    tx_pathid: NotRequired[str]
+    community: NotRequired[str]
+    extended_community: NotRequired[str]
+    originator: NotRequired[str]
+    cluster_list: NotRequired[str]
+    mpls_labels_in: NotRequired[str]
+    mpls_labels_out: NotRequired[str]
+    evpn_esi: NotRequired[str]
+    gateway_address: NotRequired[str]
+    local_vtep: NotRequired[str]
+    evpn_label: NotRequired[int]
+    updated: NotRequired[str]
+
+
+class RouteEntry(TypedDict):
+    """Schema for a single BGP route (prefix)."""
+
+    version: int
+    paths_available: int
+    best_path: int
+    table: str
+    paths: list[PathEntry]
+    rib_failure: NotRequired[str]
+    multipath: NotRequired[str]
+    bestpath: NotRequired[str]
+
+
+class AddressFamilyEntry(TypedDict):
+    """Schema for routes within an address family."""
+
+    route_distinguisher: NotRequired[str]
+    default_vrf: NotRequired[str]
+    routes: dict[str, RouteEntry]
+
+
+class ShowBgpAllDetailResult(TypedDict):
+    """Schema for 'show bgp all detail' parsed output."""
+
+    address_families: dict[str, list[AddressFamilyEntry]]
+
+
+# --- Compiled regex patterns ---
+
+_AF_HEADER_RE = re.compile(r"^\s*For address family:\s+(.+?)\s*$")
+
+_RD_RE = re.compile(
+    r"^\s*Route Distinguisher:\s+(\S+)"
+    r"(?:\s+\(default for vrf (\S+)\))?\s*$"
+)
+
+_ROUTE_ENTRY_RE = re.compile(
+    r"^\s*BGP routing table entry for\s+"
+    r"(?:\[[\d:]+\])?"  # optional EVPN RD prefix like [5][65535:1][0][24][...]
+    r"(?:\d+:\d+:)?"  # optional VPN RD prefix like 100:100:
+    r"(\S+),\s+version\s+(\d+)"
+)
+
+_ROUTE_FULL_PREFIX_RE = re.compile(
+    r"^\s*BGP routing table entry for\s+(\S+),\s+version\s+(\d+)"
+)
+
+_PATHS_RE = re.compile(
+    r"^\s*Paths:\s+\((\d+)\s+available,\s+best\s+#(\d+),\s+table\s+([^,)\s]+)"
+    r"(?:,\s*(.+?)\s*)?\)\s*$"
+)
+
+_BESTPATH_RE = re.compile(r"^\s*BGP Bestpath:\s+(.+?)\s*$")
+
+_MULTIPATH_RE = re.compile(r"^\s*Multipath:\s+(.+?)\s*$")
+
+_REFRESH_EPOCH_RE = re.compile(r"^\s*Refresh Epoch\s+(\d+)")
+
+_ORIGIN_LINE_RE = re.compile(
+    r"^\s*Origin\s+(?P<origin>\S+)"
+    r"(?:,\s*metric\s+(?P<metric>\d+))?"
+    r"(?:,\s*localpref\s+(?P<localpref>\d+))?"
+    r"(?:,\s*weight\s+(?P<weight>\d+))?"
+    r",\s*(?P<flags>.+)$"
+)
+
+_NEXT_HOP_RE = re.compile(
+    r"^\s+(?P<nexthop>\S+)"
+    r"(?:\s+\((?:metric\s+\d+\s*)?\))?"  # optional (metric N) or ()
+    r"(?:\s+\((?:inaccessible|via\s+(?:vrf\s+\S+|default))\))?"
+    r"\s+from\s+(?P<from>\S+)"
+    r"\s+\((?P<rid>[^)]+)\)"
+)
+
+_RX_TX_RE = re.compile(r"^\s*rx pathid:\s+(\S+),\s+tx pathid:\s+(\S+)")
+
+_COMMUNITY_RE = re.compile(r"^\s*Community:\s+(.+?)\s*$")
+_EXT_COMMUNITY_RE = re.compile(r"^\s*Extended Community:\s+(.+?)\s*$")
+_ORIGINATOR_RE = re.compile(r"^\s*Originator:\s+(\S+),\s+Cluster list:\s+(.+?)\s*$")
+_MPLS_RE = re.compile(r"^\s*mpls labels in/out\s+(.+)/(\S+)\s*$")
+_UPDATED_RE = re.compile(r"^\s*Updated on\s+(.+?)\s*$")
+
+_EVPN_ESI_RE = re.compile(
+    r"^\s*EVPN ESI:\s+(\S+),\s+Gateway Address:\s+(\S+)"
+    r",\s+local vtep:\s+(\S+),\s+Label\s+(\d+)"
+)
+
+
+def _is_noise_line(stripped: str) -> bool:
+    """Return True if a line is a device prompt or noise."""
+    if not stripped:
+        return True
+    if "#" in stripped and ("show " in stripped.lower() or stripped.endswith("#")):
+        return True
+    return stripped.startswith("Load for ") or stripped.startswith("Time source ")
+
+
+def _extract_as_path(line: str) -> str:
+    """Extract the AS path from the first line after Refresh Epoch."""
+    stripped = line.strip()
+    if stripped.startswith("Local"):
+        return ""
+    return stripped.split(",")[0].strip()
+
+
+def _parse_path_attributes(lines: list[str], idx: int) -> tuple[PathEntry | None, int]:
+    """Parse a single BGP path starting from the AS path / source line.
+
+    Returns the parsed PathEntry and the next line index.
+    """
+    if idx >= len(lines):
+        return None, idx
+
+    as_path = _extract_as_path(lines[idx])
+    idx += 1
+
+    if idx >= len(lines):
+        return None, idx
+
+    # Next line should be the next-hop line
+    nh_match = _NEXT_HOP_RE.match(lines[idx])
+    if not nh_match:
+        return None, idx
+
+    path: PathEntry = {
+        "as_path": as_path,
+        "origin": "",
+        "next_hop": nh_match.group("nexthop"),
+        "from_peer": nh_match.group("from"),
+        "router_id": nh_match.group("rid"),
+        "valid": False,
+        "best": False,
+    }
+    idx += 1
+
+    # Parse attribute lines until a boundary
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped:
+            idx += 1
+            continue
+        if _is_path_boundary(stripped):
+            break
+        idx = _parse_single_attribute(stripped, path, idx)
+
+    return path, idx
+
+
+def _is_path_boundary(stripped: str) -> bool:
+    """Return True if the stripped line starts a new section or path."""
+    if stripped.startswith("BGP routing table entry"):
+        return True
+    if stripped.startswith("For address family:"):
+        return True
+    if stripped.startswith("Route Distinguisher:"):
+        return True
+    if _REFRESH_EPOCH_RE.match(stripped):
+        return True
+    return False
+
+
+_ORIGIN_INT_FIELDS: tuple[tuple[str, str], ...] = (
+    ("metric", "metric"),
+    ("localpref", "localpref"),
+    ("weight", "weight"),
+)
+
+_ORIGIN_BOOL_FLAGS: tuple[tuple[str, str], ...] = (
+    ("internal", "internal"),
+    ("sourced", "sourced"),
+)
+
+
+def _apply_origin_match(m: re.Match[str], path: PathEntry) -> None:
+    """Apply Origin line match groups to a path entry."""
+    path["origin"] = m.group("origin")
+    for group_name, field_name in _ORIGIN_INT_FIELDS:
+        val = m.group(group_name)
+        if val:
+            path[field_name] = int(val)  # type: ignore[literal-required]
+    flag_set = {f.strip() for f in m.group("flags").split(",")}
+    path["valid"] = "valid" in flag_set
+    path["best"] = "best" in flag_set
+    for flag, field in _ORIGIN_BOOL_FLAGS:
+        if flag in flag_set:
+            path[field] = True  # type: ignore[literal-required]
+    if any("multipath" in f for f in flag_set):
+        path["multipath"] = True
+
+
+def _apply_evpn_match(m: re.Match[str], path: PathEntry) -> None:
+    """Apply EVPN ESI match groups to a path entry."""
+    path["evpn_esi"] = m.group(1)
+    path["gateway_address"] = m.group(2)
+    path["local_vtep"] = m.group(3)
+    path["evpn_label"] = int(m.group(4))
+
+
+def _parse_single_attribute(stripped: str, path: PathEntry, idx: int) -> int:
+    """Parse one attribute line and update the path entry.
+
+    Returns next index.
+    """
+    m = _ORIGIN_LINE_RE.match(stripped)
+    if m:
+        _apply_origin_match(m, path)
+        return idx + 1
+
+    m = _RX_TX_RE.match(stripped)
+    if m:
+        path["rx_pathid"] = m.group(1)
+        path["tx_pathid"] = m.group(2)
+        return idx + 1
+
+    m = _COMMUNITY_RE.match(stripped)
+    if m:
+        path["community"] = m.group(1)
+        return idx + 1
+
+    m = _EXT_COMMUNITY_RE.match(stripped)
+    if m:
+        path["extended_community"] = m.group(1)
+        return idx + 1
+
+    m = _ORIGINATOR_RE.match(stripped)
+    if m:
+        path["originator"] = m.group(1)
+        path["cluster_list"] = m.group(2)
+        return idx + 1
+
+    m = _MPLS_RE.match(stripped)
+    if m:
+        path["mpls_labels_in"] = m.group(1)
+        path["mpls_labels_out"] = m.group(2)
+        return idx + 1
+
+    m = _EVPN_ESI_RE.match(stripped)
+    if m:
+        _apply_evpn_match(m, path)
+        return idx + 1
+
+    m = _UPDATED_RE.match(stripped)
+    if m:
+        path["updated"] = m.group(1)
+        return idx + 1
+
+    # Skip unrecognized lines (vxlan vtep info, binding SID, etc.)
+    return idx + 1
+
+
+def _parse_route_header(
+    lines: list[str], idx: int
+) -> tuple[str, int, str | None, int, int, str, str | None, str | None, int]:
+    """Parse the header portion of a route block.
+
+    Returns (raw_prefix, version, bestpath, paths_available, best_path,
+             table, rib_failure, multipath, next_idx).
+    """
+    m = _ROUTE_FULL_PREFIX_RE.match(lines[idx])
+    if not m:
+        msg = f"Expected route entry at line {idx}"
+        raise ValueError(msg)
+
+    raw_prefix = m.group(1)
+    version = int(m.group(2))
+    idx += 1
+
+    # Optional: BGP Bestpath line
+    bestpath = None
+    if idx < len(lines) and (bp := _BESTPATH_RE.match(lines[idx])):
+        bestpath = bp.group(1)
+        idx += 1
+
+    # Paths line
+    paths_available, best_path, table, rib_failure, idx = _parse_paths_line(lines, idx)
+
+    # Optional: Multipath line
+    multipath = None
+    if idx < len(lines) and (mp := _MULTIPATH_RE.match(lines[idx])):
+        multipath = mp.group(1)
+        idx += 1
+
+    return (
+        raw_prefix,
+        version,
+        bestpath,
+        paths_available,
+        best_path,
+        table,
+        rib_failure,
+        multipath,
+        idx,
+    )
+
+
+def _parse_paths_line(
+    lines: list[str], idx: int
+) -> tuple[int, int, str, str | None, int]:
+    """Parse the 'Paths:' line. Returns (available, best, table, rib_failure, idx)."""
+    if idx >= len(lines):
+        return 0, 0, "", None, idx
+    pm = _PATHS_RE.match(lines[idx])
+    if not pm:
+        return 0, 0, "", None, idx
+    extra = pm.group(4)
+    rib_failure = extra.strip() if extra and "RIB-failure" in extra else None
+    return int(pm.group(1)), int(pm.group(2)), pm.group(3), rib_failure, idx + 1
+
+
+def _parse_route_block(lines: list[str], idx: int) -> tuple[str, RouteEntry, int]:
+    """Parse a single BGP route block.
+
+    Returns (prefix, route_entry, next_line_index).
+    """
+    (
+        raw_prefix,
+        version,
+        bestpath,
+        paths_available,
+        best_path,
+        table,
+        rib_failure,
+        multipath,
+        idx,
+    ) = _parse_route_header(lines, idx)
+
+    # Skip "Advertised to" / "Not advertised" lines
+    idx = _skip_advertised_lines(lines, idx)
+
+    # Parse individual paths
+    paths: list[PathEntry] = []
+    idx = _parse_all_paths(lines, idx, paths)
+
+    # Strip RD prefix from the route key for cleaner output
+    prefix = _strip_rd_prefix(raw_prefix)
+
+    route: RouteEntry = {
+        "version": version,
+        "paths_available": paths_available,
+        "best_path": best_path,
+        "table": table,
+        "paths": paths,
+    }
+    if rib_failure:
+        route["rib_failure"] = rib_failure
+    if multipath:
+        route["multipath"] = multipath
+    if bestpath:
+        route["bestpath"] = bestpath
+
+    return prefix, route, idx
+
+
+def _is_update_group_line(text: str) -> bool:
+    """Return True if text contains only digits and spaces (update group IDs)."""
+    return all(c.isdigit() or c.isspace() for c in text)
+
+
+def _skip_advertised_lines(lines: list[str], idx: int) -> int:
+    """Skip 'Advertised to' and 'Not advertised' block lines."""
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped:
+            idx += 1
+            continue
+        if not stripped.startswith(("Advertised to", "Not advertised")):
+            break
+        idx += 1
+        idx = _skip_update_group_ids(lines, idx)
+    return idx
+
+
+def _skip_update_group_ids(lines: list[str], idx: int) -> int:
+    """Skip lines that contain only update-group ID numbers."""
+    while idx < len(lines):
+        next_stripped = lines[idx].strip()
+        if not next_stripped:
+            return idx + 1
+        if _is_update_group_line(next_stripped):
+            idx += 1
+            continue
+        break
+    return idx
+
+
+def _parse_all_paths(lines: list[str], idx: int, paths: list[PathEntry]) -> int:
+    """Parse all path entries for a route. Returns next line index."""
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if not stripped:
+            idx += 1
+            continue
+
+        # Check for section boundaries
+        if stripped.startswith("BGP routing table entry"):
+            break
+        if stripped.startswith("For address family:"):
+            break
+        if stripped.startswith("Route Distinguisher:"):
+            break
+
+        epoch_match = _REFRESH_EPOCH_RE.match(stripped)
+        if epoch_match:
+            refresh_epoch = int(epoch_match.group(1))
+            idx += 1
+            path_entry, idx = _parse_path_attributes(lines, idx)
+            if path_entry:
+                path_entry["refresh_epoch"] = refresh_epoch
+                paths.append(path_entry)
+            continue
+
+        # Skip any other unrecognized lines
+        idx += 1
+
+    return idx
+
+
+def _strip_rd_prefix(prefix: str) -> str:
+    """Strip route distinguisher prefix from a route prefix.
+
+    Examples:
+        '100:100:10.229.11.11/32' -> '10.229.11.11/32'
+        '10.100.1.1:3014:0.0.0.0/0' -> '0.0.0.0/0'
+        '[5][65535:1][0][24][10.36.3.0]/17' -> '[5][65535:1][0][24][10.36.3.0]/17'
+        '2001:1:1:1::1/128' -> '2001:1:1:1::1/128'
+    """
+    # EVPN prefixes with brackets are never stripped
+    if prefix.startswith("["):
+        return prefix
+    # VPN RD formats: N:N: or IP:N: before the actual prefix
+    # Match RD patterns like 100:100: or 10.100.1.1:3014:
+    rd_match = re.match(r"^(\S+:\d+:)(.+)$", prefix)
+    if rd_match:
+        candidate = rd_match.group(2)
+        # If the remainder looks like an IPv4 prefix, strip the RD
+        if re.match(r"^\d{1,3}\.", candidate):
+            return candidate
+    return prefix
+
+
+def _parse_address_family(
+    lines: list[str], idx: int, af_name: str
+) -> tuple[list[AddressFamilyEntry], int]:
+    """Parse all content within a single address family section.
+
+    Returns (list of AF entries, next line index).
+    Multiple entries can exist when there are multiple Route Distinguishers.
+    """
+    entries: list[AddressFamilyEntry] = []
+    current_rd: str | None = None
+    current_vrf: str | None = None
+    current_routes: dict[str, RouteEntry] = {}
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+
+        if not stripped:
+            idx += 1
+            continue
+
+        # New address family = end of this one
+        if stripped.startswith("For address family:"):
+            break
+
+        # Route Distinguisher
+        rd_match = _RD_RE.match(stripped)
+        if rd_match:
+            # Save previous RD block if it has routes
+            if current_rd is not None and current_routes:
+                entries.append(_build_af_entry(current_rd, current_vrf, current_routes))
+                current_routes = {}
+            current_rd = rd_match.group(1)
+            current_vrf = rd_match.group(2)
+            idx += 1
+            continue
+
+        # Route entry
+        if stripped.startswith("BGP routing table entry"):
+            prefix, route, idx = _parse_route_block(lines, idx)
+            current_routes[prefix] = route
+            continue
+
+        # Skip noise
+        idx += 1
+
+    # Save final block
+    if current_routes:
+        entries.append(_build_af_entry(current_rd, current_vrf, current_routes))
+
+    return entries, idx
+
+
+def _build_af_entry(
+    rd: str | None,
+    vrf: str | None,
+    routes: dict[str, RouteEntry],
+) -> AddressFamilyEntry:
+    """Build an AddressFamilyEntry with optional RD and VRF."""
+    entry: AddressFamilyEntry = {"routes": routes}
+    if rd is not None:
+        entry["route_distinguisher"] = rd
+    if vrf is not None:
+        entry["default_vrf"] = vrf
+    return entry
+
+
+@register(OS.CISCO_IOSXE, "show bgp all detail")
+class ShowBgpAllDetailParser(BaseParser["ShowBgpAllDetailResult"]):
+    """Parser for 'show bgp all detail' command.
+
+    Example output:
+        For address family: IPv4 Unicast
+        BGP routing table entry for 10.4.1.1/32, version 4
+        Paths: (1 available, best #1, table default)
+          0.0.0.0 from 0.0.0.0 (10.1.1.1)
+            Origin incomplete, localpref 100, valid, sourced, best
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowBgpAllDetailResult:
+        """Parse 'show bgp all detail' output.
+
+        Args:
+            output: Raw CLI output from 'show bgp all detail' command.
+
+        Returns:
+            Parsed data organized by address family.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+        address_families: dict[str, list[AddressFamilyEntry]] = {}
+        idx = 0
+
+        while idx < len(lines):
+            stripped = lines[idx].strip()
+
+            if _is_noise_line(stripped):
+                idx += 1
+                continue
+
+            af_match = _AF_HEADER_RE.match(stripped)
+            if af_match:
+                af_name = af_match.group(1)
+                idx += 1
+                af_entries, idx = _parse_address_family(lines, idx, af_name)
+                if af_entries:
+                    if af_name not in address_families:
+                        address_families[af_name] = []
+                    address_families[af_name].extend(af_entries)
+                continue
+
+            idx += 1
+
+        if not address_families:
+            msg = "No BGP route detail entries found in output"
+            raise ValueError(msg)
+
+        return {"address_families": address_families}

--- a/src/muninn/parsers/iosxe/show_bgp_all_detail.py
+++ b/src/muninn/parsers/iosxe/show_bgp_all_detail.py
@@ -53,18 +53,24 @@ class RouteEntry(TypedDict):
     bestpath: NotRequired[str]
 
 
+class RouteDistinguisherEntry(TypedDict):
+    """Schema for a Route Distinguisher group."""
+
+    default_vrf: NotRequired[str]
+    routes: dict[str, RouteEntry]
+
+
 class AddressFamilyEntry(TypedDict):
     """Schema for routes within an address family."""
 
-    route_distinguisher: NotRequired[str]
-    default_vrf: NotRequired[str]
-    routes: dict[str, RouteEntry]
+    routes: NotRequired[dict[str, RouteEntry]]
+    route_distinguishers: NotRequired[dict[str, RouteDistinguisherEntry]]
 
 
 class ShowBgpAllDetailResult(TypedDict):
     """Schema for 'show bgp all detail' parsed output."""
 
-    address_families: dict[str, list[AddressFamilyEntry]]
+    address_families: dict[str, AddressFamilyEntry]
 
 
 # --- Compiled regex patterns ---
@@ -481,14 +487,14 @@ def _strip_rd_prefix(prefix: str) -> str:
 
 
 def _parse_address_family(
-    lines: list[str], idx: int, af_name: str
-) -> tuple[list[AddressFamilyEntry], int]:
+    lines: list[str], idx: int
+) -> tuple[AddressFamilyEntry | None, int]:
     """Parse all content within a single address family section.
 
-    Returns (list of AF entries, next line index).
-    Multiple entries can exist when there are multiple Route Distinguishers.
+    Returns (address family entry, next line index).
     """
-    entries: list[AddressFamilyEntry] = []
+    direct_routes: dict[str, RouteEntry] = {}
+    route_distinguishers: dict[str, RouteDistinguisherEntry] = {}
     current_rd: str | None = None
     current_vrf: str | None = None
     current_routes: dict[str, RouteEntry] = {}
@@ -507,10 +513,12 @@ def _parse_address_family(
         # Route Distinguisher
         rd_match = _RD_RE.match(stripped)
         if rd_match:
-            # Save previous RD block if it has routes
-            if current_rd is not None and current_routes:
-                entries.append(_build_af_entry(current_rd, current_vrf, current_routes))
-                current_routes = {}
+            current_routes = _flush_current_rd(
+                route_distinguishers,
+                current_rd,
+                current_vrf,
+                current_routes,
+            )
             current_rd = rd_match.group(1)
             current_vrf = rd_match.group(2)
             idx += 1
@@ -519,31 +527,98 @@ def _parse_address_family(
         # Route entry
         if stripped.startswith("BGP routing table entry"):
             prefix, route, idx = _parse_route_block(lines, idx)
-            current_routes[prefix] = route
+            if current_rd is None:
+                direct_routes[prefix] = route
+            else:
+                current_routes[prefix] = route
             continue
 
         # Skip noise
         idx += 1
 
-    # Save final block
-    if current_routes:
-        entries.append(_build_af_entry(current_rd, current_vrf, current_routes))
+    _flush_current_rd(route_distinguishers, current_rd, current_vrf, current_routes)
 
-    return entries, idx
+    entry: AddressFamilyEntry = {}
+    if direct_routes:
+        entry["routes"] = direct_routes
+    if route_distinguishers:
+        entry["route_distinguishers"] = route_distinguishers
+
+    return (entry or None), idx
 
 
-def _build_af_entry(
-    rd: str | None,
+def _build_rd_entry(
     vrf: str | None,
     routes: dict[str, RouteEntry],
-) -> AddressFamilyEntry:
-    """Build an AddressFamilyEntry with optional RD and VRF."""
-    entry: AddressFamilyEntry = {"routes": routes}
-    if rd is not None:
-        entry["route_distinguisher"] = rd
+) -> RouteDistinguisherEntry:
+    """Build a RouteDistinguisherEntry with optional VRF."""
+    entry: RouteDistinguisherEntry = {"routes": routes}
     if vrf is not None:
         entry["default_vrf"] = vrf
     return entry
+
+
+def _flush_current_rd(
+    route_distinguishers: dict[str, RouteDistinguisherEntry],
+    rd: str | None,
+    vrf: str | None,
+    routes: dict[str, RouteEntry],
+) -> dict[str, RouteEntry]:
+    """Store the current RD block if it has routes and reset state."""
+    if rd is not None and routes:
+        _merge_rd_entry(route_distinguishers, rd, vrf, routes)
+        return {}
+    return routes
+
+
+def _merge_rd_entry(
+    route_distinguishers: dict[str, RouteDistinguisherEntry],
+    rd: str,
+    vrf: str | None,
+    routes: dict[str, RouteEntry],
+) -> None:
+    """Merge routes into a Route Distinguisher entry."""
+    entry = route_distinguishers.setdefault(rd, {"routes": {}})
+    if vrf is not None:
+        entry["default_vrf"] = vrf
+    entry["routes"].update(routes)
+
+
+def _merge_address_family_entry(
+    current: AddressFamilyEntry,
+    new: AddressFamilyEntry,
+) -> AddressFamilyEntry:
+    """Merge parsed address family data from repeated sections."""
+    merged: AddressFamilyEntry = {}
+
+    if "routes" in current or "routes" in new:
+        merged["routes"] = {
+            **current.get("routes", {}),
+            **new.get("routes", {}),
+        }
+
+    merged_rds = {
+        rd: {
+            **rd_entry,
+            "routes": dict(rd_entry["routes"]),
+        }
+        for rd, rd_entry in current.get("route_distinguishers", {}).items()
+    }
+    for rd, rd_entry in new.get("route_distinguishers", {}).items():
+        if rd not in merged_rds:
+            merged_rds[rd] = {
+                **rd_entry,
+                "routes": dict(rd_entry["routes"]),
+            }
+            continue
+        if "default_vrf" in rd_entry:
+            merged_rds[rd]["default_vrf"] = rd_entry["default_vrf"]
+        merged_rds[rd]["routes"].update(rd_entry["routes"])
+
+    if merged_rds:
+        merged["route_distinguishers"] = merged_rds
+
+    return merged
 
 
 @register(OS.CISCO_IOSXE, "show bgp all detail")
@@ -572,7 +647,7 @@ class ShowBgpAllDetailParser(BaseParser["ShowBgpAllDetailResult"]):
             ValueError: If the output cannot be parsed.
         """
         lines = output.splitlines()
-        address_families: dict[str, list[AddressFamilyEntry]] = {}
+        address_families: dict[str, AddressFamilyEntry] = {}
         idx = 0
 
         while idx < len(lines):
@@ -586,11 +661,16 @@ class ShowBgpAllDetailParser(BaseParser["ShowBgpAllDetailResult"]):
             if af_match:
                 af_name = af_match.group(1)
                 idx += 1
-                af_entries, idx = _parse_address_family(lines, idx, af_name)
-                if af_entries:
-                    if af_name not in address_families:
-                        address_families[af_name] = []
-                    address_families[af_name].extend(af_entries)
+                af_entry, idx = _parse_address_family(lines, idx)
+                if af_entry:
+                    existing_entry = address_families.get(af_name)
+                    if existing_entry is None:
+                        address_families[af_name] = af_entry
+                    else:
+                        address_families[af_name] = _merge_address_family_entry(
+                            existing_entry,
+                            af_entry,
+                        )
                 continue
 
             idx += 1

--- a/tests/parsers/iosxe/show_bgp_all_detail/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_detail/001_basic/expected.json
@@ -1,0 +1,283 @@
+{
+    "address_families": {
+        "IPv4 Unicast": [
+            {
+                "routes": {
+                    "10.1.1.0/24": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "0.0.0.0",
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "0.0.0.0",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.1",
+                                "rx_pathid": "0",
+                                "sourced": true,
+                                "tx_pathid": "0x0",
+                                "valid": true,
+                                "weight": 32768
+                            },
+                            {
+                                "as_path": "",
+                                "best": false,
+                                "from_peer": "10.1.1.2",
+                                "internal": true,
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "10.1.1.2",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.2",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0",
+                                "valid": true
+                            }
+                        ],
+                        "paths_available": 2,
+                        "table": "default",
+                        "version": 5
+                    },
+                    "10.16.2.2/32": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "10.1.1.2",
+                                "internal": true,
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "10.1.1.2",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.2",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0x0",
+                                "valid": true
+                            }
+                        ],
+                        "paths_available": 1,
+                        "table": "default",
+                        "version": 2
+                    },
+                    "10.4.1.1/32": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "0.0.0.0",
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "0.0.0.0",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.1",
+                                "rx_pathid": "0",
+                                "sourced": true,
+                                "tx_pathid": "0x0",
+                                "valid": true,
+                                "weight": 32768
+                            }
+                        ],
+                        "paths_available": 1,
+                        "rib_failure": "RIB-failure(17)",
+                        "table": "default",
+                        "version": 4
+                    }
+                }
+            }
+        ],
+        "IPv6 Unicast": [
+            {
+                "routes": {
+                    "2001:1:1:1::1/128": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "0.0.0.0",
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "::",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.1",
+                                "rx_pathid": "0",
+                                "sourced": true,
+                                "tx_pathid": "0x0",
+                                "valid": true,
+                                "weight": 32768
+                            }
+                        ],
+                        "paths_available": 1,
+                        "table": "default",
+                        "version": 4
+                    },
+                    "2001:2:2:2::2/128": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "2001:DB8:1:1::2",
+                                "internal": true,
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "2001:DB8:1:1::2",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.2",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0x0",
+                                "valid": true
+                            },
+                            {
+                                "as_path": "",
+                                "best": false,
+                                "from_peer": "10.1.1.2",
+                                "internal": true,
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "::FFFF:10.1.1.2",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.2",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0",
+                                "valid": true
+                            }
+                        ],
+                        "paths_available": 2,
+                        "table": "default",
+                        "version": 2
+                    },
+                    "2001:DB8:1:1::/64": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "0.0.0.0",
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "::",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.1",
+                                "rx_pathid": "0",
+                                "sourced": true,
+                                "tx_pathid": "0x0",
+                                "valid": true,
+                                "weight": 32768
+                            },
+                            {
+                                "as_path": "",
+                                "best": false,
+                                "from_peer": "2001:DB8:1:1::2",
+                                "internal": true,
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "2001:DB8:1:1::2",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.2",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0",
+                                "valid": true
+                            },
+                            {
+                                "as_path": "",
+                                "best": false,
+                                "from_peer": "10.1.1.2",
+                                "internal": true,
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "::FFFF:10.1.1.2",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.2",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0",
+                                "valid": true
+                            }
+                        ],
+                        "paths_available": 3,
+                        "table": "default",
+                        "version": 5
+                    }
+                }
+            }
+        ],
+        "VPNv4 Unicast": [
+            {
+                "default_vrf": "VRF1",
+                "route_distinguisher": "100:100",
+                "routes": {
+                    "10.229.11.11/32": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "0.0.0.0",
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "0.0.0.0",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.1",
+                                "rx_pathid": "0",
+                                "sourced": true,
+                                "tx_pathid": "0x0",
+                                "valid": true,
+                                "weight": 32768
+                            }
+                        ],
+                        "paths_available": 1,
+                        "table": "VRF1",
+                        "version": 2
+                    }
+                }
+            }
+        ],
+        "VPNv6 Unicast": [
+            {
+                "default_vrf": "VRF1",
+                "route_distinguisher": "100:100",
+                "routes": {
+                    "[100:100]2001:11:11::11/128": {
+                        "best_path": 1,
+                        "paths": [
+                            {
+                                "as_path": "",
+                                "best": true,
+                                "from_peer": "0.0.0.0",
+                                "localpref": 100,
+                                "metric": 0,
+                                "next_hop": "::",
+                                "origin": "incomplete",
+                                "refresh_epoch": 1,
+                                "router_id": "10.1.1.1",
+                                "rx_pathid": "0",
+                                "sourced": true,
+                                "tx_pathid": "0x0",
+                                "valid": true,
+                                "weight": 32768
+                            }
+                        ],
+                        "paths_available": 1,
+                        "table": "VRF1",
+                        "version": 2
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_all_detail/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_detail/001_basic/expected.json
@@ -1,283 +1,281 @@
 {
     "address_families": {
-        "IPv4 Unicast": [
-            {
-                "routes": {
-                    "10.1.1.0/24": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "0.0.0.0",
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "0.0.0.0",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.1",
-                                "rx_pathid": "0",
-                                "sourced": true,
-                                "tx_pathid": "0x0",
-                                "valid": true,
-                                "weight": 32768
-                            },
-                            {
-                                "as_path": "",
-                                "best": false,
-                                "from_peer": "10.1.1.2",
-                                "internal": true,
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "10.1.1.2",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.2",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0",
-                                "valid": true
-                            }
-                        ],
-                        "paths_available": 2,
-                        "table": "default",
-                        "version": 5
-                    },
-                    "10.16.2.2/32": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "10.1.1.2",
-                                "internal": true,
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "10.1.1.2",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.2",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0x0",
-                                "valid": true
-                            }
-                        ],
-                        "paths_available": 1,
-                        "table": "default",
-                        "version": 2
-                    },
-                    "10.4.1.1/32": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "0.0.0.0",
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "0.0.0.0",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.1",
-                                "rx_pathid": "0",
-                                "sourced": true,
-                                "tx_pathid": "0x0",
-                                "valid": true,
-                                "weight": 32768
-                            }
-                        ],
-                        "paths_available": 1,
-                        "rib_failure": "RIB-failure(17)",
-                        "table": "default",
-                        "version": 4
-                    }
+        "IPv4 Unicast": {
+            "routes": {
+                "10.1.1.0/24": {
+                    "best_path": 1,
+                    "paths": [
+                        {
+                            "as_path": "",
+                            "best": true,
+                            "from_peer": "0.0.0.0",
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "0.0.0.0",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.1",
+                            "rx_pathid": "0",
+                            "sourced": true,
+                            "tx_pathid": "0x0",
+                            "valid": true,
+                            "weight": 32768
+                        },
+                        {
+                            "as_path": "",
+                            "best": false,
+                            "from_peer": "10.1.1.2",
+                            "internal": true,
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "10.1.1.2",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.2",
+                            "rx_pathid": "0",
+                            "tx_pathid": "0",
+                            "valid": true
+                        }
+                    ],
+                    "paths_available": 2,
+                    "table": "default",
+                    "version": 5
+                },
+                "10.16.2.2/32": {
+                    "best_path": 1,
+                    "paths": [
+                        {
+                            "as_path": "",
+                            "best": true,
+                            "from_peer": "10.1.1.2",
+                            "internal": true,
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "10.1.1.2",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.2",
+                            "rx_pathid": "0",
+                            "tx_pathid": "0x0",
+                            "valid": true
+                        }
+                    ],
+                    "paths_available": 1,
+                    "table": "default",
+                    "version": 2
+                },
+                "10.4.1.1/32": {
+                    "best_path": 1,
+                    "paths": [
+                        {
+                            "as_path": "",
+                            "best": true,
+                            "from_peer": "0.0.0.0",
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "0.0.0.0",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.1",
+                            "rx_pathid": "0",
+                            "sourced": true,
+                            "tx_pathid": "0x0",
+                            "valid": true,
+                            "weight": 32768
+                        }
+                    ],
+                    "paths_available": 1,
+                    "rib_failure": "RIB-failure(17)",
+                    "table": "default",
+                    "version": 4
                 }
             }
-        ],
-        "IPv6 Unicast": [
-            {
-                "routes": {
-                    "2001:1:1:1::1/128": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "0.0.0.0",
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "::",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.1",
-                                "rx_pathid": "0",
-                                "sourced": true,
-                                "tx_pathid": "0x0",
-                                "valid": true,
-                                "weight": 32768
-                            }
-                        ],
-                        "paths_available": 1,
-                        "table": "default",
-                        "version": 4
+        },
+        "IPv6 Unicast": {
+            "routes": {
+                "2001:1:1:1::1/128": {
+                    "best_path": 1,
+                    "paths": [
+                        {
+                            "as_path": "",
+                            "best": true,
+                            "from_peer": "0.0.0.0",
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "::",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.1",
+                            "rx_pathid": "0",
+                            "sourced": true,
+                            "tx_pathid": "0x0",
+                            "valid": true,
+                            "weight": 32768
+                        }
+                    ],
+                    "paths_available": 1,
+                    "table": "default",
+                    "version": 4
+                },
+                "2001:2:2:2::2/128": {
+                    "best_path": 1,
+                    "paths": [
+                        {
+                            "as_path": "",
+                            "best": true,
+                            "from_peer": "2001:DB8:1:1::2",
+                            "internal": true,
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "2001:DB8:1:1::2",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.2",
+                            "rx_pathid": "0",
+                            "tx_pathid": "0x0",
+                            "valid": true
+                        },
+                        {
+                            "as_path": "",
+                            "best": false,
+                            "from_peer": "10.1.1.2",
+                            "internal": true,
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "::FFFF:10.1.1.2",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.2",
+                            "rx_pathid": "0",
+                            "tx_pathid": "0",
+                            "valid": true
+                        }
+                    ],
+                    "paths_available": 2,
+                    "table": "default",
+                    "version": 2
+                },
+                "2001:DB8:1:1::/64": {
+                    "best_path": 1,
+                    "paths": [
+                        {
+                            "as_path": "",
+                            "best": true,
+                            "from_peer": "0.0.0.0",
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "::",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.1",
+                            "rx_pathid": "0",
+                            "sourced": true,
+                            "tx_pathid": "0x0",
+                            "valid": true,
+                            "weight": 32768
+                        },
+                        {
+                            "as_path": "",
+                            "best": false,
+                            "from_peer": "2001:DB8:1:1::2",
+                            "internal": true,
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "2001:DB8:1:1::2",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.2",
+                            "rx_pathid": "0",
+                            "tx_pathid": "0",
+                            "valid": true
+                        },
+                        {
+                            "as_path": "",
+                            "best": false,
+                            "from_peer": "10.1.1.2",
+                            "internal": true,
+                            "localpref": 100,
+                            "metric": 0,
+                            "next_hop": "::FFFF:10.1.1.2",
+                            "origin": "incomplete",
+                            "refresh_epoch": 1,
+                            "router_id": "10.1.1.2",
+                            "rx_pathid": "0",
+                            "tx_pathid": "0",
+                            "valid": true
+                        }
+                    ],
+                    "paths_available": 3,
+                    "table": "default",
+                    "version": 5
+                }
+            }
+        },
+        "VPNv4 Unicast": {
+            "route_distinguishers": {
+                "100:100": {
+                    "routes": {
+                        "10.229.11.11/32": {
+                            "best_path": 1,
+                            "paths": [
+                                {
+                                    "as_path": "",
+                                    "best": true,
+                                    "from_peer": "0.0.0.0",
+                                    "localpref": 100,
+                                    "metric": 0,
+                                    "next_hop": "0.0.0.0",
+                                    "origin": "incomplete",
+                                    "refresh_epoch": 1,
+                                    "router_id": "10.1.1.1",
+                                    "rx_pathid": "0",
+                                    "sourced": true,
+                                    "tx_pathid": "0x0",
+                                    "valid": true,
+                                    "weight": 32768
+                                }
+                            ],
+                            "paths_available": 1,
+                            "table": "VRF1",
+                            "version": 2
+                        }
                     },
-                    "2001:2:2:2::2/128": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "2001:DB8:1:1::2",
-                                "internal": true,
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "2001:DB8:1:1::2",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.2",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0x0",
-                                "valid": true
-                            },
-                            {
-                                "as_path": "",
-                                "best": false,
-                                "from_peer": "10.1.1.2",
-                                "internal": true,
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "::FFFF:10.1.1.2",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.2",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0",
-                                "valid": true
-                            }
-                        ],
-                        "paths_available": 2,
-                        "table": "default",
-                        "version": 2
+                    "default_vrf": "VRF1"
+                }
+            }
+        },
+        "VPNv6 Unicast": {
+            "route_distinguishers": {
+                "100:100": {
+                    "routes": {
+                        "[100:100]2001:11:11::11/128": {
+                            "best_path": 1,
+                            "paths": [
+                                {
+                                    "as_path": "",
+                                    "best": true,
+                                    "from_peer": "0.0.0.0",
+                                    "localpref": 100,
+                                    "metric": 0,
+                                    "next_hop": "::",
+                                    "origin": "incomplete",
+                                    "refresh_epoch": 1,
+                                    "router_id": "10.1.1.1",
+                                    "rx_pathid": "0",
+                                    "sourced": true,
+                                    "tx_pathid": "0x0",
+                                    "valid": true,
+                                    "weight": 32768
+                                }
+                            ],
+                            "paths_available": 1,
+                            "table": "VRF1",
+                            "version": 2
+                        }
                     },
-                    "2001:DB8:1:1::/64": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "0.0.0.0",
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "::",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.1",
-                                "rx_pathid": "0",
-                                "sourced": true,
-                                "tx_pathid": "0x0",
-                                "valid": true,
-                                "weight": 32768
-                            },
-                            {
-                                "as_path": "",
-                                "best": false,
-                                "from_peer": "2001:DB8:1:1::2",
-                                "internal": true,
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "2001:DB8:1:1::2",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.2",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0",
-                                "valid": true
-                            },
-                            {
-                                "as_path": "",
-                                "best": false,
-                                "from_peer": "10.1.1.2",
-                                "internal": true,
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "::FFFF:10.1.1.2",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.2",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0",
-                                "valid": true
-                            }
-                        ],
-                        "paths_available": 3,
-                        "table": "default",
-                        "version": 5
-                    }
+                    "default_vrf": "VRF1"
                 }
             }
-        ],
-        "VPNv4 Unicast": [
-            {
-                "default_vrf": "VRF1",
-                "route_distinguisher": "100:100",
-                "routes": {
-                    "10.229.11.11/32": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "0.0.0.0",
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "0.0.0.0",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.1",
-                                "rx_pathid": "0",
-                                "sourced": true,
-                                "tx_pathid": "0x0",
-                                "valid": true,
-                                "weight": 32768
-                            }
-                        ],
-                        "paths_available": 1,
-                        "table": "VRF1",
-                        "version": 2
-                    }
-                }
-            }
-        ],
-        "VPNv6 Unicast": [
-            {
-                "default_vrf": "VRF1",
-                "route_distinguisher": "100:100",
-                "routes": {
-                    "[100:100]2001:11:11::11/128": {
-                        "best_path": 1,
-                        "paths": [
-                            {
-                                "as_path": "",
-                                "best": true,
-                                "from_peer": "0.0.0.0",
-                                "localpref": 100,
-                                "metric": 0,
-                                "next_hop": "::",
-                                "origin": "incomplete",
-                                "refresh_epoch": 1,
-                                "router_id": "10.1.1.1",
-                                "rx_pathid": "0",
-                                "sourced": true,
-                                "tx_pathid": "0x0",
-                                "valid": true,
-                                "weight": 32768
-                            }
-                        ],
-                        "paths_available": 1,
-                        "table": "VRF1",
-                        "version": 2
-                    }
-                }
-            }
-        ]
+        }
     }
 }

--- a/tests/parsers/iosxe/show_bgp_all_detail/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_bgp_all_detail/001_basic/input.txt
@@ -1,0 +1,127 @@
+R1#show bgp all detail
+For address family: IPv4 Unicast
+
+BGP routing table entry for 10.4.1.1/32, version 4
+Paths: (1 available, best #1, table default, RIB-failure(17))
+Advertised to update-groups:
+   3
+Refresh Epoch 1
+Local
+  0.0.0.0 from 0.0.0.0 (10.1.1.1)
+    Origin incomplete, metric 0, localpref 100, weight 32768, valid, sourced, best
+    rx pathid: 0, tx pathid: 0x0
+BGP routing table entry for 10.16.2.2/32, version 2
+Paths: (1 available, best #1, table default)
+Not advertised to any peer
+Refresh Epoch 1
+Local
+  10.1.1.2 from 10.1.1.2 (10.1.1.2)
+    Origin incomplete, metric 0, localpref 100, valid, internal, best
+    rx pathid: 0, tx pathid: 0x0
+BGP routing table entry for 10.1.1.0/24, version 5
+Paths: (2 available, best #1, table default)
+Advertised to update-groups:
+   3
+Refresh Epoch 1
+Local
+  0.0.0.0 from 0.0.0.0 (10.1.1.1)
+    Origin incomplete, metric 0, localpref 100, weight 32768, valid, sourced, best
+    rx pathid: 0, tx pathid: 0x0
+Refresh Epoch 1
+Local
+  10.1.1.2 from 10.1.1.2 (10.1.1.2)
+    Origin incomplete, metric 0, localpref 100, valid, internal
+    rx pathid: 0, tx pathid: 0
+
+For address family: IPv6 Unicast
+
+BGP routing table entry for 2001:1:1:1::1/128, version 4
+Paths: (1 available, best #1, table default)
+Advertised to update-groups:
+   1
+Refresh Epoch 1
+Local
+  :: from 0.0.0.0 (10.1.1.1)
+    Origin incomplete, metric 0, localpref 100, weight 32768, valid, sourced, best
+    rx pathid: 0, tx pathid: 0x0
+BGP routing table entry for 2001:2:2:2::2/128, version 2
+Paths: (2 available, best #1, table default)
+Not advertised to any peer
+Refresh Epoch 1
+Local
+  2001:DB8:1:1::2 from 2001:DB8:1:1::2 (10.1.1.2)
+    Origin incomplete, metric 0, localpref 100, valid, internal, best
+    rx pathid: 0, tx pathid: 0x0
+Refresh Epoch 1
+Local
+  ::FFFF:10.1.1.2 (inaccessible) from 10.1.1.2 (10.1.1.2)
+    Origin incomplete, metric 0, localpref 100, valid, internal
+    rx pathid: 0, tx pathid: 0
+BGP routing table entry for 2001:DB8:1:1::/64, version 5
+Paths: (3 available, best #1, table default)
+Advertised to update-groups:
+   1
+Refresh Epoch 1
+Local
+  :: from 0.0.0.0 (10.1.1.1)
+    Origin incomplete, metric 0, localpref 100, weight 32768, valid, sourced, best
+    rx pathid: 0, tx pathid: 0x0
+Refresh Epoch 1
+Local
+  2001:DB8:1:1::2 from 2001:DB8:1:1::2 (10.1.1.2)
+    Origin incomplete, metric 0, localpref 100, valid, internal
+    rx pathid: 0, tx pathid: 0
+Refresh Epoch 1
+Local
+  ::FFFF:10.1.1.2 (inaccessible) from 10.1.1.2 (10.1.1.2)
+    Origin incomplete, metric 0, localpref 100, valid, internal
+    rx pathid: 0, tx pathid: 0
+
+For address family: VPNv4 Unicast
+
+
+Route Distinguisher: 100:100 (default for vrf VRF1)
+BGP routing table entry for 100:100:10.229.11.11/32, version 2
+Paths: (1 available, best #1, table VRF1)
+Not advertised to any peer
+Refresh Epoch 1
+Local
+  0.0.0.0 (via vrf VRF1) from 0.0.0.0 (10.1.1.1)
+    Origin incomplete, metric 0, localpref 100, weight 32768, valid, sourced, best
+    rx pathid: 0, tx pathid: 0x0
+
+For address family: VPNv6 Unicast
+
+
+Route Distinguisher: 100:100 (default for vrf VRF1)
+BGP routing table entry for [100:100]2001:11:11::11/128, version 2
+Paths: (1 available, best #1, table VRF1)
+Not advertised to any peer
+Refresh Epoch 1
+Local
+  :: (via vrf VRF1) from 0.0.0.0 (10.1.1.1)
+    Origin incomplete, metric 0, localpref 100, weight 32768, valid, sourced, best
+    rx pathid: 0, tx pathid: 0x0
+
+For address family: IPv4 Multicast
+
+
+For address family: L2VPN E-VPN
+
+
+For address family: VPNv4 Multicast
+
+
+For address family: MVPNv4 Unicast
+
+
+For address family: MVPNv6 Unicast
+
+
+For address family: VPNv6 Multicast
+
+
+For address family: VPNv4 Flowspec
+
+
+For address family: VPNv6 Flowspec

--- a/tests/parsers/iosxe/show_bgp_all_detail/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_all_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple address families with IPv4, IPv6, VPNv4, and VPNv6 routes
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/expected.json
@@ -1,0 +1,58 @@
+{
+    "address_families": {
+        "VPNv4 Unicast": [
+            {
+                "default_vrf": "vrf1",
+                "route_distinguisher": "10.100.1.1:3014",
+                "routes": {
+                    "0.0.0.0/0": {
+                        "best_path": 1,
+                        "bestpath": "deterministic-med",
+                        "multipath": "eBGP iBGP",
+                        "paths": [
+                            {
+                                "as_path": "64624",
+                                "best": true,
+                                "community": "163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000",
+                                "extended_community": "RT:65002:3014",
+                                "from_peer": "10.121.2.2",
+                                "localpref": 950,
+                                "mpls_labels_in": "IPv4 VRF Aggr:25",
+                                "mpls_labels_out": "nolabel",
+                                "next_hop": "10.121.2.2",
+                                "origin": "IGP",
+                                "refresh_epoch": 2,
+                                "router_id": "10.246.128.21",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0x0",
+                                "valid": true
+                            },
+                            {
+                                "as_path": "64624",
+                                "best": false,
+                                "community": "163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000",
+                                "extended_community": "RT:65002:3014",
+                                "from_peer": "10.55.117.38",
+                                "internal": true,
+                                "localpref": 950,
+                                "metric": 0,
+                                "mpls_labels_in": "IPv4 VRF Aggr:25",
+                                "mpls_labels_out": "26",
+                                "next_hop": "10.55.117.38",
+                                "origin": "IGP",
+                                "refresh_epoch": 17,
+                                "router_id": "10.55.117.38",
+                                "rx_pathid": "0",
+                                "tx_pathid": "0",
+                                "valid": true
+                            }
+                        ],
+                        "paths_available": 2,
+                        "table": "vrf1",
+                        "version": 74438
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/expected.json
+++ b/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/expected.json
@@ -1,58 +1,59 @@
 {
     "address_families": {
-        "VPNv4 Unicast": [
-            {
-                "default_vrf": "vrf1",
-                "route_distinguisher": "10.100.1.1:3014",
-                "routes": {
-                    "0.0.0.0/0": {
-                        "best_path": 1,
-                        "bestpath": "deterministic-med",
-                        "multipath": "eBGP iBGP",
-                        "paths": [
-                            {
-                                "as_path": "64624",
-                                "best": true,
-                                "community": "163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000",
-                                "extended_community": "RT:65002:3014",
-                                "from_peer": "10.121.2.2",
-                                "localpref": 950,
-                                "mpls_labels_in": "IPv4 VRF Aggr:25",
-                                "mpls_labels_out": "nolabel",
-                                "next_hop": "10.121.2.2",
-                                "origin": "IGP",
-                                "refresh_epoch": 2,
-                                "router_id": "10.246.128.21",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0x0",
-                                "valid": true
-                            },
-                            {
-                                "as_path": "64624",
-                                "best": false,
-                                "community": "163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000",
-                                "extended_community": "RT:65002:3014",
-                                "from_peer": "10.55.117.38",
-                                "internal": true,
-                                "localpref": 950,
-                                "metric": 0,
-                                "mpls_labels_in": "IPv4 VRF Aggr:25",
-                                "mpls_labels_out": "26",
-                                "next_hop": "10.55.117.38",
-                                "origin": "IGP",
-                                "refresh_epoch": 17,
-                                "router_id": "10.55.117.38",
-                                "rx_pathid": "0",
-                                "tx_pathid": "0",
-                                "valid": true
-                            }
-                        ],
-                        "paths_available": 2,
-                        "table": "vrf1",
-                        "version": 74438
-                    }
+        "VPNv4 Unicast": {
+            "route_distinguishers": {
+                "10.100.1.1:3014": {
+                    "routes": {
+                        "0.0.0.0/0": {
+                            "best_path": 1,
+                            "bestpath": "deterministic-med",
+                            "multipath": "eBGP iBGP",
+                            "paths": [
+                                {
+                                    "as_path": "64624",
+                                    "best": true,
+                                    "community": "163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000",
+                                    "extended_community": "RT:65002:3014",
+                                    "from_peer": "10.121.2.2",
+                                    "localpref": 950,
+                                    "mpls_labels_in": "IPv4 VRF Aggr:25",
+                                    "mpls_labels_out": "nolabel",
+                                    "next_hop": "10.121.2.2",
+                                    "origin": "IGP",
+                                    "refresh_epoch": 2,
+                                    "router_id": "10.246.128.21",
+                                    "rx_pathid": "0",
+                                    "tx_pathid": "0x0",
+                                    "valid": true
+                                },
+                                {
+                                    "as_path": "64624",
+                                    "best": false,
+                                    "community": "163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000",
+                                    "extended_community": "RT:65002:3014",
+                                    "from_peer": "10.55.117.38",
+                                    "internal": true,
+                                    "localpref": 950,
+                                    "metric": 0,
+                                    "mpls_labels_in": "IPv4 VRF Aggr:25",
+                                    "mpls_labels_out": "26",
+                                    "next_hop": "10.55.117.38",
+                                    "origin": "IGP",
+                                    "refresh_epoch": 17,
+                                    "router_id": "10.55.117.38",
+                                    "rx_pathid": "0",
+                                    "tx_pathid": "0",
+                                    "valid": true
+                                }
+                            ],
+                            "paths_available": 2,
+                            "table": "vrf1",
+                            "version": 74438
+                        }
+                    },
+                    "default_vrf": "vrf1"
                 }
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/input.txt
+++ b/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/input.txt
@@ -1,0 +1,26 @@
+For address family: VPNv4 Unicast
+
+
+Route Distinguisher: 10.100.1.1:3014 (default for vrf vrf1)
+BGP routing table entry for 10.100.1.1:3014:0.0.0.0/0, version 74438
+BGP Bestpath: deterministic-med
+Paths: (2 available, best #1, table vrf1)
+Multipath: eBGP iBGP
+Advertised to update-groups:
+    304        13
+Refresh Epoch 2
+64624
+    10.121.2.2 (via vrf vrf1) from 10.121.2.2 (10.246.128.21)
+    Origin IGP, localpref 950, valid, external, best
+    Community: 163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000
+    Extended Community: RT:65002:3014
+    mpls labels in/out IPv4 VRF Aggr:25/nolabel
+    rx pathid: 0, tx pathid: 0x0
+Refresh Epoch 17
+64624, imported path from 10.55.117.38:3014:0.0.0.0/0 (global)
+    10.55.117.38 (metric 11) (via default) from 10.55.117.38 (10.55.117.38)
+    Origin IGP, metric 0, localpref 950, valid, internal
+    Community: 163:43242 2002:8 2002:35 2002:53 2002:100 2002:1000
+    Extended Community: RT:65002:3014
+    mpls labels in/out IPv4 VRF Aggr:25/26
+    rx pathid: 0, tx pathid: 0

--- a/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/metadata.yaml
+++ b/tests/parsers/iosxe/show_bgp_all_detail/002_vpn_with_communities/metadata.yaml
@@ -1,0 +1,3 @@
+description: VPNv4 routes with communities, extended communities, MPLS labels, and multipath
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show bgp all detail` command on IOS-XE
- Supports multiple address families: IPv4/IPv6 Unicast, VPNv4/VPNv6 Unicast, L2VPN EVPN
- Handles route distinguishers, communities, extended communities, MPLS labels, EVPN attributes, multipath, and RIB-failure flags
- Includes 2 test cases: multi-AF basic output and VPN routes with communities/MPLS

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k "show_bgp_all_detail" -v` passes (2 tests)
- [x] `uv run ruff check` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)