### PR TITLE
feat: add parser for 'show environment temperature' on NX-OS

### DIFF
--- a/changes/396.parser_added
+++ b/changes/396.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show environment temperature' on NX-OS.

--- a/src/muninn/parsers/nxos/show_environment_temperature.py
+++ b/src/muninn/parsers/nxos/show_environment_temperature.py
@@ -70,7 +70,7 @@ class ShowEnvironmentTemperatureParser(
 
             if match := _TEMP_ROW.match(line):
                 module = match.group("module")
-                sensor = match.group("sensor").strip()
+                sensor = " ".join(match.group("sensor").split())
                 sensor_entry: TemperatureSensorEntry = {
                     "major_threshold_celsius": int(match.group("major")),
                     "minor_threshold_celsius": int(match.group("minor")),

--- a/src/muninn/parsers/nxos/show_environment_temperature.py
+++ b/src/muninn/parsers/nxos/show_environment_temperature.py
@@ -1,0 +1,88 @@
+"""Parser for 'show environment temperature' command on NX-OS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class TemperatureSensorEntry(TypedDict):
+    """Schema for a single temperature sensor entry."""
+
+    major_threshold_celsius: int
+    minor_threshold_celsius: int
+    current_temp_celsius: int
+    status: str
+
+
+class ShowEnvironmentTemperatureResult(TypedDict):
+    """Schema for 'show environment temperature' parsed output."""
+
+    temperatures: dict[str, dict[str, TemperatureSensorEntry]]
+
+
+_SEPARATOR = re.compile(r"^-{3,}")
+_HEADER_LINE = re.compile(r"^\s*(?:Module\s+Sensor|\(Celsius)")
+
+_TEMP_ROW = re.compile(
+    r"^(?P<module>\d+)\s+(?P<sensor>.+?)\s{2,}(?P<major>\d+)\s+(?P<minor>\d+)\s+"
+    r"(?P<current>\d+)\s+(?P<status>\S+)"
+)
+
+
+@register(OS.CISCO_NXOS, "show environment temperature")
+class ShowEnvironmentTemperatureParser(
+    BaseParser[ShowEnvironmentTemperatureResult],
+):
+    """Parser for 'show environment temperature' command.
+
+    Example output:
+        Temperature
+        ---------------------------------------------------------------
+        Module  Sensor             MajorThresh   MinorThres   CurTemp     Status
+                                    (Celsius)     (Celsius)   (Celsius)
+        ---------------------------------------------------------------
+        1       ASIC                101           95           52          ok
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEnvironmentTemperatureResult:
+        """Parse 'show environment temperature' output.
+
+        Args:
+            output: Raw CLI output from 'show environment temperature' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        temps: dict[str, dict[str, TemperatureSensorEntry]] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            if not line or _SEPARATOR.match(line) or _HEADER_LINE.match(line):
+                continue
+
+            if match := _TEMP_ROW.match(line):
+                module = match.group("module")
+                sensor = match.group("sensor").strip()
+                sensor_entry: TemperatureSensorEntry = {
+                    "major_threshold_celsius": int(match.group("major")),
+                    "minor_threshold_celsius": int(match.group("minor")),
+                    "current_temp_celsius": int(match.group("current")),
+                    "status": match.group("status"),
+                }
+                if module not in temps:
+                    temps[module] = {}
+                temps[module][sensor] = sensor_entry
+
+        if not temps:
+            msg = "No temperature entries found in output"
+            raise ValueError(msg)
+
+        return {"temperatures": temps}

--- a/tests/parsers/nxos/show_environment_temperature/001_basic/expected.json
+++ b/tests/parsers/nxos/show_environment_temperature/001_basic/expected.json
@@ -1,0 +1,30 @@
+{
+    "temperatures": {
+        "1": {
+            "ASIC": {
+                "current_temp_celsius": 52,
+                "major_threshold_celsius": 101,
+                "minor_threshold_celsius": 95,
+                "status": "ok"
+            },
+            "Back        (D3)": {
+                "current_temp_celsius": 28,
+                "major_threshold_celsius": 48,
+                "minor_threshold_celsius": 42,
+                "status": "ok"
+            },
+            "Front-Left  (D2)": {
+                "current_temp_celsius": 33,
+                "major_threshold_celsius": 52,
+                "minor_threshold_celsius": 44,
+                "status": "ok"
+            },
+            "Front-Middle(D1)": {
+                "current_temp_celsius": 38,
+                "major_threshold_celsius": 62,
+                "minor_threshold_celsius": 56,
+                "status": "ok"
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_environment_temperature/001_basic/expected.json
+++ b/tests/parsers/nxos/show_environment_temperature/001_basic/expected.json
@@ -7,13 +7,13 @@
                 "minor_threshold_celsius": 95,
                 "status": "ok"
             },
-            "Back        (D3)": {
+            "Back (D3)": {
                 "current_temp_celsius": 28,
                 "major_threshold_celsius": 48,
                 "minor_threshold_celsius": 42,
                 "status": "ok"
             },
-            "Front-Left  (D2)": {
+            "Front-Left (D2)": {
                 "current_temp_celsius": 33,
                 "major_threshold_celsius": 52,
                 "minor_threshold_celsius": 44,

--- a/tests/parsers/nxos/show_environment_temperature/001_basic/input.txt
+++ b/tests/parsers/nxos/show_environment_temperature/001_basic/input.txt
@@ -1,0 +1,11 @@
+
+
+Temperature
+-------------------------------------------------------------------------
+Module  Sensor             MajorThresh   MinorThres   CurTemp     Status
+                            (Celsius)     (Celsius)   (Celsius)
+-------------------------------------------------------------------------
+1       ASIC                101           95           52          ok
+1       Front-Middle(D1)    62            56           38          ok
+1       Front-Left  (D2)    52            44           33          ok
+1       Back        (D3)    48            42           28          ok

--- a/tests/parsers/nxos/show_environment_temperature/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_environment_temperature/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic temperature output with single module and four sensors
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_environment_temperature/002_multiple_modules/expected.json
+++ b/tests/parsers/nxos/show_environment_temperature/002_multiple_modules/expected.json
@@ -1,0 +1,78 @@
+{
+    "temperatures": {
+        "1": {
+            "CPU": {
+                "current_temp_celsius": 57,
+                "major_threshold_celsius": 100,
+                "minor_threshold_celsius": 98,
+                "status": "Ok"
+            },
+            "Sone-1": {
+                "current_temp_celsius": 38,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            },
+            "Sone-2": {
+                "current_temp_celsius": 44,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            },
+            "Sone-3": {
+                "current_temp_celsius": 45,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            }
+        },
+        "19": {
+            "Sone-1": {
+                "current_temp_celsius": 35,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            },
+            "Sone-2": {
+                "current_temp_celsius": 37,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            }
+        },
+        "23": {
+            "Sone-1": {
+                "current_temp_celsius": 36,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            },
+            "Sone-2": {
+                "current_temp_celsius": 38,
+                "major_threshold_celsius": 110,
+                "minor_threshold_celsius": 100,
+                "status": "Ok"
+            }
+        },
+        "27": {
+            "CPU": {
+                "current_temp_celsius": 37,
+                "major_threshold_celsius": 97,
+                "minor_threshold_celsius": 93,
+                "status": "Ok"
+            },
+            "INLET": {
+                "current_temp_celsius": 25,
+                "major_threshold_celsius": 45,
+                "minor_threshold_celsius": 42,
+                "status": "Ok"
+            },
+            "OUTLET": {
+                "current_temp_celsius": 27,
+                "major_threshold_celsius": 85,
+                "minor_threshold_celsius": 80,
+                "status": "Ok"
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_environment_temperature/002_multiple_modules/input.txt
+++ b/tests/parsers/nxos/show_environment_temperature/002_multiple_modules/input.txt
@@ -1,0 +1,16 @@
+Temperature:
+--------------------------------------------------------------------
+Module   Sensor        MajorThresh   MinorThres   CurTemp     Status
+                       (Celsius)     (Celsius)    (Celsius)
+--------------------------------------------------------------------
+1        CPU             100             98          57         Ok
+1        Sone-1          110             100         38         Ok
+1        Sone-2          110             100         44         Ok
+1        Sone-3          110             100         45         Ok
+19       Sone-1          110             100         35         Ok
+19       Sone-2          110             100         37         Ok
+23       Sone-1          110             100         36         Ok
+23       Sone-2          110             100         38         Ok
+27       OUTLET          85              80          27         Ok
+27       INLET           45              42          25         Ok
+27       CPU             97              93          37         Ok

--- a/tests/parsers/nxos/show_environment_temperature/002_multiple_modules/metadata.yaml
+++ b/tests/parsers/nxos/show_environment_temperature/002_multiple_modules/metadata.yaml
@@ -1,0 +1,3 @@
+description: Temperature output with multiple modules and varied sensors
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add dedicated parser for `show environment temperature` on NX-OS
- Extracts temperature sensor data keyed by module and sensor name, including major/minor thresholds and current temperature in Celsius
- Includes 2 test cases: single-module (4 sensors) and multi-module (11 sensors across 4 modules)

Closes #146

## Test plan
- [x] `uv run pytest tests/parsers/nxos/show_environment_temperature/ -v` passes (2 test cases)
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)