### PR TITLE
feat: add parser for 'ping' on IOS

### DIFF
--- a/changes/461.parser_added
+++ b/changes/461.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'ping' on Cisco IOS.

--- a/src/muninn/parsers/ios/ping.py
+++ b/src/muninn/parsers/ios/ping.py
@@ -8,6 +8,12 @@ from muninn.parser import BaseParser
 from muninn.registry import register
 
 
+class PingPacketData(TypedDict):
+    """Per-packet ping result."""
+
+    result: str
+
+
 class PingResult(TypedDict):
     """Schema for 'ping' parsed output.
 
@@ -17,6 +23,7 @@ class PingResult(TypedDict):
     packets_sent: int
     packets_received: int
     success_rate_percent: int
+    packet_data: dict[str, PingPacketData]
     rtt_min_ms: NotRequired[int]
     rtt_avg_ms: NotRequired[int]
     rtt_max_ms: NotRequired[int]
@@ -33,6 +40,19 @@ _SUCCESS_RATE_RE = re.compile(
     r"(?:,\s*round-trip min/avg/max\s*=\s*"
     r"(?P<rtt_min>\d+)/(?P<rtt_avg>\d+)/(?P<rtt_max>\d+)\s*ms)?"
 )
+
+_PACKET_LINE_RE = re.compile(r"^[!.UQM&?]+$")
+
+
+_PACKET_RESULT_MAP = {
+    "!": "successful",
+    ".": "failed",
+    "U": "unreachable",
+    "Q": "source_quench",
+    "M": "cannot_fragment",
+    "&": "time_exceeded",
+    "?": "unknown",
+}
 
 
 @register(OS.CISCO_IOS, "ping")
@@ -60,6 +80,8 @@ class PingParser(BaseParser["PingResult"]):
         Raises:
             ValueError: If no success rate line is found in the output.
         """
+        packet_symbols: list[str] = []
+
         for line in output.splitlines():
             match = _SUCCESS_RATE_RE.search(line)
             if match:
@@ -67,6 +89,12 @@ class PingParser(BaseParser["PingResult"]):
                     "success_rate_percent": int(match.group("success_rate")),
                     "packets_received": int(match.group("received")),
                     "packets_sent": int(match.group("sent")),
+                    "packet_data": {
+                        str(index): {
+                            "result": _PACKET_RESULT_MAP.get(symbol, "unknown")
+                        }
+                        for index, symbol in enumerate(packet_symbols, start=1)
+                    },
                 }
 
                 if match.group("rtt_min") is not None:
@@ -75,6 +103,10 @@ class PingParser(BaseParser["PingResult"]):
                     result["rtt_max_ms"] = int(match.group("rtt_max"))
 
                 return result
+
+            stripped = line.strip()
+            if _PACKET_LINE_RE.fullmatch(stripped):
+                packet_symbols.extend(stripped)
 
         msg = "No success rate line found in ping output"
         raise ValueError(msg)

--- a/src/muninn/parsers/ios/ping.py
+++ b/src/muninn/parsers/ios/ping.py
@@ -1,0 +1,80 @@
+"""Parser for 'ping' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class PingResult(TypedDict):
+    """Schema for 'ping' parsed output.
+
+    RTT fields are only present when at least one reply was received.
+    """
+
+    packets_sent: int
+    packets_received: int
+    success_rate_percent: int
+    rtt_min_ms: NotRequired[int]
+    rtt_avg_ms: NotRequired[int]
+    rtt_max_ms: NotRequired[int]
+
+
+# --- Regex patterns ---
+
+# Success rate line:
+#   Success rate is 100 percent (5/5), round-trip min/avg/max = 1/2/10 ms
+#   Success rate is 0 percent (0/5)
+_SUCCESS_RATE_RE = re.compile(
+    r"Success rate is (?P<success_rate>\d+) percent"
+    r" \((?P<received>\d+)/(?P<sent>\d+)\)"
+    r"(?:,\s*round-trip min/avg/max\s*=\s*"
+    r"(?P<rtt_min>\d+)/(?P<rtt_avg>\d+)/(?P<rtt_max>\d+)\s*ms)?"
+)
+
+
+@register(OS.CISCO_IOS, "ping")
+class PingParser(BaseParser["PingResult"]):
+    """Parser for 'ping' command.
+
+    Example output:
+        Type escape sequence to abort.
+        Sending 5, 100-byte ICMP Echos to 192.168.0.1, timeout is 2 seconds:
+        !!!!!
+        Success rate is 100 percent (5/5), round-trip min/avg/max = 1/2/10 ms
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> PingResult:
+        """Parse 'ping' output into structured data.
+
+        Args:
+            output: Raw CLI output from 'ping' command.
+
+        Returns:
+            Parsed ping result with success rate, packet counts,
+            and optional RTT statistics.
+
+        Raises:
+            ValueError: If no success rate line is found in the output.
+        """
+        for line in output.splitlines():
+            match = _SUCCESS_RATE_RE.search(line)
+            if match:
+                result: PingResult = {
+                    "success_rate_percent": int(match.group("success_rate")),
+                    "packets_received": int(match.group("received")),
+                    "packets_sent": int(match.group("sent")),
+                }
+
+                if match.group("rtt_min") is not None:
+                    result["rtt_min_ms"] = int(match.group("rtt_min"))
+                    result["rtt_avg_ms"] = int(match.group("rtt_avg"))
+                    result["rtt_max_ms"] = int(match.group("rtt_max"))
+
+                return result
+
+        msg = "No success rate line found in ping output"
+        raise ValueError(msg)

--- a/tests/parsers/ios/ping/001_basic/expected.json
+++ b/tests/parsers/ios/ping/001_basic/expected.json
@@ -2,6 +2,23 @@
     "success_rate_percent": 100,
     "packets_received": 5,
     "packets_sent": 5,
+    "packet_data": {
+        "1": {
+            "result": "successful"
+        },
+        "2": {
+            "result": "successful"
+        },
+        "3": {
+            "result": "successful"
+        },
+        "4": {
+            "result": "successful"
+        },
+        "5": {
+            "result": "successful"
+        }
+    },
     "rtt_min_ms": 1,
     "rtt_avg_ms": 2,
     "rtt_max_ms": 10

--- a/tests/parsers/ios/ping/001_basic/expected.json
+++ b/tests/parsers/ios/ping/001_basic/expected.json
@@ -1,0 +1,8 @@
+{
+    "success_rate_percent": 100,
+    "packets_received": 5,
+    "packets_sent": 5,
+    "rtt_min_ms": 1,
+    "rtt_avg_ms": 2,
+    "rtt_max_ms": 10
+}

--- a/tests/parsers/ios/ping/001_basic/input.txt
+++ b/tests/parsers/ios/ping/001_basic/input.txt
@@ -1,0 +1,4 @@
+Type escape sequence to abort.
+Sending 5, 100-byte ICMP Echos to 192.168.0.1, timeout is 2 seconds:
+!!!!!
+Success rate is 100 percent (5/5), round-trip min/avg/max = 1/2/10 ms

--- a/tests/parsers/ios/ping/001_basic/metadata.yaml
+++ b/tests/parsers/ios/ping/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic successful ping with 100% success rate and RTT statistics
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/ping/002_no_reply/expected.json
+++ b/tests/parsers/ios/ping/002_no_reply/expected.json
@@ -1,5 +1,22 @@
 {
     "success_rate_percent": 0,
     "packets_received": 0,
-    "packets_sent": 5
+    "packets_sent": 5,
+    "packet_data": {
+        "1": {
+            "result": "unreachable"
+        },
+        "2": {
+            "result": "failed"
+        },
+        "3": {
+            "result": "failed"
+        },
+        "4": {
+            "result": "unreachable"
+        },
+        "5": {
+            "result": "failed"
+        }
+    }
 }

--- a/tests/parsers/ios/ping/002_no_reply/expected.json
+++ b/tests/parsers/ios/ping/002_no_reply/expected.json
@@ -1,0 +1,5 @@
+{
+    "success_rate_percent": 0,
+    "packets_received": 0,
+    "packets_sent": 5
+}

--- a/tests/parsers/ios/ping/002_no_reply/input.txt
+++ b/tests/parsers/ios/ping/002_no_reply/input.txt
@@ -1,0 +1,4 @@
+Type escape sequence to abort.
+Sending 5, 100-byte ICMP Echos to 10.245.179.14, timeout is 2 seconds:
+U..U.
+Success rate is 0 percent (0/5)

--- a/tests/parsers/ios/ping/002_no_reply/metadata.yaml
+++ b/tests/parsers/ios/ping/002_no_reply/metadata.yaml
@@ -1,0 +1,3 @@
+description: Failed ping with 0% success rate and no RTT statistics
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for the `ping` command on Cisco IOS
- Extracts success rate, packets sent/received, and optional RTT min/avg/max statistics
- RTT fields use `NotRequired` since they are absent on fully failed pings (0% success with no round-trip data)

Closes #210

## Test plan
- [x] `tests/parsers/ios/ping/001_basic/` - Successful ping (100%, 5/5) with RTT stats
- [x] `tests/parsers/ios/ping/002_no_reply/` - Failed ping (0%, 0/5) without RTT stats
- [x] `uv run ruff check` and `uv run ruff format` pass
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)