### PR TITLE
feat: add parser for 'show mpls l2transport vc' on IOS

### DIFF
--- a/changes/490.parser_added
+++ b/changes/490.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show mpls l2transport vc' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_mpls_l2transport_vc.py
+++ b/src/muninn/parsers/ios/show_mpls_l2transport_vc.py
@@ -1,0 +1,121 @@
+"""Parser for 'show mpls l2transport vc' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class VcEntry(TypedDict):
+    """Schema for a single MPLS L2 transport virtual circuit entry."""
+
+    local_interface: str
+    local_circuit: str
+    destination: str
+    status: str
+    local_label: NotRequired[int]
+    remote_label: NotRequired[int]
+    output_interface: NotRequired[str]
+
+
+class ShowMplsL2transportVcResult(TypedDict):
+    """Schema for 'show mpls l2transport vc' parsed output."""
+
+    virtual_circuits: dict[str, VcEntry]
+
+
+# Pattern for the tabular row format of show mpls l2transport vc.
+# Example lines:
+#   Gi0/0/0.100  Ethernet VLAN 100   10.1.1.1   100   UP
+#   Fa2/0        HDLC                172.16.0.1  200   DOWN
+_ROW_PATTERN = re.compile(
+    r"^(?P<local_intf>\S+)\s+"
+    r"(?P<local_circuit>.+?)\s{2,}"
+    r"(?P<dest>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<vc_id>\d+)\s+"
+    r"(?P<status>\S+)\s*$"
+)
+
+# Header line pattern to skip.
+_HEADER_PATTERN = re.compile(r"^Local\s+intf", re.IGNORECASE)
+
+# Separator line (dashes).
+_SEPARATOR_PATTERN = re.compile(r"^[-\s]+$")
+
+# Detail line patterns for extended output (show mpls l2transport vc detail).
+_LABEL_PATTERN = re.compile(
+    r"Local\s+label:\s*(?P<local_label>\d+)\s*,?\s*"
+    r"remote\s+label:\s*(?P<remote_label>\d+)",
+    re.IGNORECASE,
+)
+
+_OUTPUT_INTERFACE_PATTERN = re.compile(
+    r"Output\s+interface:\s*(?P<output_interface>\S+)",
+    re.IGNORECASE,
+)
+
+
+@register(OS.CISCO_IOS, "show mpls l2transport vc")
+class ShowMplsL2transportVcParser(BaseParser[ShowMplsL2transportVcResult]):
+    """Parser for 'show mpls l2transport vc' command.
+
+    Example output:
+        Local intf     Local circuit              Dest address    VC ID      Status
+        -------------  -------------------------- --------------- ---------- ----------
+        Gi0/0/0.100    Ethernet VLAN 100          10.1.1.1        100        UP
+        Fa2/0          HDLC                       172.16.0.1      200        DOWN
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMplsL2transportVcResult:
+        """Parse 'show mpls l2transport vc' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed virtual circuit entries keyed by VC ID.
+
+        Raises:
+            ValueError: If no virtual circuit entries found.
+        """
+        virtual_circuits: dict[str, VcEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if _HEADER_PATTERN.match(line):
+                continue
+
+            if _SEPARATOR_PATTERN.match(line):
+                continue
+
+            match = _ROW_PATTERN.match(line)
+            if match:
+                raw_interface = match.group("local_intf")
+                local_circuit = match.group("local_circuit").strip()
+                destination = match.group("dest")
+                vc_id = match.group("vc_id")
+                status = match.group("status")
+
+                interface_name = canonical_interface_name(raw_interface)
+
+                entry: VcEntry = {
+                    "local_interface": interface_name,
+                    "local_circuit": local_circuit,
+                    "destination": destination,
+                    "status": status.upper(),
+                }
+
+                virtual_circuits[vc_id] = entry
+
+        if not virtual_circuits:
+            msg = "No MPLS L2 transport VC entries found in output"
+            raise ValueError(msg)
+
+        return ShowMplsL2transportVcResult(virtual_circuits=virtual_circuits)

--- a/tests/parsers/ios/show_mpls_l2transport_vc/001_basic/expected.json
+++ b/tests/parsers/ios/show_mpls_l2transport_vc/001_basic/expected.json
@@ -1,0 +1,28 @@
+{
+    "virtual_circuits": {
+        "100": {
+            "destination": "10.1.1.1",
+            "local_circuit": "Ethernet VLAN 100",
+            "local_interface": "GigabitEthernet0/0/0.100",
+            "status": "UP"
+        },
+        "200": {
+            "destination": "172.16.0.1",
+            "local_circuit": "HDLC",
+            "local_interface": "FastEthernet2/0",
+            "status": "DOWN"
+        },
+        "300": {
+            "destination": "192.168.1.1",
+            "local_circuit": "PPP",
+            "local_interface": "Serial0/0/0",
+            "status": "UP"
+        },
+        "400": {
+            "destination": "10.2.2.2",
+            "local_circuit": "Ethernet VLAN 50",
+            "local_interface": "GigabitEthernet0/1.50",
+            "status": "UP"
+        }
+    }
+}

--- a/tests/parsers/ios/show_mpls_l2transport_vc/001_basic/input.txt
+++ b/tests/parsers/ios/show_mpls_l2transport_vc/001_basic/input.txt
@@ -1,0 +1,6 @@
+Local intf     Local circuit              Dest address    VC ID      Status
+-------------  -------------------------- --------------- ---------- ----------
+Gi0/0/0.100    Ethernet VLAN 100          10.1.1.1        100        UP
+Fa2/0          HDLC                       172.16.0.1      200        DOWN
+Se0/0/0        PPP                        192.168.1.1     300        UP
+Gi0/1.50       Ethernet VLAN 50           10.2.2.2        400        UP

--- a/tests/parsers/ios/show_mpls_l2transport_vc/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_mpls_l2transport_vc/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple MPLS L2 transport VCs with various interface types and statuses
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show mpls l2transport vc` on Cisco IOS
- Parses MPLS L2 transport virtual circuit table into structured data keyed by VC ID (string)
- Canonicalizes interface names via `canonical_interface_name`
- Includes test case with multiple VC types and statuses

Closes #240

## Test plan
- [x] Parser test passes: `ios/show_mpls_l2transport_vc/001_basic`
- [x] `ruff check` and `ruff format` pass
- [x] `xenon` complexity check passes
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)