### PR TITLE
feat: add parser for 'show track' on IOS-XE

### DIFF
--- a/changes/413.parser_added
+++ b/changes/413.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show track' on IOS-XE.

--- a/src/muninn/parsers/iosxe/show_track.py
+++ b/src/muninn/parsers/iosxe/show_track.py
@@ -1,0 +1,294 @@
+"""Parser for 'show track' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class DelayedInfo(TypedDict):
+    """Schema for delayed state information."""
+
+    delayed_state: str
+    secs_remaining: NotRequired[int]
+    connection_state: NotRequired[str]
+
+
+class TrackedByEntry(TypedDict):
+    """Schema for a single tracked-by entry."""
+
+    name: str
+    interface: NotRequired[str]
+    group_id: NotRequired[int]
+
+
+class TrackEntry(TypedDict):
+    """Schema for a single track entry."""
+
+    track_type: str
+    state: str
+    change_count: int
+    last_change: str
+    object_name: NotRequired[str]
+    address: NotRequired[str]
+    mask: NotRequired[str]
+    parameter: NotRequired[str]
+    state_description: NotRequired[str]
+    delayed: NotRequired[DelayedInfo]
+    delay_up_secs: NotRequired[int]
+    delay_down_secs: NotRequired[int]
+    first_hop_interface_state: NotRequired[str]
+    prev_first_hop_interface: NotRequired[str]
+    threshold_down: NotRequired[int]
+    threshold_up: NotRequired[int]
+    latest_op_return_code: NotRequired[str]
+    latest_rtt_ms: NotRequired[int]
+    tracked_by: NotRequired[list[TrackedByEntry]]
+
+
+class ShowTrackResult(TypedDict):
+    """Schema for 'show track' parsed output."""
+
+    tracks: dict[str, TrackEntry]
+
+
+# --- Compiled regex patterns ---
+
+_TRACK_HEADER = re.compile(r"^Track\s+(?P<track_id>\d+)\s*$")
+
+_INTERFACE_LINE = re.compile(r"^Interface\s+(?P<name>\S+)\s+(?P<parameter>.+)$")
+
+_IP_ROUTE_LINE = re.compile(
+    r"^IP\s+route\s+(?P<address>[\d.]+)\s+(?P<mask>[\d.]+)\s+(?P<parameter>.+)$"
+)
+
+_IP_SLA_LINE = re.compile(r"^IP\s+SLA\s+(?P<sla_id>\d+)\s+(?P<parameter>.+)$")
+
+_STATE_LINE = re.compile(
+    r"^(?P<parameter>[\w ]+?)\s+is\s+(?P<state>Up|Down)"
+    r"(?:\s+\((?P<state_description>[^)]+)\)"
+    r"(?:,\s*delayed\s+(?P<delayed_state>Up|Down)"
+    r"\s+\((?P<secs_remaining>\d+)\s+sec\s+remaining\)"
+    r"(?:\s+\((?P<connection_state>\w+)\))?)?)?"
+)
+
+_CHANGE_LINE = re.compile(
+    r"^(?P<change_count>\d+)\s+changes?,\s+last\s+change\s+(?P<last_change>\S+)$"
+)
+
+_DELAY_LINE = re.compile(
+    r"^Delay\s+up\s+(?P<delay_up>\d+)\s+secs?,\s*down\s+(?P<delay_down>\d+)\s+secs?$"
+)
+
+_FIRST_HOP_LINE = re.compile(
+    r"^First-hop\s+interface\s+is\s+(?P<state>\w+)"
+    r"(?:\s+\(was\s+(?P<prev_interface>\S+)\))?$"
+)
+
+_THRESHOLD_LINE = re.compile(
+    r"^Metric\s+threshold\s+down\s+(?P<down>\d+)\s+up\s+(?P<up>\d+)$"
+)
+
+_TRACKED_BY_ENTRY = re.compile(
+    r"^(?P<name>[A-Za-z]{3,4})\s+(?P<interface>\S+)\s+(?P<group_id>\d+)$"
+)
+
+_RETURN_CODE_LINE = re.compile(r"^Latest\s+operation\s+return\s+code:\s+(?P<code>\w+)$")
+
+_RTT_LINE = re.compile(r"^Latest\s+RTT\s+\(?millisecs\)?\s+(?P<rtt>\d+)$")
+
+
+def _parse_type_line(line: str, entry: TrackEntry) -> bool:
+    """Parse a track type line (Interface, IP route, IP SLA).
+
+    Returns True if the line matched a type pattern.
+    """
+    match = _INTERFACE_LINE.match(line)
+    if match:
+        entry["track_type"] = "Interface"
+        entry["object_name"] = canonical_interface_name(match.group("name"))
+        entry["parameter"] = match.group("parameter")
+        return True
+
+    match = _IP_ROUTE_LINE.match(line)
+    if match:
+        entry["track_type"] = "IP route"
+        entry["address"] = match.group("address")
+        entry["mask"] = match.group("mask")
+        entry["parameter"] = match.group("parameter")
+        return True
+
+    match = _IP_SLA_LINE.match(line)
+    if match:
+        entry["track_type"] = "IP SLA"
+        entry["object_name"] = match.group("sla_id")
+        entry["parameter"] = match.group("parameter")
+        return True
+
+    return False
+
+
+def _parse_state_line(line: str, entry: TrackEntry) -> bool:
+    """Parse a state line. Returns True if the line matched."""
+    match = _STATE_LINE.match(line)
+    if not match:
+        return False
+
+    entry["state"] = match.group("state")
+
+    if match.group("state_description"):
+        entry["state_description"] = match.group("state_description")
+
+    if match.group("delayed_state"):
+        delayed: DelayedInfo = {"delayed_state": match.group("delayed_state")}
+        if match.group("secs_remaining"):
+            delayed["secs_remaining"] = int(match.group("secs_remaining"))
+        if match.group("connection_state"):
+            delayed["connection_state"] = match.group("connection_state")
+        entry["delayed"] = delayed
+
+    return True
+
+
+def _parse_detail_line(line: str, entry: TrackEntry) -> bool:
+    """Parse detail lines (change, delay, threshold, etc.).
+
+    Returns True if the line matched a known detail pattern.
+    """
+    match = _CHANGE_LINE.match(line)
+    if match:
+        entry["change_count"] = int(match.group("change_count"))
+        entry["last_change"] = match.group("last_change")
+        return True
+
+    match = _DELAY_LINE.match(line)
+    if match:
+        entry["delay_up_secs"] = int(match.group("delay_up"))
+        entry["delay_down_secs"] = int(match.group("delay_down"))
+        return True
+
+    match = _FIRST_HOP_LINE.match(line)
+    if match:
+        entry["first_hop_interface_state"] = match.group("state")
+        if match.group("prev_interface"):
+            entry["prev_first_hop_interface"] = canonical_interface_name(
+                match.group("prev_interface")
+            )
+        return True
+
+    match = _THRESHOLD_LINE.match(line)
+    if match:
+        entry["threshold_down"] = int(match.group("down"))
+        entry["threshold_up"] = int(match.group("up"))
+        return True
+
+    match = _RETURN_CODE_LINE.match(line)
+    if match:
+        entry["latest_op_return_code"] = match.group("code")
+        return True
+
+    match = _RTT_LINE.match(line)
+    if match:
+        entry["latest_rtt_ms"] = int(match.group("rtt"))
+        return True
+
+    return False
+
+
+def _parse_tracked_by_line(line: str, entry: TrackEntry) -> bool:
+    """Parse a tracked-by entry line. Returns True if matched."""
+    match = _TRACKED_BY_ENTRY.match(line)
+    if not match:
+        return False
+
+    tracked_entry: TrackedByEntry = {"name": match.group("name")}
+    if match.group("interface"):
+        tracked_entry["interface"] = canonical_interface_name(match.group("interface"))
+    if match.group("group_id"):
+        tracked_entry["group_id"] = int(match.group("group_id"))
+
+    tracked_by = entry.setdefault("tracked_by", [])
+    tracked_by.append(tracked_entry)
+    return True
+
+
+def _parse_entry_line(line: str, entry: TrackEntry, in_tracked_by: bool) -> bool:
+    """Dispatch a single line to the appropriate entry-level parser.
+
+    Returns the updated ``in_tracked_by`` flag.
+    """
+    if line == "Tracked by:":
+        return True
+
+    if in_tracked_by:
+        if _parse_tracked_by_line(line, entry):
+            return True
+        # Fall through — line doesn't belong to tracked-by section
+
+    if _parse_type_line(line, entry):
+        return False
+
+    if _parse_state_line(line, entry):
+        return False
+
+    _parse_detail_line(line, entry)
+    return False
+
+
+@register(OS.CISCO_IOSXE, "show track")
+class ShowTrackParser(BaseParser[ShowTrackResult]):
+    """Parser for 'show track' command.
+
+    Example output:
+        Track 1
+          Interface GigabitEthernet3.420 line-protocol
+          Line protocol is Up
+            1 change, last change 00:00:27
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowTrackResult:
+        """Parse 'show track' output.
+
+        Args:
+            output: Raw CLI output from 'show track' command.
+
+        Returns:
+            Parsed data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        tracks: dict[str, TrackEntry] = {}
+        current_entry: TrackEntry | None = None
+        in_tracked_by = False
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            # Check for new track header
+            match = _TRACK_HEADER.match(line)
+            if match:
+                track_id = match.group("track_id")
+                current_entry = TrackEntry(
+                    track_type="", state="", change_count=0, last_change=""
+                )
+                tracks[track_id] = current_entry
+                in_tracked_by = False
+                continue
+
+            if current_entry is None:
+                continue
+
+            in_tracked_by = _parse_entry_line(line, current_entry, in_tracked_by)
+
+        if not tracks:
+            msg = "No track entries found in output"
+            raise ValueError(msg)
+
+        return ShowTrackResult(tracks=tracks)

--- a/tests/parsers/iosxe/show_track/001_interface_tracking/expected.json
+++ b/tests/parsers/iosxe/show_track/001_interface_tracking/expected.json
@@ -1,0 +1,19 @@
+{
+    "tracks": {
+        "1": {
+            "change_count": 1,
+            "last_change": "00:00:27",
+            "object_name": "GigabitEthernet3.420",
+            "parameter": "line-protocol",
+            "state": "Up",
+            "track_type": "Interface",
+            "tracked_by": [
+                {
+                    "group_id": 10,
+                    "interface": "GigabitEthernet3.420",
+                    "name": "VRRP"
+                }
+            ]
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_track/001_interface_tracking/input.txt
+++ b/tests/parsers/iosxe/show_track/001_interface_tracking/input.txt
@@ -1,0 +1,6 @@
+Track 1
+  Interface GigabitEthernet3.420 line-protocol
+  Line protocol is Up
+    1 change, last change 00:00:27
+  Tracked by:
+    VRRP GigabitEthernet3.420 10

--- a/tests/parsers/iosxe/show_track/001_interface_tracking/metadata.yaml
+++ b/tests/parsers/iosxe/show_track/001_interface_tracking/metadata.yaml
@@ -1,0 +1,3 @@
+description: Interface line-protocol tracking with VRRP tracked-by
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_track/002_multiple_track_types/expected.json
+++ b/tests/parsers/iosxe/show_track/002_multiple_track_types/expected.json
@@ -1,0 +1,60 @@
+{
+    "tracks": {
+        "1": {
+            "address": "172.16.52.0",
+            "change_count": 1,
+            "delay_down_secs": 1,
+            "delay_up_secs": 2,
+            "first_hop_interface_state": "unknown",
+            "last_change": "00:00:35",
+            "mask": "255.255.255.0",
+            "parameter": "metric threshold",
+            "state": "Down",
+            "state_description": "no route",
+            "threshold_down": 255,
+            "threshold_up": 254,
+            "track_type": "IP route"
+        },
+        "2": {
+            "address": "10.21.12.0",
+            "change_count": 1,
+            "delay_down_secs": 10,
+            "delay_up_secs": 20,
+            "delayed": {
+                "connection_state": "connected",
+                "delayed_state": "Up",
+                "secs_remaining": 1
+            },
+            "first_hop_interface_state": "unknown",
+            "last_change": "00:00:24",
+            "mask": "255.255.255.0",
+            "parameter": "reachability",
+            "prev_first_hop_interface": "Ethernet1/0",
+            "state": "Down",
+            "state_description": "no ip route",
+            "track_type": "IP route",
+            "tracked_by": [
+                {
+                    "group_id": 3,
+                    "interface": "Ethernet0/0",
+                    "name": "HSRP"
+                },
+                {
+                    "group_id": 3,
+                    "interface": "Ethernet0/1",
+                    "name": "HSRP"
+                }
+            ]
+        },
+        "34": {
+            "change_count": 11,
+            "last_change": "1d16h",
+            "latest_op_return_code": "OK",
+            "latest_rtt_ms": 16,
+            "object_name": "34",
+            "parameter": "state",
+            "state": "Up",
+            "track_type": "IP SLA"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_track/002_multiple_track_types/input.txt
+++ b/tests/parsers/iosxe/show_track/002_multiple_track_types/input.txt
@@ -1,0 +1,24 @@
+Track 2
+  IP route 10.21.12.0 255.255.255.0 reachability
+  Reachability is Down (no ip route), delayed Up (1 sec remaining) (connected)
+    1 change, last change 00:00:24
+  Delay up 20 secs, down 10 secs
+  First-hop interface is unknown (was Ethernet1/0)
+  Tracked by:
+    HSRP Ethernet0/0 3
+    HSRP Ethernet0/1 3
+
+Track 1
+  IP route 172.16.52.0 255.255.255.0 metric threshold
+  Metric threshold is Down (no route)
+    1 change, last change 00:00:35
+  Metric threshold down 255 up 254
+  Delay up 2 secs, down 1 sec
+  First-hop interface is unknown
+
+Track 34
+  IP SLA 34 state
+  State is Up
+    11 changes, last change 1d16h
+  Latest operation return code: OK
+  Latest RTT (millisecs) 16

--- a/tests/parsers/iosxe/show_track/002_multiple_track_types/metadata.yaml
+++ b/tests/parsers/iosxe/show_track/002_multiple_track_types/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple track types including IP route with delay, metric threshold, and IP SLA
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `show track` command on Cisco IOS-XE
- Supports Interface line-protocol, IP route (reachability and metric threshold), and IP SLA track types
- Includes delayed state info, tracked-by entries, metric thresholds, and SLA return code/RTT fields

## Test plan
- [x] 2 test cases: interface tracking with VRRP tracked-by, and multiple track types (IP route + IP SLA)
- [x] All quality checks pass (ruff, xenon, pre-commit)
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_track` passes

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)