### PR TITLE
feat: add parser for 'show authentication sessions' on IOS

### DIFF
--- a/changes/432.parser_added
+++ b/changes/432.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show authentication sessions' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_authentication_sessions.py
+++ b/src/muninn/parsers/ios/show_authentication_sessions.py
@@ -1,0 +1,145 @@
+"""Parser for 'show authentication sessions' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+# Header line that marks the start of tabular data
+_HEADER_RE = re.compile(
+    r"^\s*Interface\s+MAC\s+Address\s+Method\s+Domain\s+Status",
+    re.IGNORECASE,
+)
+
+# Separator line of dashes
+_SEPARATOR_RE = re.compile(r"^[\s\-]+$")
+
+# Data line pattern for the summary table
+# Supports two formats:
+#   Interface  MAC Address     Method   Domain   Status          Session ID
+#   Interface  MAC Address     Method   Domain   Status   Fg     Session ID
+_DATA_RE = re.compile(
+    r"^\s*(?P<interface>\S+)\s+"
+    r"(?P<mac_address>\S+)\s+"
+    r"(?P<method>\S+)\s+"
+    r"(?P<domain>\S+)\s+"
+    r"(?P<status>(?:Authz\s+\S+|\S+))\s+"
+    r"(?:(?P<fg>\S+)\s+)?"
+    r"(?P<session_id>[0-9A-Fa-f]+)\s*$",
+)
+
+# Session count line
+_SESSION_COUNT_RE = re.compile(
+    r"^\s*Session\s+count\s*=\s*(\d+)",
+    re.IGNORECASE,
+)
+
+
+class AuthSessionEntry(TypedDict):
+    """Schema for a single authentication session entry."""
+
+    method: str
+    domain: str
+    status: str
+    session_id: str
+    fg: NotRequired[str]
+
+
+class ShowAuthenticationSessionsResult(TypedDict):
+    """Schema for 'show authentication sessions' parsed output."""
+
+    sessions: dict[str, dict[str, AuthSessionEntry]]
+    session_count: NotRequired[int]
+
+
+def _find_data_start(lines: list[str]) -> int:
+    """Find the index of the first data line after the header.
+
+    Raises:
+        ValueError: If no header line is found in the output.
+    """
+    for i, line in enumerate(lines):
+        if _HEADER_RE.match(line):
+            return i + 1
+
+    msg = "No authentication sessions header line found in output"
+    raise ValueError(msg)
+
+
+def _parse_output(output: str) -> ShowAuthenticationSessionsResult:
+    """Parse the full show authentication sessions output."""
+    lines = output.splitlines()
+    start_idx = _find_data_start(lines)
+
+    sessions: dict[str, dict[str, AuthSessionEntry]] = {}
+    session_count: int | None = None
+
+    for line in lines[start_idx:]:
+        # Skip blank lines and separator lines
+        if not line.strip() or _SEPARATOR_RE.match(line):
+            continue
+
+        # Check for session count
+        count_match = _SESSION_COUNT_RE.match(line)
+        if count_match:
+            session_count = int(count_match.group(1))
+            continue
+
+        # Try to match a data line
+        data_match = _DATA_RE.match(line)
+        if not data_match:
+            continue
+
+        raw_interface = data_match.group("interface")
+        interface = canonical_interface_name(raw_interface, os=OS.CISCO_IOS)
+        mac_address = data_match.group("mac_address")
+
+        entry: AuthSessionEntry = {
+            "method": data_match.group("method"),
+            "domain": data_match.group("domain"),
+            "status": data_match.group("status"),
+            "session_id": data_match.group("session_id"),
+        }
+
+        fg = data_match.group("fg")
+        if fg:
+            entry["fg"] = fg
+
+        if interface not in sessions:
+            sessions[interface] = {}
+        sessions[interface][mac_address] = entry
+
+    if not sessions:
+        msg = "No authentication sessions found in output"
+        raise ValueError(msg)
+
+    result: ShowAuthenticationSessionsResult = {"sessions": sessions}
+    if session_count is not None:
+        result["session_count"] = session_count
+
+    return result
+
+
+@register(OS.CISCO_IOS, "show authentication sessions")
+class ShowAuthenticationSessionsParser(
+    BaseParser[ShowAuthenticationSessionsResult],
+):
+    """Parser for 'show authentication sessions' on IOS."""
+
+    @classmethod
+    def parse(cls, output: str) -> ShowAuthenticationSessionsResult:
+        """Parse 'show authentication sessions' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed authentication sessions keyed by interface, then MAC address.
+
+        Raises:
+            ValueError: If no sessions found or no header detected.
+        """
+        return _parse_output(output)

--- a/tests/parsers/ios/show_authentication_sessions/001_basic/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions/001_basic/expected.json
@@ -1,0 +1,66 @@
+{
+    "sessions": {
+        "FastEthernet2/0/23": {
+            "347a.12cd.3ffb": {
+                "domain": "VOICE",
+                "method": "mab",
+                "session_id": "0A0A7F9B00000035000101FF",
+                "status": "Authz Success"
+            }
+        },
+        "FastEthernet2/0/27": {
+            "8c8a.12cd.3d3d": {
+                "domain": "DATA",
+                "method": "dot1x",
+                "session_id": "0A5C58FE0000000D000101FF",
+                "status": "Authz Success"
+            }
+        },
+        "FastEthernet2/0/33": {
+            "(unknown)": {
+                "domain": "UNKNOWN",
+                "method": "mab",
+                "session_id": "0A0A7F9B000001E8010101FF",
+                "status": "Running"
+            }
+        },
+        "FastEthernet3/0/1": {
+            "347a.12cd.3fe8": {
+                "domain": "VOICE",
+                "method": "mab",
+                "session_id": "0A0A7F9B00000055000101FF",
+                "status": "Authz Success"
+            }
+        },
+        "FastEthernet3/0/13": {
+            "002a.12cd.3d08": {
+                "domain": "DATA",
+                "method": "mab",
+                "session_id": "0A0A7F9B0000A92A2C0101FF",
+                "status": "Authz Success"
+            }
+        },
+        "FastEthernet3/0/21": {
+            "54ea.12cd.3236": {
+                "domain": "DATA",
+                "method": "dot1x",
+                "session_id": "0A0A7F9B00000504090101FF",
+                "status": "Authz Success"
+            },
+            "848a.12cd.33b2": {
+                "domain": "VOICE",
+                "method": "mab",
+                "session_id": "0A0A7F9B00000059000101FF",
+                "status": "Authz Success"
+            }
+        },
+        "FastEthernet3/0/40": {
+            "(unknown)": {
+                "domain": "UNKNOWN",
+                "method": "mab",
+                "session_id": "0A5C58FE00000018000101FF",
+                "status": "Running"
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_authentication_sessions/001_basic/input.txt
+++ b/tests/parsers/ios/show_authentication_sessions/001_basic/input.txt
@@ -1,0 +1,9 @@
+Interface  MAC Address     Method   Domain   Status         Session ID
+Fa3/0/40   (unknown)       mab      UNKNOWN  Running        0A5C58FE00000018000101FF
+Fa2/0/33   (unknown)       mab      UNKNOWN  Running        0A0A7F9B000001E8010101FF
+Fa3/0/13   002a.12cd.3d08  mab      DATA     Authz Success  0A0A7F9B0000A92A2C0101FF
+Fa3/0/1    347a.12cd.3fe8  mab      VOICE    Authz Success  0A0A7F9B00000055000101FF
+Fa2/0/27   8c8a.12cd.3d3d  dot1x    DATA     Authz Success  0A5C58FE0000000D000101FF
+Fa2/0/23   347a.12cd.3ffb  mab      VOICE    Authz Success  0A0A7F9B00000035000101FF
+Fa3/0/21   848a.12cd.33b2  mab      VOICE    Authz Success  0A0A7F9B00000059000101FF
+Fa3/0/21   54ea.12cd.3236  dot1x    DATA     Authz Success  0A0A7F9B00000504090101FF

--- a/tests/parsers/ios/show_authentication_sessions/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_authentication_sessions/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard authentication sessions with dot1x and mab methods across multiple interfaces
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_authentication_sessions/002_with_session_count/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions/002_with_session_count/expected.json
@@ -1,0 +1,57 @@
+{
+    "session_count": 7,
+    "sessions": {
+        "GigabitEthernet1/0/10": {
+            "c89a.12cd.3b74": {
+                "domain": "DATA",
+                "method": "dot1x",
+                "session_id": "0A0A1DFE00000FB3000101FF",
+                "status": "Auth"
+            }
+        },
+        "GigabitEthernet1/0/20": {
+            "54ea.12cd.3568": {
+                "domain": "DATA",
+                "method": "dot1x",
+                "session_id": "0A0A1DFE000013DF820101FF",
+                "status": "Auth"
+            }
+        },
+        "GigabitEthernet1/0/26": {
+            "004a.12cd.3c40": {
+                "domain": "DATA",
+                "method": "mab",
+                "session_id": "0A0A1DFE00001C8D5E0101FF",
+                "status": "Auth"
+            },
+            "005a.12cd.3567": {
+                "domain": "UNKNOWN",
+                "method": "N/A",
+                "session_id": "0A0A1DFE00001F8D160101FF",
+                "status": "Unauth"
+            }
+        },
+        "GigabitEthernet1/0/5": {
+            "848a.12cd.3636": {
+                "domain": "VOICE",
+                "method": "mab",
+                "session_id": "0A0A1DFE00000FBD000101FF",
+                "status": "Auth"
+            }
+        },
+        "GigabitEthernet2/0/1": {
+            "002a.12cd.3906": {
+                "domain": "DATA",
+                "method": "mab",
+                "session_id": "0A0A1DFE00000FB2000101FF",
+                "status": "Auth"
+            },
+            "848a.12cd.3615": {
+                "domain": "VOICE",
+                "method": "mab",
+                "session_id": "0A0A1DFE00000FBB000101FF",
+                "status": "Auth"
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_authentication_sessions/002_with_session_count/input.txt
+++ b/tests/parsers/ios/show_authentication_sessions/002_with_session_count/input.txt
@@ -1,0 +1,22 @@
+Interface    MAC Address    Method  Domain  Status Fg Session ID
+Gi1/0/10     c89a.12cd.3b74 dot1x   DATA    Auth      0A0A1DFE00000FB3000101FF
+Gi1/0/5      848a.12cd.3636 mab     VOICE   Auth      0A0A1DFE00000FBD000101FF
+Gi1/0/26     005a.12cd.3567 N/A     UNKNOWN Unauth    0A0A1DFE00001F8D160101FF
+Gi1/0/26     004a.12cd.3c40 mab     DATA    Auth      0A0A1DFE00001C8D5E0101FF
+Gi1/0/20     54ea.12cd.3568 dot1x   DATA    Auth      0A0A1DFE000013DF820101FF
+Gi2/0/1      002a.12cd.3906 mab     DATA    Auth      0A0A1DFE00000FB2000101FF
+Gi2/0/1      848a.12cd.3615 mab     VOICE   Auth      0A0A1DFE00000FBB000101FF
+
+Session count = 7
+
+Key to Session Events Blocked Status Flags:
+
+  A - Applying Policy (multi-line status for details)
+  D - Awaiting Deletion
+  F - Final Removal in progress
+  I - Awaiting IIF ID allocation
+  N - Waiting for AAA to come up
+  P - Pushed Session
+  R - Removing User Profile (multi-line status for details)
+  U - Applying User Profile (multi-line status for details)
+  X - Unknown Blocker

--- a/tests/parsers/ios/show_authentication_sessions/002_with_session_count/metadata.yaml
+++ b/tests/parsers/ios/show_authentication_sessions/002_with_session_count/metadata.yaml
@@ -1,0 +1,3 @@
+description: Authentication sessions with session count and Auth/Unauth status format
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Added parser for `show authentication sessions` command on Cisco IOS
- Supports both output formats: standard (Authz Success) and compact (Auth/Unauth with Fg column)
- Sessions keyed by interface then MAC address to handle multiple sessions per interface

## Test plan
- [x] Parser handles standard authentication sessions output (001_basic)
- [x] Parser handles output with session count and legend block (002_with_session_count)
- [x] All tests pass with `uv run pytest`
- [x] Pre-commit hooks pass

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)