### PR TITLE
feat: add parser for 'show interface transceiver' on IOS

### DIFF
--- a/changes/443.parser_added
+++ b/changes/443.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show interface transceiver' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_interface_transceiver.py
+++ b/src/muninn/parsers/ios/show_interface_transceiver.py
@@ -1,0 +1,149 @@
+"""Parser for 'show interfaces transceiver' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class TransceiverEntry(TypedDict):
+    """Schema for a single interface transceiver entry."""
+
+    temperature: NotRequired[float]
+    voltage: NotRequired[float]
+    current: NotRequired[float]
+    tx_power: NotRequired[float]
+    rx_power: NotRequired[float]
+
+
+class ShowInterfaceTransceiverResult(TypedDict):
+    """Schema for 'show interfaces transceiver' parsed output."""
+
+    interfaces: dict[str, TransceiverEntry]
+
+
+# Data line pattern:
+# "    Gi0/10       36.9       3.25     537.7      -4.5      -9.7"
+# Also handles alarm/warning markers like ++ + - -- appended to values
+_INTF_DATA_RE = re.compile(
+    r"^\s*(\S+)"  # interface name
+    r"\s+([\d.+-]+(?:\s*[-+]{1,2})?|N/?A)"  # temperature
+    r"\s+([\d.+-]+(?:\s*[-+]{1,2})?|N/?A)"  # voltage
+    r"\s+([\d.+-]+(?:\s*[-+]{1,2})?|N/?A)"  # current
+    r"\s+([\d.+-]+(?:\s*[-+]{1,2})?|N/?A)"  # tx power
+    r"\s+([\d.+-]+(?:\s*[-+]{1,2})?|N/?A)"  # rx power
+    r"\s*$"
+)
+
+# Header keywords that should not be parsed as interface names
+_HEADER_KEYWORDS = frozenset({"port", "if", "if-id", "---------", "---"})
+
+
+def _parse_value(raw: str) -> float | None:
+    """Parse a numeric value, stripping alarm/warning markers.
+
+    Args:
+        raw: Raw value string from CLI output, possibly with +/- markers.
+
+    Returns:
+        Parsed float or None if the value is N/A.
+    """
+    stripped = raw.strip().rstrip("+-").strip()
+    if stripped.upper() in ("N/A", "NA"):
+        return None
+    return float(stripped)
+
+
+def _is_data_line(line: str) -> bool:
+    """Return True if the line looks like a transceiver data row."""
+    stripped = line.strip()
+    if not stripped:
+        return False
+    first_token = stripped.split()[0].lower()
+    if first_token in _HEADER_KEYWORDS:
+        return False
+    if stripped.startswith("-") and not stripped[0:2].replace("-", "").replace(".", ""):
+        return False
+    return True
+
+
+# Mapping of regex group index to TransceiverEntry key name
+_FIELD_MAP: tuple[tuple[int, str], ...] = (
+    (2, "temperature"),
+    (3, "voltage"),
+    (4, "current"),
+    (5, "tx_power"),
+    (6, "rx_power"),
+)
+
+
+def _build_entry(m: re.Match[str]) -> TransceiverEntry:
+    """Build a TransceiverEntry from a regex match, omitting N/A values."""
+    entry: TransceiverEntry = {}
+    for group_idx, key in _FIELD_MAP:
+        value = _parse_value(m.group(group_idx))
+        if value is not None:
+            entry[key] = value  # type: ignore[literal-required]
+    return entry
+
+
+def _parse_line(line: str) -> tuple[str, TransceiverEntry] | None:
+    """Parse a single data line into an interface name and entry.
+
+    Returns:
+        Tuple of (canonical_name, entry) or None if line is not data.
+    """
+    if not _is_data_line(line):
+        return None
+
+    m = _INTF_DATA_RE.match(line)
+    if not m:
+        return None
+
+    raw_name = m.group(1)
+    if raw_name.lower() in _HEADER_KEYWORDS:
+        return None
+
+    intf_name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
+    return intf_name, _build_entry(m)
+
+
+@register(OS.CISCO_IOS, "show interfaces transceiver")
+class ShowInterfaceTransceiverParser(
+    BaseParser[ShowInterfaceTransceiverResult],
+):
+    """Parser for 'show interfaces transceiver' on IOS.
+
+    Parses optical transceiver DOM readings including temperature,
+    voltage, bias current, transmit power, and receive power per
+    interface.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfaceTransceiverResult:
+        """Parse 'show interfaces transceiver' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed transceiver data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no transceiver entries are found.
+        """
+        interfaces: dict[str, TransceiverEntry] = {}
+
+        for line in output.splitlines():
+            parsed = _parse_line(line)
+            if parsed is not None:
+                interfaces[parsed[0]] = parsed[1]
+
+        if not interfaces:
+            msg = "No transceiver entries found in output"
+            raise ValueError(msg)
+
+        return ShowInterfaceTransceiverResult(interfaces=interfaces)

--- a/tests/parsers/ios/show_interfaces_transceiver/001_basic/expected.json
+++ b/tests/parsers/ios/show_interfaces_transceiver/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/9": {
+            "temperature": 32.5,
+            "voltage": 3.2,
+            "current": 385.1,
+            "tx_power": -5.5,
+            "rx_power": -5.0
+        },
+        "GigabitEthernet0/10": {
+            "temperature": 36.9,
+            "voltage": 3.25,
+            "current": 537.7,
+            "tx_power": -4.5,
+            "rx_power": -9.7
+        },
+        "GigabitEthernet0/11": {
+            "temperature": 35.8,
+            "voltage": 3.22,
+            "current": 393.6,
+            "tx_power": -5.5,
+            "rx_power": -5.0
+        },
+        "TenGigabitEthernet0/1": {
+            "temperature": 28.1,
+            "voltage": 3.3,
+            "current": 19.8,
+            "tx_power": 2.4,
+            "rx_power": -4.2
+        }
+    }
+}

--- a/tests/parsers/ios/show_interfaces_transceiver/001_basic/input.txt
+++ b/tests/parsers/ios/show_interfaces_transceiver/001_basic/input.txt
@@ -1,0 +1,13 @@
+If device is externally calibrated, only calibrated values are printed.
+++ : high alarm, +  : high warning, -  : low warning, -- : low alarm.
+NA or N/A: not applicable, Tx: transmit, Rx: receive.
+mA: milliamperes, dBm: decibels (milliwatts).
+
+                                               Optical   Optical
+               Temperature  Voltage  Current   Tx Power  Rx Power
+    Port       (Celsius)    (Volts)  (mA)      (dBm)     (dBm)
+    ---------  -----------  -------  --------  --------  --------
+    Gi0/9        32.5       3.20     385.1      -5.5      -5.0
+    Gi0/10       36.9       3.25     537.7      -4.5      -9.7
+    Gi0/11       35.8       3.22     393.6      -5.5      -5.0
+    Te0/1        28.1       3.30      19.8       2.4      -4.2

--- a/tests/parsers/ios/show_interfaces_transceiver/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_interfaces_transceiver/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces with transceiver DOM readings
+platform: Cisco Router
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Add parser for `show interfaces transceiver` on Cisco IOS
- Parses optical transceiver DOM readings (temperature, voltage, bias current, tx power, rx power) keyed by canonical interface name
- Omits N/A values using `NotRequired` fields rather than storing None

Closes #188

## Test plan
- [x] Test case `001_basic` with multiple GigabitEthernet and TenGigabitEthernet interfaces
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `xenon` complexity check passes (max-absolute B)
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)