### PR TITLE
feat: add parser for 'show ip vrf interfaces' on IOS

### DIFF
--- a/changes/406.parser_added
+++ b/changes/406.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip vrf interfaces' on IOS.

--- a/src/muninn/parsers/ios/show_ip_vrf_interfaces.py
+++ b/src/muninn/parsers/ios/show_ip_vrf_interfaces.py
@@ -1,0 +1,91 @@
+"""Parser for 'show ip vrf interfaces' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class VrfInterfaceEntry(TypedDict):
+    """Schema for a single VRF interface entry."""
+
+    vrf: str
+    protocol: str
+    ip_address: NotRequired[str]
+
+
+class ShowIpVrfInterfacesResult(TypedDict):
+    """Schema for 'show ip vrf interfaces' parsed output."""
+
+    interfaces: dict[str, VrfInterfaceEntry]
+
+
+@register(OS.CISCO_IOS, "show ip vrf interfaces")
+class ShowIpVrfInterfacesParser(BaseParser[ShowIpVrfInterfacesResult]):
+    """Parser for 'show ip vrf interfaces' command.
+
+    Example output:
+        Interface              IP-Address      VRF                              Protocol
+        Vl1100                 192.168.100.1   BYOD-Guest                       up
+        Gi0/0                  unassigned      Mgmt-vrf                         down
+    """
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+"
+        r"(?P<ip_address>\S+)\s+"
+        r"(?P<vrf>\S+)\s+"
+        r"(?P<protocol>\S+)\s*$"
+    )
+
+    _HEADER_PATTERN = re.compile(r"^Interface\s+IP-Address", re.IGNORECASE)
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpVrfInterfacesResult:
+        """Parse 'show ip vrf interfaces' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed VRF interface entries keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no VRF interface entries found.
+        """
+        interfaces: dict[str, VrfInterfaceEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if cls._HEADER_PATTERN.match(line):
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if match:
+                raw_interface = match.group("interface")
+                ip_address = match.group("ip_address")
+                vrf = match.group("vrf")
+                protocol = match.group("protocol")
+
+                interface_name = canonical_interface_name(raw_interface)
+
+                entry: VrfInterfaceEntry = {
+                    "vrf": vrf,
+                    "protocol": protocol,
+                }
+
+                if ip_address != "unassigned":
+                    entry["ip_address"] = ip_address
+
+                interfaces[interface_name] = entry
+
+        if not interfaces:
+            msg = "No VRF interface entries found in output"
+            raise ValueError(msg)
+
+        return ShowIpVrfInterfacesResult(interfaces=interfaces)

--- a/tests/parsers/ios/show_ip_vrf_interfaces/001_basic/expected.json
+++ b/tests/parsers/ios/show_ip_vrf_interfaces/001_basic/expected.json
@@ -1,0 +1,33 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/0": {
+            "protocol": "down",
+            "vrf": "Mgmt-vrf"
+        },
+        "VLAN1100": {
+            "ip_address": "192.168.100.1",
+            "protocol": "up",
+            "vrf": "BYOD-Guest"
+        },
+        "VLAN1200": {
+            "ip_address": "192.168.200.1",
+            "protocol": "up",
+            "vrf": "BYOD-Guest"
+        },
+        "VLAN1832": {
+            "ip_address": "10.255.0.10",
+            "protocol": "up",
+            "vrf": "BYOD-Guest"
+        },
+        "VLAN1836": {
+            "ip_address": "10.255.0.18",
+            "protocol": "up",
+            "vrf": "SP-INET"
+        },
+        "VLAN520": {
+            "ip_address": "172.31.2.253",
+            "protocol": "up",
+            "vrf": "SP-INET"
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_vrf_interfaces/001_basic/input.txt
+++ b/tests/parsers/ios/show_ip_vrf_interfaces/001_basic/input.txt
@@ -1,0 +1,7 @@
+Interface              IP-Address      VRF                              Protocol
+Vl1100                 192.168.100.1   BYOD-Guest                       up
+Vl1200                 192.168.200.1   BYOD-Guest                       up
+Vl1832                 10.255.0.10     BYOD-Guest                       up
+Gi0/0                  unassigned      Mgmt-vrf                         down
+Vl520                  172.31.2.253    SP-INET                          up
+Vl1836                 10.255.0.18     SP-INET                          up

--- a/tests/parsers/ios/show_ip_vrf_interfaces/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ip_vrf_interfaces/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with several interfaces including an unassigned IP
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_ip_vrf_interfaces/002_single_entry/expected.json
+++ b/tests/parsers/ios/show_ip_vrf_interfaces/002_single_entry/expected.json
@@ -1,0 +1,9 @@
+{
+    "interfaces": {
+        "Loopback100": {
+            "ip_address": "10.10.10.1",
+            "protocol": "up",
+            "vrf": "CORPORATE"
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_vrf_interfaces/002_single_entry/input.txt
+++ b/tests/parsers/ios/show_ip_vrf_interfaces/002_single_entry/input.txt
@@ -1,0 +1,2 @@
+Interface              IP-Address      VRF                              Protocol
+Loopback100            10.10.10.1      CORPORATE                        up

--- a/tests/parsers/ios/show_ip_vrf_interfaces/002_single_entry/metadata.yaml
+++ b/tests/parsers/ios/show_ip_vrf_interfaces/002_single_entry/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single VRF interface entry
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show ip vrf interfaces` command on Cisco IOS
- Parses tabular output extracting interface name, IP address, VRF name, and protocol status
- Interfaces keyed by canonical interface name; unassigned IPs are omitted as optional fields

## Test plan
- [x] 2 test cases: basic multi-VRF output and single entry
- [x] All pre-commit hooks pass
- [x] ruff check/format clean
- [x] xenon complexity check passes

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)