### PR TITLE
feat: add parser for 'show ipv6 eigrp interfaces' on IOS-XE

### DIFF
--- a/changes/450.parser_added
+++ b/changes/450.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ipv6 eigrp interfaces' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_eigrp_interfaces.py
+++ b/src/muninn/parsers/iosxe/show_ip_eigrp_interfaces.py
@@ -163,6 +163,7 @@ def _build_result(
 
 
 @register(OS.CISCO_IOSXE, "show ip eigrp interfaces")
+@register(OS.CISCO_IOSXE, "show ipv6 eigrp interfaces")
 class ShowIpEigrpInterfacesParser(
     BaseParser[ShowIpEigrpInterfacesResult],
 ):

--- a/tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/expected.json
@@ -1,0 +1,43 @@
+{
+    "address_family": "ipv6",
+    "as_number": 100,
+    "interfaces": {
+        "GigabitEthernet1": {
+            "mcast_flow_timer": 106,
+            "mean_srtt": 15,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 2,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        },
+        "GigabitEthernet3": {
+            "mcast_flow_timer": 50,
+            "mean_srtt": 10,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 1,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        },
+        "Loopback0": {
+            "mcast_flow_timer": 0,
+            "mean_srtt": 0,
+            "pacing_time_reliable": 0,
+            "pacing_time_unreliable": 0,
+            "peer_q_reliable": 0,
+            "peer_q_unreliable": 0,
+            "peers": 0,
+            "pending_routes": 0,
+            "xmit_q_reliable": 0,
+            "xmit_q_unreliable": 0
+        }
+    },
+    "named_mode": false
+}

--- a/tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/input.txt
@@ -1,0 +1,6 @@
+EIGRP-IPv6 Interfaces for AS(100)
+                              Xmit Queue   PeerQ        Mean   Pacing Time   Multicast    Pending
+Interface              Peers  Un/Reliable  Un/Reliable  SRTT   Un/Reliable   Flow Timer   Routes
+Gi1                      2        0/0       0/0          15       0/0          106           0
+Gi3                      1        0/0       0/0          10       0/0           50           0
+Lo0                      0        0/0       0/0           0       0/0            0           0

--- a/tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic IPv6 EIGRP interfaces output with multiple interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Registers `show ipv6 eigrp interfaces` as an additional command on the existing `ShowIpEigrpInterfacesParser` in `src/muninn/parsers/iosxe/show_ip_eigrp_interfaces.py`
- The IPv4 and IPv6 variants share identical output format (only the `EIGRP-IPv4`/`EIGRP-IPv6` header differs), so no new parser logic was needed
- Adds test case `tests/parsers/iosxe/show_ipv6_eigrp_interfaces/001_basic/` with IPv6 sample data

Closes #202

## Test plan
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_ipv6_eigrp_interfaces` passes
- [x] Existing `show_ip_eigrp_interfaces` tests still pass
- [x] `uv run ruff check` and `uv run ruff format` clean
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)