### PR TITLE
feat: add parser for 'show platform software audit ruleset' on IOS-XE

### DIFF
--- a/changes/508.parser_added
+++ b/changes/508.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform software audit ruleset' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_software_audit_ruleset.py
+++ b/src/muninn/parsers/iosxe/show_platform_software_audit_ruleset.py
@@ -1,0 +1,85 @@
+"""Parser for 'show platform software audit ruleset' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class RulesetEntry(TypedDict):
+    """Schema for a single audit ruleset containing its rules."""
+
+    rules: list[str]
+
+
+class ShowPlatformSoftwareAuditRulesetResult(TypedDict):
+    """Schema for 'show platform software audit ruleset' parsed output."""
+
+    rulesets: dict[str, RulesetEntry]
+
+
+# Matches a ruleset name line, e.g. "    user_group_config_files :"
+_RULESET_NAME = re.compile(r"^\s{4}(?P<name>\S+)\s+:\s*$")
+
+# Matches a rule line, e.g. "                         :    -a exit,always ..."
+_RULE_LINE = re.compile(r"^\s+:\s{4}(?P<rule>.+?)\s*$")
+
+
+@register(OS.CISCO_IOSXE, "show platform software audit ruleset")
+class ShowPlatformSoftwareAuditRulesetParser(
+    BaseParser[ShowPlatformSoftwareAuditRulesetResult],
+):
+    """Parser for 'show platform software audit ruleset' command.
+
+    Example output::
+
+        ====================================================================
+              AUDIT RULESET       :           RULES
+        ====================================================================
+
+            user_group_config_files :
+                             :    -a exit,always -F arch=b64 -F path=/etc/passwd ...
+                             :    -a exit,always -F arch=b64 -F path=/etc/shadow ...
+
+        ____________________________________________________________________
+
+            kernel_module_mgmt :
+                             :    -a exit,always -F arch=b64 -F path=/sbin/insmod ...
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformSoftwareAuditRulesetResult:
+        """Parse 'show platform software audit ruleset' output.
+
+        Args:
+            output: Raw CLI output from 'show platform software audit ruleset'.
+
+        Returns:
+            Parsed audit ruleset data keyed by ruleset name.
+
+        Raises:
+            ValueError: If no audit ruleset data is found.
+        """
+        rulesets: dict[str, RulesetEntry] = {}
+        current_name: str | None = None
+
+        for line in output.splitlines():
+            # Skip empty lines, header/separator lines
+            if not line.strip() or line.strip().startswith(("=", "_")):
+                continue
+
+            if match := _RULESET_NAME.match(line):
+                current_name = match.group("name")
+                rulesets[current_name] = RulesetEntry(rules=[])
+                continue
+
+            if current_name is not None and (match := _RULE_LINE.match(line)):
+                rulesets[current_name]["rules"].append(match.group("rule"))
+
+        if not rulesets:
+            msg = "No audit ruleset data found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformSoftwareAuditRulesetResult(rulesets=rulesets)

--- a/tests/parsers/iosxe/show_platform_software_audit_ruleset/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_software_audit_ruleset/001_basic/expected.json
@@ -1,0 +1,40 @@
+{
+    "rulesets": {
+        "user_group_config_files": {
+            "rules": [
+                "-a exit,always -F arch=b64 -F path=/etc/passwd -F perm=wa -k user_group_config_files",
+                "-a exit,always -F arch=b64 -F path=/etc/shadow -F perm=wa -k user_group_config_files",
+                "-a exit,always -F arch=b64 -F path=/etc/group -F perm=wa -k user_group_config_files"
+            ]
+        },
+        "user_privilege_mgmt": {
+            "rules": [
+                "-a always,exit -F arch=b64 -S setuid,setresuid,setreuid,setfsuid,setgid,setresgid,setregid,setfsgid -F key=user_privilege_mgmt",
+                "-a always,exit -F arch=b32 -S setgid32,setuid32,setresuid32,setfsuid32,setresgid32,setregid32,setfsgid32,setreuid32 -F key=user_privilege_mgmt"
+            ]
+        },
+        "dns_client_files": {
+            "rules": [
+                "-a exit,always -F arch=b64 -F path=/etc/hosts -F perm=wa -k dns_client_files",
+                "-a exit,always -F arch=b64 -F path=/etc/resolv.conf -F perm=wa -k dns_client_files",
+                "-a exit,always -F arch=b64 -F path=/var/run/resolv.conf -F perm=wa -k dns_client_files"
+            ]
+        },
+        "kernel_module_mgmt": {
+            "rules": [
+                "-a exit,always -F arch=b64 -F path=/sbin/insmod -F perm=x -k kernel_module_mgmt",
+                "-a exit,always -F arch=b64 -F path=/sbin/rmmod -F perm=x -k kernel_module_mgmt",
+                "-a exit,always -F arch=b64 -F path=/sbin/modprobe -F perm=x -k kernel_module_mgmt",
+                "-a exit,always -F arch=b64 -F path=/bin/kmod -F perm=x -k kernel_module_mgmt"
+            ]
+        },
+        "system_software": {
+            "rules": [
+                "-a exit,always -F arch=b64 -F dir=/bin -F perm=wa -k system_software",
+                "-a exit,always -F arch=b64 -F dir=/sbin -F perm=wa -k system_software",
+                "-a exit,always -F arch=b64 -F dir=/usr/bin -F perm=wa -k system_software",
+                "-a exit,always -F arch=b64 -F dir=/usr/sbin -F perm=wa -k system_software"
+            ]
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_software_audit_ruleset/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_software_audit_ruleset/001_basic/input.txt
@@ -1,0 +1,40 @@
+Router#show platform software audit ruleset
+================================================================================
+      AUDIT RULESET       :           RULES
+================================================================================
+
+    user_group_config_files :
+                         :    -a exit,always -F arch=b64 -F path=/etc/passwd -F perm=wa -k user_group_config_files
+                         :    -a exit,always -F arch=b64 -F path=/etc/shadow -F perm=wa -k user_group_config_files
+                         :    -a exit,always -F arch=b64 -F path=/etc/group -F perm=wa -k user_group_config_files
+
+________________________________________________________________________________
+
+    user_privilege_mgmt :
+                         :    -a always,exit -F arch=b64 -S setuid,setresuid,setreuid,setfsuid,setgid,setresgid,setregid,setfsgid -F key=user_privilege_mgmt
+                         :    -a always,exit -F arch=b32 -S setgid32,setuid32,setresuid32,setfsuid32,setresgid32,setregid32,setfsgid32,setreuid32 -F key=user_privilege_mgmt
+
+________________________________________________________________________________
+
+    dns_client_files :
+                         :    -a exit,always -F arch=b64 -F path=/etc/hosts -F perm=wa -k dns_client_files
+                         :    -a exit,always -F arch=b64 -F path=/etc/resolv.conf -F perm=wa -k dns_client_files
+                         :    -a exit,always -F arch=b64 -F path=/var/run/resolv.conf -F perm=wa -k dns_client_files
+
+________________________________________________________________________________
+
+    kernel_module_mgmt :
+                         :    -a exit,always -F arch=b64 -F path=/sbin/insmod -F perm=x -k kernel_module_mgmt
+                         :    -a exit,always -F arch=b64 -F path=/sbin/rmmod -F perm=x -k kernel_module_mgmt
+                         :    -a exit,always -F arch=b64 -F path=/sbin/modprobe -F perm=x -k kernel_module_mgmt
+                         :    -a exit,always -F arch=b64 -F path=/bin/kmod -F perm=x -k kernel_module_mgmt
+
+________________________________________________________________________________
+
+    system_software :
+                         :    -a exit,always -F arch=b64 -F dir=/bin -F perm=wa -k system_software
+                         :    -a exit,always -F arch=b64 -F dir=/sbin -F perm=wa -k system_software
+                         :    -a exit,always -F arch=b64 -F dir=/usr/bin -F perm=wa -k system_software
+                         :    -a exit,always -F arch=b64 -F dir=/usr/sbin -F perm=wa -k system_software
+
+________________________________________________________________________________

--- a/tests/parsers/iosxe/show_platform_software_audit_ruleset/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_software_audit_ruleset/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show platform software audit ruleset output with five rulesets
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show platform software audit ruleset` on Cisco IOS-XE
- Parses SELinux auditd rulesets into structured data keyed by ruleset name
- Includes test case with real CLI output covering five ruleset categories

Closes #254

## Test plan
- [x] Parser correctly extracts all five rulesets (user_group_config_files, user_privilege_mgmt, dns_client_files, kernel_module_mgmt, system_software)
- [x] Golden test passes: `uv run pytest tests/parsers/ -k show_platform_software_audit_ruleset -v`
- [x] `ruff check` and `ruff format` pass
- [x] `xenon` complexity check passes
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)