### PR TITLE
feat: add parser for 'show authentication sessions method details' on IOS

### DIFF
--- a/changes/529.parser_added
+++ b/changes/529.parser_added
@@ -1,0 +1,1 @@
+Added parser support for IOS `show authentication sessions method details`.

--- a/src/muninn/parsers/ios/show_authentication_sessions_method_details.py
+++ b/src/muninn/parsers/ios/show_authentication_sessions_method_details.py
@@ -52,6 +52,9 @@ class SessionEntry(TypedDict):
     resultant_policy_sgt: NotRequired[int]
 
 
+ShowAuthenticationSessionsMethodDetailsResult = dict[str, list[SessionEntry]]
+
+
 # --- Session block separator ---
 _BLOCK_SEPARATOR_RE = re.compile(r"^-{3,}$")
 
@@ -291,7 +294,7 @@ def _parse_block(lines: list[str]) -> tuple[str, SessionEntry] | None:
     """Parse a single session block.
 
     Returns:
-        Tuple of (common_session_id, entry) or None if unparseable.
+        Tuple of (interface_name, entry) or None if unparseable.
     """
     if not lines or not any(line.strip() for line in lines):
         return None
@@ -299,43 +302,43 @@ def _parse_block(lines: list[str]) -> tuple[str, SessionEntry] | None:
     entry: dict = {}
     _parse_session_fields(lines, entry)
 
-    if "common_session_id" not in entry:
+    if "interface" not in entry:
         return None
 
     _parse_sections(lines, entry)
 
-    session_id = entry["common_session_id"]
-    return session_id, entry  # type: ignore[return-value]
+    interface = entry["interface"]
+    return interface, entry  # type: ignore[return-value]
 
 
 @register(OS.CISCO_IOS, "show authentication sessions method details")
 class ShowAuthenticationSessionsMethodDetailsParser(
-    BaseParser["dict[str, SessionEntry]"],
+    BaseParser[ShowAuthenticationSessionsMethodDetailsResult],
 ):
     """Parser for 'show authentication sessions method details' on IOS."""
 
     @classmethod
-    def parse(cls, output: str) -> dict[str, SessionEntry]:
+    def parse(cls, output: str) -> ShowAuthenticationSessionsMethodDetailsResult:
         """Parse 'show authentication sessions method details' output.
 
         Args:
             output: Raw CLI output from command.
 
         Returns:
-            Parsed authentication session details keyed by Common Session ID.
+            Parsed authentication session details keyed by interface name.
 
         Raises:
             ValueError: If no authentication session entries found in output.
         """
         blocks = _split_session_blocks(output)
-        sessions: dict[str, SessionEntry] = {}
+        sessions: ShowAuthenticationSessionsMethodDetailsResult = {}
 
         for block_lines in blocks:
             result = _parse_block(block_lines)
             if result is None:
                 continue
-            session_id, entry = result
-            sessions[session_id] = entry
+            interface, entry = result
+            sessions.setdefault(interface, []).append(entry)
 
         if not sessions:
             msg = "No authentication session entries found in output"

--- a/src/muninn/parsers/ios/show_authentication_sessions_method_details.py
+++ b/src/muninn/parsers/ios/show_authentication_sessions_method_details.py
@@ -52,7 +52,7 @@ class SessionEntry(TypedDict):
     resultant_policy_sgt: NotRequired[int]
 
 
-ShowAuthenticationSessionsMethodDetailsResult = dict[str, list[SessionEntry]]
+ShowAuthenticationSessionsMethodDetailsResult = dict[str, dict[str, SessionEntry]]
 
 
 # --- Session block separator ---
@@ -290,11 +290,11 @@ def _parse_sections(lines: list[str], entry: dict) -> None:
         entry["methods"] = {}
 
 
-def _parse_block(lines: list[str]) -> tuple[str, SessionEntry] | None:
+def _parse_block(lines: list[str]) -> tuple[str, str, SessionEntry] | None:
     """Parse a single session block.
 
     Returns:
-        Tuple of (interface_name, entry) or None if unparseable.
+        Tuple of (interface_name, session_id, entry) or None if unparseable.
     """
     if not lines or not any(line.strip() for line in lines):
         return None
@@ -302,13 +302,14 @@ def _parse_block(lines: list[str]) -> tuple[str, SessionEntry] | None:
     entry: dict = {}
     _parse_session_fields(lines, entry)
 
-    if "interface" not in entry:
+    if "interface" not in entry or "common_session_id" not in entry:
         return None
 
     _parse_sections(lines, entry)
 
     interface = entry["interface"]
-    return interface, entry  # type: ignore[return-value]
+    session_id = entry["common_session_id"]
+    return interface, session_id, entry  # type: ignore[return-value]
 
 
 @register(OS.CISCO_IOS, "show authentication sessions method details")
@@ -337,8 +338,8 @@ class ShowAuthenticationSessionsMethodDetailsParser(
             result = _parse_block(block_lines)
             if result is None:
                 continue
-            interface, entry = result
-            sessions.setdefault(interface, []).append(entry)
+            interface, session_id, entry = result
+            sessions.setdefault(interface, {})[session_id] = entry
 
         if not sessions:
             msg = "No authentication session entries found in output"

--- a/src/muninn/parsers/ios/show_authentication_sessions_method_details.py
+++ b/src/muninn/parsers/ios/show_authentication_sessions_method_details.py
@@ -1,0 +1,344 @@
+"""Parser for 'show authentication sessions method details' command on IOS."""
+
+import re
+from collections.abc import Callable
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class MethodEntry(TypedDict):
+    """Schema for a single authentication method status."""
+
+    method: str
+    state: str
+
+
+class SessionEntry(TypedDict):
+    """Schema for a single authentication session."""
+
+    interface: str
+    iif_id: str
+    mac_address: str
+    ipv4_address: str
+    user_name: str
+    status: str
+    domain: str
+    oper_host_mode: str
+    oper_control_dir: str
+    current_policy: str
+    common_session_id: str
+    acct_session_id: str
+    handle: str
+    methods: dict[str, MethodEntry]
+    ipv6_address: NotRequired[str]
+    device_type: NotRequired[str]
+    device_name: NotRequired[str]
+    session_timeout: NotRequired[int]
+    session_timeout_remaining: NotRequired[int]
+    timeout_action: NotRequired[str]
+    acct_update_timeout: NotRequired[int]
+    acct_update_remaining: NotRequired[int]
+    server_policy_vn: NotRequired[str]
+    server_policy_vlan: NotRequired[int]
+    server_policy_sgt: NotRequired[int]
+    server_policy_session_timeout: NotRequired[int]
+    server_policy_template: NotRequired[str]
+    resultant_policy_vn: NotRequired[str]
+    resultant_policy_vlan: NotRequired[int]
+    resultant_policy_sgt: NotRequired[int]
+
+
+# --- Session block separator ---
+_BLOCK_SEPARATOR_RE = re.compile(r"^-{3,}$")
+
+# --- Key-value field patterns ---
+_INTERFACE_RE = re.compile(r"^\s*Interface:\s+(\S+)\s*$")
+_IIF_ID_RE = re.compile(r"^\s*IIF-ID:\s+(\S+)\s*$")
+_MAC_RE = re.compile(r"^\s*MAC Address:\s+(\S+)\s*$")
+_IPV6_RE = re.compile(r"^\s*IPv6 Address:\s+(\S+)\s*$")
+_IPV4_RE = re.compile(r"^\s*IPv4 Address:\s+(\S+)\s*$")
+_USER_RE = re.compile(r"^\s*User-Name:\s+(.+?)\s*$")
+_DEVICE_TYPE_RE = re.compile(r"^\s*Device-type:\s+(.+?)\s*$")
+_DEVICE_NAME_RE = re.compile(r"^\s*Device-name:\s+(.+?)\s*$")
+_STATUS_RE = re.compile(r"^\s*Status:\s+(\S+)\s*$")
+_DOMAIN_RE = re.compile(r"^\s*Domain:\s+(\S+)\s*$")
+_HOST_MODE_RE = re.compile(r"^\s*Oper host mode:\s+(\S+)\s*$")
+_CONTROL_DIR_RE = re.compile(r"^\s*Oper control dir:\s+(\S+)\s*$")
+_SESSION_TIMEOUT_RE = re.compile(
+    r"^\s*Session timeout:\s+"
+    r"(?:(\d+)s\s+\(\w+\),\s+Remaining:\s+(\d+)s|(\S+))\s*$"
+)
+_TIMEOUT_ACTION_RE = re.compile(r"^\s*Timeout action:\s+(.+?)\s*$")
+_ACCT_UPDATE_RE = re.compile(
+    r"^\s*Acct update timeout:\s+(\d+)s\s+\(\w+\),\s+Remaining:\s+(\d+)s\s*$"
+)
+_COMMON_SESSION_RE = re.compile(r"^\s*Common Session ID:\s+(\S+)\s*$")
+_ACCT_SESSION_RE = re.compile(r"^\s*Acct Session ID:\s+(\S+)\s*$")
+_HANDLE_RE = re.compile(r"^\s*Handle:\s+(\S+)\s*$")
+_CURRENT_POLICY_RE = re.compile(r"^\s*Current Policy:\s+(\S+)\s*$")
+
+# --- Server/Resultant policy fields ---
+_VN_VALUE_RE = re.compile(r"^\s*VN Value:\s+(\S+)\s*$")
+_VLAN_GROUP_RE = re.compile(r"^\s*Vlan Group:\s+Vlan:\s+(\d+)\s*$")
+_SGT_VALUE_RE = re.compile(r"^\s*SGT Value:\s+(\d+)\s*$")
+_SERVER_SESSION_TIMEOUT_RE = re.compile(r"^\s*Session-Timeout:\s+(\d+)\s+sec\s*$")
+_INTERFACE_TEMPLATE_RE = re.compile(r"^\s*Interface Template:\s+(\S+)\s*$")
+
+# --- Method status ---
+_METHOD_RE = re.compile(r"^\s+(\S+)\s+((?:Authc|Authz)\s+\S+|Stopped|Running)\s*$")
+
+# --- Section headers ---
+_SERVER_POLICIES_RE = re.compile(r"^Server Policies:\s*$")
+_RESULTANT_POLICIES_RE = re.compile(r"^Resultant Policies:\s*$")
+_METHOD_STATUS_RE = re.compile(r"^Method status list:\s*$")
+_METHOD_HEADER_RE = re.compile(r"^\s+Method\s+State\s*$")
+
+_UNKNOWN_IPV6 = "Unknown"
+_UNKNOWN_DEVICE_NAME = "Unknown Device"
+
+
+def _store_interface(m: re.Match[str], entry: dict) -> None:
+    entry["interface"] = canonical_interface_name(m.group(1), os=OS.CISCO_IOS)
+
+
+def _store_ipv6(m: re.Match[str], entry: dict) -> None:
+    if m.group(1) != _UNKNOWN_IPV6:
+        entry["ipv6_address"] = m.group(1)
+
+
+def _store_device_name(m: re.Match[str], entry: dict) -> None:
+    if m.group(1) != _UNKNOWN_DEVICE_NAME:
+        entry["device_name"] = m.group(1)
+
+
+def _store_session_timeout(m: re.Match[str], entry: dict) -> None:
+    if m.group(1) is not None:
+        entry["session_timeout"] = int(m.group(1))
+        entry["session_timeout_remaining"] = int(m.group(2))
+
+
+def _store_acct_update(m: re.Match[str], entry: dict) -> None:
+    entry["acct_update_timeout"] = int(m.group(1))
+    entry["acct_update_remaining"] = int(m.group(2))
+
+
+def _store_str(key: str) -> Callable[[re.Match[str], dict], None]:
+    """Create a handler that stores match group 1 as a string."""
+
+    def handler(m: re.Match[str], entry: dict) -> None:
+        entry[key] = m.group(1)
+
+    return handler
+
+
+# Dispatch table: (pattern, handler) pairs for session field parsing.
+# Evaluated in order; first match wins for each line.
+_SESSION_FIELD_DISPATCH: list[
+    tuple[re.Pattern[str], Callable[[re.Match[str], dict], None]]
+] = [
+    (_INTERFACE_RE, _store_interface),
+    (_IIF_ID_RE, _store_str("iif_id")),
+    (_MAC_RE, _store_str("mac_address")),
+    (_IPV6_RE, _store_ipv6),
+    (_IPV4_RE, _store_str("ipv4_address")),
+    (_USER_RE, _store_str("user_name")),
+    (_DEVICE_TYPE_RE, _store_str("device_type")),
+    (_DEVICE_NAME_RE, _store_device_name),
+    (_STATUS_RE, _store_str("status")),
+    (_DOMAIN_RE, _store_str("domain")),
+    (_HOST_MODE_RE, _store_str("oper_host_mode")),
+    (_CONTROL_DIR_RE, _store_str("oper_control_dir")),
+    (_SESSION_TIMEOUT_RE, _store_session_timeout),
+    (_TIMEOUT_ACTION_RE, _store_str("timeout_action")),
+    (_ACCT_UPDATE_RE, _store_acct_update),
+    (_COMMON_SESSION_RE, _store_str("common_session_id")),
+    (_ACCT_SESSION_RE, _store_str("acct_session_id")),
+    (_HANDLE_RE, _store_str("handle")),
+    (_CURRENT_POLICY_RE, _store_str("current_policy")),
+]
+
+
+def _split_session_blocks(output: str) -> list[list[str]]:
+    """Split output into per-session blocks separated by dashed lines."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+
+    for line in output.splitlines():
+        if _BLOCK_SEPARATOR_RE.match(line.strip()):
+            if current:
+                blocks.append(current)
+                current = []
+            continue
+        current.append(line)
+
+    if current and any(line.strip() for line in current):
+        blocks.append(current)
+
+    return blocks
+
+
+def _parse_session_fields(lines: list[str], entry: dict) -> None:
+    """Parse core session key-value fields via dispatch table."""
+    for line in lines:
+        for pattern, handler in _SESSION_FIELD_DISPATCH:
+            m = pattern.match(line)
+            if m:
+                handler(m, entry)
+                break
+
+
+def _is_section_boundary(stripped: str) -> bool:
+    """Check if a stripped line marks a policy/method section boundary."""
+    return bool(
+        _SERVER_POLICIES_RE.match(stripped)
+        or _RESULTANT_POLICIES_RE.match(stripped)
+        or _METHOD_STATUS_RE.match(stripped)
+    )
+
+
+def _parse_policy_line(line: str, prefix: str, entry: dict) -> None:
+    """Parse a single line within a policy section."""
+    m = _VN_VALUE_RE.match(line)
+    if m:
+        entry[f"{prefix}_vn"] = m.group(1)
+        return
+
+    m = _VLAN_GROUP_RE.match(line)
+    if m:
+        entry[f"{prefix}_vlan"] = int(m.group(1))
+        return
+
+    m = _SGT_VALUE_RE.match(line)
+    if m:
+        # Take the first SGT value only (duplicates appear in output)
+        if f"{prefix}_sgt" not in entry:
+            entry[f"{prefix}_sgt"] = int(m.group(1))
+        return
+
+    m = _SERVER_SESSION_TIMEOUT_RE.match(line)
+    if m:
+        entry[f"{prefix}_session_timeout"] = int(m.group(1))
+        return
+
+    m = _INTERFACE_TEMPLATE_RE.match(line)
+    if m:
+        entry[f"{prefix}_template"] = m.group(1)
+
+
+def _parse_policy_section(
+    lines: list[str],
+    start_idx: int,
+    prefix: str,
+    entry: dict,
+) -> int:
+    """Parse a Server Policies or Resultant Policies section.
+
+    Returns the index after the last consumed line.
+    """
+    idx = start_idx
+    while idx < len(lines):
+        if _is_section_boundary(lines[idx].strip()) and idx > start_idx:
+            break
+        _parse_policy_line(lines[idx], prefix, entry)
+        idx += 1
+
+    return idx
+
+
+def _parse_methods(lines: list[str], start_idx: int, entry: dict) -> None:
+    """Parse Method status list section."""
+    methods: dict[str, MethodEntry] = {}
+
+    for line in lines[start_idx:]:
+        if _METHOD_HEADER_RE.match(line):
+            continue
+        m = _METHOD_RE.match(line)
+        if m:
+            methods[m.group(1)] = MethodEntry(method=m.group(1), state=m.group(2))
+
+    entry["methods"] = methods
+
+
+def _parse_sections(lines: list[str], entry: dict) -> None:
+    """Parse policy sections and method status from a block."""
+    idx = 0
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+
+        if _SERVER_POLICIES_RE.match(stripped):
+            idx = _parse_policy_section(lines, idx + 1, "server_policy", entry)
+            continue
+
+        if _RESULTANT_POLICIES_RE.match(stripped):
+            idx = _parse_policy_section(lines, idx + 1, "resultant_policy", entry)
+            continue
+
+        if _METHOD_STATUS_RE.match(stripped):
+            _parse_methods(lines, idx + 1, entry)
+            break
+
+        idx += 1
+
+    if "methods" not in entry:
+        entry["methods"] = {}
+
+
+def _parse_block(lines: list[str]) -> tuple[str, SessionEntry] | None:
+    """Parse a single session block.
+
+    Returns:
+        Tuple of (common_session_id, entry) or None if unparseable.
+    """
+    if not lines or not any(line.strip() for line in lines):
+        return None
+
+    entry: dict = {}
+    _parse_session_fields(lines, entry)
+
+    if "common_session_id" not in entry:
+        return None
+
+    _parse_sections(lines, entry)
+
+    session_id = entry["common_session_id"]
+    return session_id, entry  # type: ignore[return-value]
+
+
+@register(OS.CISCO_IOS, "show authentication sessions method details")
+class ShowAuthenticationSessionsMethodDetailsParser(
+    BaseParser["dict[str, SessionEntry]"],
+):
+    """Parser for 'show authentication sessions method details' on IOS."""
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, SessionEntry]:
+        """Parse 'show authentication sessions method details' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed authentication session details keyed by Common Session ID.
+
+        Raises:
+            ValueError: If no authentication session entries found in output.
+        """
+        blocks = _split_session_blocks(output)
+        sessions: dict[str, SessionEntry] = {}
+
+        for block_lines in blocks:
+            result = _parse_block(block_lines)
+            if result is None:
+                continue
+            session_id, entry = result
+            sessions[session_id] = entry
+
+        if not sessions:
+            msg = "No authentication session entries found in output"
+            raise ValueError(msg)
+
+        return sessions

--- a/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/expected.json
@@ -1,39 +1,41 @@
 {
-    "0A4014AC0000002F555FD224": {
-        "interface": "GigabitEthernet1/0/31",
-        "iif_id": "0x18438F31",
-        "mac_address": "cc96.abcd.1234",
-        "ipv4_address": "10.10.10.190",
-        "user_name": "CC-96-AA-BB-CC-DD",
-        "device_type": "Microsoft-Workstation",
-        "device_name": "MOED-9212345",
-        "status": "Authorized",
-        "domain": "DATA",
-        "oper_host_mode": "multi-auth",
-        "oper_control_dir": "both",
-        "session_timeout": 43200,
-        "session_timeout_remaining": 3574,
-        "timeout_action": "Reauthenticate",
-        "acct_update_timeout": 172800,
-        "acct_update_remaining": 89824,
-        "common_session_id": "0A4014AC0000002F555FD224",
-        "acct_session_id": "0x00000027",
-        "handle": "0xe0000025",
-        "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
-        "server_policy_vn": "WALKUPED_VN",
-        "server_policy_session_timeout": 43200,
-        "server_policy_vlan": 1011,
-        "server_policy_template": "PXE-ClosedMode-Template",
-        "server_policy_sgt": 40,
-        "methods": {
-            "dot1x": {
-                "method": "dot1x",
-                "state": "Stopped"
-            },
-            "mab": {
-                "method": "mab",
-                "state": "Authc Success"
+    "GigabitEthernet1/0/31": [
+        {
+            "interface": "GigabitEthernet1/0/31",
+            "iif_id": "0x18438F31",
+            "mac_address": "cc96.abcd.1234",
+            "ipv4_address": "10.10.10.190",
+            "user_name": "CC-96-AA-BB-CC-DD",
+            "device_type": "Microsoft-Workstation",
+            "device_name": "MOED-9212345",
+            "status": "Authorized",
+            "domain": "DATA",
+            "oper_host_mode": "multi-auth",
+            "oper_control_dir": "both",
+            "session_timeout": 43200,
+            "session_timeout_remaining": 3574,
+            "timeout_action": "Reauthenticate",
+            "acct_update_timeout": 172800,
+            "acct_update_remaining": 89824,
+            "common_session_id": "0A4014AC0000002F555FD224",
+            "acct_session_id": "0x00000027",
+            "handle": "0xe0000025",
+            "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
+            "server_policy_vn": "WALKUPED_VN",
+            "server_policy_session_timeout": 43200,
+            "server_policy_vlan": 1011,
+            "server_policy_template": "PXE-ClosedMode-Template",
+            "server_policy_sgt": 40,
+            "methods": {
+                "dot1x": {
+                    "method": "dot1x",
+                    "state": "Stopped"
+                },
+                "mab": {
+                    "method": "mab",
+                    "state": "Authc Success"
+                }
             }
         }
-    }
+    ]
 }

--- a/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/expected.json
@@ -1,0 +1,39 @@
+{
+    "0A4014AC0000002F555FD224": {
+        "interface": "GigabitEthernet1/0/31",
+        "iif_id": "0x18438F31",
+        "mac_address": "cc96.abcd.1234",
+        "ipv4_address": "10.10.10.190",
+        "user_name": "CC-96-AA-BB-CC-DD",
+        "device_type": "Microsoft-Workstation",
+        "device_name": "MOED-9212345",
+        "status": "Authorized",
+        "domain": "DATA",
+        "oper_host_mode": "multi-auth",
+        "oper_control_dir": "both",
+        "session_timeout": 43200,
+        "session_timeout_remaining": 3574,
+        "timeout_action": "Reauthenticate",
+        "acct_update_timeout": 172800,
+        "acct_update_remaining": 89824,
+        "common_session_id": "0A4014AC0000002F555FD224",
+        "acct_session_id": "0x00000027",
+        "handle": "0xe0000025",
+        "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
+        "server_policy_vn": "WALKUPED_VN",
+        "server_policy_session_timeout": 43200,
+        "server_policy_vlan": 1011,
+        "server_policy_template": "PXE-ClosedMode-Template",
+        "server_policy_sgt": 40,
+        "methods": {
+            "dot1x": {
+                "method": "dot1x",
+                "state": "Stopped"
+            },
+            "mab": {
+                "method": "mab",
+                "state": "Authc Success"
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/expected.json
@@ -1,6 +1,6 @@
 {
-    "GigabitEthernet1/0/31": [
-        {
+    "GigabitEthernet1/0/31": {
+        "0A4014AC0000002F555FD224": {
             "interface": "GigabitEthernet1/0/31",
             "iif_id": "0x18438F31",
             "mac_address": "cc96.abcd.1234",
@@ -37,5 +37,5 @@
                 }
             }
         }
-    ]
+    }
 }

--- a/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/input.txt
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/input.txt
@@ -1,0 +1,33 @@
+            Interface:  GigabitEthernet1/0/31
+               IIF-ID:  0x18438F31
+          MAC Address:  cc96.abcd.1234
+         IPv6 Address:  Unknown
+         IPv4 Address:  10.10.10.190
+            User-Name:  CC-96-AA-BB-CC-DD
+          Device-type:  Microsoft-Workstation
+          Device-name:  MOED-9212345
+               Status:  Authorized
+               Domain:  DATA
+       Oper host mode:  multi-auth
+     Oper control dir:  both
+      Session timeout:  43200s (server), Remaining: 3574s
+       Timeout action:  Reauthenticate
+  Acct update timeout:  172800s (local), Remaining: 89824s
+    Common Session ID:  0A4014AC0000002F555FD224
+      Acct Session ID:  0x00000027
+               Handle:  0xe0000025
+       Current Policy:  PMAP_DefaultWiredDot1xClosedAuth_1X
+
+Local Policies:
+
+Server Policies:
+             VN Value:  WALKUPED_VN
+      Session-Timeout: 43200 sec
+           Vlan Group:  Vlan: 1011
+   Interface Template:  PXE-ClosedMode-Template
+            SGT Value:  40
+
+Method status list:
+       Method           State
+        dot1x           Stopped
+          mab           Authc Success

--- a/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single session with session timeout, timeout action, and interface template
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/expected.json
@@ -1,0 +1,98 @@
+{
+    "123414AC000066635A83835D": {
+        "interface": "TenGigabitEthernet2/0/39",
+        "iif_id": "0x16191B90",
+        "mac_address": "0060.aaaa.bbbb",
+        "ipv4_address": "10.11.11.117",
+        "user_name": "00-60-AA-AA-BB-BB",
+        "device_type": "IP-Phone",
+        "status": "Authorized",
+        "domain": "VOICE",
+        "oper_host_mode": "multi-auth",
+        "oper_control_dir": "both",
+        "acct_update_timeout": 172800,
+        "acct_update_remaining": 77097,
+        "common_session_id": "123414AC000066635A83835D",
+        "acct_session_id": "0x00002dfd",
+        "handle": "0xb100018c",
+        "current_policy": "PMAP_DefaultWDot1xClosedAuth_1X",
+        "server_policy_vn": "STAFF_VN",
+        "server_policy_vlan": 1133,
+        "server_policy_sgt": 20,
+        "resultant_policy_vn": "STAFF_VN",
+        "resultant_policy_vlan": 1133,
+        "resultant_policy_sgt": 20,
+        "methods": {
+            "dot1x": {
+                "method": "dot1x",
+                "state": "Authc Success"
+            },
+            "mab": {
+                "method": "mab",
+                "state": "Stopped"
+            }
+        }
+    },
+    "118214AC11110C6A86D02356": {
+        "interface": "GigabitEthernet1/0/21",
+        "iif_id": "0x1239EA14",
+        "mac_address": "707d.b9aa.bbcc",
+        "ipv6_address": "fe80::727d:abcd:abcd:abcd",
+        "ipv4_address": "172.22.5.2",
+        "user_name": "70-7D-B9-AA-BB-CC",
+        "device_type": "Cisco-AIR-LAP",
+        "device_name": "cisco AIR-AP2802I-Z-K9",
+        "status": "Authorized",
+        "domain": "DATA",
+        "oper_host_mode": "multi-auth",
+        "oper_control_dir": "both",
+        "acct_update_timeout": 172800,
+        "acct_update_remaining": 145579,
+        "common_session_id": "118214AC11110C6A86D02356",
+        "acct_session_id": "0x00001da4",
+        "handle": "0x5c000c60",
+        "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
+        "server_policy_vn": "INFRA_VN",
+        "server_policy_vlan": 1000,
+        "server_policy_sgt": 35,
+        "methods": {
+            "dot1x": {
+                "method": "dot1x",
+                "state": "Stopped"
+            },
+            "mab": {
+                "method": "mab",
+                "state": "Authc Success"
+            }
+        }
+    },
+    "118214AC000017C56C52F101": {
+        "interface": "GigabitEthernet2/0/1",
+        "iif_id": "0x12776C48",
+        "mac_address": "3814.28aa.bbcc",
+        "ipv6_address": "fe80::75e2:aaaa:bbbb:cccc",
+        "ipv4_address": "10.11.12.83",
+        "user_name": "DOMAIN\\koli",
+        "device_type": "Microsoft-Workstation",
+        "device_name": "IDC-2AE53D34",
+        "status": "Authorized",
+        "domain": "DATA",
+        "oper_host_mode": "multi-auth",
+        "oper_control_dir": "both",
+        "acct_update_timeout": 172800,
+        "acct_update_remaining": 169278,
+        "common_session_id": "118214AC000017C56C52F101",
+        "acct_session_id": "0x00003a04",
+        "handle": "0x0e0007c3",
+        "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
+        "server_policy_vn": "STAFF_VN",
+        "server_policy_vlan": 1133,
+        "server_policy_sgt": 20,
+        "methods": {
+            "dot1x": {
+                "method": "dot1x",
+                "state": "Authc Success"
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/expected.json
@@ -1,6 +1,6 @@
 {
-    "TenGigabitEthernet2/0/39": [
-        {
+    "TenGigabitEthernet2/0/39": {
+        "123414AC000066635A83835D": {
             "interface": "TenGigabitEthernet2/0/39",
             "iif_id": "0x16191B90",
             "mac_address": "0060.aaaa.bbbb",
@@ -34,9 +34,9 @@
                 }
             }
         }
-    ],
-    "GigabitEthernet1/0/21": [
-        {
+    },
+    "GigabitEthernet1/0/21": {
+        "118214AC11110C6A86D02356": {
             "interface": "GigabitEthernet1/0/21",
             "iif_id": "0x1239EA14",
             "mac_address": "707d.b9aa.bbcc",
@@ -69,9 +69,9 @@
                 }
             }
         }
-    ],
-    "GigabitEthernet2/0/1": [
-        {
+    },
+    "GigabitEthernet2/0/1": {
+        "118214AC000017C56C52F101": {
             "interface": "GigabitEthernet2/0/1",
             "iif_id": "0x12776C48",
             "mac_address": "3814.28aa.bbcc",
@@ -100,5 +100,5 @@
                 }
             }
         }
-    ]
+    }
 }

--- a/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/expected.json
@@ -1,98 +1,104 @@
 {
-    "123414AC000066635A83835D": {
-        "interface": "TenGigabitEthernet2/0/39",
-        "iif_id": "0x16191B90",
-        "mac_address": "0060.aaaa.bbbb",
-        "ipv4_address": "10.11.11.117",
-        "user_name": "00-60-AA-AA-BB-BB",
-        "device_type": "IP-Phone",
-        "status": "Authorized",
-        "domain": "VOICE",
-        "oper_host_mode": "multi-auth",
-        "oper_control_dir": "both",
-        "acct_update_timeout": 172800,
-        "acct_update_remaining": 77097,
-        "common_session_id": "123414AC000066635A83835D",
-        "acct_session_id": "0x00002dfd",
-        "handle": "0xb100018c",
-        "current_policy": "PMAP_DefaultWDot1xClosedAuth_1X",
-        "server_policy_vn": "STAFF_VN",
-        "server_policy_vlan": 1133,
-        "server_policy_sgt": 20,
-        "resultant_policy_vn": "STAFF_VN",
-        "resultant_policy_vlan": 1133,
-        "resultant_policy_sgt": 20,
-        "methods": {
-            "dot1x": {
-                "method": "dot1x",
-                "state": "Authc Success"
-            },
-            "mab": {
-                "method": "mab",
-                "state": "Stopped"
+    "TenGigabitEthernet2/0/39": [
+        {
+            "interface": "TenGigabitEthernet2/0/39",
+            "iif_id": "0x16191B90",
+            "mac_address": "0060.aaaa.bbbb",
+            "ipv4_address": "10.11.11.117",
+            "user_name": "00-60-AA-AA-BB-BB",
+            "device_type": "IP-Phone",
+            "status": "Authorized",
+            "domain": "VOICE",
+            "oper_host_mode": "multi-auth",
+            "oper_control_dir": "both",
+            "acct_update_timeout": 172800,
+            "acct_update_remaining": 77097,
+            "common_session_id": "123414AC000066635A83835D",
+            "acct_session_id": "0x00002dfd",
+            "handle": "0xb100018c",
+            "current_policy": "PMAP_DefaultWDot1xClosedAuth_1X",
+            "server_policy_vn": "STAFF_VN",
+            "server_policy_vlan": 1133,
+            "server_policy_sgt": 20,
+            "resultant_policy_vn": "STAFF_VN",
+            "resultant_policy_vlan": 1133,
+            "resultant_policy_sgt": 20,
+            "methods": {
+                "dot1x": {
+                    "method": "dot1x",
+                    "state": "Authc Success"
+                },
+                "mab": {
+                    "method": "mab",
+                    "state": "Stopped"
+                }
             }
         }
-    },
-    "118214AC11110C6A86D02356": {
-        "interface": "GigabitEthernet1/0/21",
-        "iif_id": "0x1239EA14",
-        "mac_address": "707d.b9aa.bbcc",
-        "ipv6_address": "fe80::727d:abcd:abcd:abcd",
-        "ipv4_address": "172.22.5.2",
-        "user_name": "70-7D-B9-AA-BB-CC",
-        "device_type": "Cisco-AIR-LAP",
-        "device_name": "cisco AIR-AP2802I-Z-K9",
-        "status": "Authorized",
-        "domain": "DATA",
-        "oper_host_mode": "multi-auth",
-        "oper_control_dir": "both",
-        "acct_update_timeout": 172800,
-        "acct_update_remaining": 145579,
-        "common_session_id": "118214AC11110C6A86D02356",
-        "acct_session_id": "0x00001da4",
-        "handle": "0x5c000c60",
-        "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
-        "server_policy_vn": "INFRA_VN",
-        "server_policy_vlan": 1000,
-        "server_policy_sgt": 35,
-        "methods": {
-            "dot1x": {
-                "method": "dot1x",
-                "state": "Stopped"
-            },
-            "mab": {
-                "method": "mab",
-                "state": "Authc Success"
+    ],
+    "GigabitEthernet1/0/21": [
+        {
+            "interface": "GigabitEthernet1/0/21",
+            "iif_id": "0x1239EA14",
+            "mac_address": "707d.b9aa.bbcc",
+            "ipv6_address": "fe80::727d:abcd:abcd:abcd",
+            "ipv4_address": "172.22.5.2",
+            "user_name": "70-7D-B9-AA-BB-CC",
+            "device_type": "Cisco-AIR-LAP",
+            "device_name": "cisco AIR-AP2802I-Z-K9",
+            "status": "Authorized",
+            "domain": "DATA",
+            "oper_host_mode": "multi-auth",
+            "oper_control_dir": "both",
+            "acct_update_timeout": 172800,
+            "acct_update_remaining": 145579,
+            "common_session_id": "118214AC11110C6A86D02356",
+            "acct_session_id": "0x00001da4",
+            "handle": "0x5c000c60",
+            "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
+            "server_policy_vn": "INFRA_VN",
+            "server_policy_vlan": 1000,
+            "server_policy_sgt": 35,
+            "methods": {
+                "dot1x": {
+                    "method": "dot1x",
+                    "state": "Stopped"
+                },
+                "mab": {
+                    "method": "mab",
+                    "state": "Authc Success"
+                }
             }
         }
-    },
-    "118214AC000017C56C52F101": {
-        "interface": "GigabitEthernet2/0/1",
-        "iif_id": "0x12776C48",
-        "mac_address": "3814.28aa.bbcc",
-        "ipv6_address": "fe80::75e2:aaaa:bbbb:cccc",
-        "ipv4_address": "10.11.12.83",
-        "user_name": "DOMAIN\\koli",
-        "device_type": "Microsoft-Workstation",
-        "device_name": "IDC-2AE53D34",
-        "status": "Authorized",
-        "domain": "DATA",
-        "oper_host_mode": "multi-auth",
-        "oper_control_dir": "both",
-        "acct_update_timeout": 172800,
-        "acct_update_remaining": 169278,
-        "common_session_id": "118214AC000017C56C52F101",
-        "acct_session_id": "0x00003a04",
-        "handle": "0x0e0007c3",
-        "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
-        "server_policy_vn": "STAFF_VN",
-        "server_policy_vlan": 1133,
-        "server_policy_sgt": 20,
-        "methods": {
-            "dot1x": {
-                "method": "dot1x",
-                "state": "Authc Success"
+    ],
+    "GigabitEthernet2/0/1": [
+        {
+            "interface": "GigabitEthernet2/0/1",
+            "iif_id": "0x12776C48",
+            "mac_address": "3814.28aa.bbcc",
+            "ipv6_address": "fe80::75e2:aaaa:bbbb:cccc",
+            "ipv4_address": "10.11.12.83",
+            "user_name": "DOMAIN\\koli",
+            "device_type": "Microsoft-Workstation",
+            "device_name": "IDC-2AE53D34",
+            "status": "Authorized",
+            "domain": "DATA",
+            "oper_host_mode": "multi-auth",
+            "oper_control_dir": "both",
+            "acct_update_timeout": 172800,
+            "acct_update_remaining": 169278,
+            "common_session_id": "118214AC000017C56C52F101",
+            "acct_session_id": "0x00003a04",
+            "handle": "0x0e0007c3",
+            "current_policy": "PMAP_DefaultWiredDot1xClosedAuth_1X",
+            "server_policy_vn": "STAFF_VN",
+            "server_policy_vlan": 1133,
+            "server_policy_sgt": 20,
+            "methods": {
+                "dot1x": {
+                    "method": "dot1x",
+                    "state": "Authc Success"
+                }
             }
         }
-    }
+    ]
 }

--- a/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/input.txt
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/input.txt
@@ -1,0 +1,109 @@
+
+            Interface:  TenGigabitEthernet2/0/39
+               IIF-ID:  0x16191B90
+          MAC Address:  0060.aaaa.bbbb
+         IPv6 Address:  Unknown
+         IPv4 Address:  10.11.11.117
+            User-Name:  00-60-AA-AA-BB-BB
+          Device-type:  IP-Phone
+          Device-name:  Unknown Device
+               Status:  Authorized
+               Domain:  VOICE
+       Oper host mode:  multi-auth
+     Oper control dir:  both
+      Session timeout:  N/A
+  Acct update timeout:  172800s (local), Remaining: 77097s
+    Common Session ID:  123414AC000066635A83835D
+      Acct Session ID:  0x00002dfd
+               Handle:  0xb100018c
+       Current Policy:  PMAP_DefaultWDot1xClosedAuth_1X
+
+Local Policies:
+
+Server Policies:
+             VN Value:  STAFF_VN
+           Vlan Group:  Vlan: 1133
+            SGT Value:  20
+            SGT Value:  20
+
+Resultant Policies:
+             VN Value:  STAFF_VN
+           Vlan Group:  Vlan: 1133
+            SGT Value:  20
+            SGT Value:  20
+
+Method status list:
+       Method           State
+        dot1x           Authc Success
+          mab           Stopped
+
+----------------------------------------
+
+            Interface:  GigabitEthernet1/0/21
+               IIF-ID:  0x1239EA14
+          MAC Address:  707d.b9aa.bbcc
+         IPv6 Address:  fe80::727d:abcd:abcd:abcd
+         IPv4 Address:  172.22.5.2
+            User-Name:  70-7D-B9-AA-BB-CC
+          Device-type:  Cisco-AIR-LAP
+          Device-name:  cisco AIR-AP2802I-Z-K9
+               Status:  Authorized
+               Domain:  DATA
+       Oper host mode:  multi-auth
+     Oper control dir:  both
+      Session timeout:  N/A
+  Acct update timeout:  172800s (local), Remaining: 145579s
+    Common Session ID:  118214AC11110C6A86D02356
+      Acct Session ID:  0x00001da4
+               Handle:  0x5c000c60
+       Current Policy:  PMAP_DefaultWiredDot1xClosedAuth_1X
+
+
+Local Policies:
+
+Server Policies:
+             VN Value:  INFRA_VN
+           Vlan Group:  Vlan: 1000
+            SGT Value:  35
+            SGT Value:  35
+
+
+Method status list:
+       Method           State
+        dot1x           Stopped
+          mab           Authc Success
+
+----------------------------------------
+
+            Interface:  GigabitEthernet2/0/1
+               IIF-ID:  0x12776C48
+          MAC Address:  3814.28aa.bbcc
+         IPv6 Address:  fe80::75e2:aaaa:bbbb:cccc
+         IPv4 Address:  10.11.12.83
+            User-Name:  DOMAIN\koli
+          Device-type:  Microsoft-Workstation
+          Device-name:  IDC-2AE53D34
+               Status:  Authorized
+               Domain:  DATA
+       Oper host mode:  multi-auth
+     Oper control dir:  both
+      Session timeout:  N/A
+  Acct update timeout:  172800s (local), Remaining: 169278s
+    Common Session ID:  118214AC000017C56C52F101
+      Acct Session ID:  0x00003a04
+               Handle:  0x0e0007c3
+       Current Policy:  PMAP_DefaultWiredDot1xClosedAuth_1X
+
+
+Local Policies:
+
+Server Policies:
+             VN Value:  STAFF_VN
+           Vlan Group:  Vlan: 1133
+            SGT Value:  20
+            SGT Value:  20
+
+
+Method status list:
+       Method           State
+        dot1x           Authc Success

--- a/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/metadata.yaml
+++ b/tests/parsers/ios/show_authentication_sessions_method_details/002_multi_session/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple sessions with varying interfaces, IPv6 addresses, and resultant policies
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show authentication sessions method details` on Cisco IOS
- Sessions keyed by Common Session ID with full support for server/resultant policies, method status, and session timeout fields
- Omits keys for unknown/N/A values per project conventions; deduplicates SGT values from CLI output

## Test plan
- [x] Test 001_basic: Single session with session timeout, timeout action, and interface template
- [x] Test 002_multi_session: Three sessions with varying interfaces, IPv6 addresses, and resultant policies
- [x] All pre-commit hooks pass (ruff check, ruff format, xenon)
- [x] pytest passes for both test cases

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)