### PR TITLE
feat: add parser for 'show platform hardware throughput crypto' on IOS-XE

### DIFF
--- a/changes/504.parser_added
+++ b/changes/504.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform hardware throughput crypto' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_hardware_throughput_crypto.py
+++ b/src/muninn/parsers/iosxe/show_platform_hardware_throughput_crypto.py
@@ -1,0 +1,125 @@
+"""Parser for 'show platform hardware throughput crypto' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ShowPlatformHardwareThroughputCryptoResult(TypedDict):
+    """Schema for 'show platform hardware throughput crypto' parsed output."""
+
+    current_configured_crypto_throughput_level: str
+    level_saved: bool
+    reboot_required: bool
+    current_enforced_crypto_throughput_level: str
+    crypto_throughput_throttled: bool
+    default_crypto_throughput_level: str
+    current_boot_level: NotRequired[str]
+
+
+# Pattern: "Current configured crypto throughput level: T3"
+_CONFIGURED_LEVEL = re.compile(
+    r"^Current\s+configured\s+crypto\s+throughput\s+level:\s+(?P<value>\S+)$",
+    re.IGNORECASE,
+)
+
+# Pattern: "Level is saved, reboot is not required"
+_LEVEL_STATUS = re.compile(
+    r"^Level\s+is\s+(?P<saved>not\s+saved|saved),\s+"
+    r"reboot\s+is\s+(?P<reboot>not\s+required|required)$",
+    re.IGNORECASE,
+)
+
+# Pattern: "Current enforced crypto throughput level: 10G"
+_ENFORCED_LEVEL = re.compile(
+    r"^Current\s+enforced\s+crypto\s+throughput\s+level:\s+(?P<value>\S+)$",
+    re.IGNORECASE,
+)
+
+# Pattern: "Crypto Throughput is not throttled" or "Crypto Throughput is throttled"
+_THROTTLED = re.compile(
+    r"^Crypto\s+Throughput\s+is\s+(?P<value>not\s+throttled|throttled)$",
+    re.IGNORECASE,
+)
+
+# Pattern: "Default Crypto throughput level: 2.5G"
+_DEFAULT_LEVEL = re.compile(
+    r"^Default\s+Crypto\s+throughput\s+level:\s+(?P<value>\S+)$",
+    re.IGNORECASE,
+)
+
+# Pattern: "Current boot level is network-premier"
+_BOOT_LEVEL = re.compile(
+    r"^Current\s+boot\s+level\s+is\s+(?P<value>\S+)$",
+    re.IGNORECASE,
+)
+
+# Patterns that extract a single string value keyed by field name
+_STRING_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_CONFIGURED_LEVEL, "current_configured_crypto_throughput_level"),
+    (_ENFORCED_LEVEL, "current_enforced_crypto_throughput_level"),
+    (_DEFAULT_LEVEL, "default_crypto_throughput_level"),
+    (_BOOT_LEVEL, "current_boot_level"),
+)
+
+
+def _process_line(line: str, result: dict[str, str | bool]) -> None:
+    """Match a single line against all patterns and update result dict."""
+    for pattern, field in _STRING_PATTERNS:
+        if match := pattern.match(line):
+            result[field] = match.group("value")
+            return
+
+    if match := _LEVEL_STATUS.match(line):
+        result["level_saved"] = "not" not in match.group("saved").lower()
+        result["reboot_required"] = "not" not in match.group("reboot").lower()
+    elif match := _THROTTLED.match(line):
+        result["crypto_throughput_throttled"] = (
+            "not" not in match.group("value").lower()
+        )
+
+
+@register(OS.CISCO_IOSXE, "show platform hardware throughput crypto")
+class ShowPlatformHardwareThroughputCryptoParser(
+    BaseParser[ShowPlatformHardwareThroughputCryptoResult],
+):
+    """Parser for 'show platform hardware throughput crypto' command.
+
+    Example output::
+
+        Current configured crypto throughput level: T3
+        Level is saved, reboot is not required
+        Current enforced crypto throughput level: 10G
+        Crypto Throughput is not throttled
+        Default Crypto throughput level: 2.5G
+        Current boot level is network-premier
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformHardwareThroughputCryptoResult:
+        """Parse 'show platform hardware throughput crypto' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed crypto throughput data.
+
+        Raises:
+            ValueError: If no crypto throughput data is found.
+        """
+        result: dict[str, str | bool] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped:
+                _process_line(stripped, result)
+
+        if not result:
+            msg = "No crypto throughput data found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformHardwareThroughputCryptoResult(**result)  # type: ignore[typeddict-item]

--- a/tests/parsers/iosxe/show_platform_hardware_throughput_crypto/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_hardware_throughput_crypto/001_basic/expected.json
@@ -1,0 +1,9 @@
+{
+    "crypto_throughput_throttled": false,
+    "current_boot_level": "network-premier",
+    "current_configured_crypto_throughput_level": "T3",
+    "current_enforced_crypto_throughput_level": "10G",
+    "default_crypto_throughput_level": "2.5G",
+    "level_saved": true,
+    "reboot_required": false
+}

--- a/tests/parsers/iosxe/show_platform_hardware_throughput_crypto/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_hardware_throughput_crypto/001_basic/input.txt
@@ -1,0 +1,6 @@
+Current configured crypto throughput level: T3
+Level is saved, reboot is not required
+Current enforced crypto throughput level: 10G
+Crypto Throughput is not throttled
+Default Crypto throughput level: 2.5G
+Current boot level is network-premier

--- a/tests/parsers/iosxe/show_platform_hardware_throughput_crypto/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_hardware_throughput_crypto/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with configured, enforced, and default throughput levels plus boot level
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show platform hardware throughput crypto` command on Cisco IOS-XE
- Parses configured/enforced/default crypto throughput levels, level save status, reboot requirement, throttle state, and optional boot level
- Flat dict schema with boolean fields for save/reboot/throttle status

Closes #251

## Test plan
- [x] Parser test case `001_basic` with real CLI output from Genie reference data
- [x] All quality checks pass: ruff check, ruff format, xenon complexity, pre-commit hooks
- [x] Test passes: `uv run pytest tests/parsers/test_parsers.py -k show_platform_hardware_throughput_crypto -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)