### PR TITLE
feat: add parser for 'show ip ospf neighbor' on NX-OS

### DIFF
--- a/changes/417.parser_added
+++ b/changes/417.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip ospf neighbor' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
@@ -91,34 +91,7 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
                 current_vrf, current_process_id = section
                 continue
 
-            match = _NEIGHBOR_PATTERN.match(line)
-            if not match:
-                continue
-
-            if current_vrf is None or current_process_id is None:
-                continue
-
-            interface = canonical_interface_name(
-                match.group("interface"), os=OS.CISCO_NXOS
-            )
-            neighbor_id = match.group("neighbor_id")
-            state, role = cls._parse_state_role(match.group("state_role"))
-            neighbors = vrfs[current_vrf]["processes"][current_process_id]["neighbors"]
-
-            if interface not in neighbors:
-                neighbors[interface] = {}
-
-            entry: OspfNeighborEntry = {
-                "priority": int(match.group("priority")),
-                "state": state,
-                "up_time": match.group("up_time"),
-                "address": match.group("address"),
-            }
-
-            if role and role != "-":
-                entry["role"] = role
-
-            neighbors[interface][neighbor_id] = entry
+            cls._parse_neighbor_line(line, vrfs, current_vrf, current_process_id)
 
         if not vrfs:
             msg = "No OSPF neighbors found in output"
@@ -145,6 +118,45 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
             processes[process_id] = {"neighbors": {}}
 
         return vrf, process_id
+
+    @classmethod
+    def _parse_neighbor_line(
+        cls,
+        line: str,
+        vrfs: dict[str, OspfVrfEntry],
+        current_vrf: str | None,
+        current_process_id: str | None,
+    ) -> None:
+        if current_vrf is None or current_process_id is None:
+            return
+
+        match = _NEIGHBOR_PATTERN.match(line)
+        if match is None:
+            return
+
+        interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_NXOS)
+        neighbor_id = match.group("neighbor_id")
+        neighbors = vrfs[current_vrf]["processes"][current_process_id]["neighbors"]
+
+        if interface not in neighbors:
+            neighbors[interface] = {}
+
+        neighbors[interface][neighbor_id] = cls._build_neighbor_entry(match)
+
+    @classmethod
+    def _build_neighbor_entry(cls, match: re.Match[str]) -> OspfNeighborEntry:
+        state, role = cls._parse_state_role(match.group("state_role"))
+        entry: OspfNeighborEntry = {
+            "priority": int(match.group("priority")),
+            "state": state,
+            "up_time": match.group("up_time"),
+            "address": match.group("address"),
+        }
+
+        if role and role != "-":
+            entry["role"] = role
+
+        return entry
 
     @staticmethod
     def _parse_state_role(state_role: str) -> tuple[str, str]:

--- a/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
@@ -29,10 +29,11 @@ class ShowIpOspfNeighborResult(TypedDict):
 # Neighbor ID     Pri State            Up Time  Address         Interface
 # 192.168.1.8       1 FULL/ -          2y0w     192.168.2.2     Vlan2
 # 10.0.0.6          1 INIT/DROTHER     -        77.77.77.77     Po4
+# 10.0.0.7          1 FULL/            4d19h    88.88.88.88     Eth1/3
 _NEIGHBOR_PATTERN = re.compile(
     r"^(?P<neighbor_id>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
     r"(?P<priority>\d+)\s+"
-    r"(?P<state>\w+)/\s*(?P<role>DR|BDR|DROTHER|-)\s+"
+    r"(?P<state_role>.+?)\s{2,}"
     r"(?P<up_time>\S+)\s+"
     r"(?P<address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
     r"(?P<interface>\S+)\s*$"
@@ -75,19 +76,19 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
                 match.group("interface"), os=OS.CISCO_NXOS
             )
             neighbor_id = match.group("neighbor_id")
-            role = match.group("role")
+            state, role = cls._parse_state_role(match.group("state_role"))
 
             if interface not in neighbors:
                 neighbors[interface] = {}
 
             entry: OspfNeighborEntry = {
                 "priority": int(match.group("priority")),
-                "state": match.group("state").upper(),
+                "state": state,
                 "up_time": match.group("up_time"),
                 "address": match.group("address"),
             }
 
-            if role != "-":
+            if role and role != "-":
                 entry["role"] = role
 
             neighbors[interface][neighbor_id] = entry
@@ -97,3 +98,8 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
             raise ValueError(msg)
 
         return ShowIpOspfNeighborResult(neighbors=neighbors)
+
+    @staticmethod
+    def _parse_state_role(state_role: str) -> tuple[str, str]:
+        state, _, role = state_role.partition("/")
+        return state.strip().upper(), role.strip()

--- a/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
@@ -19,10 +19,22 @@ class OspfNeighborEntry(TypedDict):
     role: NotRequired[str]
 
 
+class OspfProcessEntry(TypedDict):
+    """Schema for an OSPF process within a VRF."""
+
+    neighbors: dict[str, dict[str, OspfNeighborEntry]]
+
+
+class OspfVrfEntry(TypedDict):
+    """Schema for a VRF containing one or more OSPF processes."""
+
+    processes: dict[str, OspfProcessEntry]
+
+
 class ShowIpOspfNeighborResult(TypedDict):
     """Schema for 'show ip ospf neighbor' parsed output."""
 
-    neighbors: dict[str, dict[str, OspfNeighborEntry]]
+    vrfs: dict[str, OspfVrfEntry]
 
 
 # Pattern for neighbor table rows on NX-OS:
@@ -37,6 +49,10 @@ _NEIGHBOR_PATTERN = re.compile(
     r"(?P<up_time>\S+)\s+"
     r"(?P<address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
     r"(?P<interface>\S+)\s*$"
+)
+
+_SECTION_PATTERN = re.compile(
+    r"^OSPF Process ID (?P<process_id>\S+) VRF (?P<vrf>\S+)\s*$"
 )
 
 
@@ -61,15 +77,25 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
         Raises:
             ValueError: If no neighbors found in output.
         """
-        neighbors: dict[str, dict[str, OspfNeighborEntry]] = {}
+        vrfs: dict[str, OspfVrfEntry] = {}
+        current_vrf: str | None = None
+        current_process_id: str | None = None
 
         for line in output.splitlines():
             line = line.strip()
             if not line:
                 continue
 
+            section = cls._parse_section(line, vrfs)
+            if section is not None:
+                current_vrf, current_process_id = section
+                continue
+
             match = _NEIGHBOR_PATTERN.match(line)
             if not match:
+                continue
+
+            if current_vrf is None or current_process_id is None:
                 continue
 
             interface = canonical_interface_name(
@@ -77,6 +103,7 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
             )
             neighbor_id = match.group("neighbor_id")
             state, role = cls._parse_state_role(match.group("state_role"))
+            neighbors = vrfs[current_vrf]["processes"][current_process_id]["neighbors"]
 
             if interface not in neighbors:
                 neighbors[interface] = {}
@@ -93,11 +120,31 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
 
             neighbors[interface][neighbor_id] = entry
 
-        if not neighbors:
+        if not vrfs:
             msg = "No OSPF neighbors found in output"
             raise ValueError(msg)
 
-        return ShowIpOspfNeighborResult(neighbors=neighbors)
+        return ShowIpOspfNeighborResult(vrfs=vrfs)
+
+    @staticmethod
+    def _parse_section(
+        line: str, vrfs: dict[str, OspfVrfEntry]
+    ) -> tuple[str, str] | None:
+        section_match = _SECTION_PATTERN.match(line)
+        if section_match is None:
+            return None
+
+        vrf = section_match.group("vrf")
+        process_id = section_match.group("process_id")
+
+        if vrf not in vrfs:
+            vrfs[vrf] = {"processes": {}}
+
+        processes = vrfs[vrf]["processes"]
+        if process_id not in processes:
+            processes[process_id] = {"neighbors": {}}
+
+        return vrf, process_id
 
     @staticmethod
     def _parse_state_role(state_role: str) -> tuple[str, str]:

--- a/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
@@ -1,0 +1,99 @@
+"""Parser for 'show ip ospf neighbor' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class OspfNeighborEntry(TypedDict):
+    """Schema for a single NX-OS OSPF neighbor entry."""
+
+    priority: int
+    state: str
+    up_time: str
+    address: str
+    role: NotRequired[str]
+
+
+class ShowIpOspfNeighborResult(TypedDict):
+    """Schema for 'show ip ospf neighbor' parsed output."""
+
+    neighbors: dict[str, dict[str, OspfNeighborEntry]]
+
+
+# Pattern for neighbor table rows on NX-OS:
+# Neighbor ID     Pri State            Up Time  Address         Interface
+# 192.168.1.8       1 FULL/ -          2y0w     192.168.2.2     Vlan2
+# 10.0.0.6          1 INIT/DROTHER     -        77.77.77.77     Po4
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<neighbor_id>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+    r"(?P<priority>\d+)\s+"
+    r"(?P<state>\w+)/\s*(?P<role>DR|BDR|DROTHER|-)\s+"
+    r"(?P<up_time>\S+)\s+"
+    r"(?P<address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+    r"(?P<interface>\S+)\s*$"
+)
+
+
+@register(OS.CISCO_NXOS, "show ip ospf neighbor")
+class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
+    """Parser for 'show ip ospf neighbor' command on NX-OS.
+
+    Parses OSPF neighbor adjacency information from the neighbor table.
+    Neighbors are keyed by canonical interface name, then by neighbor router ID.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfNeighborResult:
+        """Parse 'show ip ospf neighbor' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed neighbor data keyed by interface then neighbor ID.
+
+        Raises:
+            ValueError: If no neighbors found in output.
+        """
+        neighbors: dict[str, dict[str, OspfNeighborEntry]] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = _NEIGHBOR_PATTERN.match(line)
+            if not match:
+                continue
+
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.CISCO_NXOS
+            )
+            neighbor_id = match.group("neighbor_id")
+            role = match.group("role")
+
+            if interface not in neighbors:
+                neighbors[interface] = {}
+
+            entry: OspfNeighborEntry = {
+                "priority": int(match.group("priority")),
+                "state": match.group("state").upper(),
+                "up_time": match.group("up_time"),
+                "address": match.group("address"),
+            }
+
+            if role != "-":
+                entry["role"] = role
+
+            neighbors[interface][neighbor_id] = entry
+
+        if not neighbors:
+            msg = "No OSPF neighbors found in output"
+            raise ValueError(msg)
+
+        return ShowIpOspfNeighborResult(neighbors=neighbors)

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/expected.json
@@ -1,27 +1,35 @@
 {
-    "neighbors": {
-        "Ethernet1/1": {
-            "192.168.1.3": {
-                "address": "192.168.1.3",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "2y10w"
-            }
-        },
-        "Ethernet1/2": {
-            "192.168.1.4": {
-                "address": "192.168.1.4",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "2y11w"
-            }
-        },
-        "Vlan2": {
-            "192.168.1.8": {
-                "address": "192.168.2.2",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "2y0w"
+    "vrfs": {
+        "default": {
+            "processes": {
+                "DC_UNDERLAY": {
+                    "neighbors": {
+                        "Ethernet1/1": {
+                            "192.168.1.3": {
+                                "address": "192.168.1.3",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "2y10w"
+                            }
+                        },
+                        "Ethernet1/2": {
+                            "192.168.1.4": {
+                                "address": "192.168.1.4",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "2y11w"
+                            }
+                        },
+                        "Vlan2": {
+                            "192.168.1.8": {
+                                "address": "192.168.2.2",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "2y0w"
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/expected.json
@@ -1,0 +1,28 @@
+{
+    "neighbors": {
+        "Ethernet1/1": {
+            "192.168.1.3": {
+                "address": "192.168.1.3",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "2y10w"
+            }
+        },
+        "Ethernet1/2": {
+            "192.168.1.4": {
+                "address": "192.168.1.4",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "2y11w"
+            }
+        },
+        "Vlan2": {
+            "192.168.1.8": {
+                "address": "192.168.2.2",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "2y0w"
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/input.txt
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/input.txt
@@ -1,0 +1,6 @@
+ OSPF Process ID DC_UNDERLAY VRF default
+ Total number of neighbors: 3
+ Neighbor ID     Pri State            Up Time  Address         Interface
+ 192.168.1.8       1 FULL/ -          2y0w     192.168.2.2     Vlan2
+ 192.168.1.3       1 FULL/ -          2y10w    192.168.1.3    Eth1/1
+ 192.168.1.4       1 FULL/ -          2y11w    192.168.1.4    Eth1/2

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple OSPF neighbors on different interfaces
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json
@@ -1,52 +1,72 @@
 {
-    "neighbors": {
-        "Port-channel1": {
-            "10.0.0.2": {
-                "address": "22.22.22.22",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "5w6d"
+    "vrfs": {
+        "CUSTVRF1": {
+            "processes": {
+                "1111": {
+                    "neighbors": {
+                        "Port-channel1": {
+                            "10.0.0.2": {
+                                "address": "22.22.22.22",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "5w6d"
+                            }
+                        },
+                        "Port-channel2": {
+                            "10.0.0.3": {
+                                "address": "44.44.44.44",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "5w6d"
+                            }
+                        },
+                        "Vlan999": {
+                            "10.0.0.1": {
+                                "address": "11.11.11.11",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "8w6d"
+                            }
+                        }
+                    }
+                }
             }
         },
-        "Port-channel2": {
-            "10.0.0.3": {
-                "address": "44.44.44.44",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "5w6d"
-            }
-        },
-        "Port-channel3": {
-            "10.0.0.5": {
-                "address": "66.66.66.66",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "7w2d"
-            }
-        },
-        "Port-channel4": {
-            "10.0.0.6": {
-                "address": "77.77.77.77",
-                "priority": 1,
-                "role": "DROTHER",
-                "state": "INIT",
-                "up_time": "-"
-            }
-        },
-        "Vlan1000": {
-            "10.0.0.4": {
-                "address": "55.55.55.55",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "8w6d"
-            }
-        },
-        "Vlan999": {
-            "10.0.0.1": {
-                "address": "11.11.11.11",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "8w6d"
+        "CUSTVRF2": {
+            "processes": {
+                "2222": {
+                    "neighbors": {
+                        "Vlan1000": {
+                            "10.0.0.4": {
+                                "address": "55.55.55.55",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "8w6d"
+                            }
+                        }
+                    }
+                },
+                "3333": {
+                    "neighbors": {
+                        "Port-channel3": {
+                            "10.0.0.5": {
+                                "address": "66.66.66.66",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "7w2d"
+                            }
+                        },
+                        "Port-channel4": {
+                            "10.0.0.6": {
+                                "address": "77.77.77.77",
+                                "priority": 1,
+                                "role": "DROTHER",
+                                "state": "INIT",
+                                "up_time": "-"
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json
@@ -1,0 +1,53 @@
+{
+    "neighbors": {
+        "Port-channel1": {
+            "10.0.0.2": {
+                "address": "22.22.22.22",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "5w6d"
+            }
+        },
+        "Port-channel2": {
+            "10.0.0.3": {
+                "address": "44.44.44.44",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "5w6d"
+            }
+        },
+        "Port-channel3": {
+            "10.0.0.5": {
+                "address": "66.66.66.66",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "7w2d"
+            }
+        },
+        "Port-channel4": {
+            "10.0.0.6": {
+                "address": "77.77.77.77",
+                "priority": 1,
+                "role": "DROTHER",
+                "state": "INIT",
+                "up_time": "-"
+            }
+        },
+        "Vlan1000": {
+            "10.0.0.4": {
+                "address": "55.55.55.55",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "8w6d"
+            }
+        },
+        "Vlan999": {
+            "10.0.0.1": {
+                "address": "11.11.11.11",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "8w6d"
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/input.txt
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/input.txt
@@ -1,0 +1,16 @@
+router1# sh ip ospf neighbors vrf all
+ OSPF Process ID 1111 VRF CUSTVRF1
+ Total number of neighbors: 3
+ Neighbor ID     Pri State            Up Time  Address         Interface
+ 10.0.0.1          1 FULL/ -          8w6d     11.11.11.11     Vlan999
+ 10.0.0.2          1 FULL/ -          5w6d     22.22.22.22     Po1
+ 10.0.0.3          1 FULL/ -          5w6d     44.44.44.44     Po2
+ OSPF Process ID 2222 VRF CUSTVRF2
+ Total number of neighbors: 1
+ Neighbor ID     Pri State            Up Time  Address         Interface
+ 10.0.0.4          1 FULL/ -          8w6d     55.55.55.55     Vlan1000
+ OSPF Process ID 3333 VRF CUSTVRF2
+ Total number of neighbors: 2
+ Neighbor ID     Pri State            Up Time  Address         Interface
+ 10.0.0.5          1 FULL/ -          7w2d     66.66.66.66     Po3
+ 10.0.0.6          1 INIT/DROTHER     -        77.77.77.77     Po4

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with DROTHER role and dash up_time
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/expected.json
@@ -1,0 +1,21 @@
+{
+    "neighbors": {
+        "Ethernet1/3": {
+            "10.0.0.7": {
+                "address": "88.88.88.88",
+                "priority": 1,
+                "state": "FULL",
+                "up_time": "4d19h"
+            }
+        },
+        "Ethernet1/4": {
+            "10.0.0.8": {
+                "address": "99.99.99.99",
+                "priority": 1,
+                "role": "BDR",
+                "state": "EXSTART",
+                "up_time": "33m"
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/expected.json
@@ -1,20 +1,28 @@
 {
-    "neighbors": {
-        "Ethernet1/3": {
-            "10.0.0.7": {
-                "address": "88.88.88.88",
-                "priority": 1,
-                "state": "FULL",
-                "up_time": "4d19h"
-            }
-        },
-        "Ethernet1/4": {
-            "10.0.0.8": {
-                "address": "99.99.99.99",
-                "priority": 1,
-                "role": "BDR",
-                "state": "EXSTART",
-                "up_time": "33m"
+    "vrfs": {
+        "default": {
+            "processes": {
+                "4444": {
+                    "neighbors": {
+                        "Ethernet1/3": {
+                            "10.0.0.7": {
+                                "address": "88.88.88.88",
+                                "priority": 1,
+                                "state": "FULL",
+                                "up_time": "4d19h"
+                            }
+                        },
+                        "Ethernet1/4": {
+                            "10.0.0.8": {
+                                "address": "99.99.99.99",
+                                "priority": 1,
+                                "role": "BDR",
+                                "state": "EXSTART",
+                                "up_time": "33m"
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/input.txt
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/input.txt
@@ -1,0 +1,5 @@
+ OSPF Process ID 4444 VRF default
+ Total number of neighbors: 2
+ Neighbor ID     Pri State            Up Time  Address         Interface
+ 10.0.0.7          1 FULL/            4d19h    88.88.88.88     Eth1/3
+ 10.0.0.8          1 EXSTART/BDR      33m      99.99.99.99     Eth1/4

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/003_empty_role/metadata.yaml
@@ -1,0 +1,3 @@
+description: Empty role column does not consume uptime
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added parser for `show ip ospf neighbor` command on Cisco NX-OS
- Handles NX-OS-specific output format: uptime (instead of dead time), DROTHER role, multi-VRF/process sections
- Neighbors keyed by canonical interface name, then by neighbor router ID
- Two test cases: basic single-VRF and multi-VRF with DROTHER role

## Test plan
- [x] Parser handles standard OSPF neighbor table output
- [x] Parser handles multi-VRF output with mixed roles (FULL, INIT/DROTHER)
- [x] All tests pass with `uv run pytest`
- [x] Pre-commit hooks pass
- [x] Ruff check, ruff format, and xenon complexity checks pass

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)