### PR TITLE
feat: add parser for 'show graceful-reload' on IOS-XE

### DIFF
--- a/changes/486.parser_added
+++ b/changes/486.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show graceful-reload' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_graceful_reload.py
+++ b/src/muninn/parsers/iosxe/show_graceful_reload.py
@@ -1,0 +1,117 @@
+"""Parser for 'show graceful-reload' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ClientEntry(TypedDict):
+    """Schema for a single graceful reload client."""
+
+    id: str
+    status: str
+
+
+class ShowGracefulReloadResult(TypedDict):
+    """Schema for 'show graceful-reload' parsed output."""
+
+    infra_status: str
+    minimum_uptime_seconds: int
+    clients: NotRequired[dict[str, ClientEntry]]
+
+
+_INFRA_STATUS_PATTERN = re.compile(
+    r"^Graceful\s+Reload\s+Infra\s+Status:\s+(?P<value>.+)$", re.IGNORECASE
+)
+
+_UPTIME_PATTERN = re.compile(
+    r"^Minimum\s+required\s+system\s+uptime\s+before\s+fast\s+reload\s+"
+    r"can\s+be\s+supported\s+is\s+(?P<seconds>\d+)\s+seconds$",
+    re.IGNORECASE,
+)
+
+_CLIENT_PATTERN = re.compile(
+    r"^Client\s+(?P<name>\S+)\s*:\s*\((?P<id>0x[0-9a-fA-F]+)\)\s*Status:\s*(?P<status>.+)$"
+)
+
+
+def _normalize_client_name(name: str) -> str:
+    """Normalize a client name to a lowercase key with hyphens replaced by underscores.
+
+    Converts names like 'IS-IS' to 'is_is' and 'OSPFV3' to 'ospfv3'.
+    """
+    return name.lower().replace("-", "_")
+
+
+@register(OS.CISCO_IOSXE, "show graceful-reload")
+class ShowGracefulReloadParser(BaseParser[ShowGracefulReloadResult]):
+    """Parser for 'show graceful-reload' command.
+
+    Example output:
+        Graceful Reload Infra Status: Started in stacking mode, not running
+        Minimum required system uptime before fast reload can be supported is 5 seconds
+        Client OSPFV3                          : (0x10203004) Status: GR stack none: Up
+        Client OSPF                            : (0x10203003) Status: GR stack none: Up
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowGracefulReloadResult:
+        """Parse 'show graceful-reload' output.
+
+        Args:
+            output: Raw CLI output from 'show graceful-reload' command.
+
+        Returns:
+            Parsed graceful reload status data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        infra_status: str | None = None
+        minimum_uptime: int | None = None
+        clients: dict[str, ClientEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = _INFRA_STATUS_PATTERN.match(line)
+            if match:
+                infra_status = match.group("value").strip()
+                continue
+
+            match = _UPTIME_PATTERN.match(line)
+            if match:
+                minimum_uptime = int(match.group("seconds"))
+                continue
+
+            match = _CLIENT_PATTERN.match(line)
+            if match:
+                name = _normalize_client_name(match.group("name"))
+                clients[name] = ClientEntry(
+                    id=match.group("id"),
+                    status=match.group("status").strip(),
+                )
+                continue
+
+        if infra_status is None:
+            msg = "No graceful reload infra status found in output"
+            raise ValueError(msg)
+
+        if minimum_uptime is None:
+            msg = "No minimum uptime value found in output"
+            raise ValueError(msg)
+
+        result: dict[str, object] = {
+            "infra_status": infra_status,
+            "minimum_uptime_seconds": minimum_uptime,
+        }
+
+        if clients:
+            result["clients"] = clients
+
+        return ShowGracefulReloadResult(**result)  # type: ignore[typeddict-item]

--- a/tests/parsers/iosxe/show_graceful-reload/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_graceful-reload/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "infra_status": "Started in stacking mode, not running",
+    "minimum_uptime_seconds": 5,
+    "clients": {
+        "ospfv3": {
+            "id": "0x10203004",
+            "status": "GR stack none: Up"
+        },
+        "ospf": {
+            "id": "0x10203003",
+            "status": "GR stack none: Up"
+        },
+        "is_is": {
+            "id": "0x10203002",
+            "status": "GR stack none: Up"
+        },
+        "gr_client_fib": {
+            "id": "0x10203001",
+            "status": "GR stack none: Up"
+        },
+        "gr_client_rib": {
+            "id": "0x10203000",
+            "status": "GR stack none: Up"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_graceful-reload/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_graceful-reload/001_basic/input.txt
@@ -1,0 +1,7 @@
+Graceful Reload Infra Status: Started in stacking mode, not running
+Minimum required system uptime before fast reload can be supported is 5 seconds
+Client OSPFV3                          : (0x10203004) Status: GR stack none: Up
+Client OSPF                            : (0x10203003) Status: GR stack none: Up
+Client IS-IS                           : (0x10203002) Status: GR stack none: Up
+Client GR_CLIENT_FIB                   : (0x10203001) Status: GR stack none: Up
+Client GR_CLIENT_RIB                   : (0x10203000) Status: GR stack none: Up

--- a/tests/parsers/iosxe/show_graceful-reload/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_graceful-reload/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic graceful reload status with five clients
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show graceful-reload` command on Cisco IOS-XE
- Parses infra status, minimum uptime, and client entries keyed by normalized name
- Includes test case with golden output from Genie parser reference data

Closes #235

## Test plan
- [x] Parser test passes: `uv run pytest tests/parsers/ -k show_graceful -v`
- [x] Ruff lint and format pass
- [x] Xenon complexity check passes
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)