### PR TITLE
feat: add parser for 'show ip dhcp snooping statistics' on IOS-XE

### DIFF
--- a/changes/499.parser_added
+++ b/changes/499.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show ip dhcp snooping statistics' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_statistics.py
+++ b/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_statistics.py
@@ -1,0 +1,62 @@
+"""Parser for 'show ip dhcp snooping statistics' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ShowIpDhcpSnoopingStatisticsResult(TypedDict):
+    """Schema for 'show ip dhcp snooping statistics' parsed output."""
+
+    packets_forwarded: int
+    packets_dropped: int
+    packets_dropped_from_untrusted_ports: int
+
+
+@register(OS.CISCO_IOSXE, "show ip dhcp snooping statistics")
+class ShowIpDhcpSnoopingStatisticsParser(
+    BaseParser[ShowIpDhcpSnoopingStatisticsResult]
+):
+    """Parser for 'show ip dhcp snooping statistics' command."""
+
+    _STAT_PATTERN = re.compile(r"^(?P<key>[\w\s]+?)\s*=\s*(?P<value>\d+)$")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpDhcpSnoopingStatisticsResult:
+        """Parse 'show ip dhcp snooping statistics' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed DHCP snooping statistics counters.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        result: dict[str, int] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = cls._STAT_PATTERN.match(line)
+            if match:
+                key = match.group("key").strip().lower().replace(" ", "_")
+                result[key] = int(match.group("value"))
+
+        if not result:
+            msg = "No DHCP snooping statistics found in output"
+            raise ValueError(msg)
+
+        return ShowIpDhcpSnoopingStatisticsResult(
+            packets_forwarded=result.get("packets_forwarded", 0),
+            packets_dropped=result.get("packets_dropped", 0),
+            packets_dropped_from_untrusted_ports=result.get(
+                "packets_dropped_from_untrusted_ports", 0
+            ),
+        )

--- a/tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/001_basic/expected.json
@@ -1,0 +1,5 @@
+{
+    "packets_forwarded": 122,
+    "packets_dropped": 0,
+    "packets_dropped_from_untrusted_ports": 0
+}

--- a/tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/001_basic/input.txt
@@ -1,0 +1,3 @@
+Packets Forwarded                                     = 122
+Packets Dropped                                       = 0
+Packets Dropped From untrusted ports                  = 0

--- a/tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Show ip dhcp snooping statistics with forwarded and zero drop counters
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ip dhcp snooping statistics` on Cisco IOS-XE
- Parses flat counter fields: `packets_forwarded`, `packets_dropped`, `packets_dropped_from_untrusted_ports`
- Includes test case with real CLI output format

Closes #247

## Test plan
- [x] Parser produces correct expected.json from sample input
- [x] `uv run pytest tests/parsers/iosxe/show_ip_dhcp_snooping_statistics/ -v` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)