### PR TITLE
feat: add parser for 'show power inline consumption' on IOS-XE

### DIFF
--- a/changes/390.parser_added
+++ b/changes/390.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show power inline consumption' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_power_inline_consumption.py
+++ b/src/muninn/parsers/iosxe/show_power_inline_consumption.py
@@ -1,0 +1,83 @@
+"""Parser for 'show power inline consumption' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class PowerInlineConsumptionEntry(TypedDict):
+    """Schema for a single power inline consumption entry."""
+
+    consumption_configured: str
+    admin_consumption_watts: float
+
+
+class ShowPowerInlineConsumptionResult(TypedDict):
+    """Schema for 'show power inline consumption' parsed output."""
+
+    interfaces: dict[str, PowerInlineConsumptionEntry]
+
+
+@register(OS.CISCO_IOSXE, "show power inline consumption")
+class ShowPowerInlineConsumptionParser(
+    BaseParser[ShowPowerInlineConsumptionResult],
+):
+    """Parser for 'show power inline consumption' command.
+
+    Example output:
+        Interface  Consumption      Admin
+                   Configured    Consumption (Watts)
+        ---------- -----------  -------------------
+        Gi1/3          NO                 0.0
+        Gi1/4          NO                 0.0
+    """
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+(?P<configured>YES|NO)\s+(?P<watts>\d+(?:\.\d+)?)$",
+    )
+
+    _HEADER_PATTERN = re.compile(r"^-{2,}")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPowerInlineConsumptionResult:
+        """Parse 'show power inline consumption' output.
+
+        Args:
+            output: Raw CLI output from 'show power inline consumption' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        interfaces: dict[str, PowerInlineConsumptionEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if cls._HEADER_PATTERN.match(line):
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if match:
+                interface = canonical_interface_name(
+                    match.group("interface"),
+                    os=OS.CISCO_IOSXE,
+                )
+                interfaces[interface] = {
+                    "consumption_configured": match.group("configured"),
+                    "admin_consumption_watts": float(match.group("watts")),
+                }
+
+        if not interfaces:
+            msg = "No power inline consumption entries found in output"
+            raise ValueError(msg)
+
+        return {"interfaces": interfaces}

--- a/tests/parsers/iosxe/show_power_inline_consumption/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_power_inline_consumption/001_basic/expected.json
@@ -1,0 +1,52 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/10": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/3": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/4": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/5": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/6": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/7": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/8": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "GigabitEthernet1/9": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "TwoGigabitEthernet2/1": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "TwoGigabitEthernet2/2": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "TwoGigabitEthernet2/3": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        },
+        "TwoGigabitEthernet2/4": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_power_inline_consumption/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_power_inline_consumption/001_basic/input.txt
@@ -1,0 +1,16 @@
+Interface  Consumption      Admin
+           Configured    Consumption (Watts)
+---------- -----------  -------------------
+
+Gi1/3          NO                 0.0
+Gi1/4          NO                 0.0
+Gi1/5          NO                 0.0
+Gi1/6          NO                 0.0
+Gi1/7          NO                 0.0
+Gi1/8          NO                 0.0
+Gi1/9          NO                 0.0
+Gi1/10         NO                 0.0
+Tw2/1          NO                 0.0
+Tw2/2          NO                 0.0
+Tw2/3          NO                 0.0
+Tw2/4          NO                 0.0

--- a/tests/parsers/iosxe/show_power_inline_consumption/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_power_inline_consumption/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces with no consumption configured
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_power_inline_consumption/002_single_entry/expected.json
+++ b/tests/parsers/iosxe/show_power_inline_consumption/002_single_entry/expected.json
@@ -1,0 +1,8 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/4": {
+            "admin_consumption_watts": 0.0,
+            "consumption_configured": "NO"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_power_inline_consumption/002_single_entry/input.txt
+++ b/tests/parsers/iosxe/show_power_inline_consumption/002_single_entry/input.txt
@@ -1,0 +1,5 @@
+Interface  Consumption      Admin
+           Configured    Consumption (Watts)
+---------- -----------  -------------------
+
+Gi1/4          NO                 0.0

--- a/tests/parsers/iosxe/show_power_inline_consumption/002_single_entry/metadata.yaml
+++ b/tests/parsers/iosxe/show_power_inline_consumption/002_single_entry/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single interface entry
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show power inline consumption` command on Cisco IOS-XE
- Parses per-interface consumption configuration status and admin consumption wattage
- Canonicalizes interface names (e.g., `Gi1/3` -> `GigabitEthernet1/3`)

## Test plan
- [x] 2 test cases: basic multi-interface output and single-entry output
- [x] All pre-commit hooks pass
- [x] `ruff check`, `ruff format`, and `xenon` complexity checks pass

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)