### PR TITLE
feat: add parser for 'show logging onboard rp active clilog detail' on IOS-XE

### DIFF
--- a/changes/473.parser_added
+++ b/changes/473.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show logging onboard rp active clilog detail' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail.py
+++ b/src/muninn/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail.py
@@ -23,8 +23,7 @@ class SummaryEntry(TypedDict):
 class ContinuousEntry(TypedDict):
     """Schema for a single CLI logging continuous entry."""
 
-    date: str
-    time: str
+    timestamp: str
     command: str
 
 
@@ -201,8 +200,7 @@ class ShowLoggingOnboardRpActiveClilogDetailParser(
 
         seq += 1
         continuous[str(seq)] = {
-            "date": match.group("date"),
-            "time": match.group("time"),
+            "timestamp": f"{match.group('date')} {match.group('time')}",
             "command": match.group("command"),
         }
 

--- a/src/muninn/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail.py
+++ b/src/muninn/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail.py
@@ -1,0 +1,209 @@
+"""Parser for 'show logging onboard rp active clilog detail' command on IOS-XE."""
+
+from __future__ import annotations
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+# ---------------------------------------------------------------------------
+# TypedDict schemas
+# ---------------------------------------------------------------------------
+
+
+class SummaryEntry(TypedDict):
+    """Schema for a single CLI logging summary entry."""
+
+    count: int
+
+
+class ContinuousEntry(TypedDict):
+    """Schema for a single CLI logging continuous entry."""
+
+    date: str
+    time: str
+    command: str
+
+
+class ShowLoggingOnboardRpActiveClilogDetailResult(TypedDict):
+    """Schema for 'show logging onboard rp active clilog detail' parsed output.
+
+    Top-level keys:
+        summary: Command execution counts keyed by command string.
+        continuous: Timestamped command entries keyed by sequence number.
+    """
+
+    summary: NotRequired[dict[str, SummaryEntry]]
+    continuous: NotRequired[dict[str, ContinuousEntry]]
+
+
+# ---------------------------------------------------------------------------
+# Compiled regex patterns
+# ---------------------------------------------------------------------------
+
+# Summary section entry: " 1    show logging onboard RP active clilog detail"
+_SUMMARY_ENTRY_RE = re.compile(r"^\s*(?P<count>\d+)\s+(?P<command>.+?)\s*$")
+
+# Continuous section entry: " 03/30/2023 02:41:08 show logging onboard ..."
+_CONTINUOUS_ENTRY_RE = re.compile(
+    r"^\s*(?P<date>\d{2}/\d{2}/\d{4})\s+"
+    r"(?P<time>\d{2}:\d{2}:\d{2})\s+"
+    r"(?P<command>.+?)\s*$"
+)
+
+# Section headers
+_SUMMARY_HEADER_RE = re.compile(r"^-*\s*CLI LOGGING SUMMARY INFORMATION\s*-*$")
+_CONTINUOUS_HEADER_RE = re.compile(r"^-*\s*CLI LOGGING CONTINUOUS INFORMATION\s*-*$")
+
+# Separator and column header lines
+_SEPARATOR_RE = re.compile(r"^-{2,}$")
+_COLUMN_HEADER_RE = re.compile(r"^\s*(COUNT\s+COMMAND|MM/DD/YYYY\s+HH:MM:SS\s+COMMAND)")
+
+# Lines indicating no data
+_NO_DATA_RE = re.compile(r"^\s*No\s+(summary|continuous)\s+data", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Main parser
+# ---------------------------------------------------------------------------
+
+
+@register(OS.CISCO_IOSXE, "show logging onboard rp active clilog detail")
+class ShowLoggingOnboardRpActiveClilogDetailParser(
+    BaseParser["ShowLoggingOnboardRpActiveClilogDetailResult"],
+):
+    """Parser for 'show logging onboard rp active clilog detail' on IOS-XE.
+
+    Parses CLI logging summary (command execution counts) and continuous
+    (timestamped command history) sections from onboard logging output.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLoggingOnboardRpActiveClilogDetailResult:
+        """Parse 'show logging onboard rp active clilog detail' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed CLI logging data with summary and continuous sections.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+
+        if not lines or all(not line.strip() for line in lines):
+            msg = "No output to parse"
+            raise ValueError(msg)
+
+        summary, continuous = cls._parse_sections(lines)
+
+        result: ShowLoggingOnboardRpActiveClilogDetailResult = {}
+        if summary:
+            result["summary"] = summary
+        if continuous:
+            result["continuous"] = continuous
+
+        if not result:
+            msg = "No CLI logging data found in output"
+            raise ValueError(msg)
+
+        return result
+
+    @classmethod
+    def _parse_sections(
+        cls, lines: list[str]
+    ) -> tuple[
+        dict[str, SummaryEntry],
+        dict[str, ContinuousEntry],
+    ]:
+        """Split output into summary and continuous sections and parse each.
+
+        Returns:
+            Tuple of (summary_dict, continuous_dict).
+        """
+        section: str | None = None
+        summary: dict[str, SummaryEntry] = {}
+        continuous: dict[str, ContinuousEntry] = {}
+        continuous_seq = 0
+
+        for line in lines:
+            stripped = line.strip()
+
+            if not stripped:
+                continue
+
+            # Detect section transitions
+            if _SUMMARY_HEADER_RE.match(stripped):
+                section = "summary"
+                continue
+
+            if _CONTINUOUS_HEADER_RE.match(stripped):
+                section = "continuous"
+                continue
+
+            # Skip separator and column header lines
+            if _SEPARATOR_RE.match(stripped) or _COLUMN_HEADER_RE.match(stripped):
+                continue
+
+            # Skip "no data" lines
+            if _NO_DATA_RE.match(stripped):
+                continue
+
+            # Parse entries based on current section
+            if section == "summary":
+                cls._parse_summary_line(stripped, summary)
+            elif section == "continuous":
+                continuous_seq = cls._parse_continuous_line(
+                    stripped, continuous, continuous_seq
+                )
+
+        return summary, continuous
+
+    @classmethod
+    def _parse_summary_line(
+        cls,
+        line: str,
+        summary: dict[str, SummaryEntry],
+    ) -> None:
+        """Parse a single summary section line and aggregate by command."""
+        match = _SUMMARY_ENTRY_RE.match(line)
+        if not match:
+            return
+
+        command = match.group("command")
+        count = int(match.group("count"))
+
+        if command in summary:
+            summary[command]["count"] += count
+        else:
+            summary[command] = {"count": count}
+
+    @classmethod
+    def _parse_continuous_line(
+        cls,
+        line: str,
+        continuous: dict[str, ContinuousEntry],
+        seq: int,
+    ) -> int:
+        """Parse a single continuous section line.
+
+        Returns:
+            Updated sequence counter.
+        """
+        match = _CONTINUOUS_ENTRY_RE.match(line)
+        if not match:
+            return seq
+
+        seq += 1
+        continuous[str(seq)] = {
+            "date": match.group("date"),
+            "time": match.group("time"),
+            "command": match.group("command"),
+        }
+
+        return seq

--- a/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/expected.json
@@ -27,58 +27,47 @@
     },
     "continuous": {
         "1": {
-            "date": "03/30/2023",
-            "time": "02:41:08",
+            "timestamp": "03/30/2023 02:41:08",
             "command": "show logging onboard RP active clilog detail"
         },
         "2": {
-            "date": "03/30/2023",
-            "time": "02:41:43",
+            "timestamp": "03/30/2023 02:41:43",
             "command": "show logging onboard RP active counter detail"
         },
         "3": {
-            "date": "03/30/2023",
-            "time": "02:42:29",
+            "timestamp": "03/30/2023 02:42:29",
             "command": "show logging onboard RP active environment detail"
         },
         "4": {
-            "date": "03/30/2023",
-            "time": "02:43:32",
+            "timestamp": "03/30/2023 02:43:32",
             "command": "show logging onboard RP active message detail"
         },
         "5": {
-            "date": "03/30/2023",
-            "time": "02:44:21",
+            "timestamp": "03/30/2023 02:44:21",
             "command": "show logging onboard RP active temperature detail"
         },
         "6": {
-            "date": "03/30/2023",
-            "time": "02:45:25",
+            "timestamp": "03/30/2023 02:45:25",
             "command": "show logging onboard RP active uptime detail"
         },
         "7": {
-            "date": "03/30/2023",
-            "time": "02:46:31",
+            "timestamp": "03/30/2023 02:46:31",
             "command": "show logging onboard RP active voltage detail"
         },
         "8": {
-            "date": "04/13/2023",
-            "time": "09:22:40",
+            "timestamp": "04/13/2023 09:22:40",
             "command": "show logging onboard RP standby message detail"
         },
         "9": {
-            "date": "04/20/2023",
-            "time": "03:20:33",
+            "timestamp": "04/20/2023 03:20:33",
             "command": "show logging onboard RP active counter detail"
         },
         "10": {
-            "date": "04/20/2023",
-            "time": "07:40:41",
+            "timestamp": "04/20/2023 07:40:41",
             "command": "show logging onboard RP active counter detail"
         },
         "11": {
-            "date": "04/20/2023",
-            "time": "09:41:11",
+            "timestamp": "04/20/2023 09:41:11",
             "command": "show logging onboard RP active counter detail"
         }
     }

--- a/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/expected.json
@@ -1,0 +1,85 @@
+{
+    "summary": {
+        "show logging onboard RP active clilog detail": {
+            "count": 1
+        },
+        "show logging onboard RP active counter detail": {
+            "count": 4
+        },
+        "show logging onboard RP active environment detail": {
+            "count": 1
+        },
+        "show logging onboard RP active message detail": {
+            "count": 1
+        },
+        "show logging onboard RP active temperature detail": {
+            "count": 1
+        },
+        "show logging onboard RP active uptime detail": {
+            "count": 1
+        },
+        "show logging onboard RP active voltage detail": {
+            "count": 1
+        },
+        "show logging onboard RP standby message detail": {
+            "count": 1
+        }
+    },
+    "continuous": {
+        "1": {
+            "date": "03/30/2023",
+            "time": "02:41:08",
+            "command": "show logging onboard RP active clilog detail"
+        },
+        "2": {
+            "date": "03/30/2023",
+            "time": "02:41:43",
+            "command": "show logging onboard RP active counter detail"
+        },
+        "3": {
+            "date": "03/30/2023",
+            "time": "02:42:29",
+            "command": "show logging onboard RP active environment detail"
+        },
+        "4": {
+            "date": "03/30/2023",
+            "time": "02:43:32",
+            "command": "show logging onboard RP active message detail"
+        },
+        "5": {
+            "date": "03/30/2023",
+            "time": "02:44:21",
+            "command": "show logging onboard RP active temperature detail"
+        },
+        "6": {
+            "date": "03/30/2023",
+            "time": "02:45:25",
+            "command": "show logging onboard RP active uptime detail"
+        },
+        "7": {
+            "date": "03/30/2023",
+            "time": "02:46:31",
+            "command": "show logging onboard RP active voltage detail"
+        },
+        "8": {
+            "date": "04/13/2023",
+            "time": "09:22:40",
+            "command": "show logging onboard RP standby message detail"
+        },
+        "9": {
+            "date": "04/20/2023",
+            "time": "03:20:33",
+            "command": "show logging onboard RP active counter detail"
+        },
+        "10": {
+            "date": "04/20/2023",
+            "time": "07:40:41",
+            "command": "show logging onboard RP active counter detail"
+        },
+        "11": {
+            "date": "04/20/2023",
+            "time": "09:41:11",
+            "command": "show logging onboard RP active counter detail"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/input.txt
@@ -1,0 +1,34 @@
+--------------------------------------------------------------------------------
+CLI LOGGING SUMMARY INFORMATION
+--------------------------------------------------------------------------------
+COUNT COMMAND
+--------------------------------------------------------------------------------
+ 1    show logging onboard RP active clilog detail
+ 1    show logging onboard RP active counter detail
+ 1    show logging onboard RP active environment detail
+ 1    show logging onboard RP active message detail
+ 1    show logging onboard RP active temperature detail
+ 1    show logging onboard RP active uptime detail
+ 1    show logging onboard RP active voltage detail
+ 1    show logging onboard RP standby message detail
+ 1    show logging onboard RP active counter detail
+ 1    show logging onboard RP active counter detail
+ 1    show logging onboard RP active counter detail
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+CLI LOGGING CONTINUOUS INFORMATION
+--------------------------------------------------------------------------------
+MM/DD/YYYY HH:MM:SS COMMAND
+--------------------------------------------------------------------------------
+ 03/30/2023 02:41:08 show logging onboard RP active clilog detail
+ 03/30/2023 02:41:43 show logging onboard RP active counter detail
+ 03/30/2023 02:42:29 show logging onboard RP active environment detail
+ 03/30/2023 02:43:32 show logging onboard RP active message detail
+ 03/30/2023 02:44:21 show logging onboard RP active temperature detail
+ 03/30/2023 02:45:25 show logging onboard RP active uptime detail
+ 03/30/2023 02:46:31 show logging onboard RP active voltage detail
+ 04/13/2023 09:22:40 show logging onboard RP standby message detail
+ 04/20/2023 03:20:33 show logging onboard RP active counter detail
+ 04/20/2023 07:40:41 show logging onboard RP active counter detail
+ 04/20/2023 09:41:11 show logging onboard RP active counter detail
+--------------------------------------------------------------------------------

--- a/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_logging_onboard_rp_active_clilog_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show logging onboard rp active clilog detail output with summary and continuous sections
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show logging onboard rp active clilog detail` on Cisco IOS-XE
- Parses both CLI logging summary (command execution counts aggregated by command name) and continuous (timestamped command history) sections
- Includes test case with real CLI output from Genie parser test data

## Test plan
- [x] Parser produces correct output for basic input with both summary and continuous sections
- [x] Summary section aggregates duplicate command entries by summing counts
- [x] Continuous section preserves chronological order with sequence-numbered keys
- [x] All quality checks pass: ruff check, ruff format, xenon complexity, pre-commit hooks
- [x] `uv run pytest tests/parsers/ -k "show_logging_onboard_rp_active_clilog_detail" -v` passes

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)