### PR TITLE
feat: add parser for 'show ipv6 interface brief' on IOS

### DIFF
--- a/changes/491.parser_added
+++ b/changes/491.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ipv6 interface brief' on Cisco IOS.

--- a/src/muninn/parsers/ios/show_ipv6_interface_brief.py
+++ b/src/muninn/parsers/ios/show_ipv6_interface_brief.py
@@ -1,0 +1,90 @@
+"""Parser for 'show ipv6 interface brief' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+# Interface header line: "InterfaceName    [status/protocol]"
+_INTF_RE = re.compile(
+    r"^(?P<interface>\S+)\s+\[(?P<status>.+?)/(?P<protocol>\S+)\]\s*$"
+)
+
+# Indented address line (IPv6 address or "unassigned")
+_ADDR_RE = re.compile(r"^\s+(?P<address>\S+)\s*$")
+
+
+class Ipv6InterfaceBriefEntry(TypedDict):
+    """Schema for a single IPv6 interface brief entry."""
+
+    status: str
+    protocol: str
+    ipv6_addresses: NotRequired[list[str]]
+
+
+class ShowIpv6InterfaceBriefResult(TypedDict):
+    """Schema for 'show ipv6 interface brief' parsed output."""
+
+    interfaces: dict[str, Ipv6InterfaceBriefEntry]
+
+
+@register(OS.CISCO_IOS, "show ipv6 interface brief")
+class ShowIpv6InterfaceBriefParser(
+    BaseParser[ShowIpv6InterfaceBriefResult],
+):
+    """Parser for 'show ipv6 interface brief' on IOS.
+
+    Parses the IPv6 interface summary table showing interface name,
+    status, protocol, and assigned IPv6 addresses.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpv6InterfaceBriefResult:
+        """Parse 'show ipv6 interface brief' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IPv6 interface brief entries keyed by canonical
+            interface name.
+
+        Raises:
+            ValueError: If no valid interface entries are found.
+        """
+        interfaces: dict[str, Ipv6InterfaceBriefEntry] = {}
+        current_name: str | None = None
+
+        for line in output.splitlines():
+            # Try interface header line
+            intf_match = _INTF_RE.match(line)
+            if intf_match:
+                raw_name = intf_match.group("interface")
+                current_name = canonical_interface_name(raw_name, os=OS.CISCO_IOS)
+                entry: Ipv6InterfaceBriefEntry = {
+                    "status": intf_match.group("status"),
+                    "protocol": intf_match.group("protocol"),
+                }
+                interfaces[current_name] = entry
+                continue
+
+            # Try indented address line
+            addr_match = _ADDR_RE.match(line)
+            if addr_match and current_name is not None:
+                address = addr_match.group("address")
+                # Skip "unassigned" — omit ipv6_addresses key entirely
+                if address.lower() == "unassigned":
+                    continue
+                current_entry = interfaces[current_name]
+                if "ipv6_addresses" not in current_entry:
+                    current_entry["ipv6_addresses"] = []
+                current_entry["ipv6_addresses"].append(address)
+
+        if not interfaces:
+            msg = "No valid interface entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpv6InterfaceBriefResult, {"interfaces": interfaces})

--- a/tests/parsers/ios/show_ipv6_interface_brief/001_basic/expected.json
+++ b/tests/parsers/ios/show_ipv6_interface_brief/001_basic/expected.json
@@ -1,0 +1,400 @@
+{
+    "interfaces": {
+        "TenGigabitEthernet1/1": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3333::5"
+            ]
+        },
+        "TenGigabitEthernet2/1": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3333::9"
+            ]
+        },
+        "TenGigabitEthernet2/2": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet2/3": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet2/4": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet2/5": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet2/6": {
+            "status": "up",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/9": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet3/10": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/11": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/12": {
+            "status": "down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/13": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/14": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/15": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet3/16": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/1": {
+            "status": "up",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/2": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/3": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/4": {
+            "status": "down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/5": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/6": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/7": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/8": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/9": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/10": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "TenGigabitEthernet4/11": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/12": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/13": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/14": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/15": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet4/16": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "GigabitEthernet5/1": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "GigabitEthernet5/2": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "GigabitEthernet5/3": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet5/4": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet5/5": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "GigabitEthernet6/1": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "GigabitEthernet6/2": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "GigabitEthernet6/3": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet6/4": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "TenGigabitEthernet6/5": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "GigabitEthernet1/1": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "GigabitEthernet1/16": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3333::9A"
+            ]
+        },
+        "GigabitEthernet1/17": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3333::9E"
+            ]
+        },
+        "GigabitEthernet1/18": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3333::A2"
+            ]
+        },
+        "GigabitEthernet1/48": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "Loopback0": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:5A20:1FFF::13"
+            ]
+        },
+        "Port-channel1": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel2": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel3": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel4": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel5": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel6": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel7": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel8": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel9": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel10": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Port-channel11": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Vlan1": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "Vlan76": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3333:33::1",
+                "2A01:3333:3333:33::2"
+            ]
+        },
+        "Vlan77": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Vlan100": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:100::1",
+                "2A01:3333:3336:100::2"
+            ]
+        },
+        "Vlan762": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:101::1",
+                "2A01:3333:3336:101::2"
+            ]
+        },
+        "Vlan763": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:102::1",
+                "2A01:3333:3336:102::2"
+            ]
+        },
+        "Vlan764": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:103::1",
+                "2A01:3333:3336:103::2"
+            ]
+        },
+        "Vlan765": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:104::1",
+                "2A01:3333:3336:104::2"
+            ]
+        },
+        "Vlan767": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:110::1",
+                "2A01:3333:3336:110::2"
+            ]
+        },
+        "Vlan768": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:111::1",
+                "2A01:3333:3336:111::2"
+            ]
+        },
+        "Vlan769": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:112::1",
+                "2A01:3333:3336:112::2"
+            ]
+        },
+        "Vlan770": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:113::1",
+                "2A01:3333:3336:113::2"
+            ]
+        },
+        "Vlan771": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Vlan772": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Vlan773": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "Vlan774": {
+            "status": "administratively down",
+            "protocol": "down"
+        },
+        "Vlan775": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:220::1",
+                "2A01:3333:3336:220::2"
+            ]
+        },
+        "Vlan776": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "Vlan777": {
+            "status": "up",
+            "protocol": "up",
+            "ipv6_addresses": [
+                "FE80::333:3333:3333:3333",
+                "2A01:3333:3336:225::1",
+                "2A01:3333:3336:225::2"
+            ]
+        },
+        "Vlan2300": {
+            "status": "administratively down",
+            "protocol": "down"
+        }
+    }
+}

--- a/tests/parsers/ios/show_ipv6_interface_brief/001_basic/input.txt
+++ b/tests/parsers/ios/show_ipv6_interface_brief/001_basic/input.txt
@@ -1,0 +1,186 @@
+TenGigabitEthernet1/1  [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3333::5
+TenGigabitEthernet2/1  [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3333::9
+TenGigabitEthernet2/2  [up/up]
+    unassigned
+TenGigabitEthernet2/3  [up/up]
+    unassigned
+TenGigabitEthernet2/4  [up/up]
+    unassigned
+TenGigabitEthernet2/5  [up/up]
+    unassigned
+TenGigabitEthernet2/6  [up/down]
+    unassigned
+TenGigabitEthernet3/9  [up/up]
+    unassigned
+TenGigabitEthernet3/10 [administratively down/down]
+    unassigned
+TenGigabitEthernet3/11 [administratively down/down]
+    unassigned
+TenGigabitEthernet3/12 [down/down]
+    unassigned
+TenGigabitEthernet3/13 [administratively down/down]
+    unassigned
+TenGigabitEthernet3/14 [administratively down/down]
+    unassigned
+TenGigabitEthernet3/15 [administratively down/down]
+    unassigned
+TenGigabitEthernet3/16 [up/up]
+    unassigned
+TenGigabitEthernet4/1  [up/down]
+    unassigned
+TenGigabitEthernet4/2  [up/up]
+    unassigned
+TenGigabitEthernet4/3  [up/up]
+    unassigned
+TenGigabitEthernet4/4  [down/down]
+    unassigned
+TenGigabitEthernet4/5  [administratively down/down]
+    unassigned
+TenGigabitEthernet4/6  [administratively down/down]
+    unassigned
+TenGigabitEthernet4/7  [up/up]
+    unassigned
+TenGigabitEthernet4/8  [up/up]
+    unassigned
+TenGigabitEthernet4/9  [up/up]
+    unassigned
+TenGigabitEthernet4/10 [up/up]
+    unassigned
+TenGigabitEthernet4/11 [administratively down/down]
+    unassigned
+TenGigabitEthernet4/12 [administratively down/down]
+    unassigned
+TenGigabitEthernet4/13 [administratively down/down]
+    unassigned
+TenGigabitEthernet4/14 [administratively down/down]
+    unassigned
+TenGigabitEthernet4/15 [administratively down/down]
+    unassigned
+TenGigabitEthernet4/16 [up/up]
+    unassigned
+GigabitEthernet5/1     [administratively down/down]
+    unassigned
+GigabitEthernet5/2     [administratively down/down]
+    unassigned
+GigabitEthernet5/3     [administratively down/down]
+    unassigned
+TenGigabitEthernet5/4  [administratively down/down]
+    unassigned
+TenGigabitEthernet5/5  [administratively down/down]
+    unassigned
+GigabitEthernet6/1     [administratively down/down]
+    unassigned
+GigabitEthernet6/2     [administratively down/down]
+    unassigned
+GigabitEthernet6/3     [administratively down/down]
+    unassigned
+TenGigabitEthernet6/4  [administratively down/down]
+    unassigned
+TenGigabitEthernet6/5  [administratively down/down]
+    unassigned
+GigabitEthernet1/1     [up/up]
+    unassigned
+GigabitEthernet1/16    [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3333::9A
+GigabitEthernet1/17    [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3333::9E
+GigabitEthernet1/18    [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3333::A2
+GigabitEthernet1/48    [administratively down/down]
+    unassigned
+Loopback0              [up/up]
+    FE80::333:3333:3333:3333
+    2A01:5A20:1FFF::13
+Port-channel1          [up/up]
+    unassigned
+Port-channel2          [up/up]
+    unassigned
+Port-channel3          [up/up]
+    unassigned
+Port-channel4          [up/up]
+    unassigned
+Port-channel5          [up/up]
+    unassigned
+Port-channel6          [up/up]
+    unassigned
+Port-channel7          [up/up]
+    unassigned
+Port-channel8          [up/up]
+    unassigned
+Port-channel9          [up/up]
+    unassigned
+Port-channel10         [up/up]
+    unassigned
+Port-channel11         [up/up]
+    unassigned
+Vlan1                  [administratively down/down]
+    unassigned
+Vlan76                 [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3333:33::1
+    2A01:3333:3333:33::2
+Vlan77                 [up/up]
+    unassigned
+Vlan100                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:100::1
+    2A01:3333:3336:100::2
+Vlan762                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:101::1
+    2A01:3333:3336:101::2
+Vlan763                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:102::1
+    2A01:3333:3336:102::2
+Vlan764                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:103::1
+    2A01:3333:3336:103::2
+Vlan765                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:104::1
+    2A01:3333:3336:104::2
+Vlan767                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:110::1
+    2A01:3333:3336:110::2
+Vlan768                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:111::1
+    2A01:3333:3336:111::2
+Vlan769                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:112::1
+    2A01:3333:3336:112::2
+Vlan770                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:113::1
+    2A01:3333:3336:113::2
+Vlan771                [up/up]
+    unassigned
+Vlan772                [up/up]
+    unassigned
+Vlan773                [administratively down/down]
+    unassigned
+Vlan774                [administratively down/down]
+    unassigned
+Vlan775                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:220::1
+    2A01:3333:3336:220::2
+Vlan776                [up/up]
+    unassigned
+Vlan777                [up/up]
+    FE80::333:3333:3333:3333
+    2A01:3333:3336:225::1
+    2A01:3333:3336:225::2
+Vlan2300               [administratively down/down]
+    unassigned

--- a/tests/parsers/ios/show_ipv6_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_ipv6_interface_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: IPv6 interface brief with multiple interface types, various statuses, and multiple addresses per interface
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ipv6 interface brief` on Cisco IOS
- Keyed by canonical interface name with `ipv6_addresses` as `list[str]` (omitted when unassigned)
- Handles multiple IPv6 addresses per interface, `administratively down` status, and all interface types

Closes #238

## Test plan
- [x] Parser test with real CLI output covering TenGigabitEthernet, GigabitEthernet, Loopback, Port-channel, and Vlan interfaces
- [x] Interfaces with 0, 2, and 3 IPv6 addresses verified
- [x] All quality checks pass (ruff, xenon, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)