### PR TITLE
feat: add parser for 'show mac-address-table' on IOS

### DIFF
--- a/changes/524.parser_added
+++ b/changes/524.parser_added
@@ -1,0 +1,1 @@
+Added `show mac-address-table` command alias for IOS and IOS-XE.

--- a/src/muninn/parsers/ios/show_mac_address_table.py
+++ b/src/muninn/parsers/ios/show_mac_address_table.py
@@ -364,7 +364,9 @@ def _parse_output(output: str) -> ShowMacAddressTableResult:
 
 
 @register(OS.CISCO_IOS, "show mac address-table")
+@register(OS.CISCO_IOS, "show mac-address-table")
 @register(OS.CISCO_IOSXE, "show mac address-table")
+@register(OS.CISCO_IOSXE, "show mac-address-table")
 class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
     """Parser for 'show mac address-table' on IOS/IOS-XE."""
 

--- a/tests/parsers/ios/show_mac-address-table/001_basic/expected.json
+++ b/tests/parsers/ios/show_mac-address-table/001_basic/expected.json
@@ -1,0 +1,53 @@
+{
+    "entries": [
+        {
+            "vlan": "All",
+            "mac_address": "0100.0cff.9999",
+            "type": "static",
+            "ports": [
+                "CPU"
+            ]
+        },
+        {
+            "vlan": "20",
+            "mac_address": "aaaa.bbff.8888",
+            "type": "static",
+            "ports": [
+                "Drop"
+            ]
+        },
+        {
+            "vlan": "100",
+            "mac_address": "3820.56ff.6f75",
+            "type": "dynamic",
+            "ports": [
+                "Port-channel12"
+            ]
+        },
+        {
+            "vlan": "100",
+            "mac_address": "58bf.eaff.e508",
+            "type": "static",
+            "ports": [
+                "VLAN100"
+            ]
+        },
+        {
+            "vlan": "101",
+            "mac_address": "3820.56ff.6f75",
+            "type": "dynamic",
+            "ports": [
+                "Port-channel12"
+            ]
+        },
+        {
+            "vlan": "101",
+            "mac_address": "58bf.eaff.e5f7",
+            "type": "static",
+            "ports": [
+                "VLAN101"
+            ]
+        }
+    ],
+    "total_mac_addresses": 6
+}

--- a/tests/parsers/ios/show_mac-address-table/001_basic/input.txt
+++ b/tests/parsers/ios/show_mac-address-table/001_basic/input.txt
@@ -1,0 +1,12 @@
+         Mac Address Table
+-------------------------------------------
+
+Vlan    Mac Address       Type        Ports
+----    -----------       --------    -----
+ All    0100.0cff.9999    STATIC      CPU
+  20    aaaa.bbff.8888    STATIC      Drop
+ 100    3820.56ff.6f75    DYNAMIC     Po12
+ 100    58bf.eaff.e508    STATIC      Vl100
+ 101    3820.56ff.6f75    DYNAMIC     Po12
+ 101    58bf.eaff.e5f7    STATIC      Vl101
+Total Mac Addresses for this criterion: 6

--- a/tests/parsers/ios/show_mac-address-table/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_mac-address-table/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard MAC address table with static, dynamic, special VLAN, and interface normalization
+platform: Cisco Switch
+software_version: IOS


### PR DESCRIPTION
## Summary
- Register `show mac-address-table` as a command alias for the existing `show mac address-table` parser on both IOS and IOS-XE
- Cisco IOS accepts both command variants (with and without hyphen between `mac` and `address`), so both should be supported
- Added test case `tests/parsers/ios/show_mac-address-table/001_basic/` verifying the alias works correctly

Closes #271

## Test plan
- [x] New test `ios/show_mac-address-table/001_basic` passes with standard MAC table output
- [x] All 28 existing MAC-related tests continue to pass
- [x] `ruff check` and `ruff format` pass
- [x] `xenon` complexity check passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)