### PR TITLE
feat: add parser for 'show esmc' on IOS-XE

### DIFF
--- a/changes/485.parser_added
+++ b/changes/485.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show esmc' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_esmc.py
+++ b/src/muninn/parsers/iosxe/show_esmc.py
@@ -1,0 +1,179 @@
+"""Parser for 'show esmc' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class EsmcAdminConfig(TypedDict):
+    """Schema for ESMC administrative configurations."""
+
+    mode: str
+    esmc_tx: str
+    esmc_rx: str
+    ql_rx_configured: NotRequired[str]
+    ql_tx_configured: NotRequired[str]
+
+
+class EsmcOperStatus(TypedDict):
+    """Schema for ESMC operational status."""
+
+    port_status: str
+    ql_receive: NotRequired[str]
+    esmc_information_rate: NotRequired[str]
+    esmc_expiry: NotRequired[str]
+
+
+class EsmcInterfaceEntry(TypedDict):
+    """Schema for a single interface ESMC entry."""
+
+    admin: EsmcAdminConfig
+    oper: EsmcOperStatus
+
+
+class ShowEsmcResult(TypedDict):
+    """Schema for 'show esmc' parsed output."""
+
+    interfaces: dict[str, EsmcInterfaceEntry]
+
+
+_INTERFACE_RE = re.compile(r"^Interface\s*:\s*(?P<interface>\S+)", re.IGNORECASE)
+_MODE_RE = re.compile(r"^\s*Mode\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_ESMC_TX_RE = re.compile(r"^\s*ESMC\s+TX\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_ESMC_RX_RE = re.compile(r"^\s*ESMC\s+RX\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_QL_RX_RE = re.compile(r"^\s*QL\s+RX\s+configured\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_QL_TX_RE = re.compile(r"^\s*QL\s+TX\s+configured\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_PORT_STATUS_RE = re.compile(r"^\s*Port\s+status\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_QL_RECEIVE_RE = re.compile(r"^\s*QL\s+Receive\s*:\s*(?P<value>\S+)", re.IGNORECASE)
+_INFO_RATE_RE = re.compile(
+    r"^\s*ESMC\s+Information\s+rate\s*:\s*(?P<value>.+?)\s*$", re.IGNORECASE
+)
+_EXPIRY_RE = re.compile(r"^\s*ESMC\s+Expiry\s*:\s*(?P<value>.+?)\s*$", re.IGNORECASE)
+
+
+def _split_interface_sections(output: str) -> list[tuple[str, list[str]]]:
+    """Split raw output into per-interface sections.
+
+    Returns:
+        List of (raw_interface_name, lines) tuples.
+    """
+    sections: list[tuple[str, list[str]]] = []
+    current_name: str | None = None
+    current_lines: list[str] = []
+
+    for line in output.splitlines():
+        match = _INTERFACE_RE.match(line.strip())
+        if match:
+            if current_name is not None:
+                sections.append((current_name, current_lines))
+            current_name = match.group("interface")
+            current_lines = []
+            continue
+        if current_name is not None:
+            current_lines.append(line)
+
+    if current_name is not None:
+        sections.append((current_name, current_lines))
+
+    return sections
+
+
+def _parse_admin_config(lines: list[str]) -> EsmcAdminConfig:
+    """Extract administrative configuration fields from section lines."""
+    admin: EsmcAdminConfig = {"mode": "", "esmc_tx": "", "esmc_rx": ""}
+
+    for line in lines:
+        if match := _MODE_RE.match(line):
+            admin["mode"] = match.group("value")
+        elif match := _ESMC_TX_RE.match(line):
+            admin["esmc_tx"] = match.group("value")
+        elif match := _ESMC_RX_RE.match(line):
+            admin["esmc_rx"] = match.group("value")
+        elif match := _QL_RX_RE.match(line):
+            value = match.group("value")
+            if value.upper() != "NA":
+                admin["ql_rx_configured"] = value
+        elif match := _QL_TX_RE.match(line):
+            value = match.group("value")
+            if value.upper() != "NA":
+                admin["ql_tx_configured"] = value
+
+    return admin
+
+
+def _parse_oper_status(lines: list[str]) -> EsmcOperStatus:
+    """Extract operational status fields from section lines."""
+    oper: EsmcOperStatus = {"port_status": ""}
+
+    for line in lines:
+        if match := _PORT_STATUS_RE.match(line):
+            oper["port_status"] = match.group("value")
+        elif match := _QL_RECEIVE_RE.match(line):
+            oper["ql_receive"] = match.group("value")
+        elif match := _INFO_RATE_RE.match(line):
+            oper["esmc_information_rate"] = match.group("value")
+        elif match := _EXPIRY_RE.match(line):
+            oper["esmc_expiry"] = match.group("value")
+
+    return oper
+
+
+def _parse_interface_section(lines: list[str]) -> EsmcInterfaceEntry:
+    """Parse a single interface section into an EsmcInterfaceEntry."""
+    return EsmcInterfaceEntry(
+        admin=_parse_admin_config(lines),
+        oper=_parse_oper_status(lines),
+    )
+
+
+@register(OS.CISCO_IOSXE, "show esmc")
+class ShowEsmcParser(BaseParser[ShowEsmcResult]):
+    """Parser for 'show esmc' command.
+
+    Parses Ethernet Synchronization Messaging Channel (ESMC) status
+    for each interface, including administrative configuration and
+    operational status.
+
+    Example output:
+        Interface: GigabitEthernet0/0/0
+        Administrative configurations:
+          Mode: Synchronous
+          ESMC TX: Enable
+          ESMC RX : Enable
+          QL RX configured : NA
+          QL TX configured : NA
+        Operational status:
+          Port status: UP
+          QL Receive: QL-SSU-B
+          ESMC Information rate : 1 packet/second
+          ESMC Expiry: 5 second
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEsmcResult:
+        """Parse 'show esmc' output.
+
+        Args:
+            output: Raw CLI output from 'show esmc' command.
+
+        Returns:
+            Parsed ESMC data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interfaces are found in the output.
+        """
+        sections = _split_interface_sections(output)
+        if not sections:
+            msg = "No ESMC interface entries found in output"
+            raise ValueError(msg)
+
+        interfaces: dict[str, EsmcInterfaceEntry] = {}
+        for raw_name, lines in sections:
+            interface = canonical_interface_name(raw_name, os=OS.CISCO_IOSXE)
+            interfaces[interface] = _parse_interface_section(lines)
+
+        return ShowEsmcResult(interfaces=interfaces)

--- a/tests/parsers/iosxe/show_esmc/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_esmc/001_basic/expected.json
@@ -1,0 +1,45 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/0/0": {
+            "admin": {
+                "mode": "Synchronous",
+                "esmc_tx": "Enable",
+                "esmc_rx": "Enable"
+            },
+            "oper": {
+                "port_status": "UP",
+                "ql_receive": "QL-SSU-B",
+                "esmc_information_rate": "1 packet/second",
+                "esmc_expiry": "5 second"
+            }
+        },
+        "GigabitEthernet0/0/1": {
+            "admin": {
+                "mode": "Synchronous",
+                "esmc_tx": "Disable",
+                "esmc_rx": "Enable",
+                "ql_rx_configured": "QL-PRC"
+            },
+            "oper": {
+                "port_status": "DOWN",
+                "ql_receive": "QL-DNU",
+                "esmc_information_rate": "1 packet/second",
+                "esmc_expiry": "5 second"
+            }
+        },
+        "TenGigabitEthernet0/1/0": {
+            "admin": {
+                "mode": "Synchronous",
+                "esmc_tx": "Enable",
+                "esmc_rx": "Enable",
+                "ql_tx_configured": "QL-SEC"
+            },
+            "oper": {
+                "port_status": "UP",
+                "ql_receive": "QL-SEC",
+                "esmc_information_rate": "1 packet/second",
+                "esmc_expiry": "5 second"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_esmc/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_esmc/001_basic/input.txt
@@ -1,0 +1,39 @@
+Router#show esmc
+Interface: GigabitEthernet0/0/0
+Administrative configurations:
+  Mode: Synchronous
+  ESMC TX: Enable
+  ESMC RX : Enable
+  QL RX configured : NA
+  QL TX configured : NA
+Operational status:
+  Port status: UP
+  QL Receive: QL-SSU-B
+  ESMC Information rate : 1 packet/second
+  ESMC Expiry: 5 second
+
+Interface: GigabitEthernet0/0/1
+Administrative configurations:
+  Mode: Synchronous
+  ESMC TX: Disable
+  ESMC RX : Enable
+  QL RX configured : QL-PRC
+  QL TX configured : NA
+Operational status:
+  Port status: DOWN
+  QL Receive: QL-DNU
+  ESMC Information rate : 1 packet/second
+  ESMC Expiry: 5 second
+
+Interface: TenGigabitEthernet0/1/0
+Administrative configurations:
+  Mode: Synchronous
+  ESMC TX: Enable
+  ESMC RX : Enable
+  QL RX configured : NA
+  QL TX configured : QL-SEC
+Operational status:
+  Port status: UP
+  QL Receive: QL-SEC
+  ESMC Information rate : 1 packet/second
+  ESMC Expiry: 5 second

--- a/tests/parsers/iosxe/show_esmc/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_esmc/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show esmc output with multiple interfaces and varying QL values
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show esmc` on Cisco IOS-XE, parsing Ethernet Synchronization Messaging Channel (ESMC) interface status
- Parses per-interface administrative configuration (mode, ESMC TX/RX, configured QL values) and operational status (port status, QL receive, information rate, expiry)
- Keys output by canonical interface name with nested `admin` and `oper` dicts; omits `NA` values using `NotRequired`

Closes #234

## Test plan
- [x] Test case `001_basic` with multiple interfaces (GigabitEthernet, TenGigabitEthernet) and varying QL values
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pytest -k show_esmc` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)