### PR TITLE
feat: add parser for 'show platform software meraki-service' on IOS-XE

### DIFF
--- a/changes/462.parser_added
+++ b/changes/462.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform software meraki-service' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_software_meraki_service.py
+++ b/src/muninn/parsers/iosxe/show_platform_software_meraki_service.py
@@ -1,0 +1,102 @@
+"""Parser for 'show platform software meraki-service' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single Meraki process status."""
+
+    running: bool
+
+
+class ShowPlatformSoftwareMerakiServiceResult(TypedDict):
+    """Schema for 'show platform software meraki-service' parsed output.
+
+    Keyed by process name (e.g., "meraki_mgrd", "meraki_tunnel_client").
+    Each entry contains a boolean indicating whether the process is running.
+    """
+
+    processes: dict[str, ProcessEntry]
+
+
+# Pattern matches lines like:
+#   Meraki Mgrd                    : Running
+#   Nextunnel Packet Capture       : Not Running
+_PROCESS_LINE = re.compile(r"^(?P<name>[A-Za-z][A-Za-z0-9 ]+?)\s*:\s*(?P<status>.+)$")
+
+# Header and separator lines to skip
+_HEADER_LINE = re.compile(r"^Meraki Process Summary", re.IGNORECASE)
+_SEPARATOR_LINE = re.compile(r"^-+$")
+
+
+def _normalize_name(name: str) -> str:
+    """Convert a display name to a snake_case key.
+
+    Example: "Meraki Mgrd" -> "meraki_mgrd"
+    """
+    return name.strip().lower().replace(" ", "_")
+
+
+def _is_running(status: str) -> bool:
+    """Determine if a process status indicates running."""
+    return status.strip().lower() == "running"
+
+
+@register(OS.CISCO_IOSXE, "show platform software meraki-service")
+class ShowPlatformSoftwareMerakiServiceParser(
+    BaseParser[ShowPlatformSoftwareMerakiServiceResult],
+):
+    """Parser for 'show platform software meraki-service' command.
+
+    Parses the Meraki process summary output into structured data keyed
+    by process name.
+
+    Example output:
+        Meraki Process Summary:
+        ----------------------------------------------
+        Meraki Mgrd                    : Running
+        Meraki Tunnel Client           : Running
+        IOS Console Service            : Running
+        Nextunnel Packet Capture       : Not Running
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformSoftwareMerakiServiceResult:
+        """Parse 'show platform software meraki-service' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed process status data keyed by normalized process name.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        processes: dict[str, ProcessEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            if not line:
+                continue
+
+            if _HEADER_LINE.match(line) or _SEPARATOR_LINE.match(line):
+                continue
+
+            match = _PROCESS_LINE.match(line)
+            if match:
+                name = _normalize_name(match.group("name"))
+                status = match.group("status")
+                processes[name] = ProcessEntry(running=_is_running(status))
+
+        if not processes:
+            msg = "No Meraki process information found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformSoftwareMerakiServiceResult(processes=processes)

--- a/tests/parsers/iosxe/show_platform_software_meraki-service/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_software_meraki-service/001_basic/expected.json
@@ -1,0 +1,16 @@
+{
+    "processes": {
+        "meraki_mgrd": {
+            "running": true
+        },
+        "meraki_tunnel_client": {
+            "running": true
+        },
+        "ios_console_service": {
+            "running": true
+        },
+        "nextunnel_packet_capture": {
+            "running": false
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_software_meraki-service/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_software_meraki-service/001_basic/input.txt
@@ -1,0 +1,7 @@
+
+Meraki Process Summary:
+----------------------------------------------
+Meraki Mgrd                    : Running
+Meraki Tunnel Client           : Running
+IOS Console Service            : Running
+Nextunnel Packet Capture       : Not Running

--- a/tests/parsers/iosxe/show_platform_software_meraki-service/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_software_meraki-service/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic Meraki service output with four processes
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_platform_software_meraki-service/002_with_ncmd/expected.json
+++ b/tests/parsers/iosxe/show_platform_software_meraki-service/002_with_ncmd/expected.json
@@ -1,0 +1,19 @@
+{
+    "processes": {
+        "meraki_mgrd": {
+            "running": true
+        },
+        "meraki_tunnel_client": {
+            "running": true
+        },
+        "ios_console_service": {
+            "running": true
+        },
+        "nextunnel_packet_capture": {
+            "running": false
+        },
+        "meraki_ncmd": {
+            "running": true
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_software_meraki-service/002_with_ncmd/input.txt
+++ b/tests/parsers/iosxe/show_platform_software_meraki-service/002_with_ncmd/input.txt
@@ -1,0 +1,8 @@
+
+Meraki Process Summary:
+----------------------------------------------
+Meraki Mgrd                    : Running
+Meraki Tunnel Client           : Running
+IOS Console Service            : Running
+Nextunnel Packet Capture       : Not Running
+Meraki Ncmd                    : Running

--- a/tests/parsers/iosxe/show_platform_software_meraki-service/002_with_ncmd/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_software_meraki-service/002_with_ncmd/metadata.yaml
@@ -1,0 +1,3 @@
+description: Meraki service output with five processes including Meraki Ncmd
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show platform software meraki-service` on Cisco IOS-XE
- Parses Meraki process summary output into structured dict keyed by normalized process name (e.g., `meraki_mgrd`, `ios_console_service`)
- Each process entry contains a `running` boolean indicating process status
- Includes two test cases: basic (4 processes) and with Meraki Ncmd (5 processes)

Closes #208

## Test plan
- [x] Parser correctly handles basic output with 4 processes
- [x] Parser correctly handles output with optional Meraki Ncmd process
- [x] Parser raises `ValueError` on empty/unparseable output
- [x] All ruff, format, xenon, and pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)