### PR TITLE
feat: add parser for 'show environment power all' on IOS

### DIFF
--- a/changes/402.parser_added
+++ b/changes/402.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show environment power all' on IOS.

--- a/src/muninn/parsers/ios/show_environment_power_all.py
+++ b/src/muninn/parsers/ios/show_environment_power_all.py
@@ -1,0 +1,101 @@
+"""Parser for 'show environment power all' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PowerSupplyEntry(TypedDict):
+    """Schema for a single power supply entry."""
+
+    pid: str
+    serial: str
+    status: str
+    sys_pwr: str
+    poe_pwr: str
+    watts: NotRequired[int]
+
+
+class ShowEnvironmentPowerAllResult(TypedDict):
+    """Schema for 'show environment power all' parsed output."""
+
+    power_supplies: dict[str, PowerSupplyEntry]
+
+
+_ROW_PATTERN = re.compile(
+    r"^(?P<sw>\d+[A-Z])\s+"
+    r"(?P<pid>\S+)\s+"
+    r"(?P<serial>\S+)\s+"
+    r"(?P<status>.+?)\s{2,}"
+    r"(?P<sys_pwr>\S+)\s+"
+    r"(?P<poe_pwr>\S+)\s+"
+    r"(?P<watts>\d+)\s*$"
+)
+
+
+def _is_header_or_separator(line: str) -> bool:
+    """Check if a line is a table header or separator."""
+    stripped = line.strip()
+    if not stripped:
+        return True
+    if stripped.startswith("--"):
+        return True
+    lower = stripped.lower()
+    return "pid" in lower and "serial" in lower and "status" in lower
+
+
+@register(OS.CISCO_IOS, "show environment power all")
+class ShowEnvironmentPowerAllParser(BaseParser[ShowEnvironmentPowerAllResult]):
+    """Parser for 'show environment power all' command.
+
+    Example output:
+        SW  PID                 Serial#     Status           Sys Pwr  PoE Pwr  Watts
+        --  ------------------  ----------  ---------------  -------  -------  -----
+        1A  PWR-C1-1100WAC      ABC123456AB  OK              Good     Good     1100
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEnvironmentPowerAllResult:
+        """Parse 'show environment power all' output.
+
+        Args:
+            output: Raw CLI output from 'show environment power all' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        power_supplies: dict[str, PowerSupplyEntry] = {}
+
+        for line in output.splitlines():
+            if _is_header_or_separator(line):
+                continue
+
+            match = _ROW_PATTERN.match(line.strip())
+            if not match:
+                continue
+
+            sw = match.group("sw")
+            entry: PowerSupplyEntry = {
+                "pid": match.group("pid"),
+                "serial": match.group("serial"),
+                "status": match.group("status").strip(),
+                "sys_pwr": match.group("sys_pwr"),
+                "poe_pwr": match.group("poe_pwr"),
+            }
+
+            watts_str = match.group("watts")
+            entry["watts"] = int(watts_str)
+
+            power_supplies[sw] = entry
+
+        if not power_supplies:
+            msg = "No power supply entries found in output"
+            raise ValueError(msg)
+
+        return {"power_supplies": power_supplies}

--- a/tests/parsers/ios/show_environment_power_all/001_basic/expected.json
+++ b/tests/parsers/ios/show_environment_power_all/001_basic/expected.json
@@ -1,0 +1,52 @@
+{
+    "power_supplies": {
+        "1A": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "ABC123456AB",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "1B": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "ABC123456CD",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "2A": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "ABC123456EF",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "2B": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "ABC123456GH",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "3A": {
+            "pid": "Unknown",
+            "poe_pwr": "Bad",
+            "serial": "Unknown",
+            "status": "No Input Power",
+            "sys_pwr": "Bad",
+            "watts": 235
+        },
+        "3B": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "ABC123456KL",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        }
+    }
+}

--- a/tests/parsers/ios/show_environment_power_all/001_basic/input.txt
+++ b/tests/parsers/ios/show_environment_power_all/001_basic/input.txt
@@ -1,0 +1,8 @@
+SW  PID                 Serial#     Status           Sys Pwr  PoE Pwr  Watts
+--  ------------------  ----------  ---------------  -------  -------  -----
+1A  PWR-C1-1100WAC      ABC123456AB  OK              Good     Good     1100
+1B  PWR-C1-1100WAC      ABC123456CD  OK              Good     Good     1100
+2A  PWR-C1-1100WAC      ABC123456EF  OK              Good     Good     1100
+2B  PWR-C1-1100WAC      ABC123456GH  OK              Good     Good     1100
+3A  Unknown             Unknown      No Input Power  Bad      Bad      235
+3B  PWR-C1-1100WAC      ABC123456KL  OK              Good     Good     1100

--- a/tests/parsers/ios/show_environment_power_all/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_environment_power_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed power supply states including one with no input power
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_environment_power_all/002_all_ok/expected.json
+++ b/tests/parsers/ios/show_environment_power_all/002_all_ok/expected.json
@@ -1,0 +1,36 @@
+{
+    "power_supplies": {
+        "1A": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "DEF123456AB",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "1B": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "DEF123456CD",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "2A": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "DEF123456EF",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        },
+        "2B": {
+            "pid": "PWR-C1-1100WAC",
+            "poe_pwr": "Good",
+            "serial": "DEF123456GH",
+            "status": "OK",
+            "sys_pwr": "Good",
+            "watts": 1100
+        }
+    }
+}

--- a/tests/parsers/ios/show_environment_power_all/002_all_ok/input.txt
+++ b/tests/parsers/ios/show_environment_power_all/002_all_ok/input.txt
@@ -1,0 +1,6 @@
+SW  PID                 Serial#     Status           Sys Pwr  PoE Pwr  Watts
+--  ------------------  ----------  ---------------  -------  -------  -----
+1A  PWR-C1-1100WAC      DEF123456AB  OK              Good     Good     1100
+1B  PWR-C1-1100WAC      DEF123456CD  OK              Good     Good     1100
+2A  PWR-C1-1100WAC      DEF123456EF  OK              Good     Good     1100
+2B  PWR-C1-1100WAC      DEF123456GH  OK              Good     Good     1100

--- a/tests/parsers/ios/show_environment_power_all/002_all_ok/metadata.yaml
+++ b/tests/parsers/ios/show_environment_power_all/002_all_ok/metadata.yaml
@@ -1,0 +1,3 @@
+description: All power supplies in OK state
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show environment power all` command on Cisco IOS
- Parses tabular power supply output into a dict keyed by supply slot (e.g. `1A`, `2B`) with PID, serial, status, sys/PoE power state, and wattage
- Includes 2 test cases: mixed states (including no input power) and all-OK

## Test plan
- [x] `uv run pytest tests/parsers/ios/show_environment_power_all/ -v` -- 2 tests pass
- [x] `uv run ruff check` -- clean
- [x] `uv run xenon --max-absolute B` -- clean
- [x] `uv run pre-commit run --all-files` -- all hooks pass

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)