### PR TITLE
feat: add parser for 'show vpdn' on IOS-XE

### DIFF
--- a/changes/497.parser_added
+++ b/changes/497.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show vpdn' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vpdn.py
+++ b/src/muninn/parsers/iosxe/show_vpdn.py
@@ -1,0 +1,198 @@
+"""Parser for 'show vpdn' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class VpdnTunnelEntry(TypedDict):
+    """Schema for a single VPDN L2TP tunnel."""
+
+    local_tunnel_id: int
+    remote_tunnel_id: int
+    remote_name: str
+    state: str
+    remote_address: str
+    session_count: int
+    vpdn_group: str
+
+
+class VpdnSessionEntry(TypedDict):
+    """Schema for a single VPDN L2TP session."""
+
+    local_id: int
+    remote_id: int
+    tunnel_id: int
+    username: str
+    interface: str
+    state: str
+    last_change: str
+    unique_id: int
+
+
+class ShowVpdnResult(TypedDict):
+    """Schema for 'show vpdn' parsed output."""
+
+    total_tunnels: NotRequired[int]
+    total_sessions: NotRequired[int]
+    tunnels: NotRequired[dict[str, VpdnTunnelEntry]]
+    sessions: NotRequired[dict[str, VpdnSessionEntry]]
+
+
+# L2TP Tunnel and Session Information Total tunnels 1 sessions 1
+_SUMMARY_PATTERN = re.compile(
+    r"L2TP Tunnel and Session Information Total "
+    r"tunnels\s+(?P<total_tunnels>\d+)\s+"
+    r"sessions\s+(?P<total_sessions>\d+)"
+)
+
+# 35231      38883      LAC           est    18.18.18.1      1     1
+_TUNNEL_PATTERN = re.compile(
+    r"^(?P<loc_tun_id>\d+)\s+"
+    r"(?P<rem_tun_id>\d+)\s+"
+    r"(?P<remote_name>\S+)\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<remote_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+"
+    r"(?P<session_count>\d+)\s+"
+    r"(?P<vpdn_group>\S+)"
+)
+
+# 57471      22313      35231      lns@cisco.com, Vi2.1 est    00:00:09 2
+_SESSION_PATTERN = re.compile(
+    r"^(?P<local_id>\d+)\s+"
+    r"(?P<remote_id>\d+)\s+"
+    r"(?P<tunnel_id>\d+)\s+"
+    r"(?P<username>\S+),\s+"
+    r"(?P<intf>\S+)\s+"
+    r"(?P<state>[a-zA-Z]\S*)\s+"
+    r"(?P<last_chg>[\d:]+)\s+"
+    r"(?P<uniq_id>\d+)"
+)
+
+# %%No active L2TP tunnels
+_NO_ACTIVE_PATTERN = re.compile(r"^%%No active L2TP tunnels$")
+
+
+def _build_tunnel_entry(match: re.Match[str]) -> tuple[str, VpdnTunnelEntry]:
+    """Build a tunnel entry from a regex match.
+
+    Returns:
+        Tuple of (local_tunnel_id_str, tunnel_entry).
+    """
+    loc_id = match.group("loc_tun_id")
+    entry = VpdnTunnelEntry(
+        local_tunnel_id=int(loc_id),
+        remote_tunnel_id=int(match.group("rem_tun_id")),
+        remote_name=match.group("remote_name"),
+        state=match.group("state"),
+        remote_address=match.group("remote_ip"),
+        session_count=int(match.group("session_count")),
+        vpdn_group=match.group("vpdn_group"),
+    )
+    return loc_id, entry
+
+
+def _build_session_entry(match: re.Match[str]) -> tuple[str, VpdnSessionEntry]:
+    """Build a session entry from a regex match.
+
+    Returns:
+        Tuple of (local_id_str, session_entry).
+    """
+    local_id = match.group("local_id")
+    entry = VpdnSessionEntry(
+        local_id=int(local_id),
+        remote_id=int(match.group("remote_id")),
+        tunnel_id=int(match.group("tunnel_id")),
+        username=match.group("username"),
+        interface=match.group("intf"),
+        state=match.group("state"),
+        last_change=match.group("last_chg"),
+        unique_id=int(match.group("uniq_id")),
+    )
+    return local_id, entry
+
+
+@register(OS.CISCO_IOSXE, "show vpdn")
+class ShowVpdnParser(BaseParser[ShowVpdnResult]):
+    """Parser for 'show vpdn' command.
+
+    Parses L2TP tunnel and session information from VPDN output.
+
+    Example output:
+        L2TP Tunnel and Session Information Total tunnels 1 sessions 1
+
+         LocTunID   RemTunID   Remote Name   State  Remote Address  Sessn L2TP Class/
+                                                                    Count VPDN Group
+         7658       8656       LAC           est    18.18.18.1      1     1
+
+         LocID      RemID      TunID      Username, Intf/      State  Last Chg Uniq ID
+                                          Vcid, Circuit
+         3542       56774      7658       lns@cisco.com, -     est    00:10:09 645
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVpdnResult:
+        """Parse 'show vpdn' output.
+
+        Args:
+            output: Raw CLI output from 'show vpdn' command.
+
+        Returns:
+            Parsed VPDN data with tunnels and sessions keyed by local ID.
+
+        Raises:
+            ValueError: If no VPDN information found in output.
+        """
+        result: ShowVpdnResult = {}
+        tunnels: dict[str, VpdnTunnelEntry] = {}
+        sessions: dict[str, VpdnSessionEntry] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            if _NO_ACTIVE_PATTERN.match(line):
+                msg = "No active L2TP tunnels"
+                raise ValueError(msg)
+
+            _parse_line(line, result, tunnels, sessions)
+
+        if not result:
+            msg = "No VPDN information found in output"
+            raise ValueError(msg)
+
+        if tunnels:
+            result["tunnels"] = tunnels
+        if sessions:
+            result["sessions"] = sessions
+
+        return result
+
+
+def _parse_line(
+    line: str,
+    result: ShowVpdnResult,
+    tunnels: dict[str, VpdnTunnelEntry],
+    sessions: dict[str, VpdnSessionEntry],
+) -> None:
+    """Parse a single line and update result, tunnels, or sessions."""
+    summary_match = _SUMMARY_PATTERN.match(line)
+    if summary_match:
+        result["total_tunnels"] = int(summary_match.group("total_tunnels"))
+        result["total_sessions"] = int(summary_match.group("total_sessions"))
+        return
+
+    tunnel_match = _TUNNEL_PATTERN.match(line)
+    if tunnel_match:
+        key, entry = _build_tunnel_entry(tunnel_match)
+        tunnels[key] = entry
+        return
+
+    session_match = _SESSION_PATTERN.match(line)
+    if session_match:
+        key, entry = _build_session_entry(session_match)
+        sessions[key] = entry

--- a/tests/parsers/iosxe/show_vpdn/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vpdn/001_basic/expected.json
@@ -1,0 +1,46 @@
+{
+    "total_tunnels": 2,
+    "total_sessions": 2,
+    "tunnels": {
+        "7658": {
+            "local_tunnel_id": 7658,
+            "remote_tunnel_id": 8656,
+            "remote_name": "LAC",
+            "state": "est",
+            "remote_address": "18.18.18.1",
+            "session_count": 1,
+            "vpdn_group": "1"
+        },
+        "11479": {
+            "local_tunnel_id": 11479,
+            "remote_tunnel_id": 56539,
+            "remote_name": "LNS2",
+            "state": "est",
+            "remote_address": "14.14.14.2",
+            "session_count": 1,
+            "vpdn_group": "TowardsLNS2"
+        }
+    },
+    "sessions": {
+        "3542": {
+            "local_id": 3542,
+            "remote_id": 56774,
+            "tunnel_id": 7658,
+            "username": "lns@cisco.com",
+            "interface": "-",
+            "state": "est",
+            "last_change": "00:10:09",
+            "unique_id": 645
+        },
+        "24593": {
+            "local_id": 24593,
+            "remote_id": 3791,
+            "tunnel_id": 11479,
+            "username": "lns@cisco.com",
+            "interface": "-",
+            "state": "est",
+            "last_change": "00:10:08",
+            "unique_id": 645
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vpdn/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vpdn/001_basic/input.txt
@@ -1,0 +1,17 @@
+L2TP Tunnel and Session Information Total tunnels 2 sessions 2
+
+ LocTunID   RemTunID   Remote Name   State  Remote Address  Sessn L2TP Class/
+                                                            Count VPDN Group
+ 7658       8656       LAC           est    18.18.18.1      1     1
+
+ LocID      RemID      TunID      Username, Intf/      State  Last Chg Uniq ID
+                                  Vcid, Circuit
+ 3542       56774      7658       lns@cisco.com, -     est    00:10:09 645
+
+ LocTunID   RemTunID   Remote Name   State  Remote Address  Sessn L2TP Class/
+                                                            Count VPDN Group
+ 11479      56539      LNS2          est    14.14.14.2      1     TowardsLNS2
+
+ LocID      RemID      TunID      Username, Intf/      State  Last Chg Uniq ID
+                                  Vcid, Circuit
+ 24593      3791       11479      lns@cisco.com, -     est    00:10:08 645

--- a/tests/parsers/iosxe/show_vpdn/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vpdn/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic VPDN output with two L2TP tunnels and two sessions
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for the `show vpdn` command on Cisco IOS-XE
- Parses L2TP tunnel and session information (tunnel IDs, remote names, states, addresses, session counts, VPDN groups)
- Tunnels keyed by local tunnel ID, sessions keyed by local session ID
- Includes test case with two tunnels and two sessions from Genie golden output

Closes #244

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_vpdn" -v` passes
- [x] `uv run ruff check` and `uv run ruff format` pass
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)