### PR TITLE
feat: add parser for 'show ip mroute' on IOS

### DIFF
--- a/changes/440.parser_added
+++ b/changes/440.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip mroute' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_ip_mroute.py
+++ b/src/muninn/parsers/ios/show_ip_mroute.py
@@ -1,0 +1,219 @@
+"""Parser for 'show ip mroute' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+# Multicast route entry header:
+# (*, 239.0.0.1), 00:00:58/00:02:02, RP 172.16.2.1, flags: SJC
+# (192.168.2.44, 239.0.0.5), 00:00:07/00:02:58, flags: FT
+_ROUTE_HEADER_RE = re.compile(
+    r"^\((?P<source>\*|[\d.]+),\s+(?P<group>[\d.]+)\),\s+"
+    r"(?P<uptime>\S+)/(?P<expires>\S+)"
+    r"(?:,\s+RP\s+(?P<rp>[\d.]+))?"
+    r",\s+flags:\s+(?P<flags>\S+)\s*$"
+)
+
+# Incoming interface line:
+# Incoming interface: FastEthernet0/1, RPF nbr 172.16.2.1
+# Incoming interface: Vlan1, RPF nbr 0.0.0.0, Registering
+# Incoming interface: Null, RPF nbr 0.0.0.0
+_INCOMING_RE = re.compile(
+    r"^\s+Incoming interface:\s+(?P<interface>\S+)"
+    r",\s+RPF nbr\s+(?P<rpf_neighbor>[\d.]+)"
+    r"(?:,\s+(?P<rpf_info>.+?))?\s*$"
+)
+
+# Outgoing interface entry:
+# Vlan1, Forward/Sparse, 00:00:58/00:02:02
+# FastEthernet0/1, Forward/Dense, 00:00:07/00:00:00
+# ATM0/0, VCD 14, Forward/Sparse, 00:03:57/00:02:53
+_OIF_RE = re.compile(
+    r"^\s+(?P<interface>\S+)"
+    r"(?:,\s+VCD\s+(?P<vcd>\d+))?"
+    r",\s+(?P<state_mode>\S+/\S+)"
+    r",\s+(?P<uptime>\S+)/(?P<expires>\S+)\s*$"
+)
+
+# Outgoing interface list: Null
+_OIF_NULL_RE = re.compile(r"^\s+Outgoing interface list:\s*Null\s*$")
+
+# Outgoing interface list:
+_OIF_HEADER_RE = re.compile(r"^\s+Outgoing interface list:\s*$")
+
+
+class OutgoingInterfaceEntry(TypedDict):
+    """Schema for a single outgoing interface."""
+
+    state_mode: str
+    uptime: str
+    expires: str
+    vcd: NotRequired[int]
+
+
+class SourceEntry(TypedDict):
+    """Schema for a source entry within a multicast group."""
+
+    uptime: str
+    expires: str
+    flags: str
+    rpf_neighbor: str
+    incoming_interface: NotRequired[str]
+    rpf_info: NotRequired[str]
+    rp: NotRequired[str]
+    outgoing_interfaces: NotRequired[dict[str, OutgoingInterfaceEntry]]
+
+
+class GroupEntry(TypedDict):
+    """Schema for a multicast group."""
+
+    sources: dict[str, SourceEntry]
+
+
+class ShowIpMrouteResult(TypedDict):
+    """Schema for 'show ip mroute' parsed output."""
+
+    groups: dict[str, GroupEntry]
+
+
+def _parse_route_blocks(output: str) -> list[tuple[re.Match[str], list[str]]]:
+    """Split output into per-route blocks, each starting with a route header."""
+    blocks: list[tuple[re.Match[str], list[str]]] = []
+    current_match: re.Match[str] | None = None
+    current_lines: list[str] = []
+
+    for line in output.splitlines():
+        m = _ROUTE_HEADER_RE.match(line)
+        if m:
+            if current_match is not None:
+                blocks.append((current_match, current_lines))
+            current_match = m
+            current_lines = []
+        elif current_match is not None:
+            current_lines.append(line)
+
+    if current_match is not None:
+        blocks.append((current_match, current_lines))
+
+    return blocks
+
+
+def _parse_incoming(body_lines: list[str], entry: dict[str, object]) -> None:
+    """Parse the incoming interface line from body lines."""
+    for line in body_lines:
+        m = _INCOMING_RE.match(line)
+        if m:
+            iface = m.group("interface")
+            if iface != "Null":
+                entry["incoming_interface"] = canonical_interface_name(
+                    iface, os=OS.CISCO_IOS
+                )
+            entry["rpf_neighbor"] = m.group("rpf_neighbor")
+            rpf_info = m.group("rpf_info")
+            if rpf_info:
+                entry["rpf_info"] = rpf_info
+            return
+
+
+def _parse_oif_entry(m: re.Match[str]) -> tuple[str, OutgoingInterfaceEntry]:
+    """Build a single outgoing interface entry from a regex match."""
+    iface_name = canonical_interface_name(m.group("interface"), os=OS.CISCO_IOS)
+    oif_entry: OutgoingInterfaceEntry = {
+        "state_mode": m.group("state_mode"),
+        "uptime": m.group("uptime"),
+        "expires": m.group("expires"),
+    }
+    vcd = m.group("vcd")
+    if vcd:
+        oif_entry["vcd"] = int(vcd)
+    return iface_name, oif_entry
+
+
+def _parse_outgoing(body_lines: list[str], entry: dict[str, object]) -> None:
+    """Parse outgoing interface list from body lines."""
+    oif: dict[str, OutgoingInterfaceEntry] = {}
+    in_oif_list = False
+
+    for line in body_lines:
+        if _OIF_NULL_RE.match(line):
+            return
+        if _OIF_HEADER_RE.match(line):
+            in_oif_list = True
+            continue
+        if in_oif_list:
+            m = _OIF_RE.match(line)
+            if m:
+                name, oif_entry = _parse_oif_entry(m)
+                oif[name] = oif_entry
+            else:
+                break
+
+    if oif:
+        entry["outgoing_interfaces"] = oif
+
+
+def _parse_source_entry(
+    header: re.Match[str],
+    body_lines: list[str],
+) -> SourceEntry:
+    """Parse a single route block into a SourceEntry."""
+    entry: dict[str, object] = {
+        "uptime": header.group("uptime"),
+        "expires": header.group("expires"),
+        "flags": header.group("flags"),
+    }
+
+    rp = header.group("rp")
+    if rp:
+        entry["rp"] = rp
+
+    _parse_incoming(body_lines, entry)
+    _parse_outgoing(body_lines, entry)
+
+    return entry  # type: ignore[return-value]
+
+
+@register(OS.CISCO_IOS, "show ip mroute")
+class ShowIpMrouteParser(BaseParser[ShowIpMrouteResult]):
+    """Parser for 'show ip mroute' on IOS.
+
+    Parses IP multicast routing table entries with group/source
+    hierarchy, incoming/outgoing interfaces, flags, and timers.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpMrouteResult:
+        """Parse 'show ip mroute' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed multicast route entries keyed by group then source.
+
+        Raises:
+            ValueError: If no multicast route entries found.
+        """
+        blocks = _parse_route_blocks(output)
+
+        if not blocks:
+            msg = "No multicast route entries found in output"
+            raise ValueError(msg)
+
+        groups: dict[str, GroupEntry] = {}
+
+        for header, body_lines in blocks:
+            group = header.group("group")
+            source = header.group("source")
+            source_entry = _parse_source_entry(header, body_lines)
+
+            if group not in groups:
+                groups[group] = {"sources": {}}
+
+            groups[group]["sources"][source] = source_entry
+
+        return {"groups": groups}

--- a/tests/parsers/ios/show_ip_mroute/001_basic/expected.json
+++ b/tests/parsers/ios/show_ip_mroute/001_basic/expected.json
@@ -1,0 +1,109 @@
+{
+    "groups": {
+        "239.0.0.1": {
+            "sources": {
+                "*": {
+                    "uptime": "00:00:58",
+                    "expires": "00:02:02",
+                    "flags": "SJC",
+                    "rp": "172.16.2.1",
+                    "incoming_interface": "FastEthernet0/1",
+                    "rpf_neighbor": "172.16.2.1",
+                    "outgoing_interfaces": {
+                        "Vlan1": {
+                            "state_mode": "Forward/Sparse",
+                            "uptime": "00:00:58",
+                            "expires": "00:02:02"
+                        }
+                    }
+                }
+            }
+        },
+        "239.0.0.2": {
+            "sources": {
+                "*": {
+                    "uptime": "00:01:02",
+                    "expires": "00:01:57",
+                    "flags": "SJC",
+                    "rp": "172.16.2.1",
+                    "incoming_interface": "FastEthernet0/1",
+                    "rpf_neighbor": "172.16.2.1",
+                    "outgoing_interfaces": {
+                        "Vlan1": {
+                            "state_mode": "Forward/Sparse",
+                            "uptime": "00:01:03",
+                            "expires": "00:01:57"
+                        }
+                    }
+                }
+            }
+        },
+        "239.0.0.3": {
+            "sources": {
+                "*": {
+                    "uptime": "00:00:58",
+                    "expires": "00:02:57",
+                    "flags": "SJC",
+                    "rp": "172.16.2.1",
+                    "incoming_interface": "FastEthernet0/1",
+                    "rpf_neighbor": "172.16.2.1",
+                    "outgoing_interfaces": {
+                        "Vlan1": {
+                            "state_mode": "Forward/Sparse",
+                            "uptime": "00:00:58",
+                            "expires": "00:02:57"
+                        },
+                        "Vlan2": {
+                            "state_mode": "Forward/Sparse",
+                            "uptime": "00:00:58",
+                            "expires": "00:02:57"
+                        }
+                    }
+                }
+            }
+        },
+        "239.0.0.4": {
+            "sources": {
+                "*": {
+                    "uptime": "00:00:04",
+                    "expires": "stopped",
+                    "flags": "SPF",
+                    "rp": "172.16.2.1",
+                    "incoming_interface": "FastEthernet0/1",
+                    "rpf_neighbor": "172.16.2.1"
+                }
+            }
+        },
+        "239.0.0.5": {
+            "sources": {
+                "192.168.2.44": {
+                    "uptime": "00:00:07",
+                    "expires": "00:02:58",
+                    "flags": "FT",
+                    "incoming_interface": "Vlan1",
+                    "rpf_neighbor": "0.0.0.0",
+                    "rpf_info": "Registering",
+                    "outgoing_interfaces": {
+                        "FastEthernet0/1": {
+                            "state_mode": "Forward/Dense",
+                            "uptime": "00:00:07",
+                            "expires": "00:00:00"
+                        }
+                    }
+                }
+            }
+        },
+        "239.0.0.6": {
+            "sources": {
+                "*": {
+                    "uptime": "3d14h",
+                    "expires": "00:02:25",
+                    "flags": "SJPCL",
+                    "rp": "172.16.2.1",
+                    "incoming_interface": "FastEthernet0/1",
+                    "rpf_neighbor": "172.16.2.1"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_mroute/001_basic/input.txt
+++ b/tests/parsers/ios/show_ip_mroute/001_basic/input.txt
@@ -1,0 +1,35 @@
+IP Multicast Routing Table
+Flags: D - Dense, S - Sparse, B - Bidir Group, s - SSM Group, C - Connected,
+       L - Local, P - Pruned, R - RP-bit set, F - Register flag,
+       T - SPT-bit set, J - Join SPT, M - MSDP created entry,
+       X - Proxy Join Timer Running, A - Candidate for MSDP Advertisement,
+       U - URD, I - Received Source Specific Host Report,
+       Z - Multicast Tunnel, z - MDT-data group sender,
+       Y - Joined MDT-data group, y - Sending to MDT-data group
+       V - RD & Vector, v - Vector
+Outgoing interface flags: H - Hardware switched, A - Assert winner
+ Timers: Uptime/Expires
+ Interface state: Interface, Next-Hop or VCD, State/Mode
+(*, 239.0.0.1), 00:00:58/00:02:02, RP 172.16.2.1, flags: SJC
+  Incoming interface: FastEthernet0/1, RPF nbr 172.16.2.1
+  Outgoing interface list:
+    Vlan1, Forward/Sparse, 00:00:58/00:02:02
+(*, 239.0.0.2), 00:01:02/00:01:57, RP 172.16.2.1, flags: SJC
+  Incoming interface: FastEthernet0/1, RPF nbr 172.16.2.1
+  Outgoing interface list:
+    Vlan1, Forward/Sparse, 00:01:03/00:01:57
+(*, 239.0.0.3), 00:00:58/00:02:57, RP 172.16.2.1, flags: SJC
+  Incoming interface: FastEthernet0/1, RPF nbr 172.16.2.1
+  Outgoing interface list:
+    Vlan1, Forward/Sparse, 00:00:58/00:02:57
+    Vlan2, Forward/Sparse, 00:00:58/00:02:57
+(*, 239.0.0.4), 00:00:04/stopped, RP 172.16.2.1, flags: SPF
+  Incoming interface: FastEthernet0/1, RPF nbr 172.16.2.1
+  Outgoing interface list: Null
+(192.168.2.44, 239.0.0.5), 00:00:07/00:02:58, flags: FT
+  Incoming interface: Vlan1, RPF nbr 0.0.0.0, Registering
+  Outgoing interface list:
+    FastEthernet0/1, Forward/Dense, 00:00:07/00:00:00
+(*, 239.0.0.6), 3d14h/00:02:25, RP 172.16.2.1, flags: SJPCL
+  Incoming interface: FastEthernet0/1, RPF nbr 172.16.2.1
+  Outgoing interface list: Null

--- a/tests/parsers/ios/show_ip_mroute/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ip_mroute/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multicast routing table with shared-tree, source-specific, and null OIF entries
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ip mroute` command on Cisco IOS
- Parses multicast routing table into nested structure keyed by group address then source address (`groups[group][sources][source]`)
- Handles shared-tree (`*`) and source-specific entries, incoming/outgoing interfaces with state/mode, RPF neighbors, VCD fields, flags, and timers

Closes #189

## Test plan
- [x] Test case `001_basic` covers shared-tree entries with single and multiple outgoing interfaces, source-specific entries with RPF info, null OIF entries, and various flag combinations
- [x] All quality checks pass: `ruff check`, `ruff format`, `xenon` complexity
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)