### PR TITLE
feat: add parser for 'dir' on NX-OS

### DIFF
--- a/changes/496.parser_added
+++ b/changes/496.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'dir' on Cisco NX-OS.

--- a/src/muninn/parsers/nxos/show_dir.py
+++ b/src/muninn/parsers/nxos/show_dir.py
@@ -1,0 +1,136 @@
+"""Parser for 'dir' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class FileEntry(TypedDict):
+    """Schema for a single file or directory entry."""
+
+    size: int
+    date: str
+    is_directory: NotRequired[bool]
+
+
+class UsageInfo(TypedDict):
+    """Schema for filesystem usage information."""
+
+    bytes_used: int
+    bytes_free: int
+    bytes_total: int
+
+
+class DirResult(TypedDict):
+    """Schema for 'dir' parsed output."""
+
+    files: dict[str, FileEntry]
+    filesystem: NotRequired[str]
+    usage: NotRequired[UsageInfo]
+
+
+# Pattern for file/directory entries:
+#   <size>    <month> <day> <time> <year>  <name>
+_FILE_ENTRY = re.compile(
+    r"^\s*(?P<size>\d+)\s+"
+    r"(?P<date>\w{3}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4})\s+"
+    r"(?P<name>\S+)\s*$",
+)
+
+# Usage line: "Usage for bootflash://"
+_USAGE_HEADER = re.compile(
+    r"^\s*Usage for\s+(?P<filesystem>\S+?)(?:/{0,2})\s*$",
+)
+
+# Space lines: "<number> bytes used/free/total"
+_BYTES_USED = re.compile(r"^\s*(?P<value>\d+)\s+bytes\s+used\s*$")
+_BYTES_FREE = re.compile(r"^\s*(?P<value>\d+)\s+bytes\s+free\s*$")
+_BYTES_TOTAL = re.compile(r"^\s*(?P<value>\d+)\s+bytes\s+total\s*$")
+
+
+def _parse_file_entry(line: str, files: dict[str, FileEntry]) -> bool:
+    """Parse a file/directory entry line. Returns True if matched."""
+    match = _FILE_ENTRY.match(line)
+    if not match:
+        return False
+    name = match.group("name")
+    entry: FileEntry = {
+        "size": int(match.group("size")),
+        "date": match.group("date"),
+    }
+    if name.endswith("/"):
+        entry["is_directory"] = True
+    files[name] = entry
+    return True
+
+
+def _parse_usage_line(
+    line: str,
+    usage: dict[str, int],
+) -> str | None:
+    """Parse a usage header or bytes line. Returns filesystem name if found."""
+    if match := _USAGE_HEADER.match(line):
+        return match.group("filesystem").rstrip(":/")
+
+    if match := _BYTES_USED.match(line):
+        usage["bytes_used"] = int(match.group("value"))
+    elif match := _BYTES_FREE.match(line):
+        usage["bytes_free"] = int(match.group("value"))
+    elif match := _BYTES_TOTAL.match(line):
+        usage["bytes_total"] = int(match.group("value"))
+
+    return None
+
+
+@register(OS.CISCO_NXOS, "dir")
+class DirParser(BaseParser[DirResult]):
+    """Parser for 'dir' command on NX-OS.
+
+    Parses filesystem directory listings including file entries
+    with sizes and dates, and optional usage summary.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> DirResult:
+        """Parse 'dir' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed directory listing.
+
+        Raises:
+            ValueError: If no file entries can be parsed.
+        """
+        files: dict[str, FileEntry] = {}
+        filesystem: str | None = None
+        usage: dict[str, int] = {}
+
+        for line in output.splitlines():
+            if _parse_file_entry(line, files):
+                continue
+            fs_name = _parse_usage_line(line, usage)
+            if fs_name is not None:
+                filesystem = fs_name
+
+        if not files:
+            msg = "No file entries found in output"
+            raise ValueError(msg)
+
+        result: DirResult = {"files": files}
+
+        if filesystem:
+            result["filesystem"] = filesystem
+
+        if len(usage) == 3:
+            result["usage"] = UsageInfo(
+                bytes_used=usage["bytes_used"],
+                bytes_free=usage["bytes_free"],
+                bytes_total=usage["bytes_total"],
+            )
+
+        return result

--- a/tests/parsers/nxos/dir/001_basic/expected.json
+++ b/tests/parsers/nxos/dir/001_basic/expected.json
@@ -1,0 +1,86 @@
+{
+    "files": {
+        ".patch/": {
+            "size": 4096,
+            "date": "Nov 18 15:29:15 2017",
+            "is_directory": true
+        },
+        ".snapshots/": {
+            "size": 4096,
+            "date": "Jun 28 21:35:36 2021",
+            "is_directory": true
+        },
+        "capture_auto_capture.tgz": {
+            "size": 196358,
+            "date": "Mar 10 17:15:18 2020"
+        },
+        "fault-management-logs/": {
+            "size": 4096,
+            "date": "Nov 18 15:29:15 2017",
+            "is_directory": true
+        },
+        "flash:": {
+            "size": 70076928,
+            "date": "Apr 24 17:25:03 2018"
+        },
+        "license_JPA21G_36.lic": {
+            "size": 1801,
+            "date": "Nov 18 15:49:06 2017"
+        },
+        "lost+found/": {
+            "size": 4096,
+            "date": "Sep 23 10:04:15 2019",
+            "is_directory": true
+        },
+        "n7700-s2-dk9.8.4.3.bin": {
+            "size": 538255348,
+            "date": "Jan 31 16:57:56 2021"
+        },
+        "n7700-s2-kickstart.8.4.3.bin": {
+            "size": 64396288,
+            "date": "Jan 31 17:26:12 2021"
+        },
+        "scripts/": {
+            "size": 4096,
+            "date": "Nov 18 15:30:32 2017",
+            "is_directory": true
+        },
+        "showtech_mpls_ldp_202106291259": {
+            "size": 18788554,
+            "date": "Jun 29 12:59:57 2021"
+        },
+        "sup-2/": {
+            "size": 4096,
+            "date": "Sep 10 15:01:42 2019",
+            "is_directory": true
+        },
+        "tech_bgp.txt": {
+            "size": 2813192,
+            "date": "Sep 01 08:35:52 2021"
+        },
+        "tech_mod15.txt": {
+            "size": 87673293,
+            "date": "Apr 18 09:34:13 2019"
+        },
+        "tftp": {
+            "size": 41525,
+            "date": "Jul 06 09:08:35 2020"
+        },
+        "vdc_2/": {
+            "size": 4096,
+            "date": "Nov 18 15:29:15 2017",
+            "is_directory": true
+        },
+        "virtual-instance/": {
+            "size": 4096,
+            "date": "Nov 18 15:29:17 2017",
+            "is_directory": true
+        }
+    },
+    "filesystem": "bootflash",
+    "usage": {
+        "bytes_used": 1531203584,
+        "bytes_free": 2166267904,
+        "bytes_total": 3697471488
+    }
+}

--- a/tests/parsers/nxos/dir/001_basic/input.txt
+++ b/tests/parsers/nxos/dir/001_basic/input.txt
@@ -1,0 +1,22 @@
+       4096    Nov 18 15:29:15 2017  .patch/
+       4096    Jun 28 21:35:36 2021  .snapshots/
+     196358    Mar 10 17:15:18 2020  capture_auto_capture.tgz
+       4096    Nov 18 15:29:15 2017  fault-management-logs/
+   70076928    Apr 24 17:25:03 2018  flash:
+       1801    Nov 18 15:49:06 2017  license_JPA21G_36.lic
+       4096    Sep 23 10:04:15 2019  lost+found/
+  538255348    Jan 31 16:57:56 2021  n7700-s2-dk9.8.4.3.bin
+   64396288    Jan 31 17:26:12 2021  n7700-s2-kickstart.8.4.3.bin
+       4096    Nov 18 15:30:32 2017  scripts/
+   18788554    Jun 29 12:59:57 2021  showtech_mpls_ldp_202106291259
+       4096    Sep 10 15:01:42 2019  sup-2/
+    2813192    Sep 01 08:35:52 2021  tech_bgp.txt
+   87673293    Apr 18 09:34:13 2019  tech_mod15.txt
+      41525    Jul 06 09:08:35 2020  tftp
+       4096    Nov 18 15:29:15 2017  vdc_2/
+       4096    Nov 18 15:29:17 2017  virtual-instance/
+
+Usage for bootflash://
+ 1531203584 bytes used
+ 2166267904 bytes free
+ 3697471488 bytes total

--- a/tests/parsers/nxos/dir/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/dir/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Directory listing with usage summary
+platform: Nexus 7700
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for the `dir` command on Cisco NX-OS
- Parses filesystem directory listings into structured data with files keyed by filename
- Includes file size (int), date, directory detection (`is_directory`), and optional filesystem usage summary (`bytes_used`, `bytes_free`, `bytes_total`)
- Files keyed by filename (not list of dicts), directories flagged with `is_directory: true`, optional keys omitted when absent

Closes #246

## Test plan
- [x] Test case `001_basic` with full directory listing and usage summary (Nexus 7700 sample)
- [x] `uv run ruff check` passes
- [x] `uv run ruff format` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pytest tests/parsers/nxos/dir/ -v` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)