### PR TITLE
feat: add parser for 'show platform hardware throughput level' on IOS-XE

### DIFF
--- a/changes/501.parser_added
+++ b/changes/501.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform hardware throughput level' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_hardware_throughput_level.py
+++ b/src/muninn/parsers/iosxe/show_platform_hardware_throughput_level.py
@@ -1,0 +1,71 @@
+"""Parser for 'show platform hardware throughput level' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ShowPlatformHardwareThroughputLevelResult(TypedDict):
+    """Schema for 'show platform hardware throughput level' parsed output."""
+
+    throughput_level: str
+    throughput_kbps: NotRequired[int]
+
+
+_THROUGHPUT_PATTERN = re.compile(
+    r"^The\s+current\s+throughput\s+level\s+is\s+"
+    r"(?P<level>(?P<kbps>\d+)\s*kb/s|unthrottled)$",
+    re.IGNORECASE,
+)
+
+
+@register(OS.CISCO_IOSXE, "show platform hardware throughput level")
+class ShowPlatformHardwareThroughputLevelParser(
+    BaseParser[ShowPlatformHardwareThroughputLevelResult],
+):
+    """Parser for 'show platform hardware throughput level' command.
+
+    Example output::
+
+        The current throughput level is 250000 kb/s
+
+    Or when boost performance license is active::
+
+        The current throughput level is unthrottled
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformHardwareThroughputLevelResult:
+        """Parse 'show platform hardware throughput level' output.
+
+        Args:
+            output: Raw CLI output from 'show platform hardware throughput level'.
+
+        Returns:
+            Parsed throughput level data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            match = _THROUGHPUT_PATTERN.match(line)
+            if match:
+                kbps_value = match.group("kbps")
+                if kbps_value is not None:
+                    return ShowPlatformHardwareThroughputLevelResult(
+                        throughput_level=f"{kbps_value} kb/s",
+                        throughput_kbps=int(kbps_value),
+                    )
+                return ShowPlatformHardwareThroughputLevelResult(
+                    throughput_level="unthrottled",
+                )
+
+        msg = "No throughput level data found in output"
+        raise ValueError(msg)

--- a/tests/parsers/iosxe/show_platform_hardware_throughput_level/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_hardware_throughput_level/001_basic/expected.json
@@ -1,0 +1,4 @@
+{
+    "throughput_level": "250000 kb/s",
+    "throughput_kbps": 250000
+}

--- a/tests/parsers/iosxe/show_platform_hardware_throughput_level/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_hardware_throughput_level/001_basic/input.txt
@@ -1,0 +1,2 @@
+Router#show platform hardware throughput level
+The current throughput level is 250000 kb/s

--- a/tests/parsers/iosxe/show_platform_hardware_throughput_level/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_hardware_throughput_level/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic throughput level output with throttled value in kb/s
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add Muninn parser for `show platform hardware throughput level` on Cisco IOS-XE
- Handles both throttled output (numeric kb/s value) and unthrottled (boost performance license)
- Returns flat dict with `throughput_level` (str) and optional `throughput_kbps` (int)

Closes #252

## Test plan
- [x] Golden test with throttled throughput output (250000 kb/s)
- [x] All quality checks pass (ruff check, ruff format, xenon)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)