### PR TITLE
feat: add parser for 'show ip eigrp topology' on IOS

### DIFF
--- a/changes/404.parser_added
+++ b/changes/404.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip eigrp topology' on IOS.

--- a/src/muninn/parsers/ios/show_ip_eigrp_topology.py
+++ b/src/muninn/parsers/ios/show_ip_eigrp_topology.py
@@ -1,0 +1,176 @@
+"""Parser for 'show ip eigrp topology' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PathEntry(TypedDict):
+    """Schema for a single EIGRP path (next-hop)."""
+
+    next_hop: str
+    interface: NotRequired[str]
+    reported_distance: NotRequired[int]
+
+
+class TopologyEntry(TypedDict):
+    """Schema for a single EIGRP topology table entry."""
+
+    code: str
+    successor_count: int
+    feasible_distance: NotRequired[int]
+    tag: NotRequired[int]
+    paths: list[PathEntry]
+
+
+class AutonomousSystemEntry(TypedDict):
+    """Schema for a single EIGRP autonomous system topology section."""
+
+    as_number: int
+    router_id: str
+    routes: dict[str, TopologyEntry]
+
+
+class ShowIpEigrpTopologyResult(TypedDict):
+    """Schema for 'show ip eigrp topology' parsed output."""
+
+    autonomous_systems: dict[str, AutonomousSystemEntry]
+
+
+# Header line identifying AS and router ID
+# Matches both "IP-EIGRP Topology Table" and "EIGRP-IPv4 Topology Table"
+_AS_HEADER_RE = re.compile(
+    r"^(?:IP-EIGRP|EIGRP-IPv4)\s+Topology Table for AS\((\d+)\)/ID\((\S+)\)\s*$"
+)
+
+# Route prefix line: P 10.1.1.0/24, 2 successors, FD is 264448[, tag is 53471]
+_ROUTE_RE = re.compile(
+    r"^(?P<code>[PpAaUuQqRrSs])\s+"
+    r"(?P<prefix>\S+/\d+),\s+"
+    r"(?P<successors>\d+)\s+successors?,\s+"
+    r"FD is (?P<fd>\S+)"
+    r"(?:,\s+tag is (?P<tag>\d+))?\s*$"
+)
+
+# Via line: via <next_hop> [(<composite>/<reported>)], <interface>
+_VIA_RE = re.compile(
+    r"^\s*via\s+(?P<next_hop>\S+)"
+    r"(?:\s+\((?P<composite>\d+)/(?P<reported>\d+)\))?"
+    r"(?:,\s+(?P<interface>\S+))?\s*$"
+)
+
+
+def _is_noise_line(line: str) -> bool:
+    """Return True if the line is a codes legend or blank."""
+    if not line:
+        return True
+    return line.startswith("Codes:") or line.startswith("       ") and "reply" in line
+
+
+def _parse_routes(lines: list[str]) -> dict[str, TopologyEntry]:
+    """Parse route entries from a set of lines within one AS section."""
+    routes: dict[str, TopologyEntry] = {}
+    current_entry: TopologyEntry | None = None
+    current_prefix: str | None = None
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        route_match = _ROUTE_RE.match(stripped)
+        if route_match:
+            current_prefix = route_match.group("prefix")
+            fd_str = route_match.group("fd")
+            current_entry = TopologyEntry(
+                code=route_match.group("code"),
+                successor_count=int(route_match.group("successors")),
+                paths=[],
+            )
+            # FD can be "Inaccessible" for unreachable routes
+            if fd_str != "Inaccessible":
+                current_entry["feasible_distance"] = int(fd_str)
+            tag_str = route_match.group("tag")
+            if tag_str is not None:
+                current_entry["tag"] = int(tag_str)
+            routes[current_prefix] = current_entry
+            continue
+
+        via_match = _VIA_RE.match(stripped)
+        if via_match and current_entry is not None:
+            path: PathEntry = {"next_hop": via_match.group("next_hop")}
+            reported = via_match.group("reported")
+            if reported is not None:
+                path["reported_distance"] = int(reported)
+            interface = via_match.group("interface")
+            if interface is not None:
+                path["interface"] = interface
+            current_entry["paths"].append(path)
+
+    return routes
+
+
+@register(OS.CISCO_IOS, "show ip eigrp topology")
+class ShowIpEigrpTopologyParser(BaseParser["ShowIpEigrpTopologyResult"]):
+    """Parser for 'show ip eigrp topology' command.
+
+    Example output:
+        IP-EIGRP Topology Table for AS(100)/ID(10.255.11.6)
+        P 66.128.208.232/32, 2 successors, FD is 264448
+                via 10.254.11.9, TenGigabitEthernet1/1
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpEigrpTopologyResult:
+        """Parse 'show ip eigrp topology' output.
+
+        Args:
+            output: Raw CLI output from 'show ip eigrp topology' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        autonomous_systems: dict[str, AutonomousSystemEntry] = {}
+        lines = output.splitlines()
+
+        # Split into AS sections
+        sections: list[tuple[int, str, list[str]]] = []
+        current_as: int | None = None
+        current_rid: str | None = None
+        current_lines: list[str] = []
+
+        for line in lines:
+            stripped = line.strip()
+            header_match = _AS_HEADER_RE.match(stripped)
+            if header_match:
+                if current_as is not None:
+                    sections.append((current_as, current_rid, current_lines))  # type: ignore[arg-type]
+                current_as = int(header_match.group(1))
+                current_rid = header_match.group(2)
+                current_lines = []
+            elif current_as is not None:
+                current_lines.append(line)
+
+        if current_as is not None:
+            sections.append((current_as, current_rid, current_lines))  # type: ignore[arg-type]
+
+        for as_number, router_id, section_lines in sections:
+            routes = _parse_routes(section_lines)
+            as_key = str(as_number)
+            autonomous_systems[as_key] = {
+                "as_number": as_number,
+                "router_id": router_id,
+                "routes": routes,
+            }
+
+        if not autonomous_systems:
+            msg = "No EIGRP topology data found in output"
+            raise ValueError(msg)
+
+        return {"autonomous_systems": autonomous_systems}

--- a/tests/parsers/ios/show_ip_eigrp_topology/001_basic/expected.json
+++ b/tests/parsers/ios/show_ip_eigrp_topology/001_basic/expected.json
@@ -1,0 +1,91 @@
+{
+    "autonomous_systems": {
+        "1": {
+            "as_number": 1,
+            "router_id": "172.16.0.1",
+            "routes": {
+                "10.2.2.0/24": {
+                    "code": "P",
+                    "feasible_distance": 3072,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet0/0",
+                            "next_hop": "192.168.100.1",
+                            "reported_distance": 2816
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "172.16.0.1/32": {
+                    "code": "P",
+                    "feasible_distance": 128256,
+                    "paths": [
+                        {
+                            "interface": "Loopback0",
+                            "next_hop": "Connected"
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "172.16.0.2/32": {
+                    "code": "P",
+                    "feasible_distance": 130816,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet0/0",
+                            "next_hop": "192.168.100.1",
+                            "reported_distance": 128256
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "192.168.100.0/31": {
+                    "code": "P",
+                    "feasible_distance": 2816,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet0/0",
+                            "next_hop": "Connected"
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "192.168.100.2/31": {
+                    "code": "P",
+                    "feasible_distance": 2816,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet0/1",
+                            "next_hop": "Connected"
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "192.168.100.4/31": {
+                    "code": "P",
+                    "feasible_distance": 3072,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet0/0",
+                            "next_hop": "192.168.100.1",
+                            "reported_distance": 2816
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "192.168.100.6/31": {
+                    "code": "P",
+                    "feasible_distance": 3072,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet0/0",
+                            "next_hop": "192.168.100.1",
+                            "reported_distance": 2816
+                        }
+                    ],
+                    "successor_count": 1
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_eigrp_topology/001_basic/input.txt
+++ b/tests/parsers/ios/show_ip_eigrp_topology/001_basic/input.txt
@@ -1,0 +1,18 @@
+EIGRP-IPv4 Topology Table for AS(1)/ID(172.16.0.1)
+Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+r - reply Status, s - sia Status
+
+P 172.16.0.1/32, 1 successors, FD is 128256
+via Connected, Loopback0
+P 172.16.0.2/32, 1 successors, FD is 130816
+via 192.168.100.1 (130816/128256), GigabitEthernet0/0
+P 10.2.2.0/24, 1 successors, FD is 3072
+via 192.168.100.1 (3072/2816), GigabitEthernet0/0
+P 192.168.100.4/31, 1 successors, FD is 3072
+via 192.168.100.1 (3072/2816), GigabitEthernet0/0
+P 192.168.100.0/31, 1 successors, FD is 2816
+via Connected, GigabitEthernet0/0
+P 192.168.100.2/31, 1 successors, FD is 2816
+via Connected, GigabitEthernet0/1
+P 192.168.100.6/31, 1 successors, FD is 3072
+via 192.168.100.1 (3072/2816), GigabitEthernet0/0

--- a/tests/parsers/ios/show_ip_eigrp_topology/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ip_eigrp_topology/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic EIGRP topology with connected and learned routes
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_ip_eigrp_topology/002_multiple_as/expected.json
+++ b/tests/parsers/ios/show_ip_eigrp_topology/002_multiple_as/expected.json
@@ -1,0 +1,109 @@
+{
+    "autonomous_systems": {
+        "100": {
+            "as_number": 100,
+            "router_id": "10.255.11.6",
+            "routes": {
+                "10.254.6.8/30": {
+                    "code": "P",
+                    "feasible_distance": 1024,
+                    "paths": [
+                        {
+                            "interface": "Port-channel10",
+                            "next_hop": "10.254.6.14"
+                        }
+                    ],
+                    "successor_count": 1
+                },
+                "66.128.208.232/32": {
+                    "code": "P",
+                    "feasible_distance": 264448,
+                    "paths": [
+                        {
+                            "interface": "TenGigabitEthernet1/1",
+                            "next_hop": "10.254.11.9"
+                        },
+                        {
+                            "interface": "TenGigabitEthernet2/1",
+                            "next_hop": "10.254.11.33"
+                        }
+                    ],
+                    "successor_count": 2
+                },
+                "67.230.223.128/28": {
+                    "code": "P",
+                    "feasible_distance": 5632,
+                    "paths": [
+                        {
+                            "interface": "TenGigabitEthernet1/1",
+                            "next_hop": "10.254.11.9"
+                        },
+                        {
+                            "interface": "TenGigabitEthernet2/1",
+                            "next_hop": "10.254.11.33"
+                        }
+                    ],
+                    "successor_count": 2,
+                    "tag": 53471
+                }
+            }
+        },
+        "65000": {
+            "as_number": 65000,
+            "router_id": "10.2.0.1",
+            "routes": {
+                "10.50.20.4/32": {
+                    "code": "P",
+                    "feasible_distance": 128039168,
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet1/1",
+                            "next_hop": "10.4.0.1"
+                        },
+                        {
+                            "interface": "GigabitEthernet1/2",
+                            "next_hop": "10.4.0.2"
+                        }
+                    ],
+                    "successor_count": 2
+                },
+                "10.50.21.0/27": {
+                    "code": "P",
+                    "paths": [
+                        {
+                            "interface": "GigabitEthernet1/1",
+                            "next_hop": "10.4.0.1"
+                        },
+                        {
+                            "interface": "GigabitEthernet1/2",
+                            "next_hop": "10.4.0.2"
+                        }
+                    ],
+                    "successor_count": 0,
+                    "tag": 6508497
+                },
+                "10.50.23.92/30": {
+                    "code": "P",
+                    "feasible_distance": 3840256,
+                    "paths": [
+                        {
+                            "next_hop": "Redistributed"
+                        }
+                    ],
+                    "successor_count": 1,
+                    "tag": 5507497
+                },
+                "10.50.75.0/24": {
+                    "code": "P",
+                    "feasible_distance": 2816,
+                    "paths": [
+                        {
+                            "next_hop": "Rstatic"
+                        }
+                    ],
+                    "successor_count": 1
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_eigrp_topology/002_multiple_as/input.txt
+++ b/tests/parsers/ios/show_ip_eigrp_topology/002_multiple_as/input.txt
@@ -1,0 +1,29 @@
+IP-EIGRP Topology Table for AS(100)/ID(10.255.11.6)
+
+Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+       r - reply Status, s - sia Status
+
+P 66.128.208.232/32, 2 successors, FD is 264448
+        via 10.254.11.9, TenGigabitEthernet1/1
+        via 10.254.11.33, TenGigabitEthernet2/1
+P 10.254.6.8/30, 1 successors, FD is 1024
+        via 10.254.6.14, Port-channel10
+P 67.230.223.128/28, 2 successors, FD is 5632, tag is 53471
+        via 10.254.11.9, TenGigabitEthernet1/1
+        via 10.254.11.33, TenGigabitEthernet2/1
+
+IP-EIGRP Topology Table for AS(65000)/ID(10.2.0.1)
+
+Codes: P - Passive, A - Active, U - Update, Q - Query, R - Reply,
+       r - reply Status, s - sia Status
+
+P 10.50.20.4/32, 2 successors, FD is 128039168
+        via 10.4.0.1, GigabitEthernet1/1
+        via 10.4.0.2, GigabitEthernet1/2
+P 10.50.21.0/27, 0 successors, FD is Inaccessible, tag is 6508497
+        via 10.4.0.1, GigabitEthernet1/1
+        via 10.4.0.2, GigabitEthernet1/2
+P 10.50.75.0/24, 1 successors, FD is 2816
+        via Rstatic
+P 10.50.23.92/30, 1 successors, FD is 3840256, tag is 5507497
+        via Redistributed

--- a/tests/parsers/ios/show_ip_eigrp_topology/002_multiple_as/metadata.yaml
+++ b/tests/parsers/ios/show_ip_eigrp_topology/002_multiple_as/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple autonomous systems with tags, inaccessible FD, and special next-hops
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ip eigrp topology` command on Cisco IOS
- Supports both `IP-EIGRP` and `EIGRP-IPv4` header formats
- Handles multiple autonomous systems, feasible distance (including Inaccessible), tags, and path details (next-hop, reported distance, interface)
- Supports special next-hop types: Connected, Rstatic, Redistributed

Closes #152

## Test plan
- [x] `001_basic` - EIGRP-IPv4 format with connected and learned routes, composite metrics
- [x] `002_multiple_as` - Multiple AS sections with tags, inaccessible FD, Rstatic and Redistributed paths
- [x] All pre-commit hooks pass
- [x] Xenon complexity check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)