### PR TITLE
feat: add parser for 'show ip dhcp binding' on IOS

### DIFF
--- a/changes/488.parser_added
+++ b/changes/488.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip dhcp binding' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_ip_dhcp_binding.py
+++ b/src/muninn/parsers/ios/show_ip_dhcp_binding.py
@@ -1,0 +1,99 @@
+"""Parser for 'show ip dhcp binding' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class DhcpBindingEntry(TypedDict):
+    """Schema for a single DHCP binding entry."""
+
+    client_id: str
+    lease_expiration: str
+    type: str
+    state: NotRequired[str]
+
+
+class ShowIpDhcpBindingResult(TypedDict):
+    """Schema for 'show ip dhcp binding' parsed output.
+
+    Keyed by IP address.
+    """
+
+    bindings: dict[str, DhcpBindingEntry]
+
+
+@register(OS.CISCO_IOS, "show ip dhcp binding")
+class ShowIpDhcpBindingParser(BaseParser[ShowIpDhcpBindingResult]):
+    """Parser for 'show ip dhcp binding' command.
+
+    Parses DHCP binding table entries showing IP address, client ID/hardware
+    address, lease expiration, type, and optional state.
+
+    Example output::
+
+        IP address       Client-ID/           Lease expiration  Type
+                         Hardware address/
+                         User name
+        10.100.88.26     01aa.aaaa.aaaa.aa     Infinite          Manual
+        10.100.88.197    01dd.dddd.dddd.dd     Infinite          Manual
+    """
+
+    # Matches a DHCP binding row:
+    # IP address, client-ID/MAC, lease expiration, type, and optional state/interface
+    _BINDING_PATTERN = re.compile(
+        r"^(?P<ip_address>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+        r"(?P<client_id>\S+)\s+"
+        r"(?P<lease_expiration>Infinite|"
+        r"\w+\s+\d+\s+\d+\s+\d+:\d+\s+[AP]M)\s+"
+        r"(?P<type>\S+)"
+        r"(?:\s+(?P<state>\S+))?"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpDhcpBindingResult:
+        """Parse 'show ip dhcp binding' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed DHCP binding entries keyed by IP address.
+
+        Raises:
+            ValueError: If no DHCP binding entries found.
+        """
+        bindings: dict[str, DhcpBindingEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = cls._BINDING_PATTERN.match(line)
+            if match:
+                ip_address = match.group("ip_address")
+                client_id = match.group("client_id").lower()
+                lease_expiration = match.group("lease_expiration")
+                binding_type = match.group("type")
+                state = match.group("state")
+
+                entry: DhcpBindingEntry = {
+                    "client_id": client_id,
+                    "lease_expiration": lease_expiration,
+                    "type": binding_type,
+                }
+
+                if state and state != "--":
+                    entry["state"] = state
+
+                bindings[ip_address] = entry
+
+        if not bindings:
+            msg = "No DHCP binding entries found in output"
+            raise ValueError(msg)
+
+        return ShowIpDhcpBindingResult(bindings=bindings)

--- a/tests/parsers/ios/show_ip_dhcp_binding/001_basic/expected.json
+++ b/tests/parsers/ios/show_ip_dhcp_binding/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+    "bindings": {
+        "10.100.88.26": {
+            "client_id": "01aa.aaaa.aaaa.aa",
+            "lease_expiration": "Infinite",
+            "type": "Manual"
+        },
+        "10.100.88.197": {
+            "client_id": "01dd.dddd.dddd.dd",
+            "lease_expiration": "Infinite",
+            "type": "Manual"
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_dhcp_binding/001_basic/input.txt
+++ b/tests/parsers/ios/show_ip_dhcp_binding/001_basic/input.txt
@@ -1,0 +1,6 @@
+Bindings from all pools not associated with VRF:
+IP address          Client-ID/              Lease expiration        Type
+                    Hardware address/
+                    User name
+10.100.88.26        01aa.aaaa.aaaa.aa       Infinite                Manual
+10.100.88.197       01dd.dddd.dddd.dd       Infinite                Manual

--- a/tests/parsers/ios/show_ip_dhcp_binding/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ip_dhcp_binding/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic DHCP binding output with two manual bindings
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_ip_dhcp_binding/002_with_lease_dates/expected.json
+++ b/tests/parsers/ios/show_ip_dhcp_binding/002_with_lease_dates/expected.json
@@ -1,0 +1,21 @@
+{
+    "bindings": {
+        "192.168.1.10": {
+            "client_id": "0100.1122.3344.55",
+            "lease_expiration": "Feb 12 2024 09:15 AM",
+            "type": "Automatic",
+            "state": "Active"
+        },
+        "192.168.1.20": {
+            "client_id": "0100.aabb.ccdd.ee",
+            "lease_expiration": "Mar 01 2024 03:30 PM",
+            "type": "Automatic",
+            "state": "Active"
+        },
+        "10.0.0.50": {
+            "client_id": "01ff.eedd.ccbb.aa",
+            "lease_expiration": "Infinite",
+            "type": "Manual"
+        }
+    }
+}

--- a/tests/parsers/ios/show_ip_dhcp_binding/002_with_lease_dates/input.txt
+++ b/tests/parsers/ios/show_ip_dhcp_binding/002_with_lease_dates/input.txt
@@ -1,0 +1,7 @@
+Bindings from all pools not associated with VRF:
+IP address          Client-ID/              Lease expiration        Type       State      Interface
+                    Hardware address/
+                    User name
+192.168.1.10        0100.1122.3344.55       Feb 12 2024 09:15 AM   Automatic  Active     --
+192.168.1.20        0100.aabb.ccdd.ee       Mar 01 2024 03:30 PM   Automatic  Active     --
+10.0.0.50           01ff.eedd.ccbb.aa       Infinite                Manual

--- a/tests/parsers/ios/show_ip_dhcp_binding/002_with_lease_dates/metadata.yaml
+++ b/tests/parsers/ios/show_ip_dhcp_binding/002_with_lease_dates/metadata.yaml
@@ -1,0 +1,3 @@
+description: DHCP bindings with lease expiration dates and mixed types
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ip dhcp binding` command on Cisco IOS
- Parses DHCP binding table entries: IP address, client ID/hardware address, lease expiration, type, and optional state
- Keyed by IP address following dict-of-dicts convention
- Includes two test cases: basic manual bindings and mixed types with lease dates

Closes #236

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_dhcp_binding" -v` passes (2 tests)
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)