### PR TITLE
feat: add parser for 'show ipv6 eigrp neighbors' on IOS-XE

### DIFF
--- a/changes/455.parser_added
+++ b/changes/455.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ipv6 eigrp neighbors' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ipv6_eigrp_neighbors.py
+++ b/src/muninn/parsers/iosxe/show_ipv6_eigrp_neighbors.py
@@ -1,0 +1,100 @@
+"""Parser for 'show ipv6 eigrp neighbors' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class Ipv6EigrpNeighborEntry(TypedDict):
+    """Schema for a single IPv6 EIGRP neighbor entry."""
+
+    handle: int
+    hold_time: int
+    uptime: str
+    srtt: int
+    rto: int
+    queue_count: int
+    sequence_number: int
+
+
+class ShowIpv6EigrpNeighborsResult(TypedDict):
+    """Schema for 'show ipv6 eigrp neighbors' parsed output."""
+
+    neighbors: dict[str, dict[str, Ipv6EigrpNeighborEntry]]
+
+
+@register(OS.CISCO_IOSXE, "show ipv6 eigrp neighbors")
+class ShowIpv6EigrpNeighborsParser(BaseParser[ShowIpv6EigrpNeighborsResult]):
+    """Parser for 'show ipv6 eigrp neighbors' command.
+
+    Example output::
+
+        EIGRP-IPv6 Neighbors for AS(1)
+        H   Address              Interface   Hold Uptime  SRTT  RTO Q Seq
+                                             (sec)        (ms)     Cnt Num
+        0   FE80::A8BB:CCFF:FE00:200 Gi0/0   12 00:00:21  10  100 0  3
+    """
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<handle>\d+)\s+"
+        r"(?P<address>[0-9A-Fa-f:]+(?:%\S+)?)\s+"
+        r"(?P<interface>\S+)\s+"
+        r"(?P<hold>\d+)\s+"
+        r"(?P<uptime>\S+)\s+"
+        r"(?P<srtt>\d+)\s+"
+        r"(?P<rto>\d+)\s+"
+        r"(?P<q_count>\d+)\s+"
+        r"(?P<seq_num>\d+)\s*$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpv6EigrpNeighborsResult:
+        """Parse 'show ipv6 eigrp neighbors' output.
+
+        Args:
+            output: Raw CLI output from 'show ipv6 eigrp neighbors' command.
+
+        Returns:
+            Parsed neighbor data keyed by interface then neighbor address.
+
+        Raises:
+            ValueError: If no neighbors found in output.
+        """
+        neighbors: dict[str, dict[str, Ipv6EigrpNeighborEntry]] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = cls._ROW_PATTERN.match(line)
+            if not match:
+                continue
+
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.CISCO_IOSXE
+            )
+            address = match.group("address")
+
+            if interface not in neighbors:
+                neighbors[interface] = {}
+
+            neighbors[interface][address] = Ipv6EigrpNeighborEntry(
+                handle=int(match.group("handle")),
+                hold_time=int(match.group("hold")),
+                uptime=match.group("uptime"),
+                srtt=int(match.group("srtt")),
+                rto=int(match.group("rto")),
+                queue_count=int(match.group("q_count")),
+                sequence_number=int(match.group("seq_num")),
+            )
+
+        if not neighbors:
+            msg = "No EIGRP IPv6 neighbors found in output"
+            raise ValueError(msg)
+
+        return ShowIpv6EigrpNeighborsResult(neighbors=neighbors)

--- a/tests/parsers/iosxe/show_ipv6_eigrp_neighbors/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ipv6_eigrp_neighbors/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "neighbors": {
+        "GigabitEthernet0/0": {
+            "FE80::A8BB:CCFF:FE00:200": {
+                "handle": 0,
+                "hold_time": 12,
+                "queue_count": 0,
+                "rto": 100,
+                "sequence_number": 3,
+                "srtt": 10,
+                "uptime": "00:00:21"
+            }
+        },
+        "GigabitEthernet0/1": {
+            "FE80::A8BB:CCFF:FE00:300": {
+                "handle": 1,
+                "hold_time": 14,
+                "queue_count": 0,
+                "rto": 5000,
+                "sequence_number": 8,
+                "srtt": 1996,
+                "uptime": "00:05:07"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ipv6_eigrp_neighbors/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ipv6_eigrp_neighbors/001_basic/input.txt
@@ -1,0 +1,6 @@
+
+EIGRP-IPv6 Neighbors for AS(1)
+H   Address                 Interface              Hold Uptime   SRTT   RTO  Q  Seq
+                                                   (sec)         (ms)       Cnt Num
+0   FE80::A8BB:CCFF:FE00:200 Gi0/0                  12 00:00:21    10   100  0   3
+1   FE80::A8BB:CCFF:FE00:300 Gi0/1                  14 00:05:07  1996  5000  0   8

--- a/tests/parsers/iosxe/show_ipv6_eigrp_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ipv6_eigrp_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two IPv6 EIGRP neighbors on separate interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ipv6 eigrp neighbors` on Cisco IOS-XE
- Handles IPv6 link-local addresses (FE80::) with interface -> neighbor address keying structure
- Follows the same schema as the existing `show ip eigrp neighbors` parser

Closes #203

## Test plan
- [x] Parser correctly parses two IPv6 EIGRP neighbors on separate interfaces
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `xenon` complexity check passes
- [x] `pre-commit run --all-files` passes
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)