### PR TITLE
feat: add parser for 'show ip eigrp timers' on IOS-XE

### DIFF
--- a/changes/391.parser_added
+++ b/changes/391.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip eigrp timers' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_eigrp_timers.py
+++ b/src/muninn/parsers/iosxe/show_ip_eigrp_timers.py
@@ -6,19 +6,31 @@ from typing import TypedDict
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
-class TimerEntry(TypedDict):
-    """Schema for a single timer entry."""
+class TimerAttributes(TypedDict):
+    """Schema for timer attributes."""
 
     expiration: float
-    timer_type: str
+
+
+class InterfaceTimers(TypedDict):
+    """Schema for interface-scoped timers."""
+
+    interfaces: dict[str, TimerAttributes]
+
+
+class TimerEntries(TypedDict):
+    """Schema for timers represented as repeated entries."""
+
+    entries: list[TimerAttributes]
 
 
 class EigrpProcessTimers(TypedDict):
     """Schema for timers within a single EIGRP process section."""
 
-    timers: list[TimerEntry]
+    timers: dict[str, InterfaceTimers | TimerEntries]
 
 
 class EigrpInstanceTimers(TypedDict):
@@ -38,6 +50,9 @@ _COMMAND_LINE = "show ip eigrp timers"
 _AS_PATTERN = re.compile(r"^EIGRP-IPv[46]\s+Timers\s+for\s+AS\((?P<as_number>\d+)\)")
 _SECTION_PATTERN = re.compile(r"^(?P<section>Hello|Update|SIA)\s+Process$")
 _TIMER_PATTERN = re.compile(r"^\|?\s+\|?\s*(?P<expiration>\d+\.\d+)\s+(?P<type>.+)$")
+_INTERFACE_TIMER_PATTERN = re.compile(
+    r"^(?P<timer_type>.+?)\s+\((?P<interface>[^()]+)\)$"
+)
 
 
 def _is_skip_line(line: str) -> bool:
@@ -65,17 +80,35 @@ def _handle_section_line(match: re.Match[str], state: _ParserState) -> None:
     """Handle a process section header line."""
     state.current_section = match.group("section").lower()
     processes = state.instances[state.current_as]["processes"]  # type: ignore[index]
-    processes[state.current_section] = EigrpProcessTimers(timers=[])
+    processes[state.current_section] = EigrpProcessTimers(timers={})
+
+
+def _normalize_timer_name(timer_type: str) -> str:
+    """Normalize timer names to snake_case keys."""
+    return re.sub(r"[^a-z0-9]+", "_", timer_type.lower()).strip("_")
 
 
 def _handle_timer_line(match: re.Match[str], state: _ParserState) -> None:
     """Handle a timer entry line."""
-    entry = TimerEntry(
-        expiration=float(match.group("expiration")),
-        timer_type=match.group("type").strip(),
-    )
+    timer_type = match.group("type").strip()
+    timer_data = TimerAttributes(expiration=float(match.group("expiration")))
     processes = state.instances[state.current_as]["processes"]  # type: ignore[index]
-    processes[state.current_section]["timers"].append(entry)  # type: ignore[index]
+    timers = processes[state.current_section]["timers"]  # type: ignore[index]
+
+    interface_match = _INTERFACE_TIMER_PATTERN.match(timer_type)
+    if interface_match and interface_match.group("interface") != "parent":
+        timer_name = _normalize_timer_name(interface_match.group("timer_type"))
+        interface = canonical_interface_name(
+            interface_match.group("interface"), os=OS.CISCO_IOSXE
+        )
+
+        bucket = timers.setdefault(timer_name, InterfaceTimers(interfaces={}))
+        bucket["interfaces"][interface] = timer_data  # type: ignore[index]
+        return
+
+    timer_name = _normalize_timer_name(timer_type.strip("()"))
+    bucket = timers.setdefault(timer_name, TimerEntries(entries=[]))
+    bucket["entries"].append(timer_data)  # type: ignore[index]
 
 
 @register(OS.CISCO_IOSXE, "show ip eigrp timers")
@@ -98,7 +131,7 @@ class ShowIpEigrpTimersParser(BaseParser[ShowIpEigrpTimersResult]):
             output: Raw CLI output from 'show ip eigrp timers'.
 
         Returns:
-            Parsed timer data keyed by AS number and process.
+            Parsed timer data keyed by AS number, process, and timer type.
 
         Raises:
             ValueError: If no EIGRP timer data found in output.

--- a/src/muninn/parsers/iosxe/show_ip_eigrp_timers.py
+++ b/src/muninn/parsers/iosxe/show_ip_eigrp_timers.py
@@ -1,0 +1,131 @@
+"""Parser for 'show ip eigrp timers' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class TimerEntry(TypedDict):
+    """Schema for a single timer entry."""
+
+    expiration: float
+    timer_type: str
+
+
+class EigrpProcessTimers(TypedDict):
+    """Schema for timers within a single EIGRP process section."""
+
+    timers: list[TimerEntry]
+
+
+class EigrpInstanceTimers(TypedDict):
+    """Schema for timers within a single EIGRP AS instance."""
+
+    processes: dict[str, EigrpProcessTimers]
+
+
+class ShowIpEigrpTimersResult(TypedDict):
+    """Schema for 'show ip eigrp timers' parsed output."""
+
+    instances: dict[str, EigrpInstanceTimers]
+
+
+_COMMAND_LINE = "show ip eigrp timers"
+
+_AS_PATTERN = re.compile(r"^EIGRP-IPv[46]\s+Timers\s+for\s+AS\((?P<as_number>\d+)\)")
+_SECTION_PATTERN = re.compile(r"^(?P<section>Hello|Update|SIA)\s+Process$")
+_TIMER_PATTERN = re.compile(r"^\|?\s+\|?\s*(?P<expiration>\d+\.\d+)\s+(?P<type>.+)$")
+
+
+def _is_skip_line(line: str) -> bool:
+    """Return True if the line should be skipped."""
+    return not line or line.startswith("Expiration") or line == _COMMAND_LINE
+
+
+class _ParserState:
+    """Mutable state for the EIGRP timers parser."""
+
+    def __init__(self) -> None:
+        self.instances: dict[str, EigrpInstanceTimers] = {}
+        self.current_as: str | None = None
+        self.current_section: str | None = None
+
+
+def _handle_as_line(match: re.Match[str], state: _ParserState) -> None:
+    """Handle an AS header line."""
+    state.current_as = match.group("as_number")
+    state.instances[state.current_as] = EigrpInstanceTimers(processes={})
+    state.current_section = None
+
+
+def _handle_section_line(match: re.Match[str], state: _ParserState) -> None:
+    """Handle a process section header line."""
+    state.current_section = match.group("section").lower()
+    processes = state.instances[state.current_as]["processes"]  # type: ignore[index]
+    processes[state.current_section] = EigrpProcessTimers(timers=[])
+
+
+def _handle_timer_line(match: re.Match[str], state: _ParserState) -> None:
+    """Handle a timer entry line."""
+    entry = TimerEntry(
+        expiration=float(match.group("expiration")),
+        timer_type=match.group("type").strip(),
+    )
+    processes = state.instances[state.current_as]["processes"]  # type: ignore[index]
+    processes[state.current_section]["timers"].append(entry)  # type: ignore[index]
+
+
+@register(OS.CISCO_IOSXE, "show ip eigrp timers")
+class ShowIpEigrpTimersParser(BaseParser[ShowIpEigrpTimersResult]):
+    """Parser for 'show ip eigrp timers' command.
+
+    Example output:
+        EIGRP-IPv4 Timers for AS(100)
+          Hello Process
+            Expiration    Type
+        |           1.724  (parent)
+          |           1.724  Hello (Te0/0/6.20)
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpEigrpTimersResult:
+        """Parse 'show ip eigrp timers' output.
+
+        Args:
+            output: Raw CLI output from 'show ip eigrp timers'.
+
+        Returns:
+            Parsed timer data keyed by AS number and process.
+
+        Raises:
+            ValueError: If no EIGRP timer data found in output.
+        """
+        state = _ParserState()
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if _is_skip_line(stripped):
+                continue
+
+            as_match = _AS_PATTERN.match(stripped)
+            if as_match:
+                _handle_as_line(as_match, state)
+                continue
+
+            section_match = _SECTION_PATTERN.match(stripped)
+            if section_match and state.current_as is not None:
+                _handle_section_line(section_match, state)
+                continue
+
+            timer_match = _TIMER_PATTERN.match(stripped)
+            if timer_match and state.current_section is not None:
+                _handle_timer_line(timer_match, state)
+
+        if not state.instances:
+            msg = "No EIGRP timer data found in output"
+            raise ValueError(msg)
+
+        return ShowIpEigrpTimersResult(instances=state.instances)

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/expected.json
@@ -1,0 +1,80 @@
+{
+    "instances": {
+        "100": {
+            "processes": {
+                "hello": {
+                    "timers": [
+                        {
+                            "expiration": 1.724,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 1.724,
+                            "timer_type": "Hello (Te0/0/6.20)"
+                        },
+                        {
+                            "expiration": 2.294,
+                            "timer_type": "Hello (Te0/0/4)"
+                        },
+                        {
+                            "expiration": 2.923,
+                            "timer_type": "Hello (Te0/0/10)"
+                        }
+                    ]
+                },
+                "sia": {
+                    "timers": [
+                        {
+                            "expiration": 0.0,
+                            "timer_type": "(parent)"
+                        }
+                    ]
+                },
+                "update": {
+                    "timers": [
+                        {
+                            "expiration": 4.78,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 4.78,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 4.78,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 4.78,
+                            "timer_type": "Peer transmission"
+                        },
+                        {
+                            "expiration": 10.457,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 10.457,
+                            "timer_type": "Peer holding"
+                        },
+                        {
+                            "expiration": 11.22,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 11.22,
+                            "timer_type": "Peer holding"
+                        },
+                        {
+                            "expiration": 12.303,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 12.303,
+                            "timer_type": "Peer holding"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/expected.json
@@ -3,76 +3,85 @@
         "100": {
             "processes": {
                 "hello": {
-                    "timers": [
-                        {
-                            "expiration": 1.724,
-                            "timer_type": "(parent)"
+                    "timers": {
+                        "hello": {
+                            "interfaces": {
+                                "TenGigabitEthernet0/0/10": {
+                                    "expiration": 2.923
+                                },
+                                "TenGigabitEthernet0/0/4": {
+                                    "expiration": 2.294
+                                },
+                                "TenGigabitEthernet0/0/6.20": {
+                                    "expiration": 1.724
+                                }
+                            }
                         },
-                        {
-                            "expiration": 1.724,
-                            "timer_type": "Hello (Te0/0/6.20)"
-                        },
-                        {
-                            "expiration": 2.294,
-                            "timer_type": "Hello (Te0/0/4)"
-                        },
-                        {
-                            "expiration": 2.923,
-                            "timer_type": "Hello (Te0/0/10)"
+                        "parent": {
+                            "entries": [
+                                {
+                                    "expiration": 1.724
+                                }
+                            ]
                         }
-                    ]
+                    }
                 },
                 "sia": {
-                    "timers": [
-                        {
-                            "expiration": 0.0,
-                            "timer_type": "(parent)"
+                    "timers": {
+                        "parent": {
+                            "entries": [
+                                {
+                                    "expiration": 0.0
+                                }
+                            ]
                         }
-                    ]
+                    }
                 },
                 "update": {
-                    "timers": [
-                        {
-                            "expiration": 4.78,
-                            "timer_type": "(parent)"
+                    "timers": {
+                        "parent": {
+                            "entries": [
+                                {
+                                    "expiration": 4.78
+                                },
+                                {
+                                    "expiration": 4.78
+                                },
+                                {
+                                    "expiration": 4.78
+                                },
+                                {
+                                    "expiration": 10.457
+                                },
+                                {
+                                    "expiration": 11.22
+                                },
+                                {
+                                    "expiration": 12.303
+                                }
+                            ]
                         },
-                        {
-                            "expiration": 4.78,
-                            "timer_type": "(parent)"
+                        "peer_holding": {
+                            "entries": [
+                                {
+                                    "expiration": 10.457
+                                },
+                                {
+                                    "expiration": 11.22
+                                },
+                                {
+                                    "expiration": 12.303
+                                }
+                            ]
                         },
-                        {
-                            "expiration": 4.78,
-                            "timer_type": "(parent)"
-                        },
-                        {
-                            "expiration": 4.78,
-                            "timer_type": "Peer transmission"
-                        },
-                        {
-                            "expiration": 10.457,
-                            "timer_type": "(parent)"
-                        },
-                        {
-                            "expiration": 10.457,
-                            "timer_type": "Peer holding"
-                        },
-                        {
-                            "expiration": 11.22,
-                            "timer_type": "(parent)"
-                        },
-                        {
-                            "expiration": 11.22,
-                            "timer_type": "Peer holding"
-                        },
-                        {
-                            "expiration": 12.303,
-                            "timer_type": "(parent)"
-                        },
-                        {
-                            "expiration": 12.303,
-                            "timer_type": "Peer holding"
+                        "peer_transmission": {
+                            "entries": [
+                                {
+                                    "expiration": 4.78
+                                }
+                            ]
                         }
-                    ]
+                    }
                 }
             }
         }

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/input.txt
@@ -1,0 +1,25 @@
+show ip eigrp timers
+EIGRP-IPv4 Timers for AS(100)
+  Hello Process
+    Expiration    Type
+|           1.724  (parent)
+  |           1.724  Hello (Te0/0/6.20)
+  |           2.294  Hello (Te0/0/4)
+  |           2.923  Hello (Te0/0/10)
+
+  Update Process
+    Expiration    Type
+|           4.780  (parent)
+  |           4.780  (parent)
+    |           4.780  (parent)
+      |           4.780  Peer transmission
+  |          10.457  (parent)
+    |          10.457  Peer holding
+  |          11.220  (parent)
+    |          11.220  Peer holding
+  |          12.303  (parent)
+    |          12.303  Peer holding
+
+  SIA Process
+    Expiration    Type
+|           0.000  (parent)

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple hello peers with update and SIA timers
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/expected.json
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/expected.json
@@ -1,0 +1,44 @@
+{
+    "instances": {
+        "100": {
+            "processes": {
+                "hello": {
+                    "timers": [
+                        {
+                            "expiration": 2.985,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 2.985,
+                            "timer_type": "Hello (Te0/0/4)"
+                        }
+                    ]
+                },
+                "sia": {
+                    "timers": [
+                        {
+                            "expiration": 0.0,
+                            "timer_type": "(parent)"
+                        }
+                    ]
+                },
+                "update": {
+                    "timers": [
+                        {
+                            "expiration": 13.19,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 13.19,
+                            "timer_type": "(parent)"
+                        },
+                        {
+                            "expiration": 13.19,
+                            "timer_type": "Peer holding"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/expected.json
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/expected.json
@@ -3,40 +3,54 @@
         "100": {
             "processes": {
                 "hello": {
-                    "timers": [
-                        {
-                            "expiration": 2.985,
-                            "timer_type": "(parent)"
+                    "timers": {
+                        "hello": {
+                            "interfaces": {
+                                "TenGigabitEthernet0/0/4": {
+                                    "expiration": 2.985
+                                }
+                            }
                         },
-                        {
-                            "expiration": 2.985,
-                            "timer_type": "Hello (Te0/0/4)"
+                        "parent": {
+                            "entries": [
+                                {
+                                    "expiration": 2.985
+                                }
+                            ]
                         }
-                    ]
+                    }
                 },
                 "sia": {
-                    "timers": [
-                        {
-                            "expiration": 0.0,
-                            "timer_type": "(parent)"
+                    "timers": {
+                        "parent": {
+                            "entries": [
+                                {
+                                    "expiration": 0.0
+                                }
+                            ]
                         }
-                    ]
+                    }
                 },
                 "update": {
-                    "timers": [
-                        {
-                            "expiration": 13.19,
-                            "timer_type": "(parent)"
+                    "timers": {
+                        "parent": {
+                            "entries": [
+                                {
+                                    "expiration": 13.19
+                                },
+                                {
+                                    "expiration": 13.19
+                                }
+                            ]
                         },
-                        {
-                            "expiration": 13.19,
-                            "timer_type": "(parent)"
-                        },
-                        {
-                            "expiration": 13.19,
-                            "timer_type": "Peer holding"
+                        "peer_holding": {
+                            "entries": [
+                                {
+                                    "expiration": 13.19
+                                }
+                            ]
                         }
-                    ]
+                    }
                 }
             }
         }

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/input.txt
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/input.txt
@@ -1,0 +1,16 @@
+show ip eigrp timers
+EIGRP-IPv4 Timers for AS(100)
+  Hello Process
+    Expiration    Type
+|           2.985  (parent)
+  |           2.985  Hello (Te0/0/4)
+
+  Update Process
+    Expiration    Type
+|          13.190  (parent)
+  |          13.190  (parent)
+    |          13.190  Peer holding
+
+  SIA Process
+    Expiration    Type
+|           0.000  (parent)

--- a/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_eigrp_timers/002_single_hello_peer/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single hello peer with minimal update and SIA timers
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add section-based parser for `show ip eigrp timers` on IOS-XE
- Extracts per-AS instance timer data across Hello, Update, and SIA processes
- Includes 2 test cases sourced from Genie parser test data

## Test plan
- [x] `uv run pytest tests/parsers/iosxe/show_ip_eigrp_timers/ -v` — 2 tests pass
- [x] `uv run ruff check` and `uv run ruff format` — clean
- [x] `uv run xenon --max-absolute B` — passes
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)