### PR TITLE
feat: add parser for 'show license' on IOS

### DIFF
--- a/changes/420.parser_added
+++ b/changes/420.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show license' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_license.py
+++ b/src/muninn/parsers/ios/show_license.py
@@ -1,0 +1,105 @@
+"""Parser for 'show license' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+# Pattern to match the start of each license entry
+_INDEX_FEATURE = re.compile(r"^Index\s+(\d+)\s+Feature:\s+(\S+)")
+
+# Pattern to match key-value attribute lines
+_ATTRIBUTE = re.compile(r"^\s+(\S[\w ]*\S)\s*:\s+(.+)$")
+
+
+class LicenseEntry(TypedDict):
+    """Schema for a single license feature entry."""
+
+    index: int
+    feature: str
+    license_type: NotRequired[str]
+    license_state: NotRequired[str]
+    license_count: NotRequired[str]
+    license_priority: NotRequired[str]
+    period_left: NotRequired[str]
+    period_used: NotRequired[str]
+
+
+class ShowLicenseResult(TypedDict):
+    """Schema for 'show license' parsed output."""
+
+    licenses: dict[str, LicenseEntry]
+
+
+# Maps raw attribute names to schema field names
+_ATTR_MAP: dict[str, str] = {
+    "License Type": "license_type",
+    "License State": "license_state",
+    "License Count": "license_count",
+    "License Priority": "license_priority",
+    "Period left": "period_left",
+    "Period Used": "period_used",
+}
+
+
+@register(OS.CISCO_IOS, "show license")
+class ShowLicenseParser(BaseParser[ShowLicenseResult]):
+    """Parser for 'show license' command.
+
+    Example output:
+        Index 1 Feature: appxk9
+                Period left: Life time
+                License Type: Permanent
+                License State: Active, In Use
+                License Count: Non-Counted
+                License Priority: Medium
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLicenseResult:
+        """Parse 'show license' output.
+
+        Args:
+            output: Raw CLI output from 'show license' command.
+
+        Returns:
+            Parsed data keyed by feature name.
+
+        Raises:
+            ValueError: If no license entries are found in the output.
+        """
+        licenses: dict[str, LicenseEntry] = {}
+        current_entry: LicenseEntry | None = None
+        current_feature: str | None = None
+
+        for line in output.splitlines():
+            index_match = _INDEX_FEATURE.match(line)
+            if index_match:
+                index = int(index_match.group(1))
+                feature = index_match.group(2)
+                current_entry = LicenseEntry(
+                    index=index,
+                    feature=feature,
+                )
+                current_feature = feature
+                licenses[current_feature] = current_entry
+                continue
+
+            if current_entry is None:
+                continue
+
+            attr_match = _ATTRIBUTE.match(line)
+            if attr_match:
+                raw_key = attr_match.group(1)
+                raw_value = attr_match.group(2).strip()
+                field_name = _ATTR_MAP.get(raw_key)
+                if field_name is not None:
+                    current_entry[field_name] = raw_value  # type: ignore[literal-required]
+
+        if not licenses:
+            msg = "No license entries found in output"
+            raise ValueError(msg)
+
+        return ShowLicenseResult(licenses=licenses)

--- a/tests/parsers/ios/show_license/001_basic/expected.json
+++ b/tests/parsers/ios/show_license/001_basic/expected.json
@@ -1,0 +1,94 @@
+{
+    "licenses": {
+        "AdvUCSuiteK9": {
+            "feature": "AdvUCSuiteK9",
+            "index": 6,
+            "license_count": "Non-Counted",
+            "license_priority": "None",
+            "license_state": "Active, Not in Use, EULA not accepted",
+            "license_type": "EvalRightToUse",
+            "period_left": "Not Activated",
+            "period_used": "0  minute  0  second"
+        },
+        "FoundationSuiteK9": {
+            "feature": "FoundationSuiteK9",
+            "index": 5,
+            "license_count": "Non-Counted",
+            "license_priority": "None",
+            "license_state": "Active, Not in Use, EULA not accepted",
+            "license_type": "EvalRightToUse",
+            "period_left": "Not Activated",
+            "period_used": "0  minute  0  second"
+        },
+        "appxk9": {
+            "feature": "appxk9",
+            "index": 1,
+            "license_count": "Non-Counted",
+            "license_priority": "Medium",
+            "license_state": "Active, In Use",
+            "license_type": "Permanent",
+            "period_left": "Life time"
+        },
+        "cme-srst": {
+            "feature": "cme-srst",
+            "index": 7,
+            "license_count": "0/0  (In-use/Violation)",
+            "license_priority": "None",
+            "license_state": "Active, Not in Use, EULA not accepted",
+            "license_type": "EvalRightToUse",
+            "period_left": "Not Activated",
+            "period_used": "0  minute  0  second"
+        },
+        "hseck9": {
+            "feature": "hseck9",
+            "index": 8,
+            "license_count": "Non-Counted",
+            "license_priority": "Medium",
+            "license_state": "Active, In Use",
+            "license_type": "Permanent",
+            "period_left": "Life time"
+        },
+        "internal_service": {
+            "feature": "internal_service",
+            "index": 10
+        },
+        "ipbasek9": {
+            "feature": "ipbasek9",
+            "index": 4,
+            "license_count": "Non-Counted",
+            "license_priority": "Medium",
+            "license_state": "Active, In Use",
+            "license_type": "Permanent",
+            "period_left": "Life time"
+        },
+        "securityk9": {
+            "feature": "securityk9",
+            "index": 3,
+            "license_count": "Non-Counted",
+            "license_priority": "Medium",
+            "license_state": "Active, In Use",
+            "license_type": "Permanent",
+            "period_left": "Life time"
+        },
+        "throughput": {
+            "feature": "throughput",
+            "index": 9,
+            "license_count": "Non-Counted",
+            "license_priority": "None",
+            "license_state": "Active, Not in Use, EULA not accepted",
+            "license_type": "EvalRightToUse",
+            "period_left": "Not Activated",
+            "period_used": "0  minute  0  second"
+        },
+        "uck9": {
+            "feature": "uck9",
+            "index": 2,
+            "license_count": "Non-Counted",
+            "license_priority": "None",
+            "license_state": "Active, Not in Use, EULA not accepted",
+            "license_type": "EvalRightToUse",
+            "period_left": "Not Activated",
+            "period_used": "0  minute  0  second"
+        }
+    }
+}

--- a/tests/parsers/ios/show_license/001_basic/input.txt
+++ b/tests/parsers/ios/show_license/001_basic/input.txt
@@ -1,0 +1,60 @@
+Index 1 Feature: appxk9
+        Period left: Life time
+        License Type: Permanent
+        License State: Active, In Use
+        License Count: Non-Counted
+        License Priority: Medium
+Index 2 Feature: uck9
+        Period left: Not Activated
+        Period Used: 0  minute  0  second
+        License Type: EvalRightToUse
+        License State: Active, Not in Use, EULA not accepted
+        License Count: Non-Counted
+        License Priority: None
+Index 3 Feature: securityk9
+        Period left: Life time
+        License Type: Permanent
+        License State: Active, In Use
+        License Count: Non-Counted
+        License Priority: Medium
+Index 4 Feature: ipbasek9
+        Period left: Life time
+        License Type: Permanent
+        License State: Active, In Use
+        License Count: Non-Counted
+        License Priority: Medium
+Index 5 Feature: FoundationSuiteK9
+        Period left: Not Activated
+        Period Used: 0  minute  0  second
+        License Type: EvalRightToUse
+        License State: Active, Not in Use, EULA not accepted
+        License Count: Non-Counted
+        License Priority: None
+Index 6 Feature: AdvUCSuiteK9
+        Period left: Not Activated
+        Period Used: 0  minute  0  second
+        License Type: EvalRightToUse
+        License State: Active, Not in Use, EULA not accepted
+        License Count: Non-Counted
+        License Priority: None
+Index 7 Feature: cme-srst
+        Period left: Not Activated
+        Period Used: 0  minute  0  second
+        License Type: EvalRightToUse
+        License State: Active, Not in Use, EULA not accepted
+        License Count: 0/0  (In-use/Violation)
+        License Priority: None
+Index 8 Feature: hseck9
+        Period left: Life time
+        License Type: Permanent
+        License State: Active, In Use
+        License Count: Non-Counted
+        License Priority: Medium
+Index 9 Feature: throughput
+        Period left: Not Activated
+        Period Used: 0  minute  0  second
+        License Type: EvalRightToUse
+        License State: Active, Not in Use, EULA not accepted
+        License Count: Non-Counted
+        License Priority: None
+Index 10 Feature: internal_service

--- a/tests/parsers/ios/show_license/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_license/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with multiple license features including permanent and eval licenses
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added parser for `show license` command on Cisco IOS
- Parses license feature entries keyed by feature name with support for permanent, eval, and minimal (no-attribute) entries
- Optional fields (`period_used`, etc.) are omitted when not present in the output

## Test plan
- [ ] Parser handles standard license output with mixed license types
- [ ] All tests pass with `uv run pytest`
- [ ] Pre-commit hooks pass

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)