### PR TITLE
feat: add parser for 'show vrf detail' on NX-OS

### DIFF
--- a/changes/403.parser_added
+++ b/changes/403.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show vrf detail' on NX-OS.

--- a/src/muninn/parsers/nxos/show_vrf_detail.py
+++ b/src/muninn/parsers/nxos/show_vrf_detail.py
@@ -1,0 +1,143 @@
+"""Parser for 'show vrf detail' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class AddressFamilyEntry(TypedDict):
+    """Schema for an address family table entry."""
+
+    table_id: str
+    fwd_id: str
+    state: str
+
+
+class VrfDetailEntry(TypedDict):
+    """Schema for a single VRF detail entry."""
+
+    vrf_id: int
+    state: str
+    vpn_id: NotRequired[str]
+    rd: NotRequired[str]
+    max_routes: int
+    mid_threshold: int
+    address_families: NotRequired[dict[str, AddressFamilyEntry]]
+
+
+class ShowVrfDetailResult(TypedDict):
+    """Schema for 'show vrf detail' parsed output."""
+
+    vrfs: dict[str, VrfDetailEntry]
+
+
+@register(OS.CISCO_NXOS, "show vrf detail")
+class ShowVrfDetailParser(BaseParser[ShowVrfDetailResult]):
+    """Parser for 'show vrf detail' command.
+
+    Example output:
+        VRF-Name: HUB, VRF-ID: 9, State: Up
+            VPNID: 123:456
+            RD: 172.21.111.112:197
+            Max Routes: 0  Mid-Threshold: 0
+            Table-ID: 0x00000009, AF: IPv4, Fwd-ID: 0x00000009, State: Up
+    """
+
+    _VRF_HEADER = re.compile(
+        r"^VRF-Name:\s+(?P<name>\S+),\s+"
+        r"VRF-ID:\s+(?P<vrf_id>\d+),\s+"
+        r"State:\s+(?P<state>\S+)"
+    )
+    _VPNID = re.compile(r"^\s*VPNID:\s+(?P<vpn_id>\S+)")
+    _RD = re.compile(r"^\s*RD:\s+(?P<rd>\S+)")
+    _MAX_ROUTES = re.compile(
+        r"^\s*Max Routes:\s+(?P<max_routes>\d+)\s+"
+        r"Mid-Threshold:\s+(?P<mid_threshold>\d+)"
+    )
+    _TABLE_ID = re.compile(
+        r"^\s*Table-ID:\s+(?P<table_id>\S+),\s+"
+        r"AF:\s+(?P<af>\S+),\s+"
+        r"Fwd-ID:\s+(?P<fwd_id>\S+),\s+"
+        r"State:\s+(?P<state>\S+)"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVrfDetailResult:
+        """Parse 'show vrf detail' output.
+
+        Args:
+            output: Raw CLI output from 'show vrf detail' command.
+
+        Returns:
+            Parsed VRF detail data keyed by VRF name.
+
+        Raises:
+            ValueError: If no VRFs found in output.
+        """
+        vrfs: dict[str, VrfDetailEntry] = {}
+        current_entry: VrfDetailEntry | None = None
+        current_name: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = cls._VRF_HEADER.match(stripped)
+            if match:
+                current_name = match.group("name")
+                current_entry = VrfDetailEntry(
+                    vrf_id=int(match.group("vrf_id")),
+                    state=match.group("state"),
+                    max_routes=0,
+                    mid_threshold=0,
+                )
+                vrfs[current_name] = current_entry
+                continue
+
+            if current_entry is None:
+                continue
+
+            _parse_detail_line(cls, stripped, current_entry)
+
+        if not vrfs:
+            msg = "No VRFs found in output"
+            raise ValueError(msg)
+
+        return ShowVrfDetailResult(vrfs=vrfs)
+
+
+def _parse_detail_line(
+    cls: type[ShowVrfDetailParser],
+    line: str,
+    entry: VrfDetailEntry,
+) -> None:
+    """Parse a single detail line within a VRF block."""
+    if match := cls._VPNID.match(line):
+        entry["vpn_id"] = match.group("vpn_id")
+        return
+
+    if match := cls._RD.match(line):
+        rd_value = match.group("rd")
+        if rd_value not in ("--", "N/A"):
+            entry["rd"] = rd_value
+        return
+
+    if match := cls._MAX_ROUTES.match(line):
+        entry["max_routes"] = int(match.group("max_routes"))
+        entry["mid_threshold"] = int(match.group("mid_threshold"))
+        return
+
+    if match := cls._TABLE_ID.match(line):
+        af_name = match.group("af")
+        af_entry = AddressFamilyEntry(
+            table_id=match.group("table_id"),
+            fwd_id=match.group("fwd_id"),
+            state=match.group("state"),
+        )
+        if "address_families" not in entry:
+            entry["address_families"] = {}
+        entry["address_families"][af_name] = af_entry

--- a/tests/parsers/nxos/show_vrf_detail/001_basic/expected.json
+++ b/tests/parsers/nxos/show_vrf_detail/001_basic/expected.json
@@ -1,0 +1,64 @@
+{
+    "vrfs": {
+        "HUB": {
+            "address_families": {
+                "IPv4": {
+                    "fwd_id": "0x00000009",
+                    "state": "Up",
+                    "table_id": "0x00000009"
+                },
+                "IPv6": {
+                    "fwd_id": "0x80000009",
+                    "state": "Up",
+                    "table_id": "0x80000009"
+                }
+            },
+            "max_routes": 0,
+            "mid_threshold": 0,
+            "rd": "172.21.111.112:197",
+            "state": "Up",
+            "vpn_id": "123:456",
+            "vrf_id": 9
+        },
+        "INSTRUMENTS": {
+            "address_families": {
+                "IPv4": {
+                    "fwd_id": "0x0000000a",
+                    "state": "Up",
+                    "table_id": "0x0000000a"
+                },
+                "IPv6": {
+                    "fwd_id": "0x8000000a",
+                    "state": "Up",
+                    "table_id": "0x8000000a"
+                }
+            },
+            "max_routes": 0,
+            "mid_threshold": 0,
+            "rd": "172.21.111.112:108",
+            "state": "Up",
+            "vpn_id": "3211:65",
+            "vrf_id": 10
+        },
+        "LAB": {
+            "address_families": {
+                "IPv4": {
+                    "fwd_id": "0x0000000b",
+                    "state": "Up",
+                    "table_id": "0x0000000b"
+                },
+                "IPv6": {
+                    "fwd_id": "0x8000000b",
+                    "state": "Up",
+                    "table_id": "0x8000000b"
+                }
+            },
+            "max_routes": 0,
+            "mid_threshold": 0,
+            "rd": "172.21.123.111:107",
+            "state": "Up",
+            "vpn_id": "890:765",
+            "vrf_id": 11
+        }
+    }
+}

--- a/tests/parsers/nxos/show_vrf_detail/001_basic/input.txt
+++ b/tests/parsers/nxos/show_vrf_detail/001_basic/input.txt
@@ -1,0 +1,20 @@
+VRF-Name: HUB, VRF-ID: 9, State: Up
+    VPNID: 123:456
+    RD: 172.21.111.112:197
+    Max Routes: 0  Mid-Threshold: 0
+    Table-ID: 0x80000009, AF: IPv6, Fwd-ID: 0x80000009, State: Up
+    Table-ID: 0x00000009, AF: IPv4, Fwd-ID: 0x00000009, State: Up
+
+VRF-Name: INSTRUMENTS, VRF-ID: 10, State: Up
+    VPNID: 3211:65
+    RD: 172.21.111.112:108
+    Max Routes: 0  Mid-Threshold: 0
+    Table-ID: 0x8000000a, AF: IPv6, Fwd-ID: 0x8000000a, State: Up
+    Table-ID: 0x0000000a, AF: IPv4, Fwd-ID: 0x0000000a, State: Up
+
+VRF-Name: LAB, VRF-ID: 11, State: Up
+    VPNID: 890:765
+    RD: 172.21.123.111:107
+    Max Routes: 0  Mid-Threshold: 0
+    Table-ID: 0x8000000b, AF: IPv6, Fwd-ID: 0x8000000b, State: Up
+    Table-ID: 0x0000000b, AF: IPv4, Fwd-ID: 0x0000000b, State: Up

--- a/tests/parsers/nxos/show_vrf_detail/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_vrf_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with VPNID, RD, and address families
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_vrf_detail/002_single_vrf_no_vpnid/expected.json
+++ b/tests/parsers/nxos/show_vrf_detail/002_single_vrf_no_vpnid/expected.json
@@ -1,0 +1,17 @@
+{
+    "vrfs": {
+        "default": {
+            "address_families": {
+                "IPv4": {
+                    "fwd_id": "0x00000001",
+                    "state": "Up",
+                    "table_id": "0x00000001"
+                }
+            },
+            "max_routes": 0,
+            "mid_threshold": 0,
+            "state": "Up",
+            "vrf_id": 1
+        }
+    }
+}

--- a/tests/parsers/nxos/show_vrf_detail/002_single_vrf_no_vpnid/input.txt
+++ b/tests/parsers/nxos/show_vrf_detail/002_single_vrf_no_vpnid/input.txt
@@ -1,0 +1,4 @@
+VRF-Name: default, VRF-ID: 1, State: Up
+    RD: --
+    Max Routes: 0  Mid-Threshold: 0
+    Table-ID: 0x00000001, AF: IPv4, Fwd-ID: 0x00000001, State: Up

--- a/tests/parsers/nxos/show_vrf_detail/002_single_vrf_no_vpnid/metadata.yaml
+++ b/tests/parsers/nxos/show_vrf_detail/002_single_vrf_no_vpnid/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single VRF without VPNID and with only IPv4 address family
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add block-based parser for `show vrf detail` on NX-OS that extracts VRF name, ID, state, VPNID, RD, max routes, mid-threshold, and per-address-family table entries
- Includes 2 test cases: multi-VRF with all fields and single VRF without VPNID/RD

## Test plan
- [x] `uv run pytest tests/parsers/nxos/show_vrf_detail/ -v` passes (2/2)
- [x] `uv run ruff check` passes
- [x] `uv run xenon --max-absolute B` passes
- [x] `uv run pre-commit run --all-files` passes

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)