### PR TITLE
feat: add parser for 'show platform software yang-management process' on IOS-XE

### DIFF
--- a/changes/514.parser_added
+++ b/changes/514.parser_added
@@ -1,0 +1,1 @@
+Added parser support for 'show platform software yang-management process' on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_platform_software_yang_management_process.py
+++ b/src/muninn/parsers/iosxe/show_platform_software_yang_management_process.py
@@ -1,0 +1,77 @@
+"""Parser for 'show platform software yang-management process' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single YANG management process."""
+
+    status: str
+
+
+class ShowPlatformSoftwareYangManagementProcessResult(TypedDict):
+    """Schema for 'show platform software yang-management process' parsed output."""
+
+    processes: dict[str, ProcessEntry]
+
+
+# confd            : Running
+# gnmib            : Not Running
+_PROCESS_LINE = re.compile(r"^(?P<name>\S+)\s*:\s*(?P<status>Running|Not Running)\s*$")
+
+
+@register(OS.CISCO_IOSXE, "show platform software yang-management process")
+class ShowPlatformSoftwareYangManagementProcessParser(
+    BaseParser[ShowPlatformSoftwareYangManagementProcessResult],
+):
+    """Parser for 'show platform software yang-management process' command.
+
+    Parses YANG management process names and their running status.
+
+    Example output::
+
+        confd            : Running
+        nesd             : Running
+        syncfd           : Running
+        ncsshd           : Running
+        dmiauthd         : Running
+        nginx            : Running
+        ndbmand          : Running
+        pubd             : Running
+        gnmib            : Not Running
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformSoftwareYangManagementProcessResult:
+        """Parse 'show platform software yang-management process' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed process data keyed by process name.
+
+        Raises:
+            ValueError: If no YANG management process data is found.
+        """
+        processes: dict[str, ProcessEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := _PROCESS_LINE.match(stripped):
+                name = match.group("name")
+                processes[name] = ProcessEntry(status=match.group("status"))
+
+        if not processes:
+            msg = "No YANG management process data found in output"
+            raise ValueError(msg)
+
+        return ShowPlatformSoftwareYangManagementProcessResult(processes=processes)

--- a/tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/expected.json
@@ -1,0 +1,31 @@
+{
+    "processes": {
+        "confd": {
+            "status": "Running"
+        },
+        "dmiauthd": {
+            "status": "Running"
+        },
+        "gnmib": {
+            "status": "Not Running"
+        },
+        "ncsshd": {
+            "status": "Running"
+        },
+        "ndbmand": {
+            "status": "Running"
+        },
+        "nesd": {
+            "status": "Running"
+        },
+        "nginx": {
+            "status": "Running"
+        },
+        "pubd": {
+            "status": "Running"
+        },
+        "syncfd": {
+            "status": "Running"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/input.txt
@@ -1,0 +1,9 @@
+confd            : Running
+nesd             : Running
+syncfd           : Running
+ncsshd           : Running
+dmiauthd         : Running
+nginx            : Running
+ndbmand          : Running
+pubd             : Running
+gnmib            : Not Running

--- a/tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with YANG management processes and mixed Running/Not Running states
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show platform software yang-management process` on Cisco IOS-XE
- Parses YANG management process names (confd, ncsshd, nginx, etc.) and their running status
- Output keyed by process name with `status` field (`Running` / `Not Running`)

Closes #261

## Test plan
- [x] Parser produces correct structured output from Genie golden output sample
- [x] All quality checks pass (ruff check, ruff format, xenon)
- [x] Pre-commit hooks pass
- [x] Test case: `tests/parsers/iosxe/show_platform_software_yang-management_process/001_basic/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)