### PR TITLE
feat: add parser for 'show ip eigrp interfaces' on IOS-XE

### DIFF
--- a/changes/393.parser_added
+++ b/changes/393.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip eigrp interfaces' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_eigrp_interfaces.py
+++ b/src/muninn/parsers/iosxe/show_ip_eigrp_interfaces.py
@@ -1,0 +1,200 @@
+"""Parser for 'show ip eigrp interfaces' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class EigrpInterfaceEntry(TypedDict):
+    """Schema for a single EIGRP interface entry."""
+
+    peers: int
+    xmit_q_unreliable: int
+    xmit_q_reliable: int
+    peer_q_unreliable: int
+    peer_q_reliable: int
+    mean_srtt: int
+    pacing_time_unreliable: int
+    pacing_time_reliable: int
+    mcast_flow_timer: int
+    pending_routes: int
+
+
+class _HeaderInfo(TypedDict):
+    """Parsed header metadata."""
+
+    as_number: int
+    address_family: str
+    named_mode: bool
+    vrf: NotRequired[str]
+    name: NotRequired[str]
+
+
+class ShowIpEigrpInterfacesResult(TypedDict):
+    """Schema for 'show ip eigrp interfaces' parsed output."""
+
+    as_number: int
+    address_family: str
+    named_mode: bool
+    vrf: NotRequired[str]
+    name: NotRequired[str]
+    interfaces: dict[str, EigrpInterfaceEntry]
+
+
+_HEADER_PATTERN = re.compile(
+    r"EIGRP-(?P<address_family>IPv4|IPv6)\s+"
+    r"(?:VR\((?P<name>\w+)\)\s+Address-Family\s+)?"
+    r"Interfaces\s+for\s+AS\(\s*(?P<as_number>\S+)\)"
+    r"(?:\s*VRF\((?P<vrf>\S+)\))?"
+)
+
+_VRF_LINE_PATTERN = re.compile(r"^\s*VRF\((?P<vrf>\S+)\)\s*$")
+
+_ROW_PATTERN = re.compile(
+    r"^(?P<interface>\S+\d\S*)\s+"
+    r"(?P<peers>\d+)\s+"
+    r"(?P<xmit_q_unreliable>\d+)"
+    r"/(?P<xmit_q_reliable>\d+)\s+"
+    r"(?P<peer_q_unreliable>\d+)"
+    r"/(?P<peer_q_reliable>\d+)\s+"
+    r"(?P<mean_srtt>\d+)\s+"
+    r"(?P<pacing_t_unreliable>\d+)"
+    r"/(?P<pacing_t_reliable>\d+)\s+"
+    r"(?P<mcast_flow_timer>\d+)\s+"
+    r"(?P<pend_routes>\d+)\s*$"
+)
+
+
+def _parse_header(
+    match: re.Match[str],
+) -> _HeaderInfo:
+    """Extract header metadata from a header regex match."""
+    info = _HeaderInfo(
+        as_number=int(match.group("as_number")),
+        address_family=match.group("address_family").lower(),
+        named_mode=match.group("name") is not None,
+    )
+    name = match.group("name")
+    if name is not None:
+        info["name"] = name
+    vrf = match.group("vrf")
+    if vrf:
+        info["vrf"] = vrf
+    return info
+
+
+def _build_entry(
+    match: re.Match[str],
+) -> EigrpInterfaceEntry:
+    """Build an EigrpInterfaceEntry from a row match."""
+    return EigrpInterfaceEntry(
+        peers=int(match.group("peers")),
+        xmit_q_unreliable=int(match.group("xmit_q_unreliable")),
+        xmit_q_reliable=int(match.group("xmit_q_reliable")),
+        peer_q_unreliable=int(match.group("peer_q_unreliable")),
+        peer_q_reliable=int(match.group("peer_q_reliable")),
+        mean_srtt=int(match.group("mean_srtt")),
+        pacing_time_unreliable=int(match.group("pacing_t_unreliable")),
+        pacing_time_reliable=int(match.group("pacing_t_reliable")),
+        mcast_flow_timer=int(match.group("mcast_flow_timer")),
+        pending_routes=int(match.group("pend_routes")),
+    )
+
+
+def _process_line(
+    stripped: str,
+    header: _HeaderInfo | None,
+    vrf: str | None,
+    interfaces: dict[str, EigrpInterfaceEntry],
+) -> tuple[_HeaderInfo | None, str | None]:
+    """Process a single line, returning updated header and vrf."""
+    hdr = _HEADER_PATTERN.search(stripped)
+    if hdr:
+        return _parse_header(hdr), vrf
+
+    vrf_match = _VRF_LINE_PATTERN.match(stripped)
+    if vrf_match:
+        return header, vrf_match.group("vrf")
+
+    row = _ROW_PATTERN.match(stripped)
+    if row:
+        iface = canonical_interface_name(
+            row.group("interface"),
+            os=OS.CISCO_IOSXE,
+        )
+        interfaces[iface] = _build_entry(row)
+
+    return header, vrf
+
+
+def _build_result(
+    header: _HeaderInfo | None,
+    vrf: str | None,
+    interfaces: dict[str, EigrpInterfaceEntry],
+) -> ShowIpEigrpInterfacesResult:
+    """Validate parsed data and build the result dict."""
+    if header is None:
+        msg = "No EIGRP interface header found in output"
+        raise ValueError(msg)
+
+    if not interfaces:
+        msg = "No EIGRP interface entries found"
+        raise ValueError(msg)
+
+    result = ShowIpEigrpInterfacesResult(
+        as_number=header["as_number"],
+        address_family=header["address_family"],
+        named_mode=header["named_mode"],
+        interfaces=interfaces,
+    )
+
+    if "name" in header:
+        result["name"] = header["name"]
+
+    resolved_vrf = vrf or header.get("vrf")
+    if resolved_vrf is not None:
+        result["vrf"] = resolved_vrf
+
+    return result
+
+
+@register(OS.CISCO_IOSXE, "show ip eigrp interfaces")
+class ShowIpEigrpInterfacesParser(
+    BaseParser[ShowIpEigrpInterfacesResult],
+):
+    """Parser for 'show ip eigrp interfaces' command.
+
+    Example output::
+
+        EIGRP-IPv4 Interfaces for AS(1)
+        Gi1  1  0/0  0/0  20  0/0  84  0
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpEigrpInterfacesResult:
+        """Parse 'show ip eigrp interfaces' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed EIGRP interface data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        header: _HeaderInfo | None = None
+        vrf: str | None = None
+        interfaces: dict[str, EigrpInterfaceEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            header, vrf = _process_line(stripped, header, vrf, interfaces)
+
+        return _build_result(header, vrf, interfaces)

--- a/tests/parsers/iosxe/show_ip_eigrp_interfaces/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_eigrp_interfaces/001_basic/expected.json
@@ -1,0 +1,43 @@
+{
+    "address_family": "ipv4",
+    "as_number": 1,
+    "interfaces": {
+        "GigabitEthernet1": {
+            "mcast_flow_timer": 84,
+            "mean_srtt": 20,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 1,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        },
+        "GigabitEthernet2": {
+            "mcast_flow_timer": 50,
+            "mean_srtt": 5,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 1,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        },
+        "Loopback0": {
+            "mcast_flow_timer": 0,
+            "mean_srtt": 0,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 0,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        }
+    },
+    "named_mode": false
+}

--- a/tests/parsers/iosxe/show_ip_eigrp_interfaces/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_eigrp_interfaces/001_basic/input.txt
@@ -1,0 +1,6 @@
+EIGRP-IPv4 Interfaces for AS(1)
+                              Xmit Queue   PeerQ        Mean   Pacing Time   Multicast    Pending
+Interface              Peers  Un/Reliable  Un/Reliable  SRTT   Un/Reliable   Flow Timer   Routes
+Gi1                      1        0/0       0/0          20       0/0           84           0
+Gi2                      1        0/0       0/0           5       0/0           50           0
+Lo0                      0        0/0       0/0           0       0/0            0           0

--- a/tests/parsers/iosxe/show_ip_eigrp_interfaces/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_eigrp_interfaces/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with multiple interfaces including loopback
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_ip_eigrp_interfaces/002_named_mode_with_vrf/expected.json
+++ b/tests/parsers/iosxe/show_ip_eigrp_interfaces/002_named_mode_with_vrf/expected.json
@@ -1,0 +1,21 @@
+{
+    "address_family": "ipv4",
+    "as_number": 100,
+    "interfaces": {
+        "GigabitEthernet0/0/0.1": {
+            "mcast_flow_timer": 0,
+            "mean_srtt": 0,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 0,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        }
+    },
+    "name": "test",
+    "named_mode": true,
+    "vrf": "1"
+}

--- a/tests/parsers/iosxe/show_ip_eigrp_interfaces/002_named_mode_with_vrf/input.txt
+++ b/tests/parsers/iosxe/show_ip_eigrp_interfaces/002_named_mode_with_vrf/input.txt
@@ -1,0 +1,5 @@
+EIGRP-IPv4 VR(test) Address-Family Interfaces for AS(100)
+           VRF(1)
+                              Xmit Queue   PeerQ        Mean   Pacing Time   Multicast    Pending
+Interface              Peers  Un/Reliable  Un/Reliable  SRTT   Un/Reliable   Flow Timer   Routes
+Gi0/0/0.1                0        0/0       0/0           0       0/0            0           0

--- a/tests/parsers/iosxe/show_ip_eigrp_interfaces/002_named_mode_with_vrf/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_eigrp_interfaces/002_named_mode_with_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: Named mode EIGRP with VRF and subinterface
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ip eigrp interfaces` on Cisco IOS-XE
- Supports standard and named-mode EIGRP output, including VRF
- Parses per-interface metrics: peers, queue counts, SRTT, pacing times, flow timer, pending routes
- Includes 2 test cases: basic multi-interface output and named-mode with VRF

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_ip_eigrp_interfaces -v` -- 2 tests pass
- [x] `uv run ruff check` -- clean
- [x] `uv run xenon --max-absolute B` -- clean
- [x] `uv run pre-commit run --all-files` -- all hooks pass

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)