### PR TITLE
feat: add parser for 'show interface transceiver details' on NX-OS

### DIFF
--- a/changes/525.parser_added
+++ b/changes/525.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interface transceiver details` on NX-OS with transceiver identification and DOM diagnostic readings.

--- a/src/muninn/parsers/nxos/show_interface_transceiver_details.py
+++ b/src/muninn/parsers/nxos/show_interface_transceiver_details.py
@@ -1,0 +1,361 @@
+"""Parser for 'show interface transceiver details' command on NX-OS."""
+
+import re
+from dataclasses import dataclass, field
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class DiagnosticReading(TypedDict):
+    """Schema for a single diagnostic measurement with thresholds."""
+
+    current: float
+    alarm_high: NotRequired[float]
+    alarm_low: NotRequired[float]
+    warning_high: NotRequired[float]
+    warning_low: NotRequired[float]
+
+
+class TransceiverDetailEntry(TypedDict):
+    """Schema for a single interface transceiver detail entry."""
+
+    type: str
+    name: str
+    part_number: str
+    revision: str
+    serial_number: str
+    nominal_bitrate_mbps: NotRequired[int]
+    link_lengths: NotRequired[dict[str, str]]
+    cisco_id: NotRequired[str]
+    cisco_extended_id: NotRequired[str]
+    cisco_part_number: NotRequired[str]
+    cisco_product_id: NotRequired[str]
+    cisco_version_id: NotRequired[str]
+    calibration: NotRequired[str]
+    temperature: NotRequired[DiagnosticReading]
+    voltage: NotRequired[DiagnosticReading]
+    current: NotRequired[DiagnosticReading]
+    tx_power: NotRequired[DiagnosticReading]
+    rx_power: NotRequired[DiagnosticReading]
+    transmit_fault_count: NotRequired[int]
+
+
+class ShowInterfaceTransceiverDetailsResult(TypedDict):
+    """Schema for 'show interface transceiver details' parsed output."""
+
+    interfaces: dict[str, TransceiverDetailEntry]
+
+
+# Pattern to match interface header lines like "Ethernet1/1" or "Eth1/17"
+_INTERFACE_PATTERN = re.compile(
+    r"^(?P<intf>(?:Eth(?:ernet)?|mgmt)\S+)\s*$",
+    re.IGNORECASE,
+)
+
+# Pattern matching "transceiver is present" or "sfp is present"
+_PRESENCE_PATTERN = re.compile(
+    r"^\s*(?:transceiver|sfp)\s+is\s+(?P<status>present|not\s+present)",
+    re.IGNORECASE,
+)
+
+# Key-value patterns for transceiver identification fields
+_KV_PATTERN = re.compile(r"^\s*(?P<key>[a-z][a-z _]+[a-z])\s+is\s+(?P<value>.+)$")
+
+# Diagnostic table row: field, current, alarm_high, alarm_low, warn_high, warn_low
+# Example: Temperature   34.41 C    90.00 C    -45.00 C    85.00 C    -40.00 C
+_DIAG_ROW_PATTERN = re.compile(
+    r"^\s*(?P<field>Temperature|Voltage|Current|Tx Power|Rx Power)\s+"
+    r"(?P<current>-?[\d.]+)\s+\S+\s+"
+    r"(?P<alarm_high>-?[\d.]+)\s+\S+\s+"
+    r"(?P<alarm_low>-?[\d.]+)\s+\S+\s+"
+    r"(?P<warn_high>-?[\d.]+)\s+\S+\s+"
+    r"(?P<warn_low>-?[\d.]+)\s+\S+",
+)
+
+# Transmit Fault Count = 0
+_TX_FAULT_PATTERN = re.compile(
+    r"^\s*Transmit Fault Count\s*=\s*(?P<count>\d+)",
+)
+
+# Calibration header: "SFP Detail Diagnostics Information (internal calibration)"
+_CALIBRATION_PATTERN = re.compile(
+    r"Detail Diagnostics Information\s+\((?P<cal>[^)]+)\)",
+)
+
+# Maps raw key strings to TransceiverDetailEntry field names
+_IDENTIFICATION_KEY_MAP: dict[str, str] = {
+    "type": "type",
+    "name": "name",
+    "part number": "part_number",
+    "revision": "revision",
+    "serial number": "serial_number",
+    "nominal bitrate": "nominal_bitrate_mbps",
+    "cisco id": "cisco_id",
+    "cisco extended id number": "cisco_extended_id",
+    "cisco part number": "cisco_part_number",
+    "cisco product id": "cisco_product_id",
+    "cisco version id": "cisco_version_id",
+}
+
+# Maps diagnostic field labels to entry keys
+_DIAG_FIELD_MAP: dict[str, str] = {
+    "Temperature": "temperature",
+    "Voltage": "voltage",
+    "Current": "current",
+    "Tx Power": "tx_power",
+    "Rx Power": "rx_power",
+}
+
+# Pattern for link length lines:
+# "Link length supported for 9/125um fiber is 40 km"
+# "Link length supported for 50/125um OM3 fiber is 100 m(s)"
+_LINK_LENGTH_PATTERN = re.compile(
+    r"^\s*Link length supported for\s+(?P<fiber>.+?)\s+is\s+(?P<distance>.+)$",
+)
+
+# Pattern to extract numeric bitrate value:
+# "10300 MBits/sec" or "1300 MBit/sec"
+_BITRATE_VALUE_PATTERN = re.compile(r"^(\d+)")
+
+
+def _parse_bitrate(raw: str) -> int | None:
+    """Extract integer bitrate in Mbps from a raw string.
+
+    Args:
+        raw: Value like "10300 MBits/sec".
+
+    Returns:
+        Integer bitrate or None if unparseable.
+    """
+    match = _BITRATE_VALUE_PATTERN.match(raw.strip())
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _build_diagnostic_reading(
+    match: re.Match[str],
+) -> DiagnosticReading:
+    """Build a DiagnosticReading from a regex match.
+
+    Args:
+        match: Match with groups: current, alarm_high, alarm_low,
+               warn_high, warn_low.
+
+    Returns:
+        Populated DiagnosticReading dict.
+    """
+    return DiagnosticReading(
+        current=float(match.group("current")),
+        alarm_high=float(match.group("alarm_high")),
+        alarm_low=float(match.group("alarm_low")),
+        warning_high=float(match.group("warn_high")),
+        warning_low=float(match.group("warn_low")),
+    )
+
+
+@dataclass
+class _ParseState:
+    """Mutable state for the transceiver detail parser."""
+
+    interfaces: dict[str, TransceiverDetailEntry] = field(
+        default_factory=dict,
+    )
+    current_intf: str | None = None
+    current_entry: TransceiverDetailEntry | None = None
+
+    def save_current(self) -> None:
+        """Save the current entry into interfaces if valid."""
+        if self.current_intf and self.current_entry:
+            self.interfaces[self.current_intf] = self.current_entry
+
+    def start_interface(self, name: str) -> None:
+        """Begin tracking a new interface, saving any previous entry."""
+        self.save_current()
+        self.current_intf = name
+        self.current_entry = None
+
+    def clear_interface(self) -> None:
+        """Clear the current interface without saving (not present)."""
+        self.current_intf = None
+        self.current_entry = None
+
+
+def _handle_interface_header(
+    stripped: str,
+    state: _ParseState,
+) -> bool:
+    """Check for and handle an interface header line.
+
+    Returns True if the line was consumed.
+    """
+    intf_match = _INTERFACE_PATTERN.match(stripped)
+    if not intf_match:
+        return False
+    name = canonical_interface_name(
+        intf_match.group("intf"),
+        os=OS.CISCO_NXOS,
+    )
+    state.start_interface(name)
+    return True
+
+
+def _handle_presence(stripped: str, state: _ParseState) -> bool:
+    """Check for and handle a transceiver presence line.
+
+    Returns True if the line was consumed.
+    """
+    presence_match = _PRESENCE_PATTERN.match(stripped)
+    if not presence_match:
+        return False
+    if "not" in presence_match.group("status").lower():
+        state.clear_interface()
+    return True
+
+
+def _handle_diagnostics(
+    stripped: str,
+    entry: TransceiverDetailEntry,
+) -> bool:
+    """Handle calibration header, diagnostic rows, and fault count.
+
+    Returns True if the line was consumed.
+    """
+    cal_match = _CALIBRATION_PATTERN.search(stripped)
+    if cal_match:
+        entry["calibration"] = cal_match.group("cal")
+        return True
+
+    diag_match = _DIAG_ROW_PATTERN.match(stripped)
+    if diag_match:
+        entry_key = _DIAG_FIELD_MAP.get(diag_match.group("field"))
+        if entry_key:
+            reading = _build_diagnostic_reading(diag_match)
+            entry[entry_key] = reading  # type: ignore[literal-required]
+        return True
+
+    tx_fault_match = _TX_FAULT_PATTERN.match(stripped)
+    if tx_fault_match:
+        entry["transmit_fault_count"] = int(tx_fault_match.group("count"))
+        return True
+
+    return False
+
+
+def _handle_link_length(
+    stripped: str,
+    entry: TransceiverDetailEntry,
+) -> bool:
+    """Handle link length lines.
+
+    Returns True if the line was consumed.
+    """
+    link_match = _LINK_LENGTH_PATTERN.match(stripped)
+    if not link_match:
+        return False
+    if "link_lengths" not in entry:
+        entry["link_lengths"] = {}
+    entry["link_lengths"][link_match.group("fiber").strip()] = link_match.group(
+        "distance"
+    ).strip()
+    return True
+
+
+def _handle_identification(
+    stripped: str,
+    state: _ParseState,
+) -> bool:
+    """Handle key-value identification fields.
+
+    Returns True if the line was consumed.
+    """
+    kv_match = _KV_PATTERN.match(stripped)
+    if not kv_match:
+        return False
+    raw_key = kv_match.group("key").strip().lower()
+    raw_value = kv_match.group("value").strip()
+    mapped_key = _IDENTIFICATION_KEY_MAP.get(raw_key)
+    if not mapped_key:
+        return False
+
+    # "type" initialises the entry
+    if mapped_key == "type" and state.current_entry is None:
+        state.current_entry = TransceiverDetailEntry(
+            type=raw_value,
+            name="",
+            part_number="",
+            revision="",
+            serial_number="",
+        )
+        return True
+
+    if state.current_entry is None:
+        return True
+
+    if mapped_key == "nominal_bitrate_mbps":
+        bitrate = _parse_bitrate(raw_value)
+        if bitrate is not None:
+            state.current_entry["nominal_bitrate_mbps"] = bitrate
+    else:
+        state.current_entry[mapped_key] = raw_value  # type: ignore[literal-required]
+    return True
+
+
+def _process_line(stripped: str, state: _ParseState) -> None:
+    """Process a single stripped line, updating parser state."""
+    if _handle_interface_header(stripped, state):
+        return
+    if _handle_presence(stripped, state):
+        return
+    if not state.current_intf:
+        return
+    if state.current_entry is not None:
+        if _handle_diagnostics(stripped, state.current_entry):
+            return
+        if _handle_link_length(stripped, state.current_entry):
+            return
+    _handle_identification(stripped, state)
+
+
+@register(OS.CISCO_NXOS, "show interface transceiver details")
+class ShowInterfaceTransceiverDetailsParser(
+    BaseParser[ShowInterfaceTransceiverDetailsResult],
+):
+    """Parser for 'show interface transceiver details' on NX-OS.
+
+    Parses per-interface transceiver identification and DOM diagnostic
+    data including temperature, voltage, current, Tx power, and Rx power
+    with alarm and warning thresholds.
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfaceTransceiverDetailsResult:
+        """Parse 'show interface transceiver details' output on NX-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed transceiver detail data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no transceiver detail entries found.
+        """
+        state = _ParseState()
+
+        for line in output.splitlines():
+            _process_line(line.strip(), state)
+
+        state.save_current()
+
+        if not state.interfaces:
+            msg = "No transceiver detail entries found in output"
+            raise ValueError(msg)
+
+        return ShowInterfaceTransceiverDetailsResult(
+            interfaces=state.interfaces,
+        )

--- a/tests/parsers/nxos/show_interface_transceiver_details/001_basic/expected.json
+++ b/tests/parsers/nxos/show_interface_transceiver_details/001_basic/expected.json
@@ -1,0 +1,177 @@
+{
+    "interfaces": {
+        "Ethernet1/1": {
+            "type": "QSFP-40G-SR-BD",
+            "name": "CISCO-AVAGO",
+            "part_number": "AFBR-79EQDZ-CS1",
+            "revision": "01",
+            "serial_number": "AVE204600M7",
+            "nominal_bitrate_mbps": 10300,
+            "link_lengths": {
+                "50/125um OM3 fiber": "100 m(s)",
+                "50/125um OM4 fiber": "150 m(s)"
+            },
+            "cisco_id": "13",
+            "cisco_extended_id": "204",
+            "cisco_part_number": "10-3198-01",
+            "cisco_product_id": "QSFP-40G-SR-BD",
+            "cisco_version_id": "V01",
+            "calibration": "internal calibration",
+            "temperature": {
+                "current": 35.41,
+                "alarm_high": 75.0,
+                "alarm_low": -5.0,
+                "warning_high": 70.0,
+                "warning_low": 0.0
+            },
+            "voltage": {
+                "current": 3.28,
+                "alarm_high": 3.63,
+                "alarm_low": 2.97,
+                "warning_high": 3.46,
+                "warning_low": 3.13
+            },
+            "current": {
+                "current": 6.84,
+                "alarm_high": 10.0,
+                "alarm_low": 0.5,
+                "warning_high": 9.0,
+                "warning_low": 1.0
+            },
+            "tx_power": {
+                "current": -2.48,
+                "alarm_high": 1.99,
+                "alarm_low": -6.0,
+                "warning_high": 0.99,
+                "warning_low": -5.0
+            },
+            "rx_power": {
+                "current": -2.2,
+                "alarm_high": 1.99,
+                "alarm_low": -20.0,
+                "warning_high": 0.99,
+                "warning_low": -17.0
+            },
+            "transmit_fault_count": 0
+        },
+        "Ethernet1/2": {
+            "type": "SFP-10G-SR",
+            "name": "CISCO-FINISAR",
+            "part_number": "FTLX8574D3BCL-C2",
+            "revision": "A",
+            "serial_number": "FNS17451GUE",
+            "nominal_bitrate_mbps": 10300,
+            "link_lengths": {
+                "50/125um OM3 fiber": "300 m(s)"
+            },
+            "cisco_id": "3",
+            "cisco_extended_id": "4",
+            "cisco_part_number": "10-2415-03",
+            "cisco_product_id": "SFP-10G-SR",
+            "cisco_version_id": "V03",
+            "calibration": "internal calibration",
+            "temperature": {
+                "current": 28.12,
+                "alarm_high": 75.0,
+                "alarm_low": -5.0,
+                "warning_high": 70.0,
+                "warning_low": 0.0
+            },
+            "voltage": {
+                "current": 3.3,
+                "alarm_high": 3.63,
+                "alarm_low": 2.97,
+                "warning_high": 3.46,
+                "warning_low": 3.13
+            },
+            "current": {
+                "current": 8.22,
+                "alarm_high": 12.0,
+                "alarm_low": 1.0,
+                "warning_high": 11.0,
+                "warning_low": 2.0
+            },
+            "tx_power": {
+                "current": -1.99,
+                "alarm_high": 1.99,
+                "alarm_low": -6.0,
+                "warning_high": 0.99,
+                "warning_low": -5.0
+            },
+            "rx_power": {
+                "current": -1.45,
+                "alarm_high": 1.99,
+                "alarm_low": -26.98,
+                "warning_high": 0.99,
+                "warning_low": -25.22
+            },
+            "transmit_fault_count": 0
+        },
+        "Ethernet1/4": {
+            "type": "SFP-H10GB-CU3M",
+            "name": "CISCO",
+            "part_number": "SFP-H10GB-CU3M",
+            "revision": "V02",
+            "serial_number": "MDM172702GX",
+            "nominal_bitrate_mbps": 10300,
+            "cisco_id": "3",
+            "cisco_extended_id": "4",
+            "cisco_part_number": "37-0961-03",
+            "cisco_product_id": "SFP-H10GB-CU3M",
+            "cisco_version_id": "V02"
+        },
+        "Ethernet2/1": {
+            "type": "GLC-BX40-D-I",
+            "name": "CISCO-EDGE",
+            "part_number": "BIDI1GSFP41BDSCI",
+            "revision": "A",
+            "serial_number": "EO12408230007",
+            "nominal_bitrate_mbps": 1300,
+            "link_lengths": {
+                "9/125um fiber": "40 km"
+            },
+            "cisco_id": "3",
+            "cisco_extended_id": "4",
+            "cisco_part_number": "10-2940-01",
+            "cisco_product_id": "GLC-BX40-D-I",
+            "cisco_version_id": "V01",
+            "calibration": "internal calibration",
+            "temperature": {
+                "current": 34.41,
+                "alarm_high": 90.0,
+                "alarm_low": -45.0,
+                "warning_high": 85.0,
+                "warning_low": -40.0
+            },
+            "voltage": {
+                "current": 3.22,
+                "alarm_high": 3.8,
+                "alarm_low": 2.7,
+                "warning_high": 3.7,
+                "warning_low": 2.8
+            },
+            "current": {
+                "current": 9.89,
+                "alarm_high": 100.0,
+                "alarm_low": 0.0,
+                "warning_high": 90.0,
+                "warning_low": 0.1
+            },
+            "tx_power": {
+                "current": -1.29,
+                "alarm_high": 0.99,
+                "alarm_low": -6.0,
+                "warning_high": 0.0,
+                "warning_low": -5.0
+            },
+            "rx_power": {
+                "current": -9.26,
+                "alarm_high": 0.99,
+                "alarm_low": -26.98,
+                "warning_high": 0.0,
+                "warning_low": -25.22
+            },
+            "transmit_fault_count": 0
+        }
+    }
+}

--- a/tests/parsers/nxos/show_interface_transceiver_details/001_basic/input.txt
+++ b/tests/parsers/nxos/show_interface_transceiver_details/001_basic/input.txt
@@ -1,0 +1,104 @@
+Ethernet1/1
+    transceiver is present
+    type is QSFP-40G-SR-BD
+    name is CISCO-AVAGO
+    part number is AFBR-79EQDZ-CS1
+    revision is 01
+    serial number is AVE204600M7
+    nominal bitrate is 10300 MBits/sec
+    Link length supported for 50/125um OM3 fiber is 100 m(s)
+    Link length supported for 50/125um OM4 fiber is 150 m(s)
+    cisco id is 13
+    cisco extended id number is 204
+    cisco part number is 10-3198-01
+    cisco product id is QSFP-40G-SR-BD
+    cisco version id is V01
+
+    SFP Detail Diagnostics Information (internal calibration)
+    ----------------------------------------------------------------------------
+                  Current              Alarms                  Warnings
+                  Measurement     High        Low         High          Low
+    ----------------------------------------------------------------------------
+    Temperature   35.41 C        75.00 C     -5.00 C     70.00 C       0.00 C
+    Voltage        3.28 V         3.63 V      2.97 V      3.46 V       3.13 V
+    Current        6.84 mA       10.00 mA     0.50 mA     9.00 mA      1.00 mA
+    Tx Power      -2.48 dBm       1.99 dBm   -6.00 dBm   0.99 dBm    -5.00 dBm
+    Rx Power      -2.20 dBm       1.99 dBm  -20.00 dBm   0.99 dBm   -17.00 dBm
+    Transmit Fault Count = 0
+    ----------------------------------------------------------------------------
+    Note: ++ high-alarm; + high-warning; -- low-alarm; - low-warning
+
+Ethernet1/2
+    transceiver is present
+    type is SFP-10G-SR
+    name is CISCO-FINISAR
+    part number is FTLX8574D3BCL-C2
+    revision is A
+    serial number is FNS17451GUE
+    nominal bitrate is 10300 MBits/sec
+    Link length supported for 50/125um OM3 fiber is 300 m(s)
+    cisco id is 3
+    cisco extended id number is 4
+    cisco part number is 10-2415-03
+    cisco product id is SFP-10G-SR
+    cisco version id is V03
+
+    SFP Detail Diagnostics Information (internal calibration)
+    ----------------------------------------------------------------------------
+                  Current              Alarms                  Warnings
+                  Measurement     High        Low         High          Low
+    ----------------------------------------------------------------------------
+    Temperature   28.12 C        75.00 C     -5.00 C     70.00 C       0.00 C
+    Voltage        3.30 V         3.63 V      2.97 V      3.46 V       3.13 V
+    Current        8.22 mA       12.00 mA     1.00 mA    11.00 mA      2.00 mA
+    Tx Power      -1.99 dBm       1.99 dBm   -6.00 dBm   0.99 dBm    -5.00 dBm
+    Rx Power      -1.45 dBm       1.99 dBm  -26.98 dBm   0.99 dBm   -25.22 dBm
+    Transmit Fault Count = 0
+    ----------------------------------------------------------------------------
+    Note: ++ high-alarm; + high-warning; -- low-alarm; - low-warning
+
+Ethernet1/3
+    transceiver is not present
+
+Ethernet1/4
+    transceiver is present
+    type is SFP-H10GB-CU3M
+    name is CISCO
+    part number is SFP-H10GB-CU3M
+    revision is V02
+    serial number is MDM172702GX
+    nominal bitrate is 10300 MBits/sec
+    cisco id is 3
+    cisco extended id number is 4
+    cisco part number is 37-0961-03
+    cisco product id is SFP-H10GB-CU3M
+    cisco version id is V02
+
+Ethernet2/1
+    transceiver is present
+    type is GLC-BX40-D-I
+    name is CISCO-EDGE
+    part number is BIDI1GSFP41BDSCI
+    revision is A
+    serial number is EO12408230007
+    nominal bitrate is 1300 MBits/sec
+    Link length supported for 9/125um fiber is 40 km
+    cisco id is 3
+    cisco extended id number is 4
+    cisco part number is 10-2940-01
+    cisco product id is GLC-BX40-D-I
+    cisco version id is V01
+
+    SFP Detail Diagnostics Information (internal calibration)
+    ----------------------------------------------------------------------------
+                  Current              Alarms                  Warnings
+                  Measurement     High        Low         High          Low
+    ----------------------------------------------------------------------------
+    Temperature   34.41 C        90.00 C    -45.00 C     85.00 C     -40.00 C
+    Voltage        3.22 V         3.80 V      2.70 V      3.70 V       2.80 V
+    Current        9.89 mA      100.00 mA     0.00 mA    90.00 mA      0.10 mA
+    Tx Power      -1.29 dBm       0.99 dBm   -6.00 dBm   0.00 dBm    -5.00 dBm
+    Rx Power      -9.26 dBm       0.99 dBm  -26.98 dBm   0.00 dBm   -25.22 dBm
+    Transmit Fault Count = 0
+    ----------------------------------------------------------------------------
+    Note: ++ high-alarm; + high-warning; -- low-alarm; - low-warning

--- a/tests/parsers/nxos/show_interface_transceiver_details/001_basic/metadata.yaml
+++ b/tests/parsers/nxos/show_interface_transceiver_details/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces with SFP and QSFP transceivers including DDM diagnostics
+platform: Nexus 9000
+software_version: NX-OS


### PR DESCRIPTION
## Summary
- Add parser for `show interface transceiver details` on NX-OS
- Parses per-interface transceiver identification fields (type, name, part number, serial number, nominal bitrate, link lengths, Cisco IDs) and DOM diagnostic readings (temperature, voltage, current, Tx power, Rx power) with alarm and warning thresholds
- Interfaces with no transceiver present are excluded; copper SFPs without DDM diagnostics are included with identification fields only

Closes #269

## Test plan
- [x] Golden test `001_basic` covering multiple interfaces: QSFP with multi-fiber link lengths, SFP-10G with DDM, absent transceiver (skipped), copper SFP without DDM, SFP with single-mode fiber
- [x] `uv run pytest` passes
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A` passes
- [x] `uv run pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)