### PR TITLE
feat: add parser for 'show hsrp summary' on NX-OS

### DIFF
--- a/changes/398.parser_added
+++ b/changes/398.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show hsrp summary' on NX-OS.

--- a/src/muninn/parsers/nxos/show_hsrp_summary.py
+++ b/src/muninn/parsers/nxos/show_hsrp_summary.py
@@ -1,0 +1,194 @@
+"""Parser for 'show hsrp summary' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class GroupStats(TypedDict):
+    """Schema for HSRP group statistics."""
+
+    total_groups: int
+    v1_ipv4: int
+    v2_ipv4: int
+    v2_ipv6: int
+    active: int
+    standby: int
+    listen: int
+    v6_active: int
+    v6_standby: int
+    v6_listen: int
+
+
+class PacketStats(TypedDict):
+    """Schema for HSRP packet statistics."""
+
+    tx_pass: int
+    tx_fail: int
+    rx_good: int
+
+
+class ShowHsrpSummaryResult(TypedDict):
+    """Schema for 'show hsrp summary' parsed output."""
+
+    nsf: str
+    nsf_time: NotRequired[int]
+    global_hsrp_bfd: str
+    stats: GroupStats
+    intf_total: int
+    total_packets: PacketStats
+    pkt_unknown_groups: int
+    total_mts_rx: int
+
+
+_NSF_PATTERN = re.compile(
+    r"Extended-hold\s+\(NSF\)\s+(?P<nsf>[a-zA-Z]+)"
+    r"(?:,\s+(?P<nsf_time>\d+)\s+seconds)?$"
+)
+_BFD_PATTERN = re.compile(r"Global\s+HSRP-BFD\s+(?P<bfd>[a-zA-Z]+)$")
+_TOTAL_GROUPS_PATTERN = re.compile(r"Total\s+Groups:\s+(?P<total>\d+)$")
+_VERSION_PATTERN = re.compile(
+    r"Version::\s+V1-IPV4:\s+(?P<v1_ipv4>\d+)\s+"
+    r"V2-IPV4:\s+(?P<v2_ipv4>\d+)\s+"
+    r"V2-IPV6:\s+(?P<v2_ipv6>\d+)"
+)
+_STATE_PATTERN = re.compile(
+    r"State::\s+Active:\s+(?P<active>\d+)\s+"
+    r"Standby:\s+(?P<standby>\d+)\s+"
+    r"Listen:\s+(?P<listen>\d+)"
+)
+_V6_STATE_PATTERN = re.compile(
+    r"State::\s+V6-Active:\s+(?P<v6_active>\d+)\s+"
+    r"V6-Standby:\s+(?P<v6_standby>\d+)\s+"
+    r"V6-Listen:\s+(?P<v6_listen>\d+)"
+)
+_INTF_TOTAL_PATTERN = re.compile(
+    r"Total\s+HSRP\s+Enabled\s+interfaces:\s+(?P<total>\d+)$"
+)
+_TX_PATTERN = re.compile(
+    r"Tx\s+-\s+Pass:\s+(?P<tx_pass>\d+)\s+Fail:\s+(?P<tx_fail>\d+)$"
+)
+_RX_PATTERN = re.compile(r"Rx\s+-\s+Good:\s+(?P<rx_good>\d+)")
+_PKT_UNKNOWN_PATTERN = re.compile(r"Packet\s+for\s+unknown\s+groups:\s+(?P<count>\d+)$")
+_MTS_PATTERN = re.compile(r"Total\s+MTS:\s+Rx:\s+(?P<total>\d+)$")
+
+
+def _parse_top_level(line: str, result: dict) -> None:
+    """Parse top-level fields from a single line."""
+    if m := _NSF_PATTERN.search(line):
+        result["nsf"] = m.group("nsf")
+        if m.group("nsf_time"):
+            result["nsf_time"] = int(m.group("nsf_time"))
+        return
+
+    if m := _BFD_PATTERN.search(line):
+        result["global_hsrp_bfd"] = m.group("bfd")
+        return
+
+    if m := _INTF_TOTAL_PATTERN.search(line):
+        result["intf_total"] = int(m.group("total"))
+        return
+
+    if m := _PKT_UNKNOWN_PATTERN.search(line):
+        result["pkt_unknown_groups"] = int(m.group("count"))
+        return
+
+    if m := _MTS_PATTERN.search(line):
+        result["total_mts_rx"] = int(m.group("total"))
+
+
+def _parse_stats(line: str, stats: dict) -> None:
+    """Parse group statistics from a single line."""
+    if m := _TOTAL_GROUPS_PATTERN.search(line):
+        stats["total_groups"] = int(m.group("total"))
+        return
+
+    if m := _VERSION_PATTERN.search(line):
+        stats["v1_ipv4"] = int(m.group("v1_ipv4"))
+        stats["v2_ipv4"] = int(m.group("v2_ipv4"))
+        stats["v2_ipv6"] = int(m.group("v2_ipv6"))
+        return
+
+    if m := _V6_STATE_PATTERN.search(line):
+        stats["v6_active"] = int(m.group("v6_active"))
+        stats["v6_standby"] = int(m.group("v6_standby"))
+        stats["v6_listen"] = int(m.group("v6_listen"))
+        return
+
+    if m := _STATE_PATTERN.search(line):
+        stats["active"] = int(m.group("active"))
+        stats["standby"] = int(m.group("standby"))
+        stats["listen"] = int(m.group("listen"))
+
+
+def _parse_packets(line: str, packets: dict) -> None:
+    """Parse packet statistics from a single line."""
+    if m := _TX_PATTERN.search(line):
+        packets["tx_pass"] = int(m.group("tx_pass"))
+        packets["tx_fail"] = int(m.group("tx_fail"))
+        return
+
+    if m := _RX_PATTERN.search(line):
+        packets["rx_good"] = int(m.group("rx_good"))
+
+
+@register(OS.CISCO_NXOS, "show hsrp summary")
+class ShowHsrpSummaryParser(BaseParser[ShowHsrpSummaryResult]):
+    """Parser for 'show hsrp summary' command.
+
+    Example output:
+        HSRP Summary:
+        Extended-hold (NSF) enabled, 10 seconds
+        Global HSRP-BFD enabled
+        Total Groups: 3
+             Version::    V1-IPV4: 0       V2-IPV4: 3      V2-IPV6: 0
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowHsrpSummaryResult:
+        """Parse 'show hsrp summary' output.
+
+        Args:
+            output: Raw CLI output from 'show hsrp summary' command.
+
+        Returns:
+            Parsed HSRP summary data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        result: dict = {}
+        stats: dict = {}
+        packets: dict = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            _parse_top_level(line, result)
+            _parse_stats(line, stats)
+            _parse_packets(line, packets)
+
+        if stats:
+            result["stats"] = stats
+        if packets:
+            result["total_packets"] = packets
+
+        required = (
+            "nsf",
+            "global_hsrp_bfd",
+            "stats",
+            "intf_total",
+            "total_packets",
+            "pkt_unknown_groups",
+            "total_mts_rx",
+        )
+        missing = [f for f in required if f not in result]
+        if missing:
+            msg = f"Missing HSRP summary fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return cast(ShowHsrpSummaryResult, result)

--- a/tests/parsers/nxos/show_hsrp_summary/001_basic/expected.json
+++ b/tests/parsers/nxos/show_hsrp_summary/001_basic/expected.json
@@ -1,0 +1,25 @@
+{
+    "global_hsrp_bfd": "enabled",
+    "intf_total": 1,
+    "nsf": "enabled",
+    "nsf_time": 10,
+    "pkt_unknown_groups": 0,
+    "stats": {
+        "active": 0,
+        "listen": 0,
+        "standby": 0,
+        "total_groups": 3,
+        "v1_ipv4": 0,
+        "v2_ipv4": 3,
+        "v2_ipv6": 0,
+        "v6_active": 0,
+        "v6_listen": 0,
+        "v6_standby": 0
+    },
+    "total_mts_rx": 85,
+    "total_packets": {
+        "rx_good": 0,
+        "tx_fail": 0,
+        "tx_pass": 0
+    }
+}

--- a/tests/parsers/nxos/show_hsrp_summary/001_basic/input.txt
+++ b/tests/parsers/nxos/show_hsrp_summary/001_basic/input.txt
@@ -1,0 +1,20 @@
+
+HSRP Summary:
+
+Extended-hold (NSF) enabled, 10 seconds
+Global HSRP-BFD enabled
+
+Total Groups: 3
+     Version::    V1-IPV4: 0       V2-IPV4: 3      V2-IPV6: 0
+       State::     Active: 0       Standby: 0       Listen: 0
+       State::  V6-Active: 0    V6-Standby: 0    V6-Listen: 0
+
+Total HSRP Enabled interfaces: 1
+
+Total Packets:
+	     Tx - Pass: 0       Fail: 0
+	     Rx - Good: 0
+
+Packet for unknown groups: 0
+
+Total MTS: Rx: 85

--- a/tests/parsers/nxos/show_hsrp_summary/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_hsrp_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic HSRP summary with NSF enabled and multiple groups
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_hsrp_summary/002_nsf_disabled/expected.json
+++ b/tests/parsers/nxos/show_hsrp_summary/002_nsf_disabled/expected.json
@@ -1,0 +1,24 @@
+{
+    "global_hsrp_bfd": "disabled",
+    "intf_total": 8,
+    "nsf": "disabled",
+    "pkt_unknown_groups": 42,
+    "stats": {
+        "active": 5,
+        "listen": 3,
+        "standby": 4,
+        "total_groups": 12,
+        "v1_ipv4": 4,
+        "v2_ipv4": 6,
+        "v2_ipv6": 2,
+        "v6_active": 1,
+        "v6_listen": 0,
+        "v6_standby": 1
+    },
+    "total_mts_rx": 5021,
+    "total_packets": {
+        "rx_good": 67890,
+        "tx_fail": 3,
+        "tx_pass": 12345
+    }
+}

--- a/tests/parsers/nxos/show_hsrp_summary/002_nsf_disabled/input.txt
+++ b/tests/parsers/nxos/show_hsrp_summary/002_nsf_disabled/input.txt
@@ -1,0 +1,20 @@
+
+HSRP Summary:
+
+Extended-hold (NSF) disabled
+Global HSRP-BFD disabled
+
+Total Groups: 12
+     Version::    V1-IPV4: 4       V2-IPV4: 6      V2-IPV6: 2
+       State::     Active: 5       Standby: 4       Listen: 3
+       State::  V6-Active: 1    V6-Standby: 1    V6-Listen: 0
+
+Total HSRP Enabled interfaces: 8
+
+Total Packets:
+	     Tx - Pass: 12345       Fail: 3
+	     Rx - Good: 67890
+
+Packet for unknown groups: 42
+
+Total MTS: Rx: 5021

--- a/tests/parsers/nxos/show_hsrp_summary/002_nsf_disabled/metadata.yaml
+++ b/tests/parsers/nxos/show_hsrp_summary/002_nsf_disabled/metadata.yaml
@@ -1,0 +1,3 @@
+description: HSRP summary with NSF disabled and active groups
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show hsrp summary` on NX-OS that extracts NSF state, BFD status, group version/state statistics, enabled interface count, packet counters, and MTS receive count
- Includes 2 test cases: basic output with NSF enabled and a variant with NSF disabled plus active groups

## Test plan
- [x] `uv run pytest tests/parsers/nxos/show_hsrp_summary/ -v` -- 2 tests pass
- [x] `uv run ruff check` -- clean
- [x] `uv run xenon --max-absolute B` -- passes
- [x] `uv run pre-commit run --all-files` -- all hooks pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)