### PR TITLE
feat: add parser for 'show vtemplate' on IOS-XE

### DIFF
--- a/changes/495.parser_added
+++ b/changes/495.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show vtemplate' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vtemplate.py
+++ b/src/muninn/parsers/iosxe/show_vtemplate.py
@@ -1,0 +1,97 @@
+"""Parser for 'show vtemplate' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class VtemplateEntry(TypedDict):
+    """Schema for a single virtual template entry."""
+
+    type: str
+    in_use: int
+    protect: NotRequired[bool]
+
+
+class ShowVtemplateResult(TypedDict):
+    """Schema for 'show vtemplate' parsed output.
+
+    Keyed by virtual template number (as string).
+    """
+
+    templates: dict[str, VtemplateEntry]
+
+
+# Table row pattern:
+# 1                 PPTP        0
+# 2                 L2TP        3          Yes
+_TABLE_ROW = re.compile(
+    r"^(?P<number>\d+)\s+"
+    r"(?P<type>\S+)\s+"
+    r"(?P<in_use>\d+)"
+    r"(?:\s+(?P<protect>\S+))?\s*$"
+)
+
+
+def _parse_protect(value: str | None) -> bool | None:
+    """Convert protect column value to boolean, or None if absent."""
+    if value is None:
+        return None
+    return value.strip().lower() == "yes"
+
+
+@register(OS.CISCO_IOSXE, "show vtemplate")
+class ShowVtemplateParser(BaseParser[ShowVtemplateResult]):
+    """Parser for 'show vtemplate' command.
+
+    Example output::
+
+        Virtual-Template  Type        In Use  Protect
+        1                 PPTP        0
+        2                 L2TP        3       Yes
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVtemplateResult:
+        """Parse 'show vtemplate' output.
+
+        Args:
+            output: Raw CLI output from 'show vtemplate' command.
+
+        Returns:
+            Parsed virtual template data keyed by template number.
+
+        Raises:
+            ValueError: If no virtual template entries are found.
+        """
+        templates: dict[str, VtemplateEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = _TABLE_ROW.match(line)
+            if not match:
+                continue
+
+            number = match.group("number")
+            entry = VtemplateEntry(
+                type=match.group("type"),
+                in_use=int(match.group("in_use")),
+            )
+
+            protect = _parse_protect(match.group("protect"))
+            if protect is not None:
+                entry["protect"] = protect
+
+            templates[number] = entry
+
+        if not templates:
+            msg = "No virtual template entries found in output"
+            raise ValueError(msg)
+
+        return ShowVtemplateResult(templates=templates)

--- a/tests/parsers/iosxe/show_vtemplate/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vtemplate/001_basic/expected.json
@@ -1,0 +1,17 @@
+{
+    "templates": {
+        "1": {
+            "type": "PPTP",
+            "in_use": 0
+        },
+        "2": {
+            "type": "L2TP",
+            "in_use": 3,
+            "protect": true
+        },
+        "3": {
+            "type": "GRE",
+            "in_use": 1
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vtemplate/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vtemplate/001_basic/input.txt
@@ -1,0 +1,5 @@
+Router#show vtemplate
+Virtual-Template  Type        In Use  Protect
+1                 PPTP        0
+2                 L2TP        3       Yes
+3                 GRE         1

--- a/tests/parsers/iosxe/show_vtemplate/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vtemplate/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show vtemplate output with multiple templates
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show vtemplate` command on Cisco IOS-XE
- Parses virtual template table output into structured dict keyed by template number
- Supports type, in_use count, and optional protect fields

Closes #245

## Test plan
- [x] Golden test with multiple templates including optional protect column
- [x] ruff check and format pass
- [x] xenon complexity check passes
- [x] pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)