### PR TITLE
feat: add parser for 'show bfd neighbors' on NX-OS

### DIFF
--- a/changes/463.parser_added
+++ b/changes/463.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show bfd neighbors' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_bfd_neighbors.py
+++ b/src/muninn/parsers/nxos/show_bfd_neighbors.py
@@ -1,0 +1,127 @@
+"""Parser for 'show bfd neighbors' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class BfdNeighborEntry(TypedDict):
+    """Schema for a single BFD neighbor session."""
+
+    our_address: str
+    local_discriminator: int
+    remote_discriminator: int
+    rh_rs: str
+    holddown: int
+    holddown_multiplier: int
+    state: str
+    vrf: str
+    session_type: str
+
+
+class ShowBfdNeighborsResult(TypedDict):
+    """Schema for 'show bfd neighbors' parsed output on NX-OS.
+
+    Keyed by neighbor address, then by canonical interface name.
+    Multiple sessions to the same neighbor on different interfaces
+    are represented as separate entries.
+    """
+
+    neighbors: dict[str, dict[str, BfdNeighborEntry]]
+    total_entries: NotRequired[int]
+
+
+# Matches the holddown field: digits followed by (multiplier)
+_HOLDDOWN_RE = re.compile(r"^(\d+)\((\d+)\)$")
+
+# Tabular data line — starts with optional * then an IP address
+_DATA_LINE_RE = re.compile(
+    r"^\*?"
+    r"(?P<our_addr>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<neigh_addr>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<ld>\d+)/(?P<rd>\d+)\s+"
+    r"(?P<rh_rs>\S+)\s+"
+    r"(?P<holddown>\d+\(\d+\))\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<intf>\S+)\s+"
+    r"(?P<vrf>\S+)\s+"
+    r"(?P<type>\S+)\s*$"
+)
+
+
+def _parse_holddown(raw: str) -> tuple[int, int]:
+    """Parse holddown field like '862(3)' into (holddown, multiplier).
+
+    Args:
+        raw: Raw holddown string from CLI output.
+
+    Returns:
+        Tuple of (holddown_ms, multiplier).
+
+    Raises:
+        ValueError: If the holddown format is invalid.
+    """
+    m = _HOLDDOWN_RE.match(raw)
+    if not m:
+        msg = f"Invalid holddown format: {raw!r}"
+        raise ValueError(msg)
+    return int(m.group(1)), int(m.group(2))
+
+
+@register(OS.CISCO_NXOS, "show bfd neighbors")
+class ShowBfdNeighborsParser(BaseParser["ShowBfdNeighborsResult"]):
+    """Parser for 'show bfd neighbors' command on NX-OS.
+
+    Parses BFD neighbor session information from tabular output.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowBfdNeighborsResult:
+        """Parse 'show bfd neighbors' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed BFD neighbors keyed by neighbor address, then interface.
+
+        Raises:
+            ValueError: If no BFD neighbors found in output.
+        """
+        neighbors: dict[str, dict[str, BfdNeighborEntry]] = {}
+
+        for line in output.splitlines():
+            m = _DATA_LINE_RE.match(line)
+            if not m:
+                continue
+
+            neigh_addr = m.group("neigh_addr")
+            interface = canonical_interface_name(m.group("intf"), os=OS.CISCO_NXOS)
+
+            holddown, multiplier = _parse_holddown(m.group("holddown"))
+
+            entry: BfdNeighborEntry = {
+                "our_address": m.group("our_addr"),
+                "local_discriminator": int(m.group("ld")),
+                "remote_discriminator": int(m.group("rd")),
+                "rh_rs": m.group("rh_rs"),
+                "holddown": holddown,
+                "holddown_multiplier": multiplier,
+                "state": m.group("state"),
+                "vrf": m.group("vrf"),
+                "session_type": m.group("type"),
+            }
+
+            if neigh_addr not in neighbors:
+                neighbors[neigh_addr] = {}
+            neighbors[neigh_addr][interface] = entry
+
+        if not neighbors:
+            msg = "No BFD neighbors found in output"
+            raise ValueError(msg)
+
+        return {"neighbors": neighbors}

--- a/tests/parsers/nxos/show_bfd_neighbors/001_basic/expected.json
+++ b/tests/parsers/nxos/show_bfd_neighbors/001_basic/expected.json
@@ -1,0 +1,43 @@
+{
+    "neighbors": {
+        "172.23.0.19": {
+            "Ethernet1/10": {
+                "our_address": "172.23.0.18",
+                "local_discriminator": 1090540255,
+                "remote_discriminator": 1090566886,
+                "rh_rs": "Up",
+                "holddown": 862,
+                "holddown_multiplier": 3,
+                "state": "Up",
+                "vrf": "default",
+                "session_type": "SH"
+            }
+        },
+        "172.23.0.23": {
+            "Ethernet1/12": {
+                "our_address": "172.23.0.22",
+                "local_discriminator": 1090540256,
+                "remote_discriminator": 1090561429,
+                "rh_rs": "Up",
+                "holddown": 647,
+                "holddown_multiplier": 3,
+                "state": "Up",
+                "vrf": "default",
+                "session_type": "SH"
+            }
+        },
+        "172.23.0.21": {
+            "Ethernet1/11": {
+                "our_address": "172.23.0.20",
+                "local_discriminator": 1090540257,
+                "remote_discriminator": 1090566968,
+                "rh_rs": "Up",
+                "holddown": 729,
+                "holddown_multiplier": 3,
+                "state": "Up",
+                "vrf": "default",
+                "session_type": "SH"
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_bfd_neighbors/001_basic/input.txt
+++ b/tests/parsers/nxos/show_bfd_neighbors/001_basic/input.txt
@@ -1,0 +1,4 @@
+OurAddr         NeighAddr       LD/RD                 RH/RS           Holdown(mult)     State       Int                   Vrf                              Type
+172.23.0.18     172.23.0.19     1090540255/1090566886 Up              862(3)            Up          Eth1/10               default                          SH
+172.23.0.22     172.23.0.23     1090540256/1090561429 Up              647(3)            Up          Eth1/12               default                          SH
+172.23.0.20     172.23.0.21     1090540257/1090566968 Up              729(3)            Up          Eth1/11               default                          SH

--- a/tests/parsers/nxos/show_bfd_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_bfd_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic BFD neighbors with multiple sessions
+platform: Nexus 9000
+software_version: NX-OS


### PR DESCRIPTION
## Summary
- Add new parser for `show bfd neighbors` command on Cisco NX-OS
- Parses BFD neighbor session table into structured data keyed by neighbor address then interface
- Handles interface canonicalization (e.g., `Eth1/10` -> `Ethernet1/10`), numeric holddown/multiplier extraction
- Includes test case with 3 BFD neighbor sessions

Closes #211

## Test plan
- [x] Parser produces correct structured output from NTC-templates sample data
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_bfd_neighbors` passes
- [x] `uv run ruff check` and `uv run ruff format --check` pass
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)