### PR TITLE
feat: add parser for 'show ip ospf interface brief' on NX-OS

### DIFF
--- a/changes/444.parser_added
+++ b/changes/444.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip ospf interface brief' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_ip_ospf_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_interface_brief.py
@@ -1,0 +1,82 @@
+"""Parser for 'show ip ospf interface brief' command on NX-OS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class OspfInterfaceBriefEntry(TypedDict):
+    """Schema for a single NX-OS OSPF interface brief entry."""
+
+    process_id: str
+    vrf: str
+    interface_id: int
+    area: str
+    cost: int
+    state: str
+    neighbors: int
+    status: str
+
+
+class ShowIpOspfInterfaceBriefResult(TypedDict):
+    """Schema for 'show ip ospf interface brief' parsed output."""
+
+    interfaces: dict[str, OspfInterfaceBriefEntry]
+
+
+# --- Process ID / VRF header line ---
+_PROCESS_RE = re.compile(r"^\s*OSPF Process ID (\S+) VRF (\S+)\s*$")
+
+# --- Interface data line ---
+_INTF_RE = re.compile(r"^\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)\s+(\S+)\s*$")
+
+# --- Header line (skip) ---
+_HEADER_RE = re.compile(
+    r"^\s+Interface\s+ID\s+Area\s+Cost\s+State\s+Neighbors\s+Status"
+)
+
+# --- Total number line (skip) ---
+_TOTAL_RE = re.compile(r"^\s+Total number of interface:\s*\d+")
+
+
+@register(OS.CISCO_NXOS, "show ip ospf interface brief")
+class ShowIpOspfInterfaceBriefParser(BaseParser[ShowIpOspfInterfaceBriefResult]):
+    """Parser for 'show ip ospf interface brief' on NX-OS."""
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfInterfaceBriefResult:
+        """Parse 'show ip ospf interface brief' output."""
+        interfaces: dict[str, OspfInterfaceBriefEntry] = {}
+        current_process: str | None = None
+        current_vrf: str | None = None
+
+        for line in output.splitlines():
+            m = _PROCESS_RE.match(line)
+            if m:
+                current_process = m.group(1)
+                current_vrf = m.group(2)
+                continue
+
+            if _HEADER_RE.match(line) or _TOTAL_RE.match(line):
+                continue
+
+            m = _INTF_RE.match(line)
+            if m and current_process is not None and current_vrf is not None:
+                raw_name = m.group(1)
+                name = canonical_interface_name(raw_name, os=OS.CISCO_NXOS)
+                interfaces[name] = {
+                    "process_id": current_process,
+                    "vrf": current_vrf,
+                    "interface_id": int(m.group(2)),
+                    "area": m.group(3),
+                    "cost": int(m.group(4)),
+                    "state": m.group(5),
+                    "neighbors": int(m.group(6)),
+                    "status": m.group(7),
+                }
+
+        return {"interfaces": interfaces}

--- a/tests/parsers/nxos/show_ip_ospf_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_interface_brief/001_basic/expected.json
@@ -1,0 +1,74 @@
+{
+    "interfaces": {
+        "Vlan10": {
+            "process_id": "BLU1",
+            "vrf": "BLU",
+            "interface_id": 1,
+            "area": "0.0.0.10",
+            "cost": 10,
+            "state": "DR",
+            "neighbors": 2,
+            "status": "up"
+        },
+        "Vlan2": {
+            "process_id": "DC_UNDERLAY",
+            "vrf": "default",
+            "interface_id": 3,
+            "area": "0.0.0.0",
+            "cost": 100,
+            "state": "P2P",
+            "neighbors": 1,
+            "status": "up"
+        },
+        "Loopback1": {
+            "process_id": "DC_UNDERLAY",
+            "vrf": "default",
+            "interface_id": 1,
+            "area": "0.0.0.0",
+            "cost": 1,
+            "state": "LOOPBACK",
+            "neighbors": 0,
+            "status": "up"
+        },
+        "Loopback2": {
+            "process_id": "DC_UNDERLAY",
+            "vrf": "default",
+            "interface_id": 2,
+            "area": "0.0.0.0",
+            "cost": 1,
+            "state": "LOOPBACK",
+            "neighbors": 0,
+            "status": "up"
+        },
+        "Loopback3": {
+            "process_id": "DC_UNDERLAY",
+            "vrf": "default",
+            "interface_id": 4,
+            "area": "0.0.0.0",
+            "cost": 1,
+            "state": "LOOPBACK",
+            "neighbors": 0,
+            "status": "up"
+        },
+        "Ethernet1/1": {
+            "process_id": "DC_UNDERLAY",
+            "vrf": "default",
+            "interface_id": 6,
+            "area": "0.0.0.0",
+            "cost": 1,
+            "state": "P2P",
+            "neighbors": 1,
+            "status": "up"
+        },
+        "Ethernet1/2": {
+            "process_id": "DC_UNDERLAY",
+            "vrf": "default",
+            "interface_id": 5,
+            "area": "0.0.0.0",
+            "cost": 1,
+            "state": "P2P",
+            "neighbors": 1,
+            "status": "up"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ip_ospf_interface_brief/001_basic/input.txt
+++ b/tests/parsers/nxos/show_ip_ospf_interface_brief/001_basic/input.txt
@@ -1,0 +1,14 @@
+ OSPF Process ID BLU1 VRF BLU
+ Total number of interface: 1
+ Interface               ID     Area            Cost   State    Neighbors Status
+ Vlan10                  1      0.0.0.10        10     DR       2         up
+
+ OSPF Process ID DC_UNDERLAY VRF default
+ Total number of interface: 6
+ Interface               ID     Area            Cost   State    Neighbors Status
+ Vlan2                   3      0.0.0.0         100    P2P      1         up
+ Lo1                     1      0.0.0.0         1      LOOPBACK 0         up
+ Lo2                     2      0.0.0.0         1      LOOPBACK 0         up
+ Lo3                     4      0.0.0.0         1      LOOPBACK 0         up
+ Eth1/1                  6      0.0.0.0         1      P2P      1         up
+ Eth1/2                  5      0.0.0.0         1      P2P      1         up

--- a/tests/parsers/nxos/show_ip_ospf_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_ospf_interface_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple OSPF processes with broadcast, loopback, and point-to-point interfaces across VRFs
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ip ospf interface brief` on Cisco NX-OS
- Parses tabular OSPF interface summary output keyed by canonicalized interface name
- Supports multiple OSPF processes across VRFs with fields: process_id, vrf, interface_id, area, cost, state, neighbors, status

## Test plan
- [x] Test case with multi-VRF output covering DR, P2P, and LOOPBACK states
- [x] All quality checks pass (ruff check, ruff format, xenon, pre-commit)
- [x] Full test suite passes (959 tests)

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)