### PR TITLE
feat: add parser for 'show vrrp brief all' on IOS-XE

### DIFF
--- a/changes/395.parser_added
+++ b/changes/395.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show vrrp brief all' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vrrp_brief.py
+++ b/src/muninn/parsers/iosxe/show_vrrp_brief.py
@@ -91,6 +91,7 @@ _HEADER_PATTERN = re.compile(r"^\s*Interface\s+Grp", re.IGNORECASE)
 
 
 @register(OS.CISCO_IOSXE, "show vrrp brief")
+@register(OS.CISCO_IOSXE, "show vrrp brief all")
 class ShowVrrpBriefParser(BaseParser[ShowVrrpBriefResult]):
     """Parser for 'show vrrp brief' command.
 

--- a/tests/parsers/iosxe/show_vrrp_brief_all/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vrrp_brief_all/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "interfaces": {
+        "GigabitEthernet3.415": {
+            "groups": {
+                "13": {
+                    "group": 13,
+                    "group_address": "10.13.115.254",
+                    "master_address": "10.13.115.1",
+                    "owner": false,
+                    "preempt": true,
+                    "priority": 100,
+                    "state": "master",
+                    "time": 3609
+                }
+            }
+        },
+        "GigabitEthernet3.420": {
+            "groups": {
+                "10": {
+                    "group": 10,
+                    "group_address": "10.13.120.254",
+                    "master_address": "10.13.120.1",
+                    "owner": false,
+                    "preempt": true,
+                    "priority": 100,
+                    "state": "master",
+                    "time": 3609
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vrrp_brief_all/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vrrp_brief_all/001_basic/input.txt
@@ -1,0 +1,3 @@
+Interface          Grp Pri Time  Own Pre State   Master addr     Group addr
+Gi3.420            10  100 3609       Y  Master  10.13.120.1     10.13.120.254
+Gi3.415            13  100 3609       Y  Master  10.13.115.1     10.13.115.254

--- a/tests/parsers/iosxe/show_vrrp_brief_all/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vrrp_brief_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: VRRPv2 output with two interfaces
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_vrrp_brief_all/002_vrrpv3_format/expected.json
+++ b/tests/parsers/iosxe/show_vrrp_brief_all/002_vrrpv3_format/expected.json
@@ -1,0 +1,49 @@
+{
+    "interfaces": {
+        "VLAN10": {
+            "groups": {
+                "1": {
+                    "address_family": "IPv4",
+                    "group": 1,
+                    "group_address": "10.1.0.3",
+                    "master_address": "10.1.0.1",
+                    "owner": false,
+                    "preempt": true,
+                    "priority": 150,
+                    "state": "master",
+                    "time": 0
+                }
+            }
+        },
+        "VLAN11": {
+            "groups": {
+                "2": {
+                    "address_family": "IPv4",
+                    "group": 2,
+                    "group_address": "10.1.1.3",
+                    "master_address": "10.1.1.1",
+                    "owner": false,
+                    "preempt": true,
+                    "priority": 150,
+                    "state": "master",
+                    "time": 0
+                }
+            }
+        },
+        "VLAN12": {
+            "groups": {
+                "3": {
+                    "address_family": "IPv4",
+                    "group": 3,
+                    "group_address": "10.1.2.3",
+                    "master_address": "10.1.2.100",
+                    "owner": false,
+                    "preempt": true,
+                    "priority": 100,
+                    "state": "backup",
+                    "time": 0
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vrrp_brief_all/002_vrrpv3_format/input.txt
+++ b/tests/parsers/iosxe/show_vrrp_brief_all/002_vrrpv3_format/input.txt
@@ -1,0 +1,4 @@
+Interface          Grp  A-F Pri  Time Own Pre State   Master addr/Group addr
+Vl10                 1 IPv4 150     0  N   Y  MASTER  10.1.0.1(local) 10.1.0.3
+Vl11                 2 IPv4 150     0  N   Y  MASTER  10.1.1.1(local) 10.1.1.3
+Vl12                 3 IPv4 100     0  N   Y  BACKUP  10.1.2.100 10.1.2.3

--- a/tests/parsers/iosxe/show_vrrp_brief_all/002_vrrpv3_format/metadata.yaml
+++ b/tests/parsers/iosxe/show_vrrp_brief_all/002_vrrpv3_format/metadata.yaml
@@ -1,0 +1,3 @@
+description: VRRPv3 output with address family column and local suffix
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Registers the existing `show vrrp brief` parser for `show vrrp brief all` on IOS-XE, since both commands produce identical tabular output (VRRPv2 and VRRPv3 formats)
- Adds two test cases: VRRPv2 format with multiple interfaces, and VRRPv3 format with address family column and local suffix

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_vrrp_brief_all" -v` — 2 tests pass
- [x] `uv run ruff check` and `uv run ruff format` — clean
- [x] `uv run xenon --max-absolute B` — passes
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)