### PR TITLE
feat: add parser for 'show interface transceiver' on NX-OS

### DIFF
--- a/changes/468.parser_added
+++ b/changes/468.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show interface transceiver' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_interface_transceiver.py
+++ b/src/muninn/parsers/nxos/show_interface_transceiver.py
@@ -1,0 +1,129 @@
+"""Parser for 'show interface transceiver' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class TransceiverEntry(TypedDict):
+    """Schema for a single interface transceiver entry."""
+
+    sfp: str
+    temperature_c: NotRequired[float]
+    voltage_v: NotRequired[float]
+    current_ma: NotRequired[float]
+    tx_power_dbm: NotRequired[float]
+    rx_power_dbm: NotRequired[float]
+
+
+class ShowInterfaceTransceiverResult(TypedDict):
+    """Schema for 'show interface transceiver' parsed output."""
+
+    interfaces: dict[str, TransceiverEntry]
+
+
+# Matches the header lines and separator
+_HEADER_PATTERN = re.compile(r"^\s*(?:Port|---|\()", re.IGNORECASE)
+
+# Matches transceiver data rows:
+# Eth1/1   QSFP-40G-SR-BD   35.00   3.28   6.84   -2.48   -2.20
+_ROW_PATTERN = re.compile(
+    r"^(?P<port>(?:Eth|Ethernet)\S+)\s+"
+    r"(?P<sfp>\S+)\s+"
+    r"(?P<temp>\S+)\s+"
+    r"(?P<voltage>\S+)\s+"
+    r"(?P<current>\S+)\s+"
+    r"(?P<tx_power>\S+)\s+"
+    r"(?P<rx_power>\S+)"
+)
+
+# Values that should be omitted from output
+_SKIP_VALUES = {"N/A", "--", "n/a"}
+
+# Maps regex group names to TransceiverEntry keys
+_FIELD_MAP: list[tuple[str, str]] = [
+    ("temp", "temperature_c"),
+    ("voltage", "voltage_v"),
+    ("current", "current_ma"),
+    ("tx_power", "tx_power_dbm"),
+    ("rx_power", "rx_power_dbm"),
+]
+
+
+def _parse_float(value: str) -> float | None:
+    """Parse a string to float, returning None for N/A or -- values.
+
+    Args:
+        value: Raw string value from CLI output.
+
+    Returns:
+        Parsed float or None if value should be omitted.
+    """
+    if value in _SKIP_VALUES:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+@register(OS.CISCO_NXOS, "show interface transceiver")
+class ShowInterfaceTransceiverParser(
+    BaseParser[ShowInterfaceTransceiverResult],
+):
+    """Parser for 'show interface transceiver' on NX-OS.
+
+    Parses the transceiver summary table including SFP type,
+    temperature, voltage, current, Tx power, and Rx power
+    per interface.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfaceTransceiverResult:
+        """Parse 'show interface transceiver' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed transceiver data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no transceiver entries found.
+        """
+        interfaces: dict[str, TransceiverEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped or _HEADER_PATTERN.match(stripped):
+                continue
+
+            match = _ROW_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            port = canonical_interface_name(match.group("port"), os=OS.CISCO_NXOS)
+            sfp = match.group("sfp")
+
+            # Skip rows where the SFP field indicates no transceiver
+            if sfp in _SKIP_VALUES:
+                continue
+
+            entry: TransceiverEntry = {"sfp": sfp}
+
+            for group_name, key in _FIELD_MAP:
+                val = _parse_float(match.group(group_name))
+                if val is not None:
+                    entry[key] = val  # type: ignore[literal-required]
+
+            interfaces[port] = entry
+
+        if not interfaces:
+            msg = "No transceiver entries found in output"
+            raise ValueError(msg)
+
+        return ShowInterfaceTransceiverResult(interfaces=interfaces)

--- a/tests/parsers/nxos/show_interface_transceiver/001_basic/expected.json
+++ b/tests/parsers/nxos/show_interface_transceiver/001_basic/expected.json
@@ -1,0 +1,39 @@
+{
+    "interfaces": {
+        "Ethernet1/1": {
+            "sfp": "QSFP-40G-SR-BD",
+            "temperature_c": 35.0,
+            "voltage_v": 3.28,
+            "current_ma": 6.84,
+            "tx_power_dbm": -2.48,
+            "rx_power_dbm": -2.2
+        },
+        "Ethernet1/2": {
+            "sfp": "SFP-10G-SR",
+            "temperature_c": 28.12,
+            "voltage_v": 3.3,
+            "current_ma": 8.22,
+            "tx_power_dbm": -1.99,
+            "rx_power_dbm": -1.45
+        },
+        "Ethernet1/3": {
+            "sfp": "QSFP-100G-LR4-S",
+            "temperature_c": 32.55,
+            "voltage_v": 3.25,
+            "current_ma": 35.84,
+            "tx_power_dbm": -0.75,
+            "rx_power_dbm": -3.12
+        },
+        "Ethernet1/4": {
+            "sfp": "SFP-H10GB-CU3M"
+        },
+        "Ethernet2/1": {
+            "sfp": "QSFP-40G-SR4",
+            "temperature_c": 41.23,
+            "voltage_v": 3.31,
+            "current_ma": 7.12,
+            "tx_power_dbm": -1.85,
+            "rx_power_dbm": -40.0
+        }
+    }
+}

--- a/tests/parsers/nxos/show_interface_transceiver/001_basic/input.txt
+++ b/tests/parsers/nxos/show_interface_transceiver/001_basic/input.txt
@@ -1,0 +1,8 @@
+Port          Sfp                 Temp     Voltage   Current   Tx Power  Rx Power
+                                  (C)      (V)       (mA)      (dBm)     (dBm)
+----------    ------------------  -------  --------  --------  --------  --------
+Eth1/1        QSFP-40G-SR-BD      35.00    3.28      6.84      -2.48     -2.20
+Eth1/2        SFP-10G-SR          28.12    3.30      8.22      -1.99     -1.45
+Eth1/3        QSFP-100G-LR4-S    32.55    3.25      35.84     -0.75     -3.12
+Eth1/4        SFP-H10GB-CU3M     N/A      N/A       N/A       N/A       N/A
+Eth2/1        QSFP-40G-SR4       41.23    3.31      7.12      -1.85     -40.00

--- a/tests/parsers/nxos/show_interface_transceiver/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_interface_transceiver/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic transceiver table with multiple interfaces and optical readings
+platform: Nexus 9000
+software_version: NX-OS


### PR DESCRIPTION
## Summary
- Add parser for `show interface transceiver` command on Cisco NX-OS
- Parses the transceiver summary table into structured data keyed by canonical interface name
- Extracts SFP type, temperature (C), voltage (V), current (mA), Tx power (dBm), and Rx power (dBm) per interface
- N/A and -- values are omitted rather than stored as None

Closes #217

## Test plan
- [x] Test case 001_basic: multiple interfaces with optical readings, copper SFP with N/A values
- [x] `uv run ruff check` passes
- [x] `uv run ruff format` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pytest tests/parsers/ -k show_interface_transceiver -v` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)