### PR TITLE
feat: add parser for 'show power inline priority' on IOS-XE

### DIFF
--- a/changes/389.parser_added
+++ b/changes/389.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show power inline priority' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_power_inline_priority.py
+++ b/src/muninn/parsers/iosxe/show_power_inline_priority.py
@@ -1,0 +1,116 @@
+"""Parser for 'show power inline priority' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class PowerInlinePriorityEntry(TypedDict):
+    """Schema for a single interface power inline priority entry."""
+
+    admin_state: str
+    oper_state: str
+    admin_priority: str
+    oper_priority: NotRequired[str]
+
+
+class ShowPowerInlinePriorityResult(TypedDict):
+    """Schema for 'show power inline priority' parsed output."""
+
+    power_inline_auto_shutdown: NotRequired[str]
+    interfaces: dict[str, PowerInlinePriorityEntry]
+
+
+_SHUTDOWN_PATTERN = re.compile(
+    r"^Power\s+inline\s+auto\s+shutdown:\s+(?P<value>\S+)",
+)
+
+# Matches rows like: Gi1/0/1    auto   off        low
+# or with oper priority: Te2/0/1    auto   off        n/a        1
+_ROW_PATTERN = re.compile(
+    r"^(?P<interface>\S+)\s+"
+    r"(?P<admin_state>\S+)\s+"
+    r"(?P<oper_state>\S+)\s+"
+    r"(?P<admin_priority>\S+)"
+    r"(?:\s+(?P<oper_priority>\S+))?\s*$",
+)
+
+_HEADER_KEYWORDS = frozenset({"interface", "admin", "oper", "state", "priority"})
+
+_SEPARATOR_PATTERN = re.compile(r"^[-\s]+$")
+
+
+def _is_header_or_separator(line: str) -> bool:
+    """Return True if the line is a table header or separator."""
+    lower = line.lower()
+    if all(word in _HEADER_KEYWORDS for word in lower.split()):
+        return True
+    return bool(_SEPARATOR_PATTERN.match(line))
+
+
+@register(OS.CISCO_IOSXE, "show power inline priority")
+class ShowPowerInlinePriorityParser(BaseParser[ShowPowerInlinePriorityResult]):
+    """Parser for 'show power inline priority' command.
+
+    Example output::
+
+        Interface  Admin  Oper       Admin
+                   State  State      Priority
+        ---------- ------ ---------- ----------
+
+        Gi1/0/1    auto   off        low
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPowerInlinePriorityResult:
+        """Parse 'show power inline priority' output.
+
+        Args:
+            output: Raw CLI output from 'show power inline priority' command.
+
+        Returns:
+            Parsed data with interfaces keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interface entries are found in the output.
+        """
+        interfaces: dict[str, PowerInlinePriorityEntry] = {}
+        shutdown_value: str | None = None
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if m := _SHUTDOWN_PATTERN.match(line):
+                shutdown_value = m.group("value")
+                continue
+
+            if _is_header_or_separator(line):
+                continue
+
+            if m := _ROW_PATTERN.match(line):
+                name = canonical_interface_name(m.group("interface"))
+                entry: PowerInlinePriorityEntry = {
+                    "admin_state": m.group("admin_state"),
+                    "oper_state": m.group("oper_state"),
+                    "admin_priority": m.group("admin_priority"),
+                }
+                oper_priority = m.group("oper_priority")
+                if oper_priority is not None:
+                    entry["oper_priority"] = oper_priority
+                interfaces[name] = entry
+
+        if not interfaces:
+            msg = "No interface entries found in output"
+            raise ValueError(msg)
+
+        result: ShowPowerInlinePriorityResult = {"interfaces": interfaces}
+        if shutdown_value is not None:
+            result["power_inline_auto_shutdown"] = shutdown_value
+
+        return result

--- a/tests/parsers/iosxe/show_power_inline_priority/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_power_inline_priority/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/1": {
+            "admin_priority": "low",
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/11": {
+            "admin_priority": "low",
+            "admin_state": "auto",
+            "oper_state": "off"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_power_inline_priority/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_power_inline_priority/001_basic/input.txt
@@ -1,0 +1,6 @@
+Interface  Admin  Oper       Admin
+           State  State      Priority
+---------- ------ ---------- ----------
+
+Gi1/0/1    auto   off        low
+Gi1/0/11    auto   off        low

--- a/tests/parsers/iosxe/show_power_inline_priority/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_power_inline_priority/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with two interfaces and no oper priority column
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/expected.json
+++ b/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/expected.json
@@ -1,0 +1,11 @@
+{
+    "interfaces": {
+        "TenGigabitEthernet2/0/1": {
+            "admin_priority": "n/a",
+            "admin_state": "auto",
+            "oper_priority": "1",
+            "oper_state": "off"
+        }
+    },
+    "power_inline_auto_shutdown": "Disabled"
+}

--- a/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/input.txt
+++ b/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/input.txt
@@ -1,0 +1,7 @@
+Power inline auto shutdown: Disabled
+
+Interface  Admin  Oper       Admin      Oper
+           State  State      Priority   Priority
+---------- ------ ---------- ---------- --------
+
+Te2/0/1    auto   off        n/a        1

--- a/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/metadata.yaml
+++ b/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/metadata.yaml
@@ -1,0 +1,3 @@
+description: Output with oper priority column and auto shutdown status
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show power inline priority` command on Cisco IOS-XE
- Parses interface power inline priority table with admin/oper state, admin priority, and optional oper priority
- Handles both formats: with and without the `Power inline auto shutdown` header and oper priority column

## Test plan
- [x] 2 test cases: basic output (001) and output with oper priority column (002)
- [x] All quality checks pass (ruff, xenon, pre-commit)
- [x] `uv run pytest -k show_power_inline_priority` passes

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)