### PR TITLE
feat: add parser for 'show platform hardware authentication status' on IOS-XE

### DIFF
--- a/changes/502.parser_added
+++ b/changes/502.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform hardware authentication status' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_hardware_authentication_status.py
+++ b/src/muninn/parsers/iosxe/show_platform_hardware_authentication_status.py
@@ -1,0 +1,119 @@
+"""Parser for 'show platform hardware authentication status' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ComponentAuthEntry(TypedDict):
+    """Schema for a single component's authentication status."""
+
+    status: str
+
+
+class SwitchEntry(TypedDict):
+    """Schema for a switch containing component authentication entries."""
+
+    components: dict[str, ComponentAuthEntry]
+
+
+class ShowPlatformHardwareAuthenticationStatusResult(TypedDict):
+    """Schema for 'show platform hardware authentication status' parsed output."""
+
+    switches: dict[str, SwitchEntry]
+
+
+# Switch header: "Switch 1:" or "Switch 2:"
+_SWITCH_HEADER = re.compile(r"^Switch\s+(?P<num>\d+)\s*:\s*$")
+
+# Authentication line:
+#   "Mainboard Authentication:     Passed"
+#   "Fan Tray Authentication:  pass"
+#   "Line Card:1 Authentication:  pass"
+#   "SUP 0 Authentication:  pass"
+#   "SSD FRU Authentication:  Not Available"
+_AUTH_LINE = re.compile(
+    r"^\s*(?P<component>.+?)\s+Authentication:\s+(?P<status>.+?)\s*$"
+)
+
+
+def _parse_lines(
+    lines: list[str],
+) -> dict[str, SwitchEntry]:
+    """Parse output lines into switches dict."""
+    switches: dict[str, SwitchEntry] = {}
+    current_switch = "1"
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # Skip the command echo line
+        if stripped.lower().startswith("show platform"):
+            continue
+
+        switch_match = _SWITCH_HEADER.match(stripped)
+        if switch_match:
+            current_switch = switch_match.group("num")
+            continue
+
+        auth_match = _AUTH_LINE.match(stripped)
+        if auth_match:
+            component = auth_match.group("component").strip()
+            status = auth_match.group("status").strip()
+
+            if current_switch not in switches:
+                switches[current_switch] = SwitchEntry(components={})
+
+            switches[current_switch]["components"][component] = ComponentAuthEntry(
+                status=status,
+            )
+
+    return switches
+
+
+@register(OS.CISCO_IOSXE, "show platform hardware authentication status")
+class ShowPlatformHardwareAuthenticationStatusParser(
+    BaseParser[ShowPlatformHardwareAuthenticationStatusResult],
+):
+    """Parser for 'show platform hardware authentication status' command.
+
+    Example output::
+
+        Switch 1:
+            Mainboard Authentication:     Passed
+            FRU Authentication:           Not Available
+            Stack Cable A Authentication: Passed
+
+    Or for chassis-based platforms::
+
+           Fan Tray Authentication:  pass
+        Line Card:1 Authentication:  pass
+               SUP0 Authentication:  pass
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformHardwareAuthenticationStatusResult:
+        """Parse 'show platform hardware authentication status' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed hardware authentication status data keyed by switch.
+
+        Raises:
+            ValueError: If no authentication data is found.
+        """
+        lines = output.splitlines()
+        switches = _parse_lines(lines)
+
+        if not switches:
+            msg = "No hardware authentication status data found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformHardwareAuthenticationStatusResult(switches=switches)

--- a/tests/parsers/iosxe/show_platform_hardware_authentication_status/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_hardware_authentication_status/001_basic/expected.json
@@ -1,0 +1,48 @@
+{
+    "switches": {
+        "1": {
+            "components": {
+                "Mainboard": {
+                    "status": "Passed"
+                },
+                "FRU": {
+                    "status": "Not Available"
+                },
+                "Stack Cable A": {
+                    "status": "Passed"
+                },
+                "Stack Cable B": {
+                    "status": "Passed"
+                },
+                "Stack Adapter A": {
+                    "status": "Passed"
+                },
+                "Stack Adapter B": {
+                    "status": "Passed"
+                }
+            }
+        },
+        "2": {
+            "components": {
+                "Mainboard": {
+                    "status": "Not Available"
+                },
+                "FRU": {
+                    "status": "Not Available"
+                },
+                "Stack Cable A": {
+                    "status": "Not Available"
+                },
+                "Stack Cable B": {
+                    "status": "Not Available"
+                },
+                "Stack Adapter A": {
+                    "status": "Not Available"
+                },
+                "Stack Adapter B": {
+                    "status": "Not Available"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_hardware_authentication_status/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_hardware_authentication_status/001_basic/input.txt
@@ -1,0 +1,15 @@
+Switch 1:
+    Mainboard Authentication:     Passed
+    FRU Authentication:           Not Available
+    Stack Cable A Authentication: Passed
+    Stack Cable B Authentication: Passed
+    Stack Adapter A Authentication: Passed
+    Stack Adapter B Authentication: Passed
+
+Switch 2:
+    Mainboard Authentication:     Not Available
+    FRU Authentication:           Not Available
+    Stack Cable A Authentication: Not Available
+    Stack Cable B Authentication: Not Available
+    Stack Adapter A Authentication: Not Available
+    Stack Adapter B Authentication: Not Available

--- a/tests/parsers/iosxe/show_platform_hardware_authentication_status/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_hardware_authentication_status/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic switch-based hardware authentication status with two switches
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/iosxe/show_platform_hardware_authentication_status/002_chassis/expected.json
+++ b/tests/parsers/iosxe/show_platform_hardware_authentication_status/002_chassis/expected.json
@@ -1,0 +1,32 @@
+{
+    "switches": {
+        "1": {
+            "components": {
+                "Fan Tray": {
+                    "status": "pass"
+                },
+                "Line Card:1": {
+                    "status": "Not Available"
+                },
+                "Line Card:2": {
+                    "status": "pass"
+                },
+                "SUP0": {
+                    "status": "Not Available"
+                },
+                "SUP1": {
+                    "status": "pass"
+                },
+                "Line Card:5": {
+                    "status": "Not Available"
+                },
+                "Line Card:6": {
+                    "status": "Not Available"
+                },
+                "Line Card:7": {
+                    "status": "Not Available"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_hardware_authentication_status/002_chassis/input.txt
+++ b/tests/parsers/iosxe/show_platform_hardware_authentication_status/002_chassis/input.txt
@@ -1,0 +1,8 @@
+       Fan Tray Authentication:  pass
+    Line Card:1 Authentication:  Not Available
+    Line Card:2 Authentication:  pass
+           SUP0 Authentication:  Not Available
+           SUP1 Authentication:  pass
+    Line Card:5 Authentication:  Not Available
+    Line Card:6 Authentication:  Not Available
+    Line Card:7 Authentication:  Not Available

--- a/tests/parsers/iosxe/show_platform_hardware_authentication_status/002_chassis/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_hardware_authentication_status/002_chassis/metadata.yaml
@@ -1,0 +1,3 @@
+description: Chassis-based hardware authentication status on Catalyst 9400
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show platform hardware authentication status` on Cisco IOS-XE
- Supports both switch-based (stacked) and chassis-based (modular) output formats
- Parses component authentication status (Fan Tray, Line Card, SUP, Mainboard, FRU, Stack Cable/Adapter, Chassis, SSD FRU)

Closes #250

## Test plan
- [x] Test case 001_basic: switch-based output with two switches (Passed/Not Available statuses)
- [x] Test case 002_chassis: chassis-based output with modular components (pass/Not Available statuses)
- [x] All quality checks pass (ruff, xenon, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)