### PR TITLE
feat: add parser for 'show ipv6 neighbors' on IOS

### DIFF
--- a/changes/441.parser_added
+++ b/changes/441.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ipv6 neighbors' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/ios/show_ipv6_neighbors.py
@@ -1,0 +1,111 @@
+"""Parser for 'show ipv6 neighbors' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class Ipv6NeighborEntry(TypedDict):
+    """Schema for a single IPv6 neighbor entry on a specific interface."""
+
+    age: NotRequired[int]
+    link_layer_address: NotRequired[str]
+    state: str
+
+
+class ShowIpv6NeighborsResult(TypedDict):
+    """Schema for 'show ipv6 neighbors' parsed output.
+
+    Keyed by IPv6 address, then by canonical interface name.
+    """
+
+    neighbors: dict[str, dict[str, Ipv6NeighborEntry]]
+
+
+_MISSING_VALUE = "-"
+
+
+@register(OS.CISCO_IOS, "show ipv6 neighbors")
+class ShowIpv6NeighborsParser(BaseParser[ShowIpv6NeighborsResult]):
+    """Parser for 'show ipv6 neighbors' command on IOS.
+
+    Parses IPv6 neighbor discovery cache entries.
+    """
+
+    _HEADER_PATTERN = re.compile(r"^IPv6\s+Address\s+Age\s+Link-layer\s+Addr", re.I)
+
+    # Each entry line:
+    # 2402:1234:106:100:793A:F08D:5B3A:EF89      33 54e1.addb.200f  STALE Vl6
+    # FE80::9277:EEFF:FE9B:4E00                   - -               REACH Di0
+    _ENTRY_PATTERN = re.compile(
+        r"^(?P<ipv6_address>\S+)\s+"
+        r"(?P<age>\d+|-)\s+"
+        r"(?P<link_layer>\S+)\s+"
+        r"(?P<state>\S+)\s+"
+        r"(?P<interface>\S+)$"
+    )
+
+    @classmethod
+    def _is_skippable_line(cls, line: str) -> bool:
+        """Return True if the line is blank or a header."""
+        return not line or cls._HEADER_PATTERN.match(line) is not None
+
+    @classmethod
+    def _build_entry(cls, match: re.Match[str]) -> Ipv6NeighborEntry:
+        """Build a neighbor entry from a regex match."""
+        entry: Ipv6NeighborEntry = {"state": match.group("state")}
+
+        age_raw = match.group("age")
+        if age_raw != _MISSING_VALUE:
+            entry["age"] = int(age_raw)
+
+        link_layer = match.group("link_layer")
+        if link_layer != _MISSING_VALUE:
+            entry["link_layer_address"] = link_layer
+
+        return entry
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpv6NeighborsResult:
+        """Parse 'show ipv6 neighbors' output on IOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IPv6 neighbors keyed by IPv6 address, then interface.
+
+        Raises:
+            ValueError: If no neighbor entries found in output.
+        """
+        neighbors: dict[str, dict[str, Ipv6NeighborEntry]] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            if cls._is_skippable_line(stripped):
+                continue
+
+            match = cls._ENTRY_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            ipv6_address = match.group("ipv6_address")
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.CISCO_IOS
+            )
+            entry = cls._build_entry(match)
+
+            if ipv6_address not in neighbors:
+                neighbors[ipv6_address] = {}
+            neighbors[ipv6_address][interface] = entry
+
+        if not neighbors:
+            msg = "No IPv6 neighbor entries found in output"
+            raise ValueError(msg)
+
+        return {"neighbors": neighbors}

--- a/tests/parsers/ios/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/ios/show_ipv6_neighbors/001_basic/expected.json
@@ -1,0 +1,72 @@
+{
+    "neighbors": {
+        "2402:1234:106:100:793A:F08D:5B3A:EF89": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 33,
+                "link_layer_address": "54e1.addb.200f"
+            }
+        },
+        "2402:1234:106:100:A193:9153:7CAF:9802": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 1,
+                "link_layer_address": "54e1.addb.200f"
+            }
+        },
+        "2402:1234:106:100:B419:F5DF:B315:F3C5": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 144,
+                "link_layer_address": "0800.2729.8bc1"
+            }
+        },
+        "2402:1234:106:100:B8F1:D9D3:A5F1:C1C9": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 4,
+                "link_layer_address": "507b.9dcd.c2ae"
+            }
+        },
+        "2402:1234:106:100:CC71:364E:A3E7:62B8": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 36,
+                "link_layer_address": "507b.9dcd.c2ae"
+            }
+        },
+        "FE80::5AAC:78FF:FEF8:CCCC": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 23,
+                "link_layer_address": "58ac.78f8.cccc"
+            }
+        },
+        "FE80::7A0C:F0FF:FE8E:2FF4": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 103,
+                "link_layer_address": "780c.f08e.2ff4"
+            }
+        },
+        "FE80::7EAD:74FF:FE85:B86": {
+            "VLAN6": {
+                "state": "STALE",
+                "age": 22,
+                "link_layer_address": "7cad.7485.0c16"
+            }
+        },
+        "FE80::208:E3FF:FEFF:FC28": {
+            "VLAN687": {
+                "state": "REACH",
+                "age": 0,
+                "link_layer_address": "0008.e3ff.fc28"
+            }
+        },
+        "FE80::9277:EEFF:FE9B:4E00": {
+            "Dialer0": {
+                "state": "REACH"
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_ipv6_neighbors/001_basic/input.txt
+++ b/tests/parsers/ios/show_ipv6_neighbors/001_basic/input.txt
@@ -1,0 +1,11 @@
+IPv6 Address                              Age Link-layer Addr State Interface
+2402:1234:106:100:793A:F08D:5B3A:EF89      33 54e1.addb.200f  STALE Vl6
+2402:1234:106:100:A193:9153:7CAF:9802       1 54e1.addb.200f  STALE Vl6
+2402:1234:106:100:B419:F5DF:B315:F3C5     144 0800.2729.8bc1  STALE Vl6
+2402:1234:106:100:B8F1:D9D3:A5F1:C1C9       4 507b.9dcd.c2ae  STALE Vl6
+2402:1234:106:100:CC71:364E:A3E7:62B8      36 507b.9dcd.c2ae  STALE Vl6
+FE80::5AAC:78FF:FEF8:CCCC                  23 58ac.78f8.cccc  STALE Vl6
+FE80::7A0C:F0FF:FE8E:2FF4                 103 780c.f08e.2ff4  STALE Vl6
+FE80::7EAD:74FF:FE85:B86                   22 7cad.7485.0c16  STALE Vl6
+FE80::208:E3FF:FEFF:FC28                    0 0008.e3ff.fc28  REACH Vl687
+FE80::9277:EEFF:FE9B:4E00                   - -               REACH Di0

--- a/tests/parsers/ios/show_ipv6_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ipv6_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show ipv6 neighbors with multiple states and interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ipv6 neighbors` command on Cisco IOS
- Neighbors keyed by IPv6 address then canonical interface name (nested dict, not composite keys)
- Optional `age` and `link_layer_address` fields omitted when reported as `-` by the device

Closes #192

## Test plan
- [x] Test case `001_basic` covers STALE/REACH states, multiple interfaces (Vlan, Dialer), and missing age/link-layer values
- [x] All quality checks pass: ruff check, ruff format, xenon complexity
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)