### PR TITLE
refactor: nest SNMP groups by security model

### DIFF
--- a/src/muninn/parsers/ios/show_snmp_group.py
+++ b/src/muninn/parsers/ios/show_snmp_group.py
@@ -25,7 +25,7 @@ class SnmpGroupEntry(TypedDict):
 class ShowSnmpGroupResult(TypedDict):
     """Schema for 'show snmp group' parsed output."""
 
-    groups: dict[str, SnmpGroupEntry]
+    groups: dict[str, dict[str, SnmpGroupEntry]]
 
 
 _SEPARATOR_PATTERN = re.compile(r"^\s*$")
@@ -137,20 +137,20 @@ class ShowSnmpGroupParser(BaseParser[ShowSnmpGroupResult]):
             output: Raw CLI output from 'show snmp group' command.
 
         Returns:
-            Parsed data with groups keyed by 'group_name:security_model'.
+            Parsed data with groups keyed by group name, then security model.
 
         Raises:
             ValueError: If the output cannot be parsed.
         """
-        groups: dict[str, SnmpGroupEntry] = {}
+        groups: dict[str, dict[str, SnmpGroupEntry]] = {}
         current_block: list[str] = []
 
         for line in output.splitlines():
             if _SEPARATOR_PATTERN.match(line) and current_block:
                 entry = _parse_block(current_block)
                 if entry is not None:
-                    key = f"{entry['group_name']}:{entry['security_model']}"
-                    groups[key] = entry
+                    group_entries = groups.setdefault(entry["group_name"], {})
+                    group_entries[entry["security_model"]] = entry
                 current_block = []
             else:
                 current_block.append(line)
@@ -159,8 +159,8 @@ class ShowSnmpGroupParser(BaseParser[ShowSnmpGroupResult]):
         if current_block:
             entry = _parse_block(current_block)
             if entry is not None:
-                key = f"{entry['group_name']}:{entry['security_model']}"
-                groups[key] = entry
+                group_entries = groups.setdefault(entry["group_name"], {})
+                group_entries[entry["security_model"]] = entry
 
         if not groups:
             msg = "No SNMP group entries found in output"

--- a/tests/parsers/ios/show_snmp_group/001_basic/expected.json
+++ b/tests/parsers/ios/show_snmp_group/001_basic/expected.json
@@ -1,61 +1,69 @@
 {
     "groups": {
-        "GROUP1:v3 priv": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP1",
-            "notify_view": "g1notifyview",
-            "read_view": "g1readview",
-            "row_status": "active",
-            "security_model": "v3 priv",
-            "storage_type": "nonvolatile"
+        "GROUP1": {
+            "v3 priv": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP1",
+                "notify_view": "g1notifyview",
+                "read_view": "g1readview",
+                "row_status": "active",
+                "security_model": "v3 priv",
+                "storage_type": "nonvolatile"
+            }
         },
-        "GROUP2:v1": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP2",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v1",
-            "storage_type": "nonvolatile"
+        "GROUP2": {
+            "v1": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP2",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v1",
+                "storage_type": "nonvolatile"
+            },
+            "v2c": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP2",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v2c",
+                "storage_type": "nonvolatile"
+            }
         },
-        "GROUP2:v2c": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP2",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v2c",
-            "storage_type": "nonvolatile"
+        "GROUP3": {
+            "v1": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP3",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v1",
+                "storage_type": "nonvolatile"
+            },
+            "v2c": {
+                "access_list": "snmp-acl-name",
+                "group_name": "GROUP3",
+                "read_view": "v1default",
+                "row_status": "active",
+                "security_model": "v2c",
+                "storage_type": "nonvolatile"
+            }
         },
-        "GROUP3:v1": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP3",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v1",
-            "storage_type": "nonvolatile"
-        },
-        "GROUP3:v2c": {
-            "access_list": "snmp-acl-name",
-            "group_name": "GROUP3",
-            "read_view": "v1default",
-            "row_status": "active",
-            "security_model": "v2c",
-            "storage_type": "nonvolatile"
-        },
-        "ILMI:v1": {
-            "group_name": "ILMI",
-            "read_view": "*ilmi",
-            "row_status": "active",
-            "security_model": "v1",
-            "storage_type": "permanent",
-            "write_view": "*ilmi"
-        },
-        "ILMI:v2c": {
-            "group_name": "ILMI",
-            "read_view": "*ilmi",
-            "row_status": "active",
-            "security_model": "v2c",
-            "storage_type": "permanent",
-            "write_view": "*ilmi"
+        "ILMI": {
+            "v1": {
+                "group_name": "ILMI",
+                "read_view": "*ilmi",
+                "row_status": "active",
+                "security_model": "v1",
+                "storage_type": "permanent",
+                "write_view": "*ilmi"
+            },
+            "v2c": {
+                "group_name": "ILMI",
+                "read_view": "*ilmi",
+                "row_status": "active",
+                "security_model": "v2c",
+                "storage_type": "permanent",
+                "write_view": "*ilmi"
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_snmp_group/002_single_group/expected.json
+++ b/tests/parsers/ios/show_snmp_group/002_single_group/expected.json
@@ -1,13 +1,15 @@
 {
     "groups": {
-        "NETADMIN:v3 auth": {
-            "group_name": "NETADMIN",
-            "notify_view": "fullview",
-            "read_view": "fullview",
-            "row_status": "active",
-            "security_model": "v3 auth",
-            "storage_type": "nonvolatile",
-            "write_view": "fullview"
+        "NETADMIN": {
+            "v3 auth": {
+                "group_name": "NETADMIN",
+                "notify_view": "fullview",
+                "read_view": "fullview",
+                "row_status": "active",
+                "security_model": "v3 auth",
+                "storage_type": "nonvolatile",
+                "write_view": "fullview"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- nest `show snmp group` parser results under each group name instead of flattening `group_name:security_model` into one key
- preserve the existing entry fields while allowing multiple security models under the same group
- update parser fixtures to match the new nested structure

## Testing
- `uv run pytest tests/parsers/test_parsers.py -k show_snmp_group`