### PR TITLE
feat: add parser for 'show platform software dns-umbrella statistics' on IOS-XE

### DIFF
--- a/changes/505.parser_added
+++ b/changes/505.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform software dns-umbrella statistics' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_software_dns_umbrella_statistics.py
+++ b/src/muninn/parsers/iosxe/show_platform_software_dns_umbrella_statistics.py
@@ -1,0 +1,105 @@
+"""Parser for 'show platform software dns-umbrella statistics' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class UmbrellaStatistics(TypedDict):
+    """Schema for DNS Umbrella statistics counters."""
+
+    total_packets: int
+    dnscrypt_queries: int
+    dnscrypt_responses: int
+    dns_queries: int
+    dns_bypassed_queries_regex: int
+    dns_responses_umbrella: int
+    dns_responses_other: int
+    aged_queries: int
+    dropped_packets: int
+    dns_bypass_fqdn: NotRequired[int]
+    dns_bypass_ip: NotRequired[int]
+
+
+class ShowPlatformSoftwareDnsUmbrellaStatisticsResult(TypedDict):
+    """Schema for 'show platform software dns-umbrella statistics' parsed output."""
+
+    umbrella_statistics: UmbrellaStatistics
+
+
+# Map display labels to dict keys
+_COUNTER_MAP: dict[str, str] = {
+    "Total Packets": "total_packets",
+    "DNSCrypt queries": "dnscrypt_queries",
+    "DNSCrypt responses": "dnscrypt_responses",
+    "DNS queries": "dns_queries",
+    "DNS bypassed queries(Regex)": "dns_bypassed_queries_regex",
+    "DNS responses(Umbrella)": "dns_responses_umbrella",
+    "DNS responses(Other)": "dns_responses_other",
+    "Aged queries": "aged_queries",
+    "Dropped pkts": "dropped_packets",
+    "DNS bypass(FQDN)": "dns_bypass_fqdn",
+    "DNS bypass(IP)": "dns_bypass_ip",
+}
+
+# Pattern: label followed by colon and integer value
+_COUNTER_LINE = re.compile(r"^\s*(?P<label>.+?)\s*:\s*(?P<value>\d+)\s*$")
+
+
+@register(OS.CISCO_IOSXE, "show platform software dns-umbrella statistics")
+class ShowPlatformSoftwareDnsUmbrellaStatisticsParser(
+    BaseParser[ShowPlatformSoftwareDnsUmbrellaStatisticsResult]
+):
+    """Parser for 'show platform software dns-umbrella statistics' command.
+
+    Example output::
+
+        ========================================
+                  Umbrella Statistics
+        ========================================
+         Total Packets               : 57057
+         DNSCrypt queries            : 0
+         DNSCrypt responses          : 0
+         DNS queries                 : 32321
+         DNS bypassed queries(Regex) : 0
+         DNS responses(Umbrella)     : 24693
+         DNS responses(Other)        : 37
+         Aged queries                : 7628
+         Dropped pkts                : 0
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformSoftwareDnsUmbrellaStatisticsResult:
+        """Parse 'show platform software dns-umbrella statistics' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed DNS Umbrella statistics.
+
+        Raises:
+            ValueError: If no statistics counters are found in the output.
+        """
+        stats: dict[str, int] = {}
+
+        for line in output.splitlines():
+            match = _COUNTER_LINE.match(line)
+            if not match:
+                continue
+
+            label = match.group("label")
+            key = _COUNTER_MAP.get(label)
+            if key is not None:
+                stats[key] = int(match.group("value"))
+
+        if not stats:
+            msg = "No DNS Umbrella statistics found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformSoftwareDnsUmbrellaStatisticsResult(
+            umbrella_statistics=UmbrellaStatistics(**stats),  # type: ignore[typeddict-item]
+        )

--- a/tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/001_basic/expected.json
@@ -1,0 +1,13 @@
+{
+    "umbrella_statistics": {
+        "total_packets": 57057,
+        "dnscrypt_queries": 0,
+        "dnscrypt_responses": 0,
+        "dns_queries": 32321,
+        "dns_bypassed_queries_regex": 0,
+        "dns_responses_umbrella": 24693,
+        "dns_responses_other": 37,
+        "aged_queries": 7628,
+        "dropped_packets": 0
+    }
+}

--- a/tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/001_basic/input.txt
@@ -1,0 +1,13 @@
+Router#show platform software dns-umbrella statistics
+========================================
+          Umbrella Statistics
+========================================
+ Total Packets               : 57057
+ DNSCrypt queries            : 0
+ DNSCrypt responses          : 0
+ DNS queries                 : 32321
+ DNS bypassed queries(Regex) : 0
+ DNS responses(Umbrella)     : 24693
+ DNS responses(Other)        : 37
+ Aged queries                : 7628
+ Dropped pkts                : 0

--- a/tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show platform software dns-umbrella statistics output
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show platform software dns-umbrella statistics` command on Cisco IOS-XE
- Parses all Umbrella statistics counters (total packets, DNS queries/responses, DNSCrypt, aged queries, dropped packets, etc.) into a flat dict
- Includes test case with golden output from Genie reference data

Closes #256

## Test plan
- [x] Parser produces correct expected.json from golden CLI output
- [x] `uv run pytest tests/parsers/iosxe/show_platform_software_dns-umbrella_statistics/ -v` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)