### PR TITLE
feat: add parser for 'show platform sudi pki' on IOS-XE

### DIFF
--- a/changes/460.parser_added
+++ b/changes/460.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform sudi pki' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_sudi_pki.py
+++ b/src/muninn/parsers/iosxe/show_platform_sudi_pki.py
@@ -1,0 +1,116 @@
+"""Parser for 'show platform sudi pki' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class SudiIssuerEntry(TypedDict):
+    """Schema for a single SUDI issuer."""
+
+    validation_status: str
+
+
+class ShowPlatformSudiPkiResult(TypedDict):
+    """Schema for 'show platform sudi pki' parsed output.
+
+    Keyed by SUDI Issuer-CN name.
+    """
+
+    certificate_status: NotRequired[str]
+    issuers: dict[str, SudiIssuerEntry]
+
+
+# 'Cisco Manufacturing CA III' certificate : Enabled
+_CERT_STATUS = re.compile(r"^'(?P<name>[^']+)'\s+certificate\s*:\s*(?P<status>\S+)\s*$")
+
+# Table header separator line
+_SEPARATOR = re.compile(r"^-{3,}$")
+
+# Table header line prefix
+_TABLE_HEADER_PREFIX = "SUDI Issuer-CN"
+
+# Table row: issuer CN followed by validation status
+# e.g. "Cisco Manufacturing CA              Valid"
+# e.g. "Cisco Manufacturing CA III          Not Supported"
+_ISSUER_ROW = re.compile(
+    r"^(?P<issuer>.+?)\s{2,}(?P<status>Valid|Not Supported|Init Failure|Invalid)\s*$"
+)
+
+
+def _is_skippable(line: str) -> bool:
+    """Return True if the line should be skipped during parsing."""
+    if not line or _SEPARATOR.match(line) is not None:
+        return True
+    return line.startswith(_TABLE_HEADER_PREFIX)
+
+
+def _extract_certificate_status(line: str) -> str | None:
+    """Extract certificate status from a line, or return None."""
+    match = _CERT_STATUS.match(line)
+    return match.group("status") if match else None
+
+
+def _extract_issuer(line: str) -> tuple[str, SudiIssuerEntry] | None:
+    """Extract an issuer entry from a line, or return None."""
+    match = _ISSUER_ROW.match(line)
+    if not match:
+        return None
+    return match.group("issuer").strip(), SudiIssuerEntry(
+        validation_status=match.group("status"),
+    )
+
+
+@register(OS.CISCO_IOSXE, "show platform sudi pki")
+class ShowPlatformSudiPkiParser(BaseParser["ShowPlatformSudiPkiResult"]):
+    """Parser for 'show platform sudi pki' command.
+
+    Example output::
+
+        'Cisco Manufacturing CA III' certificate : Enabled
+
+        SUDI Issuer-CN                      Validation status
+        -----------------------------------------------------
+        Cisco Manufacturing CA              Valid
+        Cisco Manufacturing CA III          Valid
+        Cisco Manufacturing CA SHA2         Valid
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformSudiPkiResult:
+        """Parse 'show platform sudi pki' output.
+
+        Args:
+            output: Raw CLI output from 'show platform sudi pki'.
+
+        Returns:
+            Parsed SUDI PKI data with certificate status and issuers.
+
+        Raises:
+            ValueError: If no SUDI PKI data is found.
+        """
+        issuers: dict[str, SudiIssuerEntry] = {}
+        result = ShowPlatformSudiPkiResult(issuers=issuers)
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if _is_skippable(stripped):
+                continue
+
+            cert_status = _extract_certificate_status(stripped)
+            if cert_status:
+                result["certificate_status"] = cert_status
+                continue
+
+            issuer = _extract_issuer(stripped)
+            if issuer:
+                issuers[issuer[0]] = issuer[1]
+
+        if not issuers and "certificate_status" not in result:
+            msg = "No SUDI PKI data found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/iosxe/show_platform_sudi_pki/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_sudi_pki/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+    "issuers": {
+        "Cisco Manufacturing CA": {
+            "validation_status": "Valid"
+        },
+        "Cisco Manufacturing CA III": {
+            "validation_status": "Valid"
+        },
+        "Cisco Manufacturing CA SHA2": {
+            "validation_status": "Valid"
+        }
+    },
+    "certificate_status": "Enabled"
+}

--- a/tests/parsers/iosxe/show_platform_sudi_pki/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_sudi_pki/001_basic/input.txt
@@ -1,0 +1,7 @@
+'Cisco Manufacturing CA III' certificate : Enabled
+
+SUDI Issuer-CN                      Validation status
+-----------------------------------------------------
+Cisco Manufacturing CA              Valid
+Cisco Manufacturing CA III          Valid
+Cisco Manufacturing CA SHA2         Valid

--- a/tests/parsers/iosxe/show_platform_sudi_pki/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_sudi_pki/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with all issuers valid and certificate enabled
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show platform sudi pki` command on Cisco IOS-XE
- Parses certificate status (Enabled/Disabled) and SUDI issuer validation table
- Handles validation statuses: Valid, Not Supported, Init Failure, Invalid

Closes #209

## Test plan
- [x] Golden test with all issuers valid and certificate enabled (001_basic)
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest tests/parsers/ -k show_platform_sudi_pki -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)