### PR TITLE
feat: add parser for 'show spanning-tree root' on NX-OS

### DIFF
--- a/changes/475.parser_added
+++ b/changes/475.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show spanning-tree root' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_spanning-tree_root.py
+++ b/src/muninn/parsers/nxos/show_spanning-tree_root.py
@@ -1,0 +1,110 @@
+"""Parser for 'show spanning-tree root' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class RootId(TypedDict):
+    """Schema for the root bridge identifier."""
+
+    priority: int
+    address: str
+
+
+class SpanningTreeRootEntry(TypedDict):
+    """Schema for a single VLAN spanning-tree root entry."""
+
+    vlan_id: int
+    root_id: RootId
+    root_cost: int
+    hello_time: int
+    max_age: int
+    forward_delay: int
+    root_port: NotRequired[str]
+    is_root: NotRequired[bool]
+
+
+class ShowSpanningTreeRootResult(TypedDict):
+    """Schema for 'show spanning-tree root' parsed output."""
+
+    vlans: dict[str, SpanningTreeRootEntry]
+
+
+# VLAN0001             1 1211.a111.1111       0    2   20  10  This bridge is root
+# VLAN0002            10 1211.a111.1112       3    2   20  10    port-channel10
+_VLAN_LINE_PATTERN = re.compile(
+    r"^VLAN(?P<vlan_id>\d+)"
+    r"\s+(?P<priority>\d+)"
+    r"\s+(?P<address>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})"
+    r"\s+(?P<cost>\d+)"
+    r"\s+(?P<hello>\d+)"
+    r"\s+(?P<max_age>\d+)"
+    r"\s+(?P<fwd_delay>\d+)"
+    r"\s+(?P<root_port>.+)$"
+)
+
+_THIS_BRIDGE_IS_ROOT = "This bridge is root"
+
+
+@register(OS.CISCO_NXOS, "show spanning-tree root")
+class ShowSpanningTreeRootParser(BaseParser[ShowSpanningTreeRootResult]):
+    """Parser for 'show spanning-tree root' command on NX-OS.
+
+    Parses spanning-tree root bridge information per VLAN, including
+    root priority, address, cost, timers, and root port.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSpanningTreeRootResult:
+        """Parse 'show spanning-tree root' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed spanning-tree root entries keyed by VLAN ID string.
+
+        Raises:
+            ValueError: If no spanning-tree root entries found in output.
+        """
+        vlans: dict[str, SpanningTreeRootEntry] = {}
+
+        for line in output.splitlines():
+            match = _VLAN_LINE_PATTERN.match(line.strip())
+            if not match:
+                continue
+
+            vlan_id_str = match.group("vlan_id")
+            root_port_raw = match.group("root_port").strip()
+
+            entry: SpanningTreeRootEntry = {
+                "vlan_id": int(vlan_id_str),
+                "root_id": RootId(
+                    priority=int(match.group("priority")),
+                    address=match.group("address"),
+                ),
+                "root_cost": int(match.group("cost")),
+                "hello_time": int(match.group("hello")),
+                "max_age": int(match.group("max_age")),
+                "forward_delay": int(match.group("fwd_delay")),
+            }
+
+            if root_port_raw == _THIS_BRIDGE_IS_ROOT:
+                entry["is_root"] = True
+            else:
+                entry["root_port"] = canonical_interface_name(
+                    root_port_raw, os=OS.CISCO_NXOS
+                )
+
+            vlans[vlan_id_str] = entry
+
+        if not vlans:
+            msg = "No spanning-tree root entries found in output"
+            raise ValueError(msg)
+
+        return ShowSpanningTreeRootResult(vlans=vlans)

--- a/tests/parsers/nxos/show_spanning-tree_root/001_basic/expected.json
+++ b/tests/parsers/nxos/show_spanning-tree_root/001_basic/expected.json
@@ -1,0 +1,52 @@
+{
+    "vlans": {
+        "0001": {
+            "vlan_id": 1,
+            "root_id": {
+                "priority": 1,
+                "address": "1211.a111.1111"
+            },
+            "root_cost": 0,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 10,
+            "is_root": true
+        },
+        "0002": {
+            "vlan_id": 2,
+            "root_id": {
+                "priority": 10,
+                "address": "1211.a111.1112"
+            },
+            "root_cost": 3,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 10,
+            "root_port": "Port-channel10"
+        },
+        "0003": {
+            "vlan_id": 3,
+            "root_id": {
+                "priority": 1111,
+                "address": "1211.a111.1113"
+            },
+            "root_cost": 1,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 10,
+            "root_port": "Port-channel1"
+        },
+        "0004": {
+            "vlan_id": 4,
+            "root_id": {
+                "priority": 11,
+                "address": "1211.a111.1114"
+            },
+            "root_cost": 0,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 10,
+            "is_root": true
+        }
+    }
+}

--- a/tests/parsers/nxos/show_spanning-tree_root/001_basic/input.txt
+++ b/tests/parsers/nxos/show_spanning-tree_root/001_basic/input.txt
@@ -1,0 +1,7 @@
+                                        Root  Hello Max Fwd
+Vlan                   Root ID          Cost  Time  Age Dly  Root Port
+---------------- -------------------- ------- ----- --- ---  ----------------
+VLAN0001             1 1211.a111.1111       0    2   20  10  This bridge is root
+VLAN0002            10 1211.a111.1112       3    2   20  10    port-channel10
+VLAN0003          1111 1211.a111.1113       1    2   20  10     port-channel1
+VLAN0004            11 1211.a111.1114       0    2   20  10  This bridge is root

--- a/tests/parsers/nxos/show_spanning-tree_root/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_spanning-tree_root/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic spanning-tree root output with mixed root bridge and non-root VLANs
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show spanning-tree root` on Cisco NX-OS
- Parses per-VLAN spanning-tree root bridge information including root ID (priority + address), cost, timers, and root port
- Keys output by VLAN ID with nested `root_id` dict (priority, address) -- never concatenated
- Uses `canonical_interface_name` for root port normalization
- Sets `is_root: true` when the local bridge is root, otherwise provides `root_port`

Closes #223

## Test plan
- [x] Golden test with mixed root/non-root VLANs (`001_basic`)
- [x] `uv run pytest tests/parsers/nxos/show_spanning-tree_root/ -v` passes
- [x] `uv run ruff check` and `uv run ruff format` pass
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)