### PR TITLE
feat: add parser for 'show udld neighbor' on IOS-XE

### DIFF
--- a/changes/430.parser_added
+++ b/changes/430.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show udld neighbor' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_udld_neighbor.py
+++ b/src/muninn/parsers/iosxe/show_udld_neighbor.py
@@ -1,0 +1,110 @@
+"""Parser for 'show udld neighbor' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class UdldNeighborEntry(TypedDict):
+    """Schema for a single UDLD neighbor entry."""
+
+    device_name: str
+    device_id: int
+    port_id: str
+    neighbor_state: str
+
+
+class ShowUdldNeighborResult(TypedDict):
+    """Schema for 'show udld neighbor' parsed output."""
+
+    neighbors: dict[str, UdldNeighborEntry]
+    total_bidirectional_entries: int
+
+
+@register(OS.CISCO_IOSXE, "show udld neighbor")
+class ShowUdldNeighborParser(BaseParser[ShowUdldNeighborResult]):
+    """Parser for 'show udld neighbor' command on IOS-XE.
+
+    Parses UDLD neighbor information showing connected devices and their
+    bidirectional state.
+    """
+
+    # Port           Device Name     Device ID    Port ID         Neighbor State
+    # Gi1/0/7        A4B43937780     1            Gi1/0/6         Bidirectional
+    _NEIGHBOR_PATTERN = re.compile(
+        r"^(?P<port>\S+)\s+"
+        r"(?P<device_name>\S+)\s+"
+        r"(?P<device_id>\d+)\s+"
+        r"(?P<port_id>\S+)\s+"
+        r"(?P<neighbor_state>\S+)$"
+    )
+
+    _TOTAL_PATTERN = re.compile(
+        r"^Total number of bidirectional entries displayed:\s*(?P<total>\d+)",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowUdldNeighborResult:
+        """Parse 'show udld neighbor' output on IOS-XE.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed UDLD neighbors keyed by local interface name.
+
+        Raises:
+            ValueError: If no UDLD neighbors found in output.
+        """
+        neighbors: dict[str, UdldNeighborEntry] = {}
+        total_bidirectional: int | None = None
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            # Skip header lines
+            if line.startswith(("Port", "----")):
+                continue
+
+            # Check for total line
+            total_match = cls._TOTAL_PATTERN.match(line)
+            if total_match:
+                total_bidirectional = int(total_match.group("total"))
+                continue
+
+            # Try neighbor entry
+            match = cls._NEIGHBOR_PATTERN.match(line)
+            if match:
+                interface = canonical_interface_name(
+                    match.group("port"), os=OS.CISCO_IOSXE
+                )
+                port_id = canonical_interface_name(
+                    match.group("port_id"), os=OS.CISCO_IOSXE
+                )
+
+                neighbors[interface] = {
+                    "device_name": match.group("device_name"),
+                    "device_id": int(match.group("device_id")),
+                    "port_id": port_id,
+                    "neighbor_state": match.group("neighbor_state"),
+                }
+
+        if not neighbors:
+            msg = "No UDLD neighbors found in output"
+            raise ValueError(msg)
+
+        if total_bidirectional is None:
+            msg = "No total bidirectional entries line found in output"
+            raise ValueError(msg)
+
+        return ShowUdldNeighborResult(
+            neighbors=neighbors,
+            total_bidirectional_entries=total_bidirectional,
+        )

--- a/tests/parsers/iosxe/show_udld_neighbor/001_single_neighbor/expected.json
+++ b/tests/parsers/iosxe/show_udld_neighbor/001_single_neighbor/expected.json
@@ -1,0 +1,11 @@
+{
+    "neighbors": {
+        "GigabitEthernet1/0/7": {
+            "device_id": 1,
+            "device_name": "A4B43937780",
+            "neighbor_state": "Bidirectional",
+            "port_id": "GigabitEthernet1/0/6"
+        }
+    },
+    "total_bidirectional_entries": 1
+}

--- a/tests/parsers/iosxe/show_udld_neighbor/001_single_neighbor/input.txt
+++ b/tests/parsers/iosxe/show_udld_neighbor/001_single_neighbor/input.txt
@@ -1,0 +1,5 @@
+Port           Device Name     Device ID    Port ID         Neighbor State
+----           -----------     ---------    -------         --------------
+Gi1/0/7        A4B43937780     1            Gi1/0/6         Bidirectional
+
+Total number of bidirectional entries displayed: 1

--- a/tests/parsers/iosxe/show_udld_neighbor/001_single_neighbor/metadata.yaml
+++ b/tests/parsers/iosxe/show_udld_neighbor/001_single_neighbor/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single UDLD neighbor on one interface
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_udld_neighbor/002_multiple_neighbors/expected.json
+++ b/tests/parsers/iosxe/show_udld_neighbor/002_multiple_neighbors/expected.json
@@ -1,0 +1,23 @@
+{
+    "neighbors": {
+        "FortyGigabitEthernet3/1/1": {
+            "device_id": 1,
+            "device_name": "78725D298A40",
+            "neighbor_state": "Bidirectional",
+            "port_id": "FortyGigabitEthernet1/0/15"
+        },
+        "FortyGigabitEthernet3/1/2": {
+            "device_id": 1,
+            "device_name": "78725D298A40",
+            "neighbor_state": "Bidirectional",
+            "port_id": "FortyGigabitEthernet2/0/15"
+        },
+        "TenGigabitEthernet4/1/1": {
+            "device_id": 1,
+            "device_name": "7C21E167CB8",
+            "neighbor_state": "Bidirectional",
+            "port_id": "TenGigabitEthernet2/6/0/7"
+        }
+    },
+    "total_bidirectional_entries": 3
+}

--- a/tests/parsers/iosxe/show_udld_neighbor/002_multiple_neighbors/input.txt
+++ b/tests/parsers/iosxe/show_udld_neighbor/002_multiple_neighbors/input.txt
@@ -1,0 +1,7 @@
+Port           Device Name     Device ID    Port ID         Neighbor State
+----           -----------     ---------    -------         --------------
+Fo3/1/1        78725D298A40    1            Fo1/0/15        Bidirectional
+Fo3/1/2        78725D298A40    1            Fo2/0/15        Bidirectional
+Te4/1/1        7C21E167CB8     1            Te2/6/0/7       Bidirectional
+
+Total number of bidirectional entries displayed: 3

--- a/tests/parsers/iosxe/show_udld_neighbor/002_multiple_neighbors/metadata.yaml
+++ b/tests/parsers/iosxe/show_udld_neighbor/002_multiple_neighbors/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple UDLD neighbors across different interface types
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added parser for `show udld neighbor` command on Cisco IOS-XE
- Extracts interface-keyed neighbor entries with device name, device ID, port ID, and neighbor state
- Includes canonicalized interface names for both local port and remote port ID

## Test plan
- [x] Parser handles single UDLD neighbor output
- [x] Parser handles multiple UDLD neighbors across different interface types
- [x] All tests pass with `uv run pytest`
- [x] Pre-commit hooks pass

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)