### PR TITLE
feat: add parser for 'show mpls interfaces' on IOS

### DIFF
--- a/changes/446.parser_added
+++ b/changes/446.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show mpls interfaces` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_mpls_interfaces.py
+++ b/src/muninn/parsers/ios/show_mpls_interfaces.py
@@ -1,0 +1,87 @@
+"""Parser for 'show mpls interfaces' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class MplsInterfaceEntry(TypedDict):
+    """Schema for a single MPLS interface entry."""
+
+    ip_enabled: bool
+    ip_protocol: NotRequired[str]
+    tunnel: bool
+    bgp: bool
+    static: bool
+    operational: bool
+
+
+class ShowMplsInterfacesResult(TypedDict):
+    """Schema for 'show mpls interfaces' parsed output."""
+
+    interfaces: dict[str, MplsInterfaceEntry]
+
+
+# Data row: interface, Yes/No (optional protocol), four Yes/No fields
+_ROW_RE = re.compile(
+    r"^(\S+)\s+"
+    r"(Yes|No)\s*(?:\((\S+)\))?\s+"
+    r"(Yes|No)\s+"
+    r"(Yes|No)\s+"
+    r"(Yes|No)\s+"
+    r"(Yes|No)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _to_bool(value: str) -> bool:
+    """Convert Yes/No string to boolean."""
+    return value.strip().lower() == "yes"
+
+
+@register(OS.CISCO_IOS, "show mpls interfaces")
+class ShowMplsInterfacesParser(BaseParser[ShowMplsInterfacesResult]):
+    """Parser for 'show mpls interfaces' on IOS.
+
+    Parses the tabular output into a dict keyed by canonical interface name.
+
+    Example output::
+
+        Interface              IP            Tunnel   BGP Static Operational
+        TenGigabitEthernet1/1  Yes (ldp)     No       No  No     Yes
+        Vlan101                Yes (ldp)     No       No  No     Yes
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMplsInterfacesResult:
+        """Parse 'show mpls interfaces' output."""
+        interfaces: dict[str, MplsInterfaceEntry] = {}
+
+        for line in output.splitlines():
+            m = _ROW_RE.match(line)
+            if not m:
+                continue
+
+            raw_name = m.group(1)
+            name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
+
+            entry: MplsInterfaceEntry = {
+                "ip_enabled": _to_bool(m.group(2)),
+                "tunnel": _to_bool(m.group(4)),
+                "bgp": _to_bool(m.group(5)),
+                "static": _to_bool(m.group(6)),
+                "operational": _to_bool(m.group(7)),
+            }
+
+            # Only include protocol when IP is enabled and a protocol is specified
+            protocol = m.group(3)
+            if protocol:
+                entry["ip_protocol"] = protocol
+
+            interfaces[name] = entry
+
+        return {"interfaces": interfaces}

--- a/tests/parsers/ios/show_mpls_interfaces/001_basic/expected.json
+++ b/tests/parsers/ios/show_mpls_interfaces/001_basic/expected.json
@@ -1,0 +1,60 @@
+{
+    "interfaces": {
+        "TenGigabitEthernet1/1": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        },
+        "TenGigabitEthernet1/5": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        },
+        "TenGigabitEthernet1/9": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        },
+        "TenGigabitEthernet1/11": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        },
+        "TenGigabitEthernet1/13": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        },
+        "TenGigabitEthernet1/15": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        },
+        "Vlan101": {
+            "ip_enabled": true,
+            "tunnel": false,
+            "bgp": false,
+            "static": false,
+            "operational": true,
+            "ip_protocol": "ldp"
+        }
+    }
+}

--- a/tests/parsers/ios/show_mpls_interfaces/001_basic/input.txt
+++ b/tests/parsers/ios/show_mpls_interfaces/001_basic/input.txt
@@ -1,0 +1,8 @@
+Interface              IP            Tunnel   BGP Static Operational
+TenGigabitEthernet1/1  Yes (ldp)     No       No  No     Yes
+TenGigabitEthernet1/5  Yes (ldp)     No       No  No     Yes
+TenGigabitEthernet1/9  Yes (ldp)     No       No  No     Yes
+TenGigabitEthernet1/11 Yes (ldp)     No       No  No     Yes
+TenGigabitEthernet1/13 Yes (ldp)     No       No  No     Yes
+TenGigabitEthernet1/15 Yes (ldp)     No       No  No     Yes
+Vlan101                Yes (ldp)     No       No  No     Yes

--- a/tests/parsers/ios/show_mpls_interfaces/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_mpls_interfaces/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic MPLS interfaces with LDP enabled on physical and VLAN interfaces
+platform: Cisco Router
+software_version: IOS


### PR DESCRIPTION
## Summary
- Add new parser for `show mpls interfaces` on Cisco IOS
- Parses tabular output into a dict keyed by canonical interface name
- Each entry contains boolean flags (`ip_enabled`, `tunnel`, `bgp`, `static`, `operational`) and optional `ip_protocol` string

Closes #195

## Test plan
- [x] Test case with real NTC-sourced CLI output (7 interfaces: TenGigabitEthernet + Vlan)
- [x] All quality checks pass: ruff check, ruff format, xenon complexity
- [x] Pre-commit hooks pass
- [x] Parser test passes via parametrized test framework

🤖 Generated with [Claude Code](https://claude.com/claude-code)