### PR TITLE
feat: add parser for 'show isis neighbors' on IOS

### DIFF
--- a/changes/445.parser_added
+++ b/changes/445.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show isis neighbors' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_isis_neighbors.py
+++ b/src/muninn/parsers/ios/show_isis_neighbors.py
@@ -1,0 +1,144 @@
+"""Parser for 'show isis neighbors' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class IsisAdjacencyEntry(TypedDict):
+    """Schema for a single IS-IS adjacency (per type on an interface)."""
+
+    state: str
+    holdtime: int
+    circuit_id: str
+    ip_address: NotRequired[str]
+
+
+class IsisInterfaceEntry(TypedDict):
+    """Schema for IS-IS adjacencies on a specific interface, keyed by type."""
+
+    adjacencies: dict[str, IsisAdjacencyEntry]
+
+
+class IsisNeighborEntry(TypedDict):
+    """Schema for an IS-IS neighbor, keyed by interface."""
+
+    interfaces: dict[str, IsisInterfaceEntry]
+
+
+class ShowIsisNeighborsResult(TypedDict):
+    """Schema for 'show isis neighbors' parsed output on IOS."""
+
+    neighbors: dict[str, IsisNeighborEntry]
+
+
+_NEIGHBOR_ROW_PATTERN = re.compile(
+    r"^(?P<system_id>\S+)\s+"
+    r"(?P<type>L[12])\s+"
+    r"(?P<interface>\S+)\s+"
+    r"(?P<ip_address>\S+)\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<holdtime>\d+)\s+"
+    r"(?P<circuit_id>\S+)\s*$"
+)
+
+_HEADER_PATTERN = re.compile(r"^System\s+Id", re.IGNORECASE)
+
+
+def _build_adjacency(match: re.Match[str]) -> IsisAdjacencyEntry:
+    """Build an adjacency entry from a regex match."""
+    holdtime_str = match.group("holdtime")
+    try:
+        holdtime = int(holdtime_str)
+    except ValueError:
+        msg = f"Invalid holdtime value: {holdtime_str!r}"
+        raise ValueError(msg) from None
+
+    adjacency: IsisAdjacencyEntry = {
+        "state": match.group("state"),
+        "holdtime": holdtime,
+        "circuit_id": match.group("circuit_id"),
+    }
+
+    ip_address = match.group("ip_address")
+    if ip_address:
+        adjacency["ip_address"] = ip_address
+
+    return adjacency
+
+
+def _insert_adjacency(
+    neighbors: dict[str, IsisNeighborEntry],
+    system_id: str,
+    interface: str,
+    adj_type: str,
+    adjacency: IsisAdjacencyEntry,
+) -> None:
+    """Insert an adjacency into the nested neighbor structure."""
+    if system_id not in neighbors:
+        neighbors[system_id] = IsisNeighborEntry(interfaces={})
+
+    interfaces = neighbors[system_id]["interfaces"]
+    if interface not in interfaces:
+        interfaces[interface] = IsisInterfaceEntry(adjacencies={})
+
+    interfaces[interface]["adjacencies"][adj_type] = adjacency
+
+
+@register(OS.CISCO_IOS, "show isis neighbors")
+class ShowIsisNeighborsParser(BaseParser["ShowIsisNeighborsResult"]):
+    """Parser for 'show isis neighbors' on IOS.
+
+    Example output:
+        System Id       Type Interface     IP Address      State Holdtime Circuit Id
+        vMX1            L1   Gi2           10.1.2.1        UP    19       XRv3.03
+        vMX1            L2   Gi2           10.1.2.1        UP    24       XRv3.03
+        XRv3            L1   Gi2           10.1.2.3        UP    8        XRv3.03
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIsisNeighborsResult:
+        """Parse 'show isis neighbors' output.
+
+        Args:
+            output: Raw CLI output from 'show isis neighbors' command.
+
+        Returns:
+            Parsed IS-IS neighbor data keyed by system ID, then interface,
+            then adjacency type.
+
+        Raises:
+            ValueError: If no IS-IS neighbor entries are found.
+        """
+        neighbors: dict[str, IsisNeighborEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line or _HEADER_PATTERN.match(line):
+                continue
+
+            match = _NEIGHBOR_ROW_PATTERN.match(line)
+            if not match:
+                continue
+
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.CISCO_IOS
+            )
+            adjacency = _build_adjacency(match)
+            _insert_adjacency(
+                neighbors,
+                match.group("system_id"),
+                interface,
+                match.group("type"),
+                adjacency,
+            )
+
+        if not neighbors:
+            msg = "No IS-IS neighbor entries found in output"
+            raise ValueError(msg)
+
+        return ShowIsisNeighborsResult(neighbors=neighbors)

--- a/tests/parsers/ios/show_isis_neighbors/001_basic/expected.json
+++ b/tests/parsers/ios/show_isis_neighbors/001_basic/expected.json
@@ -1,0 +1,58 @@
+{
+    "neighbors": {
+        "vMX1": {
+            "interfaces": {
+                "GigabitEthernet2": {
+                    "adjacencies": {
+                        "L1": {
+                            "state": "UP",
+                            "holdtime": 19,
+                            "circuit_id": "XRv3.03",
+                            "ip_address": "10.1.2.1"
+                        },
+                        "L2": {
+                            "state": "UP",
+                            "holdtime": 24,
+                            "circuit_id": "XRv3.03",
+                            "ip_address": "10.1.2.1"
+                        }
+                    }
+                }
+            }
+        },
+        "XRv3": {
+            "interfaces": {
+                "GigabitEthernet2": {
+                    "adjacencies": {
+                        "L1": {
+                            "state": "UP",
+                            "holdtime": 8,
+                            "circuit_id": "XRv3.03",
+                            "ip_address": "10.1.2.3"
+                        },
+                        "L2": {
+                            "state": "UP",
+                            "holdtime": 7,
+                            "circuit_id": "XRv3.03",
+                            "ip_address": "10.1.2.3"
+                        }
+                    }
+                }
+            }
+        },
+        "vEOS4": {
+            "interfaces": {
+                "GigabitEthernet3": {
+                    "adjacencies": {
+                        "L2": {
+                            "state": "UP",
+                            "holdtime": 23,
+                            "circuit_id": "0F",
+                            "ip_address": "10.2.4.4"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_isis_neighbors/001_basic/input.txt
+++ b/tests/parsers/ios/show_isis_neighbors/001_basic/input.txt
@@ -1,0 +1,6 @@
+System Id       Type Interface     IP Address      State Holdtime Circuit Id
+vMX1            L1   Gi2           10.1.2.1        UP    19       XRv3.03
+vMX1            L2   Gi2           10.1.2.1        UP    24       XRv3.03
+XRv3            L1   Gi2           10.1.2.3        UP    8        XRv3.03
+XRv3            L2   Gi2           10.1.2.3        UP    7        XRv3.03
+vEOS4           L2   Gi3           10.2.4.4        UP    23       0F

--- a/tests/parsers/ios/show_isis_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_isis_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic IS-IS neighbors with L1 and L2 adjacencies
+platform: Cisco Router
+software_version: IOS


### PR DESCRIPTION
## Summary
- Add new parser for `show isis neighbors` command on Cisco IOS
- Output keyed by system ID with nested interface and adjacency type (L1/L2) structure
- Includes canonical interface name normalization via `canonical_interface_name`

Closes #193

## Test plan
- [x] Basic test case with L1/L2 adjacencies across multiple system IDs and interfaces
- [x] All quality checks pass (ruff check, ruff format, xenon complexity)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)