### PR TITLE
feat: add parser for 'show module online diag' on IOS

### DIFF
--- a/changes/405.parser_added
+++ b/changes/405.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show module online diag' on IOS.

--- a/src/muninn/parsers/ios/show_module_online_diag.py
+++ b/src/muninn/parsers/ios/show_module_online_diag.py
@@ -1,0 +1,74 @@
+"""Parser for 'show module online diag' command on IOS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class OnlineDiagEntry(TypedDict):
+    """Schema for a single module online diag entry."""
+
+    status: str
+
+
+class ShowModuleOnlineDiagResult(TypedDict):
+    """Schema for 'show module online diag' parsed output."""
+
+    modules: dict[str, OnlineDiagEntry]
+
+
+_ROW_PATTERN = re.compile(r"^\s*(?P<mod>\d+)\s+(?P<status>\S+)\s*$")
+
+_HEADER_PATTERN = re.compile(r"^\s*Mod\s+Online\s+Diag\s+Status", re.IGNORECASE)
+
+_SEPARATOR = re.compile(r"^[-\s]+$")
+
+
+@register(OS.CISCO_IOS, "show module online diag")
+class ShowModuleOnlineDiagParser(BaseParser[ShowModuleOnlineDiagResult]):
+    """Parser for 'show module online diag' command.
+
+    Example output:
+        Mod  Online Diag Status
+        ---- -------------------
+        1  Pass
+        2  Pass
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowModuleOnlineDiagResult:
+        """Parse 'show module online diag' output.
+
+        Args:
+            output: Raw CLI output from 'show module online diag' command.
+
+        Returns:
+            Parsed data with module online diag status.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        modules: dict[str, OnlineDiagEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if (
+                not stripped
+                or _HEADER_PATTERN.match(stripped)
+                or _SEPARATOR.match(stripped)
+            ):
+                continue
+
+            match = _ROW_PATTERN.match(stripped)
+            if match:
+                mod = match.group("mod")
+                modules[mod] = {"status": match.group("status")}
+
+        if not modules:
+            msg = "No module online diag entries found in output"
+            raise ValueError(msg)
+
+        return {"modules": modules}

--- a/tests/parsers/ios/show_module_online_diag/001_basic/expected.json
+++ b/tests/parsers/ios/show_module_online_diag/001_basic/expected.json
@@ -1,0 +1,16 @@
+{
+    "modules": {
+        "1": {
+            "status": "Pass"
+        },
+        "2": {
+            "status": "Pass"
+        },
+        "5": {
+            "status": "Pass"
+        },
+        "6": {
+            "status": "Pass"
+        }
+    }
+}

--- a/tests/parsers/ios/show_module_online_diag/001_basic/input.txt
+++ b/tests/parsers/ios/show_module_online_diag/001_basic/input.txt
@@ -1,0 +1,6 @@
+Mod  Online Diag Status
+---- -------------------
+1  Pass
+2  Pass
+5  Pass
+6  Pass

--- a/tests/parsers/ios/show_module_online_diag/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_module_online_diag/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple modules with Pass status from Catalyst 7600
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_module_online_diag/002_single_module/expected.json
+++ b/tests/parsers/ios/show_module_online_diag/002_single_module/expected.json
@@ -1,0 +1,7 @@
+{
+    "modules": {
+        "3": {
+            "status": "Fail"
+        }
+    }
+}

--- a/tests/parsers/ios/show_module_online_diag/002_single_module/input.txt
+++ b/tests/parsers/ios/show_module_online_diag/002_single_module/input.txt
@@ -1,0 +1,3 @@
+Mod  Online Diag Status
+---- -------------------
+3  Fail

--- a/tests/parsers/ios/show_module_online_diag/002_single_module/metadata.yaml
+++ b/tests/parsers/ios/show_module_online_diag/002_single_module/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single module with Fail status
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show module online diag` command on Cisco IOS
- Parses the tabular output to extract per-module online diagnostic status (Pass/Fail)
- Includes two test cases: multiple modules and single module with Fail status

## Test plan
- [x] Two test cases pass (`001_basic`, `002_single_module`)
- [x] `ruff check` and `ruff format` pass
- [x] `xenon` complexity check passes
- [x] All pre-commit hooks pass

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)