### PR TITLE
feat: add parser for 'show ip ospf database network' on IOS

### DIFF
--- a/changes/421.parser_added
+++ b/changes/421.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip ospf database network' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_ip_ospf_database_network.py
+++ b/src/muninn/parsers/ios/show_ip_ospf_database_network.py
@@ -1,0 +1,215 @@
+"""Parser for 'show ip ospf database network' command on IOS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class NetworkLsaEntry(TypedDict):
+    """Schema for a single Network LSA entry."""
+
+    ls_age: int
+    options: str
+    ls_type: str
+    link_state_id: str
+    advertising_router: str
+    ls_seq_number: str
+    checksum: str
+    length: int
+    network_mask: str
+    attached_routers: dict[str, dict[str, object]]
+
+
+class AreaEntry(TypedDict):
+    """Schema for an OSPF area containing network LSAs."""
+
+    lsas: dict[str, dict[str, NetworkLsaEntry]]
+
+
+class ShowIpOspfDatabaseNetworkResult(TypedDict):
+    """Schema for 'show ip ospf database network' parsed output."""
+
+    router_id: str
+    process_id: int
+    areas: dict[str, AreaEntry]
+
+
+# --- Header patterns ---
+_ROUTER_PROCESS_RE = re.compile(
+    r"^\s*OSPF Router with (?:ID|id)\s*\((\S+)\)"
+    r"\s*\(Process ID (\d+)\)\s*$"
+)
+_AREA_RE = re.compile(r"^\s*Displaying Net Link States\s*\(Area (\S+)\)\s*$")
+
+# --- LSA field patterns ---
+_LS_AGE_RE = re.compile(r"^\s*LS age:\s*(\d+)\s*$")
+_OPTIONS_RE = re.compile(r"^\s*Options:\s*\((.+?)\)\s*$")
+_LS_TYPE_RE = re.compile(r"^\s*LS Type:\s*(.+?)\s*$")
+_LINK_STATE_ID_RE = re.compile(r"^\s*Link State ID:\s*(\S+)\s*(?:\(.+\))?\s*$")
+_ADV_ROUTER_RE = re.compile(r"^\s*Advertising Router:\s*(\S+)\s*$")
+_LS_SEQ_RE = re.compile(r"^\s*LS Seq Number:\s*(\S+)\s*$")
+_CHECKSUM_RE = re.compile(r"^\s*Checksum:\s*(\S+)\s*$")
+_LENGTH_RE = re.compile(r"^\s*Length:\s*(\d+)\s*$")
+_NETWORK_MASK_RE = re.compile(r"^\s*Network Mask:\s*(\S+)\s*$")
+_ATTACHED_ROUTER_RE = re.compile(r"^\s*Attached Router:\s*(\S+)\s*$")
+
+# Table-driven string field matchers: (pattern, field_name)
+_STRING_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_OPTIONS_RE, "options"),
+    (_LS_TYPE_RE, "ls_type"),
+    (_LINK_STATE_ID_RE, "link_state_id"),
+    (_ADV_ROUTER_RE, "advertising_router"),
+    (_LS_SEQ_RE, "ls_seq_number"),
+    (_CHECKSUM_RE, "checksum"),
+    (_NETWORK_MASK_RE, "network_mask"),
+)
+
+# Table-driven integer field matchers: (pattern, field_name)
+_INT_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_LS_AGE_RE, "ls_age"),
+    (_LENGTH_RE, "length"),
+)
+
+
+def _match_string_field(line: str, entry: dict[str, object]) -> bool:
+    """Try matching a string field pattern. Returns True if matched."""
+    for pattern, field_name in _STRING_FIELD_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            entry[field_name] = m.group(1)
+            return True
+    return False
+
+
+def _match_int_field(line: str, entry: dict[str, object]) -> bool:
+    """Try matching an integer field pattern. Returns True if matched."""
+    for pattern, field_name in _INT_FIELD_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            entry[field_name] = int(m.group(1))
+            return True
+    return False
+
+
+def _parse_lsa_block(
+    lines: list[str],
+) -> NetworkLsaEntry | None:
+    """Parse a single Network LSA block from its lines."""
+    entry: dict[str, object] = {}
+    attached_routers: dict[str, dict[str, object]] = {}
+
+    for line in lines:
+        if _match_int_field(line, entry):
+            continue
+        if _match_string_field(line, entry):
+            continue
+        m = _ATTACHED_ROUTER_RE.match(line)
+        if m:
+            attached_routers[m.group(1)] = {}
+
+    if not entry:
+        return None
+
+    entry["attached_routers"] = attached_routers
+    return entry  # type: ignore[return-value]
+
+
+def _store_lsa(
+    areas: dict[str, AreaEntry],
+    area: str,
+    lsa_lines: list[str],
+    link_state_id: str,
+    adv_router: str,
+) -> None:
+    """Parse and store an LSA block into the areas dict."""
+    lsa = _parse_lsa_block(lsa_lines)
+    if lsa is None:
+        return
+    area_entry = areas.setdefault(area, {"lsas": {}})
+    lsid_entry = area_entry["lsas"].setdefault(link_state_id, {})
+    lsid_entry[adv_router] = lsa
+
+
+def _extract_header(
+    output: str,
+) -> tuple[str, int]:
+    """Extract router ID and process ID from the output header."""
+    for line in output.splitlines():
+        m = _ROUTER_PROCESS_RE.match(line)
+        if m:
+            return m.group(1), int(m.group(2))
+    msg = "Could not parse router ID or process ID from output"
+    raise ValueError(msg)
+
+
+def _parse_lsa_blocks(
+    output: str,
+) -> dict[str, AreaEntry]:
+    """Parse all LSA blocks grouped by area."""
+    areas: dict[str, AreaEntry] = {}
+    current_area: str | None = None
+    lsa_lines: list[str] = []
+    link_state_id: str | None = None
+    adv_router: str | None = None
+
+    def flush() -> None:
+        nonlocal lsa_lines, link_state_id, adv_router
+        if current_area and lsa_lines and link_state_id and adv_router:
+            _store_lsa(
+                areas,
+                current_area,
+                lsa_lines,
+                link_state_id,
+                adv_router,
+            )
+        lsa_lines = []
+        link_state_id = None
+        adv_router = None
+
+    for line in output.splitlines():
+        m = _AREA_RE.match(line)
+        if m:
+            flush()
+            current_area = m.group(1)
+            continue
+
+        if _LS_AGE_RE.match(line):
+            flush()
+            lsa_lines.append(line)
+            continue
+
+        m = _LINK_STATE_ID_RE.match(line)
+        if m:
+            link_state_id = m.group(1)
+
+        m = _ADV_ROUTER_RE.match(line)
+        if m:
+            adv_router = m.group(1)
+
+        if current_area is not None:
+            lsa_lines.append(line)
+
+    flush()
+    return areas
+
+
+@register(OS.CISCO_IOS, "show ip ospf database network")
+class ShowIpOspfDatabaseNetworkParser(
+    BaseParser["ShowIpOspfDatabaseNetworkResult"],
+):
+    """Parser for 'show ip ospf database network' on IOS."""
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfDatabaseNetworkResult:
+        """Parse 'show ip ospf database network' output."""
+        router_id, process_id = _extract_header(output)
+        areas = _parse_lsa_blocks(output)
+
+        return {
+            "router_id": router_id,
+            "process_id": process_id,
+            "areas": areas,
+        }

--- a/tests/parsers/ios/show_ip_ospf_database_network/001_basic/expected.json
+++ b/tests/parsers/ios/show_ip_ospf_database_network/001_basic/expected.json
@@ -1,0 +1,69 @@
+{
+    "areas": {
+        "0.0.0.0": {
+            "lsas": {
+                "10.1.2.1": {
+                    "10.1.2.1": {
+                        "advertising_router": "10.1.2.1",
+                        "attached_routers": {
+                            "10.1.2.1": {},
+                            "10.16.2.2": {}
+                        },
+                        "checksum": "0xE9B0",
+                        "length": 32,
+                        "link_state_id": "10.1.2.1",
+                        "ls_age": 948,
+                        "ls_seq_number": "80000048",
+                        "ls_type": "Network Links",
+                        "network_mask": "255.255.255.0",
+                        "options": "No TOS-capability"
+                    }
+                },
+                "172.16.1.3": {
+                    "192.168.239.66": {
+                        "advertising_router": "192.168.239.66",
+                        "attached_routers": {
+                            "172.16.1.1": {},
+                            "172.16.1.5": {},
+                            "172.16.241.5": {},
+                            "172.16.54.5": {},
+                            "192.168.239.66": {}
+                        },
+                        "checksum": "0x1229",
+                        "length": 52,
+                        "link_state_id": "172.16.1.3",
+                        "ls_age": 1367,
+                        "ls_seq_number": "800000E7",
+                        "ls_type": "Network Links",
+                        "network_mask": "255.255.255.0",
+                        "options": "No TOS-capability"
+                    }
+                }
+            }
+        },
+        "0.0.0.1": {
+            "lsas": {
+                "10.186.5.1": {
+                    "10.229.11.11": {
+                        "advertising_router": "10.229.11.11",
+                        "attached_routers": {
+                            "10.115.55.55": {},
+                            "10.229.11.11": {},
+                            "10.84.66.66": {}
+                        },
+                        "checksum": "0x3E6C",
+                        "length": 36,
+                        "link_state_id": "10.186.5.1",
+                        "ls_age": 234,
+                        "ls_seq_number": "80000015",
+                        "ls_type": "Network Links",
+                        "network_mask": "255.255.255.0",
+                        "options": "No TOS-capability, DC"
+                    }
+                }
+            }
+        }
+    },
+    "process_id": 300,
+    "router_id": "192.168.239.66"
+}

--- a/tests/parsers/ios/show_ip_ospf_database_network/001_basic/input.txt
+++ b/tests/parsers/ios/show_ip_ospf_database_network/001_basic/input.txt
@@ -1,0 +1,46 @@
+
+            OSPF Router with ID (192.168.239.66) (Process ID 300)
+
+                Displaying Net Link States (Area 0.0.0.0)
+
+  LS age: 1367
+  Options: (No TOS-capability)
+  LS Type: Network Links
+  Link State ID: 172.16.1.3 (address of Designated Router)
+  Advertising Router: 192.168.239.66
+  LS Seq Number: 800000E7
+  Checksum: 0x1229
+  Length: 52
+  Network Mask: 255.255.255.0
+        Attached Router: 192.168.239.66
+        Attached Router: 172.16.241.5
+        Attached Router: 172.16.1.1
+        Attached Router: 172.16.54.5
+        Attached Router: 172.16.1.5
+
+  LS age: 948
+  Options: (No TOS-capability)
+  LS Type: Network Links
+  Link State ID: 10.1.2.1 (address of Designated Router)
+  Advertising Router: 10.1.2.1
+  LS Seq Number: 80000048
+  Checksum: 0xE9B0
+  Length: 32
+  Network Mask: 255.255.255.0
+        Attached Router: 10.1.2.1
+        Attached Router: 10.16.2.2
+
+                Displaying Net Link States (Area 0.0.0.1)
+
+  LS age: 234
+  Options: (No TOS-capability, DC)
+  LS Type: Network Links
+  Link State ID: 10.186.5.1 (address of Designated Router)
+  Advertising Router: 10.229.11.11
+  LS Seq Number: 80000015
+  Checksum: 0x3E6C
+  Length: 36
+  Network Mask: 255.255.255.0
+        Attached Router: 10.229.11.11
+        Attached Router: 10.115.55.55
+        Attached Router: 10.84.66.66

--- a/tests/parsers/ios/show_ip_ospf_database_network/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ip_ospf_database_network/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard OSPF network LSA database with multiple entries across two areas
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added parser for `show ip ospf database network` command on Cisco IOS
- Parses OSPF Type 2 Network LSA entries, keyed by area, link state ID, and advertising router
- Includes test case with multiple areas and multiple LSA entries

## Test plan
- [x] Parser handles standard OSPF network LSA database output
- [x] All tests pass with `uv run pytest`
- [x] Pre-commit hooks pass

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)