### PR TITLE
feat: add parser for 'show meraki' on IOS-XE

### DIFF
--- a/changes/492.parser_added
+++ b/changes/492.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show meraki' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_meraki.py
+++ b/src/muninn/parsers/iosxe/show_meraki.py
@@ -1,0 +1,114 @@
+"""Parser for 'show meraki' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class SwitchEntry(TypedDict):
+    """Schema for a single switch entry in 'show meraki' output."""
+
+    pid: str
+    serial_number: str
+    meraki_id: str
+    mac_address: str
+    registration_status: str
+    mode: NotRequired[str]
+
+
+class ShowMerakiResult(TypedDict):
+    """Schema for 'show meraki' parsed output.
+
+    Keyed by switch number (e.g., "1", "2").
+    """
+
+    switches: dict[str, SwitchEntry]
+
+
+# Matches data lines: switch_num, PID, serial, meraki/cloud ID,
+# MAC, status, optional mode
+_ENTRY_PATTERN = re.compile(
+    r"^\s*(?P<switch_num>\d+)\s+"
+    r"(?P<pid>\S+)\s+"
+    r"(?P<serial>\S+)\s+"
+    r"(?P<meraki_id>\S+)\s+"
+    r"(?P<mac>\S+)\s+"
+    r"(?P<status>\S+)"
+    r"(?:\s+(?P<mode>\S+))?\s*$"
+)
+
+# Header separator line
+_SEPARATOR = re.compile(r"^-{10,}$")
+
+
+@register(OS.CISCO_IOSXE, "show meraki")
+class ShowMerakiParser(BaseParser[ShowMerakiResult]):
+    """Parser for 'show meraki' command.
+
+    Shows Meraki cloud management registration status for each switch
+    in the stack.
+
+    Example output::
+
+        Switch              Serial                        Migration
+        Num  PID            Number       Meraki ID        Status    Mode
+        ---------------------------------------------------------------
+        1  C9300-48P        FJC2345T05A  Q5TE-5HWS-J3G8  Registered C9K-C
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMerakiResult:
+        """Parse 'show meraki' output.
+
+        Args:
+            output: Raw CLI output from 'show meraki' command.
+
+        Returns:
+            Parsed Meraki registration data keyed by switch number.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        switches: dict[str, SwitchEntry] = {}
+        past_header = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            # Detect separator line to know we've passed the header
+            if _SEPARATOR.match(stripped):
+                past_header = True
+                continue
+
+            if not past_header:
+                continue
+
+            match = _ENTRY_PATTERN.match(line)
+            if not match:
+                continue
+
+            switch_num = match.group("switch_num")
+            entry = SwitchEntry(
+                pid=match.group("pid"),
+                serial_number=match.group("serial"),
+                meraki_id=match.group("meraki_id"),
+                mac_address=match.group("mac"),
+                registration_status=match.group("status"),
+            )
+
+            mode = match.group("mode")
+            if mode:
+                entry["mode"] = mode
+
+            switches[switch_num] = entry
+
+        if not switches:
+            msg = "No Meraki switch entries found in output"
+            raise ValueError(msg)
+
+        return ShowMerakiResult(switches=switches)

--- a/tests/parsers/iosxe/show_meraki/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_meraki/001_basic/expected.json
@@ -1,0 +1,12 @@
+{
+    "switches": {
+        "1": {
+            "pid": "C9300-48P",
+            "serial_number": "FJC2345T05A",
+            "meraki_id": "Q5TE-5HWS-J3G8",
+            "mac_address": "6c41.0ed8.1780",
+            "registration_status": "Registered",
+            "mode": "C9K-C"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_meraki/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_meraki/001_basic/input.txt
@@ -1,0 +1,4 @@
+Switch                 Serial                                           Migration
+Num    PID             Number         Meraki ID       Mac Address       Status       Mode
+-----------------------------------------------------------------------------------------------
+1   C9300-48P          FJC2345T05A    Q5TE-5HWS-J3G8  6c41.0ed8.1780    Registered   C9K-C

--- a/tests/parsers/iosxe/show_meraki/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_meraki/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single switch with Meraki ID column header
+platform: C9300-48P
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show meraki` command on Cisco IOS-XE
- Parses Meraki cloud management registration status table output
- Supports single and multi-switch stacks, with optional mode field

Closes #239

## Test plan
- [x] Test case 001_basic: single switch with Meraki ID header, mode present
- [x] All quality checks pass (ruff check, ruff format, xenon)
- [x] Pre-commit hooks pass
- [x] `uv run pytest tests/parsers/test_parsers.py -k show_meraki -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)