### PR TITLE
feat: add parser for 'show interface brief' on NX-OS

### DIFF
--- a/changes/464.parser_added
+++ b/changes/464.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show interface brief' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_interface_brief.py
@@ -198,7 +198,7 @@ class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
             "mode": match.group("mode"),
             "status": match.group("status"),
             "reason": match.group("reason").strip(),
-            "speed": match.group("speed"),
+            "speed": cls._normalize_speed(match.group("speed")),
         }
         if vlan != "--":
             entry["vlan"] = vlan
@@ -206,6 +206,11 @@ class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
             entry["port_channel"] = port_ch
 
         return interface, entry
+
+    @staticmethod
+    def _normalize_speed(speed: str) -> str:
+        """Remove unsupported NX-OS speed suffixes from speed values."""
+        return speed.removesuffix("(D)")
 
     @classmethod
     def _parse_port_channel(cls, line: str) -> tuple[str, PortChannelEntry] | None:
@@ -223,7 +228,7 @@ class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
             "mode": match.group("mode"),
             "status": match.group("status"),
             "reason": match.group("reason").strip(),
-            "speed": match.group("speed"),
+            "speed": cls._normalize_speed(match.group("speed")),
             "protocol": match.group("protocol"),
         }
         if vlan != "--":

--- a/src/muninn/parsers/nxos/show_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_interface_brief.py
@@ -1,7 +1,7 @@
 """Parser for 'show interface brief' command on NX-OS."""
 
 import re
-from typing import NotRequired, TypedDict
+from typing import NotRequired, TypeAlias, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -58,14 +58,11 @@ class VlanEntry(TypedDict):
     secondary_vlan: NotRequired[str]
 
 
-class ShowInterfaceBriefResult(TypedDict):
-    """Schema for 'show interface brief' parsed output."""
+ShowInterfaceBriefEntry: TypeAlias = (
+    EthernetEntry | PortChannelEntry | ManagementEntry | LoopbackEntry | VlanEntry
+)
 
-    ethernet: NotRequired[dict[str, EthernetEntry]]
-    port_channel: NotRequired[dict[str, PortChannelEntry]]
-    management: NotRequired[dict[str, ManagementEntry]]
-    loopback: NotRequired[dict[str, LoopbackEntry]]
-    vlan: NotRequired[dict[str, VlanEntry]]
+ShowInterfaceBriefResult: TypeAlias = dict[str, ShowInterfaceBriefEntry]
 
 
 # Separator line pattern
@@ -334,9 +331,7 @@ class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
         parsed = parser_fn(stripped)
         if parsed:
             intf_name, entry = parsed
-            if current_section not in result:
-                result[current_section] = {}  # type: ignore[literal-required]
-            result[current_section][intf_name] = entry  # type: ignore[literal-required]
+            result[intf_name] = entry
 
     @classmethod
     def parse(cls, output: str) -> ShowInterfaceBriefResult:
@@ -346,7 +341,7 @@ class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed interface data organized by interface type section.
+            Parsed interface data keyed by interface name.
 
         Raises:
             ValueError: If no interfaces found in output.
@@ -367,8 +362,7 @@ class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
             if current_section:
                 cls._process_data_line(stripped, current_section, result)
 
-        total = sum(len(v) for v in result.values())  # type: ignore[arg-type]
-        if total == 0:
+        if not result:
             msg = "No interfaces found in output"
             raise ValueError(msg)
 

--- a/src/muninn/parsers/nxos/show_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_interface_brief.py
@@ -1,0 +1,375 @@
+"""Parser for 'show interface brief' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class EthernetEntry(TypedDict):
+    """Schema for an Ethernet interface entry."""
+
+    type: str
+    mode: str
+    status: str
+    reason: str
+    speed: str
+    vlan: NotRequired[str]
+    port_channel: NotRequired[str]
+
+
+class PortChannelEntry(TypedDict):
+    """Schema for a Port-channel interface entry."""
+
+    type: str
+    mode: str
+    status: str
+    reason: str
+    speed: str
+    protocol: str
+    vlan: NotRequired[str]
+
+
+class ManagementEntry(TypedDict):
+    """Schema for a management interface entry."""
+
+    status: str
+    speed: int
+    mtu: int
+    vrf: NotRequired[str]
+    ip_address: NotRequired[str]
+
+
+class LoopbackEntry(TypedDict):
+    """Schema for a Loopback interface entry."""
+
+    status: str
+    description: NotRequired[str]
+
+
+class VlanEntry(TypedDict):
+    """Schema for a VLAN interface entry."""
+
+    status: str
+    reason: NotRequired[str]
+    secondary_vlan: NotRequired[str]
+
+
+class ShowInterfaceBriefResult(TypedDict):
+    """Schema for 'show interface brief' parsed output."""
+
+    ethernet: NotRequired[dict[str, EthernetEntry]]
+    port_channel: NotRequired[dict[str, PortChannelEntry]]
+    management: NotRequired[dict[str, ManagementEntry]]
+    loopback: NotRequired[dict[str, LoopbackEntry]]
+    vlan: NotRequired[dict[str, VlanEntry]]
+
+
+# Separator line pattern
+_SEPARATOR = re.compile(r"^-{10,}$")
+
+
+@register(OS.CISCO_NXOS, "show interface brief")
+class ShowInterfaceBriefParser(BaseParser[ShowInterfaceBriefResult]):
+    """Parser for 'show interface brief' command on NX-OS.
+
+    Parses multi-section output covering Ethernet, Port-channel,
+    Management, Loopback, and VLAN interface summaries.
+    """
+
+    # Ethernet section header pattern:
+    # Ethernet      VLAN    Type Mode   Status  Reason                   Speed     Port
+    # Interface                                                                    Ch #
+    _ETHERNET_HEADER = re.compile(
+        r"Ethernet\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Port"
+    )
+
+    # Ethernet data line:
+    # Eth1/1        1      eth  trunk  up      none                        10G(D) 4000
+    # Eth1/2        --     eth  routed down    SFP not inserted            1000(D) --
+    _ETHERNET_PATTERN = re.compile(
+        r"^(?P<interface>Eth\S+)\s+"
+        r"(?P<vlan>\S+)\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<mode>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<reason>.+?)\s{2,}"
+        r"(?P<speed>\S+)\s+"
+        r"(?P<port_channel>\S+)\s*$"
+    )
+
+    # Port-channel section header pattern:
+    # Port-channel VLAN Type Mode Status Reason Speed Protocol
+    # Interface
+    _PORT_CHANNEL_HEADER = re.compile(
+        r"Port-channel\s+VLAN\s+Type\s+Mode\s+Status\s+Reason\s+Speed\s+Protocol"
+    )
+
+    # Port-channel data line:
+    # Po10         1     eth  trunk  up      none                       a-10G(D)  lacp
+    _PORT_CHANNEL_PATTERN = re.compile(
+        r"^(?P<interface>Po\S+)\s+"
+        r"(?P<vlan>\S+)\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<mode>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<reason>.+?)\s{2,}"
+        r"(?P<speed>\S+)\s+"
+        r"(?P<protocol>\S+)\s*$"
+    )
+
+    # Management section header pattern:
+    # Port   VRF          Status IP Address                              Speed    MTU
+    _MGMT_HEADER = re.compile(r"Port\s+VRF\s+Status\s+IP\s+Address\s+Speed\s+MTU")
+
+    # Management data line:
+    # mgmt0  --           up     192.168.10.37                           100      1500
+    _MGMT_PATTERN = re.compile(
+        r"^(?P<interface>mgmt\S*)\s+"
+        r"(?P<vrf>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<ip_address>\S+)\s+"
+        r"(?P<speed>\d+)\s+"
+        r"(?P<mtu>\d+)\s*$"
+    )
+
+    # Loopback/Tunnel section header with "Status" and "Description":
+    # Interface                  Status    Description
+    _LOOPBACK_HEADER = re.compile(r"Interface\s+Status\s+Description")
+
+    # Loopback data line:
+    # Lo0                        up        Router ID loopback
+    # Lo1                        up        --
+    _LOOPBACK_PATTERN = re.compile(
+        r"^(?P<interface>Lo\S+)\s+"
+        r"(?P<status>\S+)\s*"
+        r"(?P<description>.*)?$"
+    )
+
+    # VLAN section header with "Secondary VLAN":
+    # Interface   Secondary VLAN(Type)                    Status Reason
+    _VLAN_HEADER = re.compile(r"Interface\s+Secondary\s+VLAN")
+
+    # VLAN data line:
+    # Vlan1     --                                      down   Administratively down
+    _VLAN_PATTERN = re.compile(
+        r"^(?P<interface>Vlan\S+)\s+"
+        r"(?P<secondary_vlan>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<reason>.+?)\s*$"
+    )
+
+    @classmethod
+    def _detect_section(cls, line: str) -> str | None:
+        """Detect which section a header line belongs to.
+
+        Args:
+            line: A line from the CLI output.
+
+        Returns:
+            Section name string, or None if not a header.
+        """
+        if cls._ETHERNET_HEADER.search(line):
+            return "ethernet"
+        if cls._PORT_CHANNEL_HEADER.search(line):
+            return "port_channel"
+        if cls._MGMT_HEADER.search(line):
+            return "management"
+        if cls._VLAN_HEADER.search(line):
+            return "vlan"
+        if cls._LOOPBACK_HEADER.search(line):
+            return "loopback"
+        return None
+
+    @classmethod
+    def _parse_ethernet(cls, line: str) -> tuple[str, EthernetEntry] | None:
+        """Parse an Ethernet interface line."""
+        match = cls._ETHERNET_PATTERN.match(line)
+        if not match:
+            return None
+
+        interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_NXOS)
+        port_ch = match.group("port_channel").strip()
+
+        vlan = match.group("vlan")
+
+        entry: EthernetEntry = {
+            "type": match.group("type"),
+            "mode": match.group("mode"),
+            "status": match.group("status"),
+            "reason": match.group("reason").strip(),
+            "speed": match.group("speed"),
+        }
+        if vlan != "--":
+            entry["vlan"] = vlan
+        if port_ch != "--":
+            entry["port_channel"] = port_ch
+
+        return interface, entry
+
+    @classmethod
+    def _parse_port_channel(cls, line: str) -> tuple[str, PortChannelEntry] | None:
+        """Parse a Port-channel interface line."""
+        match = cls._PORT_CHANNEL_PATTERN.match(line)
+        if not match:
+            return None
+
+        interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_NXOS)
+
+        vlan = match.group("vlan")
+
+        entry: PortChannelEntry = {
+            "type": match.group("type"),
+            "mode": match.group("mode"),
+            "status": match.group("status"),
+            "reason": match.group("reason").strip(),
+            "speed": match.group("speed"),
+            "protocol": match.group("protocol"),
+        }
+        if vlan != "--":
+            entry["vlan"] = vlan
+
+        return interface, entry
+
+    @classmethod
+    def _parse_management(cls, line: str) -> tuple[str, ManagementEntry] | None:
+        """Parse a management interface line."""
+        match = cls._MGMT_PATTERN.match(line)
+        if not match:
+            return None
+
+        interface = match.group("interface")
+        ip_addr = match.group("ip_address")
+
+        vrf = match.group("vrf")
+
+        entry: ManagementEntry = {
+            "status": match.group("status"),
+            "speed": int(match.group("speed")),
+            "mtu": int(match.group("mtu")),
+        }
+        if vrf != "--":
+            entry["vrf"] = vrf
+        if ip_addr != "--":
+            entry["ip_address"] = ip_addr
+
+        return interface, entry
+
+    @classmethod
+    def _parse_loopback(cls, line: str) -> tuple[str, LoopbackEntry] | None:
+        """Parse a Loopback interface line."""
+        match = cls._LOOPBACK_PATTERN.match(line)
+        if not match:
+            return None
+
+        interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_NXOS)
+
+        entry: LoopbackEntry = {
+            "status": match.group("status"),
+        }
+        desc = match.group("description")
+        if desc:
+            desc = desc.strip()
+            if desc and desc != "--":
+                entry["description"] = desc
+
+        return interface, entry
+
+    @classmethod
+    def _parse_vlan(cls, line: str) -> tuple[str, VlanEntry] | None:
+        """Parse a VLAN interface line."""
+        match = cls._VLAN_PATTERN.match(line)
+        if not match:
+            return None
+
+        interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_NXOS)
+
+        reason = match.group("reason").strip()
+
+        entry: VlanEntry = {
+            "status": match.group("status"),
+        }
+        if reason != "--":
+            entry["reason"] = reason
+        secondary = match.group("secondary_vlan")
+        if secondary != "--":
+            entry["secondary_vlan"] = secondary
+
+        return interface, entry
+
+    # Map section names to their parser method names
+    _SECTION_PARSERS: dict[str, str] = {
+        "ethernet": "_parse_ethernet",
+        "port_channel": "_parse_port_channel",
+        "management": "_parse_management",
+        "loopback": "_parse_loopback",
+        "vlan": "_parse_vlan",
+    }
+
+    # Lines that are sub-headers to skip
+    _SKIP_LINES = frozenset({"Interface", "Ch #"})
+
+    @classmethod
+    def _is_skip_line(cls, stripped: str) -> bool:
+        """Check if a line should be skipped during parsing."""
+        if not stripped or _SEPARATOR.match(stripped):
+            return True
+        return stripped in cls._SKIP_LINES
+
+    @classmethod
+    def _process_data_line(
+        cls,
+        stripped: str,
+        current_section: str,
+        result: ShowInterfaceBriefResult,
+    ) -> None:
+        """Parse a data line and add it to the result dict."""
+        method_name = cls._SECTION_PARSERS.get(current_section)
+        if not method_name:
+            return
+        parser_fn = getattr(cls, method_name)
+        parsed = parser_fn(stripped)
+        if parsed:
+            intf_name, entry = parsed
+            if current_section not in result:
+                result[current_section] = {}  # type: ignore[literal-required]
+            result[current_section][intf_name] = entry  # type: ignore[literal-required]
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfaceBriefResult:
+        """Parse 'show interface brief' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed interface data organized by interface type section.
+
+        Raises:
+            ValueError: If no interfaces found in output.
+        """
+        result: ShowInterfaceBriefResult = {}
+        current_section: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if cls._is_skip_line(stripped):
+                continue
+
+            section = cls._detect_section(stripped)
+            if section is not None:
+                current_section = section
+                continue
+
+            if current_section:
+                cls._process_data_line(stripped, current_section, result)
+
+        total = sum(len(v) for v in result.values())  # type: ignore[arg-type]
+        if total == 0:
+            msg = "No interfaces found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/nxos/show_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_interface_brief/001_basic/expected.json
@@ -1,115 +1,105 @@
 {
-    "management": {
-        "mgmt0": {
-            "status": "up",
-            "speed": 1000,
-            "mtu": 1500,
-            "ip_address": "192.168.10.37"
-        }
+    "mgmt0": {
+        "status": "up",
+        "speed": 1000,
+        "mtu": 1500,
+        "ip_address": "192.168.10.37"
     },
-    "ethernet": {
-        "Ethernet1/1": {
-            "type": "eth",
-            "mode": "trunk",
-            "status": "up",
-            "reason": "none",
-            "speed": "10G(D)",
-            "vlan": "1",
-            "port_channel": "4000"
-        },
-        "Ethernet1/2": {
-            "type": "eth",
-            "mode": "trunk",
-            "status": "up",
-            "reason": "none",
-            "speed": "10G(D)",
-            "vlan": "1",
-            "port_channel": "4000"
-        },
-        "Ethernet1/3": {
-            "type": "eth",
-            "mode": "routed",
-            "status": "down",
-            "reason": "SFP not inserted",
-            "speed": "1000(D)"
-        },
-        "Ethernet1/4": {
-            "type": "eth",
-            "mode": "access",
-            "status": "up",
-            "reason": "none",
-            "speed": "1000(D)",
-            "vlan": "10"
-        },
-        "Ethernet1/5": {
-            "type": "eth",
-            "mode": "f-path",
-            "status": "down",
-            "reason": "SFP not inserted",
-            "speed": "10G(D)",
-            "vlan": "1"
-        },
-        "Ethernet1/6": {
-            "type": "eth",
-            "mode": "fabric",
-            "status": "down",
-            "reason": "Link not connected",
-            "speed": "10G(D)",
-            "vlan": "1"
-        }
+    "Ethernet1/1": {
+        "type": "eth",
+        "mode": "trunk",
+        "status": "up",
+        "reason": "none",
+        "speed": "10G(D)",
+        "vlan": "1",
+        "port_channel": "4000"
     },
-    "port_channel": {
-        "Port-channel10": {
-            "type": "eth",
-            "mode": "trunk",
-            "status": "up",
-            "reason": "none",
-            "speed": "a-10G(D)",
-            "protocol": "lacp",
-            "vlan": "1"
-        },
-        "Port-channel4000": {
-            "type": "eth",
-            "mode": "trunk",
-            "status": "up",
-            "reason": "none",
-            "speed": "a-10G(D)",
-            "protocol": "lacp",
-            "vlan": "1"
-        },
-        "Port-channel20": {
-            "type": "eth",
-            "mode": "routed",
-            "status": "down",
-            "reason": "No operational members",
-            "speed": "auto(D)",
-            "protocol": "lacp"
-        }
+    "Ethernet1/2": {
+        "type": "eth",
+        "mode": "trunk",
+        "status": "up",
+        "reason": "none",
+        "speed": "10G(D)",
+        "vlan": "1",
+        "port_channel": "4000"
     },
-    "loopback": {
-        "Loopback0": {
-            "status": "up",
-            "description": "Router ID loopback"
-        },
-        "Loopback1": {
-            "status": "up"
-        },
-        "Loopback100": {
-            "status": "down",
-            "description": "VTEP source"
-        }
+    "Ethernet1/3": {
+        "type": "eth",
+        "mode": "routed",
+        "status": "down",
+        "reason": "SFP not inserted",
+        "speed": "1000(D)"
     },
-    "vlan": {
-        "Vlan1": {
-            "status": "down",
-            "reason": "Administratively down"
-        },
-        "Vlan10": {
-            "status": "up"
-        },
-        "Vlan200": {
-            "status": "up",
-            "secondary_vlan": "100(community)"
-        }
+    "Ethernet1/4": {
+        "type": "eth",
+        "mode": "access",
+        "status": "up",
+        "reason": "none",
+        "speed": "1000(D)",
+        "vlan": "10"
+    },
+    "Ethernet1/5": {
+        "type": "eth",
+        "mode": "f-path",
+        "status": "down",
+        "reason": "SFP not inserted",
+        "speed": "10G(D)",
+        "vlan": "1"
+    },
+    "Ethernet1/6": {
+        "type": "eth",
+        "mode": "fabric",
+        "status": "down",
+        "reason": "Link not connected",
+        "speed": "10G(D)",
+        "vlan": "1"
+    },
+    "Port-channel10": {
+        "type": "eth",
+        "mode": "trunk",
+        "status": "up",
+        "reason": "none",
+        "speed": "a-10G(D)",
+        "protocol": "lacp",
+        "vlan": "1"
+    },
+    "Port-channel4000": {
+        "type": "eth",
+        "mode": "trunk",
+        "status": "up",
+        "reason": "none",
+        "speed": "a-10G(D)",
+        "protocol": "lacp",
+        "vlan": "1"
+    },
+    "Port-channel20": {
+        "type": "eth",
+        "mode": "routed",
+        "status": "down",
+        "reason": "No operational members",
+        "speed": "auto(D)",
+        "protocol": "lacp"
+    },
+    "Loopback0": {
+        "status": "up",
+        "description": "Router ID loopback"
+    },
+    "Loopback1": {
+        "status": "up"
+    },
+    "Loopback100": {
+        "status": "down",
+        "description": "VTEP source"
+    },
+    "Vlan1": {
+        "status": "down",
+        "reason": "Administratively down"
+    },
+    "Vlan10": {
+        "status": "up"
+    },
+    "Vlan200": {
+        "status": "up",
+        "secondary_vlan": "100(community)"
     }
 }

--- a/tests/parsers/nxos/show_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_interface_brief/001_basic/expected.json
@@ -1,0 +1,115 @@
+{
+    "management": {
+        "mgmt0": {
+            "status": "up",
+            "speed": 1000,
+            "mtu": 1500,
+            "ip_address": "192.168.10.37"
+        }
+    },
+    "ethernet": {
+        "Ethernet1/1": {
+            "type": "eth",
+            "mode": "trunk",
+            "status": "up",
+            "reason": "none",
+            "speed": "10G(D)",
+            "vlan": "1",
+            "port_channel": "4000"
+        },
+        "Ethernet1/2": {
+            "type": "eth",
+            "mode": "trunk",
+            "status": "up",
+            "reason": "none",
+            "speed": "10G(D)",
+            "vlan": "1",
+            "port_channel": "4000"
+        },
+        "Ethernet1/3": {
+            "type": "eth",
+            "mode": "routed",
+            "status": "down",
+            "reason": "SFP not inserted",
+            "speed": "1000(D)"
+        },
+        "Ethernet1/4": {
+            "type": "eth",
+            "mode": "access",
+            "status": "up",
+            "reason": "none",
+            "speed": "1000(D)",
+            "vlan": "10"
+        },
+        "Ethernet1/5": {
+            "type": "eth",
+            "mode": "f-path",
+            "status": "down",
+            "reason": "SFP not inserted",
+            "speed": "10G(D)",
+            "vlan": "1"
+        },
+        "Ethernet1/6": {
+            "type": "eth",
+            "mode": "fabric",
+            "status": "down",
+            "reason": "Link not connected",
+            "speed": "10G(D)",
+            "vlan": "1"
+        }
+    },
+    "port_channel": {
+        "Port-channel10": {
+            "type": "eth",
+            "mode": "trunk",
+            "status": "up",
+            "reason": "none",
+            "speed": "a-10G(D)",
+            "protocol": "lacp",
+            "vlan": "1"
+        },
+        "Port-channel4000": {
+            "type": "eth",
+            "mode": "trunk",
+            "status": "up",
+            "reason": "none",
+            "speed": "a-10G(D)",
+            "protocol": "lacp",
+            "vlan": "1"
+        },
+        "Port-channel20": {
+            "type": "eth",
+            "mode": "routed",
+            "status": "down",
+            "reason": "No operational members",
+            "speed": "auto(D)",
+            "protocol": "lacp"
+        }
+    },
+    "loopback": {
+        "Loopback0": {
+            "status": "up",
+            "description": "Router ID loopback"
+        },
+        "Loopback1": {
+            "status": "up"
+        },
+        "Loopback100": {
+            "status": "down",
+            "description": "VTEP source"
+        }
+    },
+    "vlan": {
+        "Vlan1": {
+            "status": "down",
+            "reason": "Administratively down"
+        },
+        "Vlan10": {
+            "status": "up"
+        },
+        "Vlan200": {
+            "status": "up",
+            "secondary_vlan": "100(community)"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_interface_brief/001_basic/expected.json
@@ -10,7 +10,7 @@
         "mode": "trunk",
         "status": "up",
         "reason": "none",
-        "speed": "10G(D)",
+        "speed": "10G",
         "vlan": "1",
         "port_channel": "4000"
     },
@@ -19,7 +19,7 @@
         "mode": "trunk",
         "status": "up",
         "reason": "none",
-        "speed": "10G(D)",
+        "speed": "10G",
         "vlan": "1",
         "port_channel": "4000"
     },
@@ -28,14 +28,14 @@
         "mode": "routed",
         "status": "down",
         "reason": "SFP not inserted",
-        "speed": "1000(D)"
+        "speed": "1000"
     },
     "Ethernet1/4": {
         "type": "eth",
         "mode": "access",
         "status": "up",
         "reason": "none",
-        "speed": "1000(D)",
+        "speed": "1000",
         "vlan": "10"
     },
     "Ethernet1/5": {
@@ -43,7 +43,7 @@
         "mode": "f-path",
         "status": "down",
         "reason": "SFP not inserted",
-        "speed": "10G(D)",
+        "speed": "10G",
         "vlan": "1"
     },
     "Ethernet1/6": {
@@ -51,7 +51,7 @@
         "mode": "fabric",
         "status": "down",
         "reason": "Link not connected",
-        "speed": "10G(D)",
+        "speed": "10G",
         "vlan": "1"
     },
     "Port-channel10": {
@@ -59,7 +59,7 @@
         "mode": "trunk",
         "status": "up",
         "reason": "none",
-        "speed": "a-10G(D)",
+        "speed": "a-10G",
         "protocol": "lacp",
         "vlan": "1"
     },
@@ -68,7 +68,7 @@
         "mode": "trunk",
         "status": "up",
         "reason": "none",
-        "speed": "a-10G(D)",
+        "speed": "a-10G",
         "protocol": "lacp",
         "vlan": "1"
     },
@@ -77,7 +77,7 @@
         "mode": "routed",
         "status": "down",
         "reason": "No operational members",
-        "speed": "auto(D)",
+        "speed": "auto",
         "protocol": "lacp"
     },
     "Loopback0": {

--- a/tests/parsers/nxos/show_interface_brief/001_basic/input.txt
+++ b/tests/parsers/nxos/show_interface_brief/001_basic/input.txt
@@ -1,0 +1,38 @@
+
+--------------------------------------------------------------------------------
+Port   VRF          Status IP Address                              Speed    MTU
+--------------------------------------------------------------------------------
+mgmt0  --           up     192.168.10.37                           1000     1500
+
+--------------------------------------------------------------------------------
+Ethernet      VLAN    Type Mode   Status  Reason                   Speed     Port
+Interface                                                                    Ch #
+--------------------------------------------------------------------------------
+Eth1/1        1      eth  trunk  up      none                       10G(D)  4000
+Eth1/2        1      eth  trunk  up      none                       10G(D)  4000
+Eth1/3        --     eth  routed down    SFP not inserted           1000(D) --
+Eth1/4        10     eth  access up      none                       1000(D) --
+Eth1/5        1      eth  f-path down    SFP not inserted           10G(D)  --
+Eth1/6        1      eth  fabric down    Link not connected         10G(D)  --
+
+--------------------------------------------------------------------------------
+Port-channel VLAN    Type Mode   Status  Reason                    Speed   Protocol
+Interface
+--------------------------------------------------------------------------------
+Po10         1      eth  trunk  up      none                       a-10G(D)  lacp
+Po4000       1      eth  trunk  up      none                       a-10G(D)  lacp
+Po20         --     eth  routed down    No operational members     auto(D)   lacp
+
+-------------------------------------------------------------------------------
+Interface                  Status    Description
+-------------------------------------------------------------------------------
+Lo0                        up        Router ID loopback
+Lo1                        up        --
+Lo100                      down      VTEP source
+
+-------------------------------------------------------------------------------
+Interface     Secondary VLAN(Type)                    Status Reason
+-------------------------------------------------------------------------------
+Vlan1         --                                      down   Administratively down
+Vlan10        --                                      up     --
+Vlan200       100(community)                          up     --

--- a/tests/parsers/nxos/show_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_interface_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interface types with various statuses
+platform: Nexus 9000
+software_version: NX-OS 10.3(2)


### PR DESCRIPTION
## Summary
- Adds a new parser for `show interface brief` on Cisco NX-OS
- Handles all five output sections with distinct column layouts: Ethernet, Port-channel, Management, Loopback, and VLAN
- Keys results by canonicalized interface name within each section; omits `--` placeholder values; uses `int()` for numeric fields (speed, MTU)
- Includes test case with realistic multi-section output covering various interface states

Closes #212

## Test plan
- [x] Parser test passes: `uv run pytest tests/parsers/ -k "show_interface_brief" -v`
- [x] Ruff lint: `uv run ruff check src/muninn/parsers/nxos/show_interface_brief.py`
- [x] Ruff format: `uv run ruff format --check src/muninn/parsers/nxos/show_interface_brief.py`
- [x] Xenon complexity: `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/nxos/show_interface_brief.py`
- [x] Pre-commit hooks: `uv run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)