### PR TITLE
feat: add parser for 'show bgp peer-template' on NX-OS

### DIFF
--- a/changes/397.parser_added
+++ b/changes/397.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bgp peer-template' on NX-OS.

--- a/src/muninn/parsers/nxos/show_bgp_peer_template.py
+++ b/src/muninn/parsers/nxos/show_bgp_peer_template.py
@@ -6,6 +6,7 @@ from typing import NotRequired, TypedDict
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.utils import canonical_interface_name
 
 
 class PeerTemplateEntry(TypedDict):
@@ -45,6 +46,7 @@ _MEMBERS_RE = re.compile(r"^Members of peer-template \S+:")
 _MEMBER_LINE_RE = re.compile(r"^\S+:\s+(\S+)")
 
 _INT_FIELDS = frozenset({"remote_as", "ebgp_multihop"})
+_INTERFACE_FIELDS = frozenset({"update_source"})
 
 _STR_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (_REMOTE_AS_RE, "remote_as"),
@@ -64,14 +66,22 @@ _BOOL_FLAG_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
 )
 
 
+def _convert_field(field: str, value: str) -> str | int:
+    """Convert a field value to its appropriate type."""
+    if field in _INT_FIELDS:
+        return int(value)
+    if field in _INTERFACE_FIELDS:
+        return canonical_interface_name(value, os=OS.CISCO_NXOS)
+    return value
+
+
 def _apply_str_fields(lines: list[str], entry: PeerTemplateEntry) -> None:
     """Extract string and integer fields using capture-group patterns."""
     for pattern, field in _STR_FIELD_PATTERNS:
         for line in lines:
             m = pattern.match(line)
             if m:
-                value = m.group(1)
-                entry[field] = int(value) if field in _INT_FIELDS else value  # type: ignore[literal-required]
+                entry[field] = _convert_field(field, m.group(1))  # type: ignore[literal-required]
                 break
 
 

--- a/src/muninn/parsers/nxos/show_bgp_peer_template.py
+++ b/src/muninn/parsers/nxos/show_bgp_peer_template.py
@@ -1,0 +1,169 @@
+"""Parser for 'show bgp peer-template' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PeerTemplateEntry(TypedDict):
+    """Schema for a single BGP peer-template entry."""
+
+    remote_as: NotRequired[int]
+    inherit_template: NotRequired[str]
+    description: NotRequired[str]
+    update_source: NotRequired[str]
+    disable_connected_check: NotRequired[bool]
+    bfd_live_detection: NotRequired[bool]
+    ebgp_multihop: NotRequired[int]
+    tcp_md5_auth: NotRequired[str]
+    passive_only: NotRequired[bool]
+    remove_private_as: NotRequired[bool]
+    holdtime: NotRequired[int]
+    keepalive_interval: NotRequired[int]
+    local_as_inactive: NotRequired[bool]
+    members: NotRequired[list[str]]
+
+
+class ShowBgpPeerTemplateResult(TypedDict):
+    """Schema for 'show bgp peer-template' parsed output."""
+
+    peer_templates: dict[str, PeerTemplateEntry]
+
+
+_TEMPLATE_HEADER_RE = re.compile(r"^BGP peer-template is (\S+)")
+_REMOTE_AS_RE = re.compile(r"^Remote AS (\d+)")
+_INHERIT_RE = re.compile(r"^Inherits session configuration from session-template (\S+)")
+_DESCRIPTION_RE = re.compile(r"^Description:\s+(.+)")
+_UPDATE_SOURCE_RE = re.compile(r"^Using (\S+) as update source")
+_EBGP_MULTIHOP_RE = re.compile(r"^External BGP peer might be upto (\d+) hops away")
+_TCP_MD5_RE = re.compile(r"^TCP MD5 authentication is (enabled|disabled)")
+_HOLD_KEEP_RE = re.compile(r"^Hold time = (\d+), keepalive interval is (\d+) seconds")
+_MEMBERS_RE = re.compile(r"^Members of peer-template \S+:")
+_MEMBER_LINE_RE = re.compile(r"^\S+:\s+(\S+)")
+
+_INT_FIELDS = frozenset({"remote_as", "ebgp_multihop"})
+
+_STR_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_REMOTE_AS_RE, "remote_as"),
+    (_INHERIT_RE, "inherit_template"),
+    (_DESCRIPTION_RE, "description"),
+    (_UPDATE_SOURCE_RE, "update_source"),
+    (_TCP_MD5_RE, "tcp_md5_auth"),
+    (_EBGP_MULTIHOP_RE, "ebgp_multihop"),
+)
+
+_BOOL_FLAG_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^Connected check is disabled"), "disable_connected_check"),
+    (re.compile(r"^BFD live-detection is configured"), "bfd_live_detection"),
+    (re.compile(r"^Only passive connection setup allowed"), "passive_only"),
+    (re.compile(r"^Private AS numbers removed"), "remove_private_as"),
+    (re.compile(r"^Neighbor local-as command not active"), "local_as_inactive"),
+)
+
+
+def _apply_str_fields(lines: list[str], entry: PeerTemplateEntry) -> None:
+    """Extract string and integer fields using capture-group patterns."""
+    for pattern, field in _STR_FIELD_PATTERNS:
+        for line in lines:
+            m = pattern.match(line)
+            if m:
+                value = m.group(1)
+                entry[field] = int(value) if field in _INT_FIELDS else value  # type: ignore[literal-required]
+                break
+
+
+def _apply_bool_flags(lines: list[str], entry: PeerTemplateEntry) -> None:
+    """Set boolean flags found in the output lines."""
+    for line in lines:
+        for pattern, field in _BOOL_FLAG_PATTERNS:
+            if pattern.match(line):
+                entry[field] = True  # type: ignore[literal-required]
+                break
+
+
+def _apply_hold_keepalive(lines: list[str], entry: PeerTemplateEntry) -> None:
+    """Parse hold time and keepalive interval."""
+    for line in lines:
+        if m := _HOLD_KEEP_RE.match(line):
+            entry["holdtime"] = int(m.group(1))
+            entry["keepalive_interval"] = int(m.group(2))
+            return
+
+
+def _collect_members(lines: list[str]) -> list[str]:
+    """Collect member addresses from lines after the Members header."""
+    members: list[str] = []
+    in_members = False
+    for line in lines:
+        if _MEMBERS_RE.match(line):
+            in_members = True
+        elif in_members and (m := _MEMBER_LINE_RE.match(line)):
+            members.append(m.group(1))
+    return members
+
+
+def _parse_template_block(lines: list[str]) -> PeerTemplateEntry:
+    """Parse a single peer-template block into a PeerTemplateEntry."""
+    entry: PeerTemplateEntry = {}
+    _apply_str_fields(lines, entry)
+    _apply_bool_flags(lines, entry)
+    _apply_hold_keepalive(lines, entry)
+    members = _collect_members(lines)
+    if members:
+        entry["members"] = members
+    return entry
+
+
+@register(OS.CISCO_NXOS, "show bgp peer-template")
+class ShowBgpPeerTemplateParser(BaseParser["ShowBgpPeerTemplateResult"]):
+    """Parser for 'show bgp peer-template' command.
+
+    Example output:
+        BGP peer-template is PEER
+        Remote AS 500
+        Inherits session configuration from session-template PEER-SESSION
+        Description: DESC
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowBgpPeerTemplateResult:
+        """Parse 'show bgp peer-template' output.
+
+        Args:
+            output: Raw CLI output from 'show bgp peer-template' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        peer_templates: dict[str, PeerTemplateEntry] = {}
+        current_name: str | None = None
+        current_lines: list[str] = []
+
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            m = _TEMPLATE_HEADER_RE.match(line)
+            if m:
+                if current_name is not None:
+                    peer_templates[current_name] = _parse_template_block(current_lines)
+                current_name = m.group(1)
+                current_lines = []
+            elif current_name is not None:
+                current_lines.append(line)
+
+        if current_name is not None:
+            peer_templates[current_name] = _parse_template_block(current_lines)
+
+        if not peer_templates:
+            msg = "No peer-template entries found in output"
+            raise ValueError(msg)
+
+        return {"peer_templates": peer_templates}

--- a/tests/parsers/nxos/show_bgp_peer-template/001_basic/expected.json
+++ b/tests/parsers/nxos/show_bgp_peer-template/001_basic/expected.json
@@ -1,0 +1,19 @@
+{
+    "peer_templates": {
+        "PEER": {
+            "bfd_live_detection": true,
+            "description": "DESC",
+            "disable_connected_check": true,
+            "ebgp_multihop": 255,
+            "holdtime": 26,
+            "inherit_template": "PEER-SESSION",
+            "keepalive_interval": 13,
+            "local_as_inactive": true,
+            "passive_only": true,
+            "remote_as": 500,
+            "remove_private_as": true,
+            "tcp_md5_auth": "enabled",
+            "update_source": "loopback1"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_bgp_peer-template/001_basic/expected.json
+++ b/tests/parsers/nxos/show_bgp_peer-template/001_basic/expected.json
@@ -13,7 +13,7 @@
             "remote_as": 500,
             "remove_private_as": true,
             "tcp_md5_auth": "enabled",
-            "update_source": "loopback1"
+            "update_source": "Loopback1"
         }
     }
 }

--- a/tests/parsers/nxos/show_bgp_peer-template/001_basic/input.txt
+++ b/tests/parsers/nxos/show_bgp_peer-template/001_basic/input.txt
@@ -1,0 +1,15 @@
+BGP peer-template is PEER
+Remote AS 500
+Inherits session configuration from session-template PEER-SESSION
+Description: DESC
+Using loopback1 as update source for this peer
+Connected check is disabled
+BFD live-detection is configured
+External BGP peer might be upto 255 hops away
+TCP MD5 authentication is enabled
+Only passive connection setup allowed
+Neighbor local-as command not active
+Private AS numbers removed from updates sent to this neighbor
+Hold time = 26, keepalive interval is 13 seconds
+
+Members of peer-template PEER:

--- a/tests/parsers/nxos/show_bgp_peer-template/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_bgp_peer-template/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic peer-template with session-level settings
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_bgp_peer-template/002_with_members/expected.json
+++ b/tests/parsers/nxos/show_bgp_peer-template/002_with_members/expected.json
@@ -1,0 +1,27 @@
+{
+    "peer_templates": {
+        "LEAF-PEERS": {
+            "disable_connected_check": true,
+            "holdtime": 90,
+            "keepalive_interval": 30,
+            "members": [
+                "10.2.1.1"
+            ],
+            "remote_as": 65002,
+            "tcp_md5_auth": "disabled"
+        },
+        "SPINE-PEERS": {
+            "description": "Spine layer peers",
+            "ebgp_multihop": 2,
+            "holdtime": 30,
+            "keepalive_interval": 10,
+            "members": [
+                "10.1.1.1",
+                "10.1.1.2",
+                "10.1.1.3"
+            ],
+            "remote_as": 65001,
+            "update_source": "loopback0"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_bgp_peer-template/002_with_members/expected.json
+++ b/tests/parsers/nxos/show_bgp_peer-template/002_with_members/expected.json
@@ -21,7 +21,7 @@
                 "10.1.1.3"
             ],
             "remote_as": 65001,
-            "update_source": "loopback0"
+            "update_source": "Loopback0"
         }
     }
 }

--- a/tests/parsers/nxos/show_bgp_peer-template/002_with_members/input.txt
+++ b/tests/parsers/nxos/show_bgp_peer-template/002_with_members/input.txt
@@ -1,0 +1,20 @@
+BGP peer-template is SPINE-PEERS
+Remote AS 65001
+Description: Spine layer peers
+Using loopback0 as update source for this peer
+External BGP peer might be upto 2 hops away
+Hold time = 30, keepalive interval is 10 seconds
+
+Members of peer-template SPINE-PEERS:
+default: 10.1.1.1
+default: 10.1.1.2
+default: 10.1.1.3
+
+BGP peer-template is LEAF-PEERS
+Remote AS 65002
+Connected check is disabled
+TCP MD5 authentication is disabled
+Hold time = 90, keepalive interval is 30 seconds
+
+Members of peer-template LEAF-PEERS:
+default: 10.2.1.1

--- a/tests/parsers/nxos/show_bgp_peer-template/002_with_members/metadata.yaml
+++ b/tests/parsers/nxos/show_bgp_peer-template/002_with_members/metadata.yaml
@@ -1,0 +1,3 @@
+description: Peer-template with member peers listed
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show bgp peer-template` command on Cisco NX-OS
- Extracts session-level peer-template configuration: remote AS, inherit template, description, update source, hold/keepalive timers, boolean flags (BFD, passive, connected-check, private AS removal), TCP MD5 auth status, and template members
- Includes 2 test cases: basic session settings and multiple templates with members

## Test plan
- [x] `uv run pytest tests/parsers/nxos/show_bgp_peer-template/ -v` — 2 tests pass
- [x] `uv run ruff check` — no lint issues
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` — complexity within limits
- [x] `uv run pre-commit run --all-files` — all hooks pass

Closes #144