### PR TITLE
feat: add parser for 'show platform resources' on IOS-XE

### DIFF
--- a/changes/426.parser_added
+++ b/changes/426.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform resources' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_resources.py
+++ b/src/muninn/parsers/iosxe/show_platform_resources.py
@@ -1,0 +1,235 @@
+"""Parser for 'show platform resources' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ResourceEntry(TypedDict):
+    """Schema for a single resource measurement."""
+
+    usage: float
+    usage_unit: str
+    usage_percent: NotRequired[int]
+    max: float
+    max_unit: str
+    warning_percent: int
+    critical_percent: int
+    state: str
+
+
+class SubComponentEntry(TypedDict):
+    """Schema for a sub-component (e.g., QFP) that contains resources."""
+
+    state: str
+    resources: NotRequired[dict[str, ResourceEntry]]
+
+
+class ComponentEntry(TypedDict):
+    """Schema for a top-level component (e.g., RP0, ESP0)."""
+
+    status: str
+    role: str
+    state: str
+    resources: NotRequired[dict[str, ResourceEntry]]
+    sub_components: NotRequired[dict[str, SubComponentEntry]]
+
+
+class ShowPlatformResourcesResult(TypedDict):
+    """Schema for 'show platform resources' parsed output."""
+
+    components: dict[str, ComponentEntry]
+
+
+# Component header: "RP0 (ok, active)" or "ESP0(ok, active)" or "SIP0"
+_COMPONENT = re.compile(
+    r"^(?P<name>(?:RP|ESP|SIP)\d+)"
+    r"(?:\s*\((?P<status>\w+),\s*(?P<role>\w+)\))?"
+    r"\s+(?P<state>[HWC])\s*$"
+)
+
+# Sub-component line (no usage data, just a name and state):
+# "QFP                                                                 H"
+# " Control Processor   12.43%   100%   80%   90%   H"
+# We detect sub-components as lines with only a name and a state letter
+_SUB_COMPONENT = re.compile(r"^(?P<name>[A-Z][A-Za-z ]+?)\s+(?P<state>[HWC])\s*$")
+
+# Resource with value+unit and percentage:
+# "DRAM    3665MB(48%)   7567MB   88%   93%   H"
+# "TCAM    8cells(0%)    1048576cells   65%   85%   H"
+# "B4Q Pool 124   15KB(0%)   1686KB   75%   85%   H"
+# "B4Q PMD    33952KB(25%)   130944KB   75%   85%   H"
+# "Pkt Buf Mem (0)   67KB(0%)   524288KB   85%   95%   H"
+# "TMPFS    666MB(16%)   3919MB   40%   50%   H"
+_RESOURCE_VALUE = re.compile(
+    r"^(?P<name>.+?)\s+"
+    r"(?P<usage>[\d.]+)(?P<usage_unit>[A-Za-z]+)"
+    r"\((?P<pct>\d+)%\)\s+"
+    r"(?P<max>[\d.]+)(?P<max_unit>[A-Za-z]+)\s+"
+    r"(?P<warn>\d+)%\s+"
+    r"(?P<crit>\d+)%\s+"
+    r"(?P<state>[HWC])\s*$"
+)
+
+# Resource as percentage only:
+# "Control Processor   12.43%   100%   80%   90%   H"
+# "CPU Utilization     0.00%    100%   90%   95%   H"
+# "Crypto Utilization  1.00%    100%   90%   95%   H"
+_RESOURCE_PCT = re.compile(
+    r"^(?P<name>.+?)\s+"
+    r"(?P<usage>[\d.]+)%\s+"
+    r"(?P<max>[\d.]+)%\s+"
+    r"(?P<warn>\d+)%\s+"
+    r"(?P<crit>\d+)%\s+"
+    r"(?P<state>[HWC])\s*$"
+)
+
+# Header / separator / state acronym lines to skip
+_SKIP = re.compile(r"^(?:\*\*State Acronym|Resource\s+Usage|---)", re.IGNORECASE)
+
+
+def _parse_resource_value(match: re.Match[str]) -> tuple[str, ResourceEntry]:
+    """Build a ResourceEntry from a value+unit resource match."""
+    name = match.group("name").strip()
+    entry = ResourceEntry(
+        usage=float(match.group("usage")),
+        usage_unit=match.group("usage_unit"),
+        usage_percent=int(match.group("pct")),
+        max=float(match.group("max")),
+        max_unit=match.group("max_unit"),
+        warning_percent=int(match.group("warn")),
+        critical_percent=int(match.group("crit")),
+        state=match.group("state"),
+    )
+    return name, entry
+
+
+def _parse_resource_pct(match: re.Match[str]) -> tuple[str, ResourceEntry]:
+    """Build a ResourceEntry from a percentage-only resource match."""
+    name = match.group("name").strip()
+    entry = ResourceEntry(
+        usage=float(match.group("usage")),
+        usage_unit="%",
+        max=float(match.group("max")),
+        max_unit="%",
+        warning_percent=int(match.group("warn")),
+        critical_percent=int(match.group("crit")),
+        state=match.group("state"),
+    )
+    return name, entry
+
+
+def _add_resource(
+    component: ComponentEntry,
+    sub_component: str | None,
+    name: str,
+    entry: ResourceEntry,
+) -> None:
+    """Add a resource entry to the appropriate component or sub-component."""
+    if sub_component is not None:
+        sub_comps = component.get("sub_components", {})
+        if sub_component in sub_comps:
+            resources = sub_comps[sub_component].get("resources", {})
+            resources[name] = entry
+            sub_comps[sub_component]["resources"] = resources
+    else:
+        if "resources" not in component:
+            component["resources"] = {}
+        component["resources"][name] = entry
+
+
+def _process_line(
+    line: str,
+    components: dict[str, ComponentEntry],
+    current_component: str | None,
+    current_sub: str | None,
+) -> tuple[str | None, str | None]:
+    """Process a single stripped line, returning updated state."""
+    if match := _COMPONENT.match(line):
+        name = match.group("name")
+        status = match.group("status") or "ok"
+        role = match.group("role") or "unknown"
+        components[name] = ComponentEntry(
+            status=status,
+            role=role,
+            state=match.group("state"),
+        )
+        return name, None
+
+    if current_component is None:
+        return None, None
+
+    if match := _RESOURCE_VALUE.match(line):
+        res_name, entry = _parse_resource_value(match)
+        _add_resource(components[current_component], current_sub, res_name, entry)
+        return current_component, current_sub
+
+    if match := _RESOURCE_PCT.match(line):
+        res_name, entry = _parse_resource_pct(match)
+        _add_resource(components[current_component], current_sub, res_name, entry)
+        return current_component, current_sub
+
+    if match := _SUB_COMPONENT.match(line):
+        sub_name = match.group("name").strip()
+        if "sub_components" not in components[current_component]:
+            components[current_component]["sub_components"] = {}
+        components[current_component]["sub_components"][sub_name] = SubComponentEntry(
+            state=match.group("state")
+        )
+        return current_component, sub_name
+
+    return current_component, current_sub
+
+
+@register(OS.CISCO_IOSXE, "show platform resources")
+class ShowPlatformResourcesParser(BaseParser[ShowPlatformResourcesResult]):
+    """Parser for 'show platform resources' command.
+
+    Example output::
+
+        **State Acronym: H - Healthy, W - Warning, C - Critical
+        Resource          Usage          Max       Warning  Critical  State
+        RP0 (ok, active)                                               H
+         Control Processor 12.43%        100%      80%      90%       H
+          DRAM             3665MB(48%)   7567MB    88%      93%       H
+        ESP0(ok, active)                                               H
+         QFP                                                           H
+          DRAM             233176KB(44%) 524288KB  85%      95%       H
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformResourcesResult:
+        """Parse 'show platform resources' output.
+
+        Args:
+            output: Raw CLI output from 'show platform resources'.
+
+        Returns:
+            Parsed platform resource data keyed by component.
+
+        Raises:
+            ValueError: If no platform resource data is found.
+        """
+        components: dict[str, ComponentEntry] = {}
+        current_component: str | None = None
+        current_sub: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped or _SKIP.match(stripped):
+                continue
+            if stripped.startswith("show platform"):
+                continue
+
+            current_component, current_sub = _process_line(
+                stripped, components, current_component, current_sub
+            )
+
+        if not components:
+            msg = "No platform resource data found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformResourcesResult(components=components)

--- a/tests/parsers/iosxe/show_platform_resources/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_resources/001_basic/expected.json
@@ -1,0 +1,201 @@
+{
+    "components": {
+        "ESP0": {
+            "role": "active",
+            "state": "H",
+            "status": "ok",
+            "sub_components": {
+                "QFP": {
+                    "resources": {
+                        "B4Q PMD": {
+                            "critical_percent": 85,
+                            "max": 130944.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 33952.0,
+                            "usage_percent": 25,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 1024": {
+                            "critical_percent": 85,
+                            "max": 7736.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 144.0,
+                            "usage_percent": 1,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 10240": {
+                            "critical_percent": 85,
+                            "max": 37820.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 380.0,
+                            "usage_percent": 1,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 124": {
+                            "critical_percent": 85,
+                            "max": 1686.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 15.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 128": {
+                            "critical_percent": 85,
+                            "max": 1740.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 6.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 1536": {
+                            "critical_percent": 85,
+                            "max": 11247.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 207.0,
+                            "usage_percent": 1,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 16384": {
+                            "critical_percent": 85,
+                            "max": 51808.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 0.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 2048": {
+                            "critical_percent": 85,
+                            "max": 14744.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 0.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 256": {
+                            "critical_percent": 85,
+                            "max": 3481.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 9.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 4096": {
+                            "critical_percent": 85,
+                            "max": 28696.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 0.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "B4Q Pool 512": {
+                            "critical_percent": 85,
+                            "max": 4177.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 9.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 75
+                        },
+                        "CPU Utilization": {
+                            "critical_percent": 95,
+                            "max": 100.0,
+                            "max_unit": "%",
+                            "state": "H",
+                            "usage": 0.0,
+                            "usage_unit": "%",
+                            "warning_percent": 90
+                        },
+                        "DRAM": {
+                            "critical_percent": 95,
+                            "max": 524288.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 233176.0,
+                            "usage_percent": 44,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "IRAM": {
+                            "critical_percent": 95,
+                            "max": 2048.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 414.0,
+                            "usage_percent": 20,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        }
+                    },
+                    "state": "H"
+                }
+            }
+        },
+        "RP0": {
+            "resources": {
+                "Control Processor": {
+                    "critical_percent": 90,
+                    "max": 100.0,
+                    "max_unit": "%",
+                    "state": "H",
+                    "usage": 12.43,
+                    "usage_unit": "%",
+                    "warning_percent": 80
+                },
+                "DRAM": {
+                    "critical_percent": 93,
+                    "max": 7567.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 3665.0,
+                    "usage_percent": 48,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                },
+                "bootflash": {
+                    "critical_percent": 90,
+                    "max": 7342.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 3303.0,
+                    "usage_percent": 45,
+                    "usage_unit": "MB",
+                    "warning_percent": 70
+                },
+                "harddisk": {
+                    "critical_percent": 95,
+                    "max": 14534.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 1015.0,
+                    "usage_percent": 7,
+                    "usage_unit": "MB",
+                    "warning_percent": 90
+                }
+            },
+            "role": "active",
+            "state": "H",
+            "status": "ok"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_resources/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_resources/001_basic/input.txt
@@ -1,0 +1,24 @@
+**State Acronym: H - Healthy, W - Warning, C - Critical
+Resource                 Usage                 Max             Warning         Critical        State
+----------------------------------------------------------------------------------------------------
+RP0 (ok, active)                                                                               H
+ Control Processor       12.43%                100%            80%             90%             H
+  DRAM                   3665MB(48%)           7567MB          88%             93%             H
+  bootflash              3303MB(45%)           7342MB          70%             90%             H
+  harddisk               1015MB(7%)            14534MB         90%             95%             H
+ESP0(ok, active)                                                                               H
+ QFP                                                                                           H
+  DRAM                   233176KB(44%)         524288KB        85%             95%             H
+  IRAM                   414KB(20%)            2048KB          85%             95%             H
+  CPU Utilization        0.00%                 100%            90%             95%             H
+  B4Q Pool 124           15KB(0%)              1686KB          75%             85%             H
+  B4Q Pool 128           6KB(0%)               1740KB          75%             85%             H
+  B4Q Pool 256           9KB(0%)               3481KB          75%             85%             H
+  B4Q Pool 512           9KB(0%)               4177KB          75%             85%             H
+  B4Q Pool 1024          144KB(1%)             7736KB          75%             85%             H
+  B4Q Pool 1536          207KB(1%)             11247KB         75%             85%             H
+  B4Q Pool 2048          0KB(0%)               14744KB         75%             85%             H
+  B4Q Pool 4096          0KB(0%)               28696KB         75%             85%             H
+  B4Q Pool 10240         380KB(1%)             37820KB         75%             85%             H
+  B4Q Pool 16384         0KB(0%)               51808KB         75%             85%             H
+  B4Q PMD                33952KB(25%)          130944KB        75%             85%             H

--- a/tests/parsers/iosxe/show_platform_resources/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_resources/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with RP and ESP components on ISR platform
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_platform_resources/002_modular/expected.json
+++ b/tests/parsers/iosxe/show_platform_resources/002_modular/expected.json
@@ -1,0 +1,306 @@
+{
+    "components": {
+        "ESP0": {
+            "resources": {
+                "Control Processor": {
+                    "critical_percent": 90,
+                    "max": 100.0,
+                    "max_unit": "%",
+                    "state": "H",
+                    "usage": 1.4,
+                    "usage_unit": "%",
+                    "warning_percent": 80
+                },
+                "DRAM": {
+                    "critical_percent": 93,
+                    "max": 15911.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 1057.0,
+                    "usage_percent": 6,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                }
+            },
+            "role": "active",
+            "state": "H",
+            "status": "ok",
+            "sub_components": {
+                "QFP": {
+                    "resources": {
+                        "CPU Utilization": {
+                            "critical_percent": 95,
+                            "max": 100.0,
+                            "max_unit": "%",
+                            "state": "H",
+                            "usage": 0.0,
+                            "usage_unit": "%",
+                            "warning_percent": 90
+                        },
+                        "DRAM": {
+                            "critical_percent": 95,
+                            "max": 4194304.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 238906.0,
+                            "usage_percent": 5,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "IRAM": {
+                            "critical_percent": 95,
+                            "max": 131072.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 13014.0,
+                            "usage_percent": 9,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "Pkt Buf Mem (0)": {
+                            "critical_percent": 95,
+                            "max": 524288.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 67.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "Pkt Buf Mem (1)": {
+                            "critical_percent": 95,
+                            "max": 524288.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 67.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "TCAM": {
+                            "critical_percent": 85,
+                            "max": 1048576.0,
+                            "max_unit": "cells",
+                            "state": "H",
+                            "usage": 16.0,
+                            "usage_percent": 0,
+                            "usage_unit": "cells",
+                            "warning_percent": 65
+                        }
+                    },
+                    "state": "H"
+                }
+            }
+        },
+        "ESP1": {
+            "resources": {
+                "Control Processor": {
+                    "critical_percent": 90,
+                    "max": 100.0,
+                    "max_unit": "%",
+                    "state": "H",
+                    "usage": 2.23,
+                    "usage_unit": "%",
+                    "warning_percent": 80
+                },
+                "DRAM": {
+                    "critical_percent": 93,
+                    "max": 15911.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 1055.0,
+                    "usage_percent": 6,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                }
+            },
+            "role": "standby",
+            "state": "H",
+            "status": "ok",
+            "sub_components": {
+                "QFP": {
+                    "resources": {
+                        "CPU Utilization": {
+                            "critical_percent": 95,
+                            "max": 100.0,
+                            "max_unit": "%",
+                            "state": "H",
+                            "usage": 0.0,
+                            "usage_unit": "%",
+                            "warning_percent": 90
+                        },
+                        "DRAM": {
+                            "critical_percent": 95,
+                            "max": 4194304.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 238906.0,
+                            "usage_percent": 5,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "IRAM": {
+                            "critical_percent": 95,
+                            "max": 131072.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 13014.0,
+                            "usage_percent": 9,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "Pkt Buf Mem (0)": {
+                            "critical_percent": 95,
+                            "max": 524288.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 67.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "Pkt Buf Mem (1)": {
+                            "critical_percent": 95,
+                            "max": 524288.0,
+                            "max_unit": "KB",
+                            "state": "H",
+                            "usage": 67.0,
+                            "usage_percent": 0,
+                            "usage_unit": "KB",
+                            "warning_percent": 85
+                        },
+                        "TCAM": {
+                            "critical_percent": 85,
+                            "max": 1048576.0,
+                            "max_unit": "cells",
+                            "state": "H",
+                            "usage": 16.0,
+                            "usage_percent": 0,
+                            "usage_unit": "cells",
+                            "warning_percent": 65
+                        }
+                    },
+                    "state": "H"
+                }
+            }
+        },
+        "RP0": {
+            "resources": {
+                "Control Processor": {
+                    "critical_percent": 90,
+                    "max": 100.0,
+                    "max_unit": "%",
+                    "state": "H",
+                    "usage": 0.25,
+                    "usage_unit": "%",
+                    "warning_percent": 80
+                },
+                "DRAM": {
+                    "critical_percent": 93,
+                    "max": 7557.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 3388.0,
+                    "usage_percent": 44,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                },
+                "bootflash": {
+                    "critical_percent": 93,
+                    "max": 7281.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 1443.0,
+                    "usage_percent": 19,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                },
+                "harddisk": {
+                    "critical_percent": 93,
+                    "max": 93836.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 69916.0,
+                    "usage_percent": 74,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                }
+            },
+            "role": "active",
+            "state": "H",
+            "status": "ok"
+        },
+        "RP1": {
+            "resources": {
+                "Control Processor": {
+                    "critical_percent": 90,
+                    "max": 100.0,
+                    "max_unit": "%",
+                    "state": "H",
+                    "usage": 0.2,
+                    "usage_unit": "%",
+                    "warning_percent": 80
+                },
+                "DRAM": {
+                    "critical_percent": 93,
+                    "max": 7557.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 3331.0,
+                    "usage_percent": 44,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                },
+                "bootflash": {
+                    "critical_percent": 93,
+                    "max": 6840.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 2162.0,
+                    "usage_percent": 31,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                },
+                "harddisk": {
+                    "critical_percent": 93,
+                    "max": 93836.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 48619.0,
+                    "usage_percent": 51,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                }
+            },
+            "role": "standby",
+            "state": "H",
+            "status": "ok"
+        },
+        "SIP0": {
+            "resources": {
+                "Control Processor": {
+                    "critical_percent": 90,
+                    "max": 100.0,
+                    "max_unit": "%",
+                    "state": "H",
+                    "usage": 13.32,
+                    "usage_unit": "%",
+                    "warning_percent": 80
+                },
+                "DRAM": {
+                    "critical_percent": 93,
+                    "max": 1955.0,
+                    "max_unit": "MB",
+                    "state": "H",
+                    "usage": 703.0,
+                    "usage_percent": 35,
+                    "usage_unit": "MB",
+                    "warning_percent": 88
+                }
+            },
+            "role": "unknown",
+            "state": "H",
+            "status": "ok"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_resources/002_modular/input.txt
+++ b/tests/parsers/iosxe/show_platform_resources/002_modular/input.txt
@@ -1,0 +1,35 @@
+Resource                 Usage                 Max             Warning         Critical        State
+----------------------------------------------------------------------------------------------------
+RP0 (ok, active)                                                                               H
+Control Processor       0.25%                 100%            80%             90%             H
+DRAM                   3388MB(44%)           7557MB          88%             93%             H
+bootflash              1443MB(19%)           7281MB          88%             93%             H
+harddisk               69916MB(74%)          93836MB         88%             93%             H
+RP1 (ok, standby)                                                              H
+Control Processor       0.20%                 100%            80%             90%             H
+DRAM                   3331MB(44%)           7557MB          88%             93%             H
+bootflash              2162MB(31%)           6840MB          88%             93%             H
+harddisk               48619MB(51%)          93836MB         88%             93%             H
+ESP0(ok, active)                                                                               H
+Control Processor       1.40%                 100%            80%             90%             H
+DRAM                   1057MB(6%)            15911MB         88%             93%             H
+QFP                                                                                           H
+TCAM                   16cells(0%)           1048576cells    65%             85%             H
+DRAM                   238906KB(5%)          4194304KB       85%             95%             H
+IRAM                   13014KB(9%)           131072KB        85%             95%             H
+CPU Utilization        0.00%                 100%            90%             95%             H
+Pkt Buf Mem (0)        67KB(0%)              524288KB        85%             95%             H
+Pkt Buf Mem (1)        67KB(0%)              524288KB        85%             95%             H
+ESP1(ok, standby)                                                                              H
+Control Processor       2.23%                 100%            80%             90%             H
+DRAM                   1055MB(6%)            15911MB         88%             93%             H
+QFP                                                                                           H
+TCAM                   16cells(0%)           1048576cells    65%             85%             H
+DRAM                   238906KB(5%)          4194304KB       85%             95%             H
+IRAM                   13014KB(9%)           131072KB        85%             95%             H
+CPU Utilization        0.00%                 100%            90%             95%             H
+Pkt Buf Mem (0)        67KB(0%)              524288KB        85%             95%             H
+Pkt Buf Mem (1)        67KB(0%)              524288KB        85%             95%             H
+SIP0                                                                                           H
+Control Processor       13.32%                100%            80%             90%             H
+DRAM                   703MB(35%)            1955MB          88%             93%             H

--- a/tests/parsers/iosxe/show_platform_resources/002_modular/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_resources/002_modular/metadata.yaml
@@ -1,0 +1,3 @@
+description: Modular chassis with dual RP, dual ESP, and SIP components
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added parser for `show platform resources` command on Cisco IOS-XE
- Supports hierarchical component structure (RP, ESP, SIP) with sub-components (QFP)
- Parses resource utilization metrics including DRAM, TCAM, IRAM, CPU, bootflash, harddisk, and B4Q pools

## Test plan
- [x] Parser handles standard platform resources output (001_basic)
- [x] Parser handles modular chassis with dual RP/ESP and SIP (002_modular)
- [x] All tests pass with `uv run pytest`
- [x] Pre-commit hooks pass

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)