### PR TITLE
feat: add parser for 'show tacacs' on IOS

### DIFF
--- a/changes/526.parser_added
+++ b/changes/526.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show tacacs` on IOS.

--- a/src/muninn/parsers/ios/show_tacacs.py
+++ b/src/muninn/parsers/ios/show_tacacs.py
@@ -1,0 +1,189 @@
+"""Parser for 'show tacacs' command on IOS."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class TacacsServerEntry(TypedDict):
+    """Schema for a single TACACS+ server entry."""
+
+    server_port: int
+    socket_opens: int
+    socket_closes: int
+    socket_aborts: int
+    socket_errors: int
+    socket_timeouts: int
+    failed_connect_attempts: int
+    total_packets_sent: int
+    total_packets_recv: int
+    server_name: NotRequired[str]
+    server_status: NotRequired[str]
+    authc_fail_count: NotRequired[int]
+    authz_fail_count: NotRequired[int]
+
+
+class ShowTacacsResult(TypedDict):
+    """Schema for 'show tacacs' parsed output."""
+
+    servers: dict[str, TacacsServerEntry]
+
+
+# Matches the server block header
+_BLOCK_SEPARATOR = re.compile(r"^Tacacs\+\s+Server\s+-\s+\S+", re.IGNORECASE)
+
+# Field patterns mapping regex to (key, should_convert_to_int)
+_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str, bool], ...] = (
+    (re.compile(r"^\s*Server\s+name:\s+(?P<val>\S+)$"), "server_name", False),
+    (re.compile(r"^\s*Server\s+address:\s+(?P<val>\S+)$"), "server_address", False),
+    (re.compile(r"^\s*Server\s+port:\s+(?P<val>\d+)$"), "server_port", True),
+    (re.compile(r"^\s*Socket\s+opens:\s+(?P<val>\d+)$"), "socket_opens", True),
+    (re.compile(r"^\s*Socket\s+closes:\s+(?P<val>\d+)$"), "socket_closes", True),
+    (re.compile(r"^\s*Socket\s+aborts:\s+(?P<val>\d+)$"), "socket_aborts", True),
+    (re.compile(r"^\s*Socket\s+errors:\s+(?P<val>\d+)$"), "socket_errors", True),
+    (re.compile(r"^\s*Socket\s+Timeouts:\s+(?P<val>\d+)$"), "socket_timeouts", True),
+    (
+        re.compile(r"^\s*Failed\s+Connect\s+Attempts:\s+(?P<val>\d+)$"),
+        "failed_connect_attempts",
+        True,
+    ),
+    (
+        re.compile(r"^\s*Total\s+Packets\s+Sent:\s+(?P<val>\d+)$"),
+        "total_packets_sent",
+        True,
+    ),
+    (
+        re.compile(r"^\s*Total\s+Packets\s+Recv:\s+(?P<val>\d+)$"),
+        "total_packets_recv",
+        True,
+    ),
+    (re.compile(r"^\s*Server\s+Status:\s+(?P<val>\S+)$"), "server_status", False),
+    (
+        re.compile(r"^\s*Continous\s+Authc\s+fail\s+count:\s+(?P<val>\d+)$"),
+        "authc_fail_count",
+        True,
+    ),
+    (
+        re.compile(r"^\s*Continous\s+Authz\s+fail\s+count:\s+(?P<val>\d+)$"),
+        "authz_fail_count",
+        True,
+    ),
+)
+
+# Required integer fields present in every server block
+_REQUIRED_INT_KEYS = (
+    "server_port",
+    "socket_opens",
+    "socket_closes",
+    "socket_aborts",
+    "socket_errors",
+    "socket_timeouts",
+    "failed_connect_attempts",
+    "total_packets_sent",
+    "total_packets_recv",
+)
+
+# Optional fields and their types (str or int)
+_OPTIONAL_STR_KEYS = ("server_name", "server_status")
+_OPTIONAL_INT_KEYS = ("authc_fail_count", "authz_fail_count")
+
+
+def _extract_fields(lines: list[str]) -> dict[str, str | int]:
+    """Extract all recognized fields from a block of lines."""
+    fields: dict[str, str | int] = {}
+    for line in lines:
+        for pattern, key, is_int in _FIELD_PATTERNS:
+            if match := pattern.match(line):
+                raw_val = match.group("val")
+                fields[key] = int(raw_val) if is_int else raw_val
+                break
+    return fields
+
+
+def _build_entry(fields: dict[str, str | int]) -> TacacsServerEntry:
+    """Build a TacacsServerEntry from extracted fields."""
+    entry = TacacsServerEntry(**{k: int(fields[k]) for k in _REQUIRED_INT_KEYS})  # type: ignore[typeddict-item]
+    for key in _OPTIONAL_STR_KEYS:
+        if key in fields:
+            entry[key] = str(fields[key])  # type: ignore[literal-required]
+    for key in _OPTIONAL_INT_KEYS:
+        if key in fields:
+            entry[key] = int(fields[key])  # type: ignore[literal-required]
+    return entry
+
+
+def _parse_block(lines: list[str]) -> tuple[str, TacacsServerEntry] | None:
+    """Parse a single TACACS+ server block into an (address, entry) tuple."""
+    fields = _extract_fields(lines)
+
+    if "server_address" not in fields or not all(
+        k in fields for k in _REQUIRED_INT_KEYS
+    ):
+        return None
+
+    address = str(fields["server_address"])
+    return address, _build_entry(fields)
+
+
+@register(OS.CISCO_IOS, "show tacacs")
+class ShowTacacsParser(BaseParser[ShowTacacsResult]):
+    """Parser for 'show tacacs' command.
+
+    Example output:
+        Tacacs+ Server -  public  :
+                    Server address: 10.1.1.140
+                       Server port: 49
+                      Socket opens:     138084
+                     Socket closes:     137992
+                     Socket aborts:          0
+                     Socket errors:          0
+                   Socket Timeouts:         59
+           Failed Connect Attempts:         52
+                Total Packets Sent:     147753
+                Total Packets Recv:     147693
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowTacacsResult:
+        """Parse 'show tacacs' output.
+
+        Args:
+            output: Raw CLI output from 'show tacacs' command.
+
+        Returns:
+            Parsed TACACS+ server data keyed by server address.
+
+        Raises:
+            ValueError: If no TACACS+ server entries found.
+        """
+        servers: dict[str, TacacsServerEntry] = {}
+
+        # Split output into blocks by server header lines
+        blocks: list[list[str]] = []
+        current_block: list[str] = []
+
+        for line in output.splitlines():
+            if _BLOCK_SEPARATOR.match(line.strip()):
+                if current_block:
+                    blocks.append(current_block)
+                current_block = []
+            else:
+                current_block.append(line)
+
+        if current_block:
+            blocks.append(current_block)
+
+        for block in blocks:
+            result = _parse_block(block)
+            if result is not None:
+                address, entry = result
+                servers[address] = entry
+
+        if not servers:
+            msg = "No TACACS+ server entries found in output"
+            raise ValueError(msg)
+
+        return ShowTacacsResult(servers=servers)

--- a/tests/parsers/ios/show_tacacs/001_basic/expected.json
+++ b/tests/parsers/ios/show_tacacs/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "servers": {
+        "10.1.1.140": {
+            "server_port": 49,
+            "socket_opens": 138084,
+            "socket_closes": 137992,
+            "socket_aborts": 0,
+            "socket_errors": 0,
+            "socket_timeouts": 59,
+            "failed_connect_attempts": 52,
+            "total_packets_sent": 147753,
+            "total_packets_recv": 147693
+        },
+        "10.2.1.140": {
+            "server_port": 49,
+            "socket_opens": 2027,
+            "socket_closes": 2027,
+            "socket_aborts": 0,
+            "socket_errors": 0,
+            "socket_timeouts": 0,
+            "failed_connect_attempts": 2,
+            "total_packets_sent": 2053,
+            "total_packets_recv": 2053
+        }
+    }
+}

--- a/tests/parsers/ios/show_tacacs/001_basic/input.txt
+++ b/tests/parsers/ios/show_tacacs/001_basic/input.txt
@@ -1,0 +1,24 @@
+Tacacs+ Server -  public  :
+            Server address: 10.1.1.140
+               Server port: 49
+              Socket opens:     138084
+             Socket closes:     137992
+             Socket aborts:          0
+             Socket errors:          0
+           Socket Timeouts:         59
+   Failed Connect Attempts:         52
+        Total Packets Sent:     147753
+        Total Packets Recv:     147693
+
+
+Tacacs+ Server -  public  :
+            Server address: 10.2.1.140
+               Server port: 49
+              Socket opens:       2027
+             Socket closes:       2027
+             Socket aborts:          0
+             Socket errors:          0
+           Socket Timeouts:          0
+   Failed Connect Attempts:          2
+        Total Packets Sent:       2053
+        Total Packets Recv:       2053

--- a/tests/parsers/ios/show_tacacs/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_tacacs/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with two TACACS+ servers
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_tacacs/002_with_server_names/expected.json
+++ b/tests/parsers/ios/show_tacacs/002_with_server_names/expected.json
@@ -1,0 +1,28 @@
+{
+    "servers": {
+        "10.1.1.141": {
+            "server_port": 49,
+            "socket_opens": 146715,
+            "socket_closes": 146715,
+            "socket_aborts": 0,
+            "socket_errors": 0,
+            "socket_timeouts": 0,
+            "failed_connect_attempts": 114,
+            "total_packets_sent": 166094,
+            "total_packets_recv": 166094,
+            "server_name": "TACACS_ABC"
+        },
+        "10.2.1.141": {
+            "server_port": 49,
+            "socket_opens": 2640,
+            "socket_closes": 2640,
+            "socket_aborts": 0,
+            "socket_errors": 0,
+            "socket_timeouts": 0,
+            "failed_connect_attempts": 0,
+            "total_packets_sent": 2954,
+            "total_packets_recv": 2953,
+            "server_name": "TACACS_XYZ"
+        }
+    }
+}

--- a/tests/parsers/ios/show_tacacs/002_with_server_names/input.txt
+++ b/tests/parsers/ios/show_tacacs/002_with_server_names/input.txt
@@ -1,0 +1,26 @@
+Tacacs+ Server -  public  :
+               Server name: TACACS_ABC
+            Server address: 10.1.1.141
+               Server port: 49
+              Socket opens:     146715
+             Socket closes:     146715
+             Socket aborts:          0
+             Socket errors:          0
+           Socket Timeouts:          0
+   Failed Connect Attempts:        114
+        Total Packets Sent:     166094
+        Total Packets Recv:     166094
+
+
+Tacacs+ Server -  public  :
+               Server name: TACACS_XYZ
+            Server address: 10.2.1.141
+               Server port: 49
+              Socket opens:       2640
+             Socket closes:       2640
+             Socket aborts:          0
+             Socket errors:          0
+           Socket Timeouts:          0
+   Failed Connect Attempts:          0
+        Total Packets Sent:       2954
+        Total Packets Recv:       2953

--- a/tests/parsers/ios/show_tacacs/002_with_server_names/metadata.yaml
+++ b/tests/parsers/ios/show_tacacs/002_with_server_names/metadata.yaml
@@ -1,0 +1,3 @@
+description: Output with named TACACS+ servers
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_tacacs/003_with_status_and_fail_counts/expected.json
+++ b/tests/parsers/ios/show_tacacs/003_with_status_and_fail_counts/expected.json
@@ -1,0 +1,34 @@
+{
+    "servers": {
+        "10.20.30.1": {
+            "server_port": 49,
+            "socket_opens": 21752,
+            "socket_closes": 21752,
+            "socket_aborts": 0,
+            "socket_errors": 0,
+            "socket_timeouts": 0,
+            "failed_connect_attempts": 52,
+            "total_packets_sent": 23450,
+            "total_packets_recv": 23439,
+            "server_name": "TACACS_1",
+            "server_status": "Alive",
+            "authc_fail_count": 2,
+            "authz_fail_count": 0
+        },
+        "10.20.30.2": {
+            "server_port": 49,
+            "socket_opens": 169,
+            "socket_closes": 169,
+            "socket_aborts": 0,
+            "socket_errors": 0,
+            "socket_timeouts": 0,
+            "failed_connect_attempts": 0,
+            "total_packets_sent": 174,
+            "total_packets_recv": 174,
+            "server_name": "TACACS_2",
+            "server_status": "Alive",
+            "authc_fail_count": 0,
+            "authz_fail_count": 0
+        }
+    }
+}

--- a/tests/parsers/ios/show_tacacs/003_with_status_and_fail_counts/input.txt
+++ b/tests/parsers/ios/show_tacacs/003_with_status_and_fail_counts/input.txt
@@ -1,0 +1,32 @@
+Tacacs+ Server -  public  :
+               Server name: TACACS_1
+            Server address: 10.20.30.1
+               Server port: 49
+              Socket opens:      21752
+             Socket closes:      21752
+             Socket aborts:          0
+             Socket errors:          0
+           Socket Timeouts:          0
+   Failed Connect Attempts:         52
+        Total Packets Sent:      23450
+        Total Packets Recv:      23439
+             Server Status: Alive
+Continous Authc fail count:          2
+Continous Authz fail count:          0
+
+
+Tacacs+ Server -  public  :
+               Server name: TACACS_2
+            Server address: 10.20.30.2
+               Server port: 49
+              Socket opens:        169
+             Socket closes:        169
+             Socket aborts:          0
+             Socket errors:          0
+           Socket Timeouts:          0
+   Failed Connect Attempts:          0
+        Total Packets Sent:        174
+        Total Packets Recv:        174
+             Server Status: Alive
+Continous Authc fail count:          0
+Continous Authz fail count:          0

--- a/tests/parsers/ios/show_tacacs/003_with_status_and_fail_counts/metadata.yaml
+++ b/tests/parsers/ios/show_tacacs/003_with_status_and_fail_counts/metadata.yaml
@@ -1,0 +1,3 @@
+description: Output with server status and authentication/authorization fail counts
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show tacacs` command on Cisco IOS (`OS.CISCO_IOS`)
- Parses TACACS+ server statistics keyed by server address
- Supports optional fields: server name, server status, authentication/authorization fail counts
- Includes 3 test cases covering basic output, named servers, and status with fail counts

Closes #273

## Test plan
- [x] 001_basic: Two servers without names or status fields
- [x] 002_with_server_names: Two servers with `Server name` field
- [x] 003_with_status_and_fail_counts: Two servers with status and authc/authz fail counts
- [x] All quality checks pass (ruff check, ruff format, xenon, pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)