### PR TITLE
feat: add parser for 'show table-map' on IOS-XE

### DIFF
--- a/changes/498.parser_added
+++ b/changes/498.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show table-map' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_table_map.py
+++ b/src/muninn/parsers/iosxe/show_table_map.py
@@ -1,0 +1,128 @@
+"""Parser for 'show table-map' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class MappingEntry(TypedDict):
+    """Schema for a single from/to mapping within a table-map."""
+
+    from_value: int
+    to_value: int
+
+
+class TableMapEntry(TypedDict):
+    """Schema for a single table-map.
+
+    Mappings are keyed by the 'from' value as a string.
+    """
+
+    default: NotRequired[str]
+    mappings: NotRequired[dict[str, MappingEntry]]
+
+
+class ShowTableMapResult(TypedDict):
+    """Schema for 'show table-map' parsed output.
+
+    Keyed by table-map name.
+    """
+
+    table_maps: dict[str, TableMapEntry]
+
+
+# Table Map <name>
+_TABLE_MAP_HEADER = re.compile(r"^\s*Table\s+Map\s+(?P<name>\S+)\s*$")
+
+# from <value> to <value>
+_MAPPING_PATTERN = re.compile(
+    r"^\s*from\s+(?P<from_val>\d+)\s+to\s+(?P<to_val>\d+)\s*$"
+)
+
+# default <action>
+_DEFAULT_PATTERN = re.compile(r"^\s*default\s+(?P<default>\S+)\s*$")
+
+
+def _parse_mapping(line: str, entry: TableMapEntry) -> bool:
+    """Try to parse a from/to mapping line. Returns True if matched."""
+    match = _MAPPING_PATTERN.match(line)
+    if not match:
+        return False
+
+    from_val = int(match.group("from_val"))
+    to_val = int(match.group("to_val"))
+    mapping = MappingEntry(from_value=from_val, to_value=to_val)
+
+    if "mappings" not in entry:
+        entry["mappings"] = {}
+    entry["mappings"][str(from_val)] = mapping
+    return True
+
+
+def _parse_default(line: str, entry: TableMapEntry) -> bool:
+    """Try to parse a default action line. Returns True if matched."""
+    match = _DEFAULT_PATTERN.match(line)
+    if not match:
+        return False
+
+    entry["default"] = match.group("default")
+    return True
+
+
+@register(OS.CISCO_IOSXE, "show table-map")
+class ShowTableMapParser(BaseParser[ShowTableMapResult]):
+    """Parser for 'show table-map' command.
+
+    Parses QoS table-map configurations showing name, from/to value
+    mappings, and default action.
+
+    Example output:
+        Table Map t1
+        from 8 to 16
+        from 16 to 32
+        default copy
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowTableMapResult:
+        """Parse 'show table-map' output.
+
+        Args:
+            output: Raw CLI output from 'show table-map' command.
+
+        Returns:
+            Parsed table-map data keyed by table-map name.
+
+        Raises:
+            ValueError: If no table-map entries found in output.
+        """
+        table_maps: dict[str, TableMapEntry] = {}
+        current_entry: TableMapEntry | None = None
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            header_match = _TABLE_MAP_HEADER.match(line)
+            if header_match:
+                name = header_match.group("name")
+                current_entry = TableMapEntry()
+                table_maps[name] = current_entry
+                continue
+
+            if current_entry is None:
+                continue
+
+            if _parse_mapping(line, current_entry):
+                continue
+
+            _parse_default(line, current_entry)
+
+        if not table_maps:
+            msg = "No table-map entries found in output"
+            raise ValueError(msg)
+
+        return ShowTableMapResult(table_maps=table_maps)

--- a/tests/parsers/iosxe/show_table-map/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_table-map/001_basic/expected.json
@@ -1,0 +1,30 @@
+{
+    "table_maps": {
+        "DSd-sds": {
+            "mappings": {
+                "0": {
+                    "from_value": 0,
+                    "to_value": 34
+                },
+                "3": {
+                    "from_value": 3,
+                    "to_value": 44
+                }
+            },
+            "default": "copy"
+        },
+        "Esd_Sdd": {
+            "mappings": {
+                "22": {
+                    "from_value": 22,
+                    "to_value": 24
+                },
+                "32": {
+                    "from_value": 32,
+                    "to_value": 44
+                }
+            },
+            "default": "8"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_table-map/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_table-map/001_basic/input.txt
@@ -1,0 +1,9 @@
+ Table Map DSd-sds
+ from 0 to 34
+ from 3 to 44
+ default copy
+
+ Table Map Esd_Sdd
+ from 22 to 24
+ from 32 to 44
+ default 8

--- a/tests/parsers/iosxe/show_table-map/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_table-map/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple table-maps with from/to mappings and default actions
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show table-map` command on Cisco IOS-XE
- Parses QoS table-map configurations including name, from/to value mappings, and default action
- Keyed by table-map name with mappings keyed by from-value

## Test plan
- [x] Test with multiple table-maps containing different default actions (copy vs numeric)
- [x] All quality checks pass (ruff, xenon, pre-commit)
- [x] `uv run pytest tests/parsers/iosxe/show_table-map/ -v` passes

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)