### PR TITLE
feat: add parser for 'show aliases' on IOS

### DIFF
--- a/changes/516.parser_added
+++ b/changes/516.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show aliases` on IOS.

--- a/src/muninn/parsers/ios/show_aliases.py
+++ b/src/muninn/parsers/ios/show_aliases.py
@@ -1,0 +1,91 @@
+"""Parser for 'show aliases' command on IOS."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class AliasEntry(TypedDict):
+    """Schema for a single alias entry."""
+
+    command: str
+
+
+class ModeEntry(TypedDict):
+    """Schema for aliases within a single mode."""
+
+    aliases: dict[str, AliasEntry]
+
+
+class ShowAliasesResult(TypedDict):
+    """Schema for 'show aliases' parsed output."""
+
+    modes: dict[str, ModeEntry]
+
+
+_MODE_HEADER_RE = re.compile(r"^(?P<mode>.+?)\s+mode\s+aliases:\s*$", re.IGNORECASE)
+_ALIAS_LINE_RE = re.compile(r"^\s{2,}(?P<alias>\S+)\s{2,}(?P<command>.+?)\s*$")
+
+
+def _normalize_mode(raw_mode: str) -> str:
+    """Normalize mode name to lowercase with underscores.
+
+    Example: 'Interface configuration' -> 'interface_configuration'
+    """
+    return raw_mode.strip().lower().replace(" ", "_")
+
+
+@register(OS.CISCO_IOS, "show aliases")
+class ShowAliasesParser(BaseParser["ShowAliasesResult"]):
+    """Parser for 'show aliases' on IOS.
+
+    Example output::
+
+        Exec mode aliases:
+          h                     help
+          lo                    logout
+          p                     ping
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowAliasesResult:
+        """Parse 'show aliases' output.
+
+        Args:
+            output: Raw CLI output from 'show aliases' command.
+
+        Returns:
+            Parsed data keyed by mode then alias name.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        modes: dict[str, ModeEntry] = {}
+        current_mode: str | None = None
+
+        for line in output.splitlines():
+            mode_match = _MODE_HEADER_RE.match(line)
+            if mode_match:
+                current_mode = _normalize_mode(mode_match.group("mode"))
+                modes[current_mode] = {"aliases": {}}
+                continue
+
+            if current_mode is None:
+                continue
+
+            alias_match = _ALIAS_LINE_RE.match(line)
+            if alias_match:
+                alias_name = alias_match.group("alias")
+                command = alias_match.group("command")
+                modes[current_mode]["aliases"][alias_name] = {
+                    "command": command,
+                }
+
+        if not modes:
+            msg = "No alias mode sections found in output"
+            raise ValueError(msg)
+
+        return {"modes": modes}

--- a/tests/parsers/ios/show_aliases/001_basic/expected.json
+++ b/tests/parsers/ios/show_aliases/001_basic/expected.json
@@ -1,0 +1,49 @@
+{
+    "modes": {
+        "exec": {
+            "aliases": {
+                "h": {
+                    "command": "help"
+                },
+                "lo": {
+                    "command": "logout"
+                },
+                "p": {
+                    "command": "ping"
+                },
+                "r": {
+                    "command": "resume"
+                },
+                "s": {
+                    "command": "show"
+                },
+                "u": {
+                    "command": "undebug"
+                },
+                "un": {
+                    "command": "undebug"
+                },
+                "w": {
+                    "command": "where"
+                }
+            }
+        },
+        "interface_configuration": {
+            "aliases": {
+                "nosh": {
+                    "command": "no shutdown"
+                },
+                "si": {
+                    "command": "shutdown"
+                }
+            }
+        },
+        "line_configuration": {
+            "aliases": {
+                "still": {
+                    "command": "no exec-timeout"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_aliases/001_basic/input.txt
+++ b/tests/parsers/ios/show_aliases/001_basic/input.txt
@@ -1,0 +1,14 @@
+Exec mode aliases:
+  h                     help
+  lo                    logout
+  p                     ping
+  r                     resume
+  s                     show
+  u                     undebug
+  un                    undebug
+  w                     where
+Interface configuration mode aliases:
+  nosh                  no shutdown
+  si                    shutdown
+Line configuration mode aliases:
+  still                 no exec-timeout

--- a/tests/parsers/ios/show_aliases/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_aliases/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple modes with default and custom aliases
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show aliases` command on Cisco IOS
- Parses alias definitions keyed by mode (e.g., `exec`, `interface_configuration`) then alias name
- Includes test case with multiple modes and aliases

Closes #266

## Test plan
- [x] Parser test passes: `uv run pytest tests/parsers/test_parsers.py -k "show_aliases"`
- [x] Ruff check and format pass
- [x] Xenon complexity check passes
- [x] Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)