### PR TITLE
feat: add parser for 'show ipv6 interface brief' on NX-OS

### DIFF
--- a/changes/522.parser_added
+++ b/changes/522.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ipv6 interface brief` on NX-OS.

--- a/src/muninn/parsers/nxos/show_ipv6_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_ipv6_interface_brief.py
@@ -9,14 +9,21 @@ from muninn.registry import register
 from muninn.utils import canonical_interface_name
 
 
+class IPv6AddressEntry(TypedDict):
+    """Schema for a single IPv6 address."""
+
+    address: str
+    flags: NotRequired[list[str]]
+
+
 class IPv6InterfaceBriefEntry(TypedDict):
     """Schema for a single IPv6 interface brief entry."""
 
-    ipv6_addresses: list[str]
+    ipv6_addresses: list[IPv6AddressEntry]
     protocol_status: str
     link_status: str
     admin_status: str
-    link_local: NotRequired[str]
+    link_local: NotRequired[IPv6AddressEntry]
 
 
 class VrfEntry(TypedDict):
@@ -41,6 +48,10 @@ _INTERFACE_LINE_PATTERN = re.compile(
     r"(?P<protocol>up|down)/(?P<link>up|down)/(?P<admin>up|down)$"
 )
 _ADDRESS_CONTINUATION_PATTERN = re.compile(r"^\s+(?P<address>\S+)$")
+_ADDRESS_WITH_FLAGS_PATTERN = re.compile(
+    r"^(?P<address>[^\[]+?)(?:\[(?P<flags>[A-Z]+)\])?$"
+)
+_ADDRESS_FLAG_MAP = {"T": "tentative"}
 
 
 def _is_skip_line(stripped: str) -> bool:
@@ -52,13 +63,27 @@ def _is_skip_line(stripped: str) -> bool:
     )
 
 
+def _parse_address(address: str) -> IPv6AddressEntry:
+    """Split an address token into address and optional flags."""
+    match = _ADDRESS_WITH_FLAGS_PATTERN.match(address)
+    if not match:
+        return {"address": address}
+
+    parsed: IPv6AddressEntry = {"address": match.group("address")}
+    flags = match.group("flags")
+    if flags:
+        parsed["flags"] = [_ADDRESS_FLAG_MAP.get(flag, flag) for flag in flags]
+    return parsed
+
+
 def _record_address(entry: IPv6InterfaceBriefEntry, address: str) -> None:
     """Store a global or link-local address on an interface entry."""
-    if address.lower().startswith("fe80:"):
-        entry["link_local"] = address
+    parsed_address = _parse_address(address)
+    if parsed_address["address"].lower().startswith("fe80:"):
+        entry["link_local"] = parsed_address
         return
-    if address not in entry["ipv6_addresses"]:
-        entry["ipv6_addresses"].append(address)
+    if parsed_address not in entry["ipv6_addresses"]:
+        entry["ipv6_addresses"].append(parsed_address)
 
 
 def _validate_result(vrfs: dict[str, VrfEntry]) -> None:

--- a/src/muninn/parsers/nxos/show_ipv6_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_ipv6_interface_brief.py
@@ -1,0 +1,90 @@
+"""Parser for 'show ipv6 interface brief' command on NX-OS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class IPv6InterfaceBriefEntry(TypedDict):
+    """Schema for a single IPv6 interface brief entry."""
+
+    ipv6_address: str
+    link_local: NotRequired[str]
+    protocol_status: str
+    link_status: str
+    admin_status: str
+
+
+class ShowIPv6InterfaceBriefResult(TypedDict):
+    """Schema for 'show ipv6 interface brief' parsed output."""
+
+    interfaces: dict[str, IPv6InterfaceBriefEntry]
+
+
+# Pattern for interface lines:
+#   Vlan44           2a01:3333:1:44::2                         up/up/up
+_INTERFACE_LINE_PATTERN = re.compile(
+    r"^(?P<interface>\S+)\s+"
+    r"(?P<ipv6_address>\S+)\s+"
+    r"(?P<protocol>up|down)/(?P<link>up|down)/(?P<admin>up|down)$"
+)
+
+# Pattern for link-local continuation lines:
+#                  fe80::333:4444:5555:8888
+_LINK_LOCAL_PATTERN = re.compile(r"^\s+(?P<link_local>fe80:\S+)$")
+
+
+@register(OS.CISCO_NXOS, "show ipv6 interface brief")
+class ShowIPv6InterfaceBriefParser(BaseParser[ShowIPv6InterfaceBriefResult]):
+    """Parser for 'show ipv6 interface brief' command on NX-OS.
+
+    Parses IPv6 interface status including address, link-local address,
+    and protocol/link/admin status.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIPv6InterfaceBriefResult:
+        """Parse 'show ipv6 interface brief' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IPv6 interface brief data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interfaces found in output.
+        """
+        interfaces: dict[str, IPv6InterfaceBriefEntry] = {}
+        last_interface: str | None = None
+
+        for line in output.splitlines():
+            intf_match = _INTERFACE_LINE_PATTERN.match(line)
+            if intf_match:
+                name = canonical_interface_name(
+                    intf_match.group("interface"), os=OS.CISCO_NXOS
+                )
+                entry: IPv6InterfaceBriefEntry = {
+                    "ipv6_address": intf_match.group("ipv6_address"),
+                    "protocol_status": intf_match.group("protocol"),
+                    "link_status": intf_match.group("link"),
+                    "admin_status": intf_match.group("admin"),
+                }
+                interfaces[name] = entry
+                last_interface = name
+                continue
+
+            ll_match = _LINK_LOCAL_PATTERN.match(line)
+            if ll_match and last_interface is not None:
+                interfaces[last_interface]["link_local"] = ll_match.group("link_local")
+                continue
+
+        if not interfaces:
+            msg = "No interfaces found in output"
+            raise ValueError(msg)
+
+        return ShowIPv6InterfaceBriefResult(interfaces=interfaces)

--- a/src/muninn/parsers/nxos/show_ipv6_interface_brief.py
+++ b/src/muninn/parsers/nxos/show_ipv6_interface_brief.py
@@ -12,38 +12,80 @@ from muninn.utils import canonical_interface_name
 class IPv6InterfaceBriefEntry(TypedDict):
     """Schema for a single IPv6 interface brief entry."""
 
-    ipv6_address: str
-    link_local: NotRequired[str]
+    ipv6_addresses: list[str]
     protocol_status: str
     link_status: str
     admin_status: str
+    link_local: NotRequired[str]
+
+
+class VrfEntry(TypedDict):
+    """Schema for a VRF entry."""
+
+    vrf_id: int
+    interfaces: dict[str, IPv6InterfaceBriefEntry]
 
 
 class ShowIPv6InterfaceBriefResult(TypedDict):
     """Schema for 'show ipv6 interface brief' parsed output."""
 
-    interfaces: dict[str, IPv6InterfaceBriefEntry]
+    vrfs: dict[str, VrfEntry]
 
 
-# Pattern for interface lines:
-#   Vlan44           2a01:3333:1:44::2                         up/up/up
+_VRF_PATTERN = re.compile(
+    r'^IPv6 Interface Status for VRF "(?P<vrf_name>[^"]+)"\((?P<vrf_id>\d+)\)$'
+)
 _INTERFACE_LINE_PATTERN = re.compile(
     r"^(?P<interface>\S+)\s+"
-    r"(?P<ipv6_address>\S+)\s+"
+    r"(?P<address>\S+)\s+"
     r"(?P<protocol>up|down)/(?P<link>up|down)/(?P<admin>up|down)$"
 )
+_ADDRESS_CONTINUATION_PATTERN = re.compile(r"^\s+(?P<address>\S+)$")
 
-# Pattern for link-local continuation lines:
-#                  fe80::333:4444:5555:8888
-_LINK_LOCAL_PATTERN = re.compile(r"^\s+(?P<link_local>fe80:\S+)$")
+
+def _is_skip_line(stripped: str) -> bool:
+    """Return True when the line is a header or otherwise non-data."""
+    return (
+        not stripped
+        or ("Interface" in stripped and "IPv6 Address/Link-local Address" in stripped)
+        or stripped == "prot/link/admin"
+    )
+
+
+def _record_address(entry: IPv6InterfaceBriefEntry, address: str) -> None:
+    """Store a global or link-local address on an interface entry."""
+    if address.lower().startswith("fe80:"):
+        entry["link_local"] = address
+        return
+    if address not in entry["ipv6_addresses"]:
+        entry["ipv6_addresses"].append(address)
+
+
+def _validate_result(vrfs: dict[str, VrfEntry]) -> None:
+    """Validate that parsed data contains VRFs and interfaces."""
+    if not vrfs:
+        msg = "No VRFs found in output"
+        raise ValueError(msg)
+
+    total_interfaces = sum(len(vrf["interfaces"]) for vrf in vrfs.values())
+    if total_interfaces == 0:
+        msg = "No interfaces found in output"
+        raise ValueError(msg)
 
 
 @register(OS.CISCO_NXOS, "show ipv6 interface brief")
+@register(
+    OS.CISCO_NXOS,
+    r"show ipv6 interface brief vrf (?P<vrf_name>\S+)",
+)
 class ShowIPv6InterfaceBriefParser(BaseParser[ShowIPv6InterfaceBriefResult]):
     """Parser for 'show ipv6 interface brief' command on NX-OS.
 
-    Parses IPv6 interface status including address, link-local address,
-    and protocol/link/admin status.
+    Example output:
+        IPv6 Interface Status for VRF "default"(1)
+        Vlan3002         79:1:1::2[T]                              down/down/up
+                         79:2:1::2[T]
+                         fe80::e6c7:22ff:fe10:afc1[T]
     """
 
     @classmethod
@@ -57,34 +99,50 @@ class ShowIPv6InterfaceBriefParser(BaseParser[ShowIPv6InterfaceBriefResult]):
             Parsed IPv6 interface brief data keyed by canonical interface name.
 
         Raises:
-            ValueError: If no interfaces found in output.
+            ValueError: If no VRFs or interfaces found in output.
         """
-        interfaces: dict[str, IPv6InterfaceBriefEntry] = {}
+        vrfs: dict[str, VrfEntry] = {}
+        current_vrf: str | None = None
         last_interface: str | None = None
 
         for line in output.splitlines():
+            stripped = line.strip()
+            vrf_match = _VRF_PATTERN.match(stripped)
+            if vrf_match:
+                current_vrf = vrf_match.group("vrf_name")
+                vrfs[current_vrf] = {
+                    "vrf_id": int(vrf_match.group("vrf_id")),
+                    "interfaces": {},
+                }
+                last_interface = None
+                continue
+
+            if _is_skip_line(stripped):
+                continue
+
             intf_match = _INTERFACE_LINE_PATTERN.match(line)
-            if intf_match:
+            if intf_match and current_vrf is not None:
                 name = canonical_interface_name(
                     intf_match.group("interface"), os=OS.CISCO_NXOS
                 )
                 entry: IPv6InterfaceBriefEntry = {
-                    "ipv6_address": intf_match.group("ipv6_address"),
+                    "ipv6_addresses": [],
                     "protocol_status": intf_match.group("protocol"),
                     "link_status": intf_match.group("link"),
                     "admin_status": intf_match.group("admin"),
                 }
-                interfaces[name] = entry
+                _record_address(entry, intf_match.group("address"))
+                vrfs[current_vrf]["interfaces"][name] = entry
                 last_interface = name
                 continue
 
-            ll_match = _LINK_LOCAL_PATTERN.match(line)
-            if ll_match and last_interface is not None:
-                interfaces[last_interface]["link_local"] = ll_match.group("link_local")
-                continue
+            cont_match = _ADDRESS_CONTINUATION_PATTERN.match(line)
+            if cont_match and current_vrf is not None and last_interface is not None:
+                _record_address(
+                    vrfs[current_vrf]["interfaces"][last_interface],
+                    cont_match.group("address"),
+                )
 
-        if not interfaces:
-            msg = "No interfaces found in output"
-            raise ValueError(msg)
+        _validate_result(vrfs)
 
-        return ShowIPv6InterfaceBriefResult(interfaces=interfaces)
+        return ShowIPv6InterfaceBriefResult(vrfs=vrfs)

--- a/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/expected.json
@@ -5,63 +5,91 @@
             "interfaces": {
                 "Vlan44": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:44::2"
+                        {
+                            "address": "2a01:3333:1:44::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan45": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:51::2"
+                        {
+                            "address": "2a01:3333:1:51::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan46": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:52::2"
+                        {
+                            "address": "2a01:3333:1:52::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan47": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:53::2"
+                        {
+                            "address": "2a01:3333:1:53::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan48": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:60::2"
+                        {
+                            "address": "2a01:3333:1:60::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan49": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:79::2"
+                        {
+                            "address": "2a01:3333:1:79::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan50": {
                     "ipv6_addresses": [
-                        "2a01:3333:1:80::2"
+                        {
+                            "address": "2a01:3333:1:80::2"
+                        }
                     ],
-                    "link_local": "fe80::333:4444:5555:8888",
+                    "link_local": {
+                        "address": "fe80::333:4444:5555:8888"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"

--- a/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/expected.json
@@ -1,0 +1,53 @@
+{
+    "interfaces": {
+        "Vlan44": {
+            "ipv6_address": "2a01:3333:1:44::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        },
+        "Vlan45": {
+            "ipv6_address": "2a01:3333:1:51::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        },
+        "Vlan46": {
+            "ipv6_address": "2a01:3333:1:52::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        },
+        "Vlan47": {
+            "ipv6_address": "2a01:3333:1:53::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        },
+        "Vlan48": {
+            "ipv6_address": "2a01:3333:1:60::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        },
+        "Vlan49": {
+            "ipv6_address": "2a01:3333:1:79::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        },
+        "Vlan50": {
+            "ipv6_address": "2a01:3333:1:80::2",
+            "link_local": "fe80::333:4444:5555:8888",
+            "protocol_status": "up",
+            "link_status": "up",
+            "admin_status": "up"
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/expected.json
@@ -1,53 +1,72 @@
 {
-    "interfaces": {
-        "Vlan44": {
-            "ipv6_address": "2a01:3333:1:44::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
-        },
-        "Vlan45": {
-            "ipv6_address": "2a01:3333:1:51::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
-        },
-        "Vlan46": {
-            "ipv6_address": "2a01:3333:1:52::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
-        },
-        "Vlan47": {
-            "ipv6_address": "2a01:3333:1:53::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
-        },
-        "Vlan48": {
-            "ipv6_address": "2a01:3333:1:60::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
-        },
-        "Vlan49": {
-            "ipv6_address": "2a01:3333:1:79::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
-        },
-        "Vlan50": {
-            "ipv6_address": "2a01:3333:1:80::2",
-            "link_local": "fe80::333:4444:5555:8888",
-            "protocol_status": "up",
-            "link_status": "up",
-            "admin_status": "up"
+    "vrfs": {
+        "default": {
+            "vrf_id": 1,
+            "interfaces": {
+                "Vlan44": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:44::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan45": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:51::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan46": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:52::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan47": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:53::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan48": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:60::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan49": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:79::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan50": {
+                    "ipv6_addresses": [
+                        "2a01:3333:1:80::2"
+                    ],
+                    "link_local": "fe80::333:4444:5555:8888",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                }
+            }
         }
     }
 }

--- a/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/input.txt
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/input.txt
@@ -1,0 +1,17 @@
+IPv6 Interface Status for VRF "default"(1)
+Interface        IPv6 Address/Link-local Address           Interface Status
+                                                           prot/link/admin
+Vlan44           2a01:3333:1:44::2                         up/up/up
+                 fe80::333:4444:5555:8888
+Vlan45           2a01:3333:1:51::2                         up/up/up
+                 fe80::333:4444:5555:8888
+Vlan46           2a01:3333:1:52::2                         up/up/up
+                 fe80::333:4444:5555:8888
+Vlan47           2a01:3333:1:53::2                         up/up/up
+                 fe80::333:4444:5555:8888
+Vlan48           2a01:3333:1:60::2                         up/up/up
+                 fe80::333:4444:5555:8888
+Vlan49           2a01:3333:1:79::2                         up/up/up
+                 fe80::333:4444:5555:8888
+Vlan50           2a01:3333:1:80::2                         up/up/up
+                 fe80::333:4444:5555:8888

--- a/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VLAN interfaces with IPv6 addresses and link-local addresses
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/001_basic/metadata.yaml
@@ -1,3 +1,3 @@
-description: Multiple VLAN interfaces with IPv6 addresses and link-local addresses
+description: Multiple VLAN interfaces with one global and one link-local IPv6 address
 platform: Unknown
 software_version: Unknown

--- a/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/expected.json
@@ -5,28 +5,51 @@
             "interfaces": {
                 "Loopback2": {
                     "ipv6_addresses": [
-                        "44:44:44::44"
+                        {
+                            "address": "44:44:44::44"
+                        }
                     ],
-                    "link_local": "fe80::e6c7:22ff:fe0f:ba0b",
+                    "link_local": {
+                        "address": "fe80::e6c7:22ff:fe0f:ba0b"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan1002": {
                     "ipv6_addresses": [
-                        "44:1:1::1"
+                        {
+                            "address": "44:1:1::1"
+                        }
                     ],
-                    "link_local": "fe80::e6c7:22ff:fe10:afc1",
+                    "link_local": {
+                        "address": "fe80::e6c7:22ff:fe10:afc1"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan3002": {
                     "ipv6_addresses": [
-                        "79:1:1::2[T]",
-                        "79:2:1::2[T]"
+                        {
+                            "address": "79:1:1::2",
+                            "flags": [
+                                "tentative"
+                            ]
+                        },
+                        {
+                            "address": "79:2:1::2",
+                            "flags": [
+                                "tentative"
+                            ]
+                        }
                     ],
-                    "link_local": "fe80::e6c7:22ff:fe10:afc1[T]",
+                    "link_local": {
+                        "address": "fe80::e6c7:22ff:fe10:afc1",
+                        "flags": [
+                            "tentative"
+                        ]
+                    },
                     "protocol_status": "down",
                     "link_status": "down",
                     "admin_status": "up"

--- a/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/expected.json
@@ -1,0 +1,37 @@
+{
+    "vrfs": {
+        "default": {
+            "vrf_id": 1,
+            "interfaces": {
+                "Loopback2": {
+                    "ipv6_addresses": [
+                        "44:44:44::44"
+                    ],
+                    "link_local": "fe80::e6c7:22ff:fe0f:ba0b",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan1002": {
+                    "ipv6_addresses": [
+                        "44:1:1::1"
+                    ],
+                    "link_local": "fe80::e6c7:22ff:fe10:afc1",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan3002": {
+                    "ipv6_addresses": [
+                        "79:1:1::2[T]",
+                        "79:2:1::2[T]"
+                    ],
+                    "link_local": "fe80::e6c7:22ff:fe10:afc1[T]",
+                    "protocol_status": "down",
+                    "link_status": "down",
+                    "admin_status": "up"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/input.txt
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/input.txt
@@ -1,0 +1,10 @@
+IPv6 Interface Status for VRF "default"(1)
+Interface        IPv6 Address/Link-local Address           Interface Status
+                                                           prot/link/admin
+Vlan1002         44:1:1::1                                 up/up/up
+                 fe80::e6c7:22ff:fe10:afc1
+Vlan3002         79:1:1::2[T]                              down/down/up
+                 79:2:1::2[T]
+                 fe80::e6c7:22ff:fe10:afc1[T]
+Lo2              44:44:44::44                              up/up/up
+                 fe80::e6c7:22ff:fe0f:ba0b

--- a/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/metadata.yaml
+++ b/tests/parsers/nxos/show_ipv6_interface_brief/002_multiple_addresses/metadata.yaml
@@ -1,0 +1,3 @@
+description: Interface with multiple global IPv6 addresses and tentative markers
+platform: Nexus 7000
+software_version: NX-OS 8.2(1)

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/expected.json
@@ -5,19 +5,29 @@
             "interfaces": {
                 "Loopback10": {
                     "ipv6_addresses": [
-                        "2001:db8:10::10"
+                        {
+                            "address": "2001:db8:10::10"
+                        }
                     ],
-                    "link_local": "fe80::10",
+                    "link_local": {
+                        "address": "fe80::10"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
                 },
                 "Vlan200": {
                     "ipv6_addresses": [
-                        "2001:db8:200::1",
-                        "2001:db8:200::2"
+                        {
+                            "address": "2001:db8:200::1"
+                        },
+                        {
+                            "address": "2001:db8:200::2"
+                        }
                     ],
-                    "link_local": "fe80::200",
+                    "link_local": {
+                        "address": "fe80::200"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/expected.json
@@ -1,0 +1,28 @@
+{
+    "vrfs": {
+        "RED": {
+            "vrf_id": 5,
+            "interfaces": {
+                "Loopback10": {
+                    "ipv6_addresses": [
+                        "2001:db8:10::10"
+                    ],
+                    "link_local": "fe80::10",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                },
+                "Vlan200": {
+                    "ipv6_addresses": [
+                        "2001:db8:200::1",
+                        "2001:db8:200::2"
+                    ],
+                    "link_local": "fe80::200",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/input.txt
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/input.txt
@@ -1,0 +1,8 @@
+IPv6 Interface Status for VRF "RED"(5)
+Interface        IPv6 Address/Link-local Address           Interface Status
+                                                           prot/link/admin
+Vlan200          2001:db8:200::1                           up/up/up
+                 2001:db8:200::2
+                 fe80::200
+Lo10             2001:db8:10::10                           up/up/up
+                 fe80::10

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/metadata.yaml
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_RED/001_single_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: VRF-specific command output with one VRF and multiple IPv6 addresses
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/expected.json
@@ -5,9 +5,13 @@
             "interfaces": {
                 "Vlan100": {
                     "ipv6_addresses": [
-                        "2001:db8:100::1"
+                        {
+                            "address": "2001:db8:100::1"
+                        }
                     ],
-                    "link_local": "fe80::100",
+                    "link_local": {
+                        "address": "fe80::100"
+                    },
                     "protocol_status": "up",
                     "link_status": "up",
                     "admin_status": "up"
@@ -19,10 +23,16 @@
             "interfaces": {
                 "Vlan200": {
                     "ipv6_addresses": [
-                        "2001:db8:200::1",
-                        "2001:db8:200::2"
+                        {
+                            "address": "2001:db8:200::1"
+                        },
+                        {
+                            "address": "2001:db8:200::2"
+                        }
                     ],
-                    "link_local": "fe80::200",
+                    "link_local": {
+                        "address": "fe80::200"
+                    },
                     "protocol_status": "down",
                     "link_status": "down",
                     "admin_status": "up"

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/expected.json
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/expected.json
@@ -1,0 +1,33 @@
+{
+    "vrfs": {
+        "default": {
+            "vrf_id": 1,
+            "interfaces": {
+                "Vlan100": {
+                    "ipv6_addresses": [
+                        "2001:db8:100::1"
+                    ],
+                    "link_local": "fe80::100",
+                    "protocol_status": "up",
+                    "link_status": "up",
+                    "admin_status": "up"
+                }
+            }
+        },
+        "RED": {
+            "vrf_id": 5,
+            "interfaces": {
+                "Vlan200": {
+                    "ipv6_addresses": [
+                        "2001:db8:200::1",
+                        "2001:db8:200::2"
+                    ],
+                    "link_local": "fe80::200",
+                    "protocol_status": "down",
+                    "link_status": "down",
+                    "admin_status": "up"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/input.txt
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/input.txt
@@ -1,0 +1,11 @@
+IPv6 Interface Status for VRF "default"(1)
+Interface        IPv6 Address/Link-local Address           Interface Status
+                                                           prot/link/admin
+Vlan100          2001:db8:100::1                           up/up/up
+                 fe80::100
+IPv6 Interface Status for VRF "RED"(5)
+Interface        IPv6 Address/Link-local Address           Interface Status
+                                                           prot/link/admin
+Vlan200          2001:db8:200::1                           down/down/up
+                 2001:db8:200::2
+                 fe80::200

--- a/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/metadata.yaml
+++ b/tests/parsers/nxos/show_ipv6_interface_brief_vrf_all/001_multiple_vrfs/metadata.yaml
@@ -1,0 +1,3 @@
+description: VRF-all output with multiple VRF sections and continuation addresses
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ipv6 interface brief` on NX-OS
- Parses IPv6 address, link-local address, and protocol/link/admin status per interface
- Interfaces keyed by canonical interface name (e.g., `Vlan44`)

Closes #270

## Test plan
- [x] Golden test with 7 VLAN interfaces (001_basic)
- [x] ruff check and ruff format pass
- [x] xenon complexity check passes
- [x] pre-commit hooks pass
- [x] pytest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)