### PR TITLE
feat: add parser for 'show control cpu' on IOS-XE

### DIFF
--- a/src/muninn/parsers/iosxe/show_control_cpu.py
+++ b/src/muninn/parsers/iosxe/show_control_cpu.py
@@ -1,0 +1,92 @@
+"""Parser for 'show control cpu' command on IOS-XE."""
+
+import re
+from typing import TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+
+
+class QueueEntry(TypedDict):
+    """Schema for a single CPU control-plane queue."""
+
+    retrieved: int
+    dropped: int
+    invalid: int
+    hol_block: int
+
+
+class ShowControlCpuResult(TypedDict):
+    """Schema for 'show control cpu' parsed output."""
+
+    queues: dict[str, QueueEntry]
+
+
+# Matches data lines: queue name followed by four integer counters.
+# Queue names may contain letters, digits, hyphens, and spaces.
+# Example: "Routing Protocol           327         0           0           0"
+_QUEUE_LINE = re.compile(
+    r"^(?P<name>.+?)\s{2,}"
+    r"(?P<retrieved>\d+)\s+"
+    r"(?P<dropped>\d+)\s+"
+    r"(?P<invalid>\d+)\s+"
+    r"(?P<hol_block>\d+)\s*$"
+)
+
+# Header and separator lines to skip
+_SKIP = re.compile(r"^(?:queue\s|---)")
+
+
+@register(OS.CISCO_IOSXE, "show control cpu")
+class ShowControlCpuParser(BaseParser[ShowControlCpuResult]):
+    """Parser for 'show control cpu' command.
+
+    Example output::
+
+        queue                      retrieved   dropped     invalid     hol-block
+        -------------------------------------------------------------------------
+        Routing Protocol           327         0           0           0
+        L2 Protocol                23362       0           0           0
+        sw forwarding              433         425         0           0
+        broadcast                  0           0           0           0
+    """
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControlCpuResult:
+        """Parse 'show control cpu' output.
+
+        Args:
+            output: Raw CLI output from 'show control cpu'.
+
+        Returns:
+            Parsed CPU control-plane queue statistics keyed by queue name.
+
+        Raises:
+            ValueError: If no queue data is found in the output.
+        """
+        queues: dict[str, QueueEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped or _SKIP.match(stripped):
+                continue
+            # Skip command echo lines
+            if stripped.startswith("show control"):
+                continue
+
+            match = _QUEUE_LINE.match(stripped)
+            if match:
+                name = match.group("name").strip()
+                queues[name] = QueueEntry(
+                    retrieved=int(match.group("retrieved")),
+                    dropped=int(match.group("dropped")),
+                    invalid=int(match.group("invalid")),
+                    hol_block=int(match.group("hol_block")),
+                )
+
+        if not queues:
+            msg = "No CPU control-plane queue data found in output"
+            raise ValueError(msg)
+
+        return ShowControlCpuResult(queues=queues)

--- a/tests/parsers/iosxe/show_control_cpu/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_control_cpu/001_basic/expected.json
@@ -1,0 +1,160 @@
+{
+    "queues": {
+        "Routing Protocol": {
+            "retrieved": 327,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "L2 Protocol": {
+            "retrieved": 23362,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "sw forwarding": {
+            "retrieved": 433,
+            "dropped": 425,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "broadcast": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "icmp gen": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "icmp redirect": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "logging": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "rpf-fail": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "DOT1X authentication": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Forus Traffic": {
+            "retrieved": 26032,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Forus Resolution": {
+            "retrieved": 516148,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Inter FED": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "L2 LVX control": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "EWLC control": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "EWLC data": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "L2 LVX data": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Openflow": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Topology control": {
+            "retrieved": 136276,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Proto snooping": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "DHCP snooping": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Transit Traffic": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Multi End station": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Webauth": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "High rate app": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "Exception": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        },
+        "System Critical": {
+            "retrieved": 0,
+            "dropped": 0,
+            "invalid": 0,
+            "hol_block": 0
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_control_cpu/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_control_cpu/001_basic/input.txt
@@ -1,0 +1,28 @@
+queue                      retrieved   dropped     invalid     hol-block
+-------------------------------------------------------------------------
+Routing Protocol           327         0           0           0
+L2 Protocol                23362       0           0           0
+sw forwarding              433         425         0           0
+broadcast                  0           0           0           0
+icmp gen                   0           0           0           0
+icmp redirect              0           0           0           0
+logging                    0           0           0           0
+rpf-fail                   0           0           0           0
+DOT1X authentication       0           0           0           0
+Forus Traffic              26032       0           0           0
+Forus Resolution           516148      0           0           0
+Inter FED                  0           0           0           0
+L2 LVX control             0           0           0           0
+EWLC control               0           0           0           0
+EWLC data                  0           0           0           0
+L2 LVX data                0           0           0           0
+Openflow                   0           0           0           0
+Topology control           136276      0           0           0
+Proto snooping             0           0           0           0
+DHCP snooping              0           0           0           0
+Transit Traffic            0           0           0           0
+Multi End station          0           0           0           0
+Webauth                    0           0           0           0
+High rate app              0           0           0           0
+Exception                  0           0           0           0
+System Critical            0           0           0           0

--- a/tests/parsers/iosxe/show_control_cpu/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_control_cpu/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with various CPU control-plane queues
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show control cpu` command on IOS-XE
- Parses CPU control-plane queue statistics (retrieved, dropped, invalid, hol_block counters) into structured data keyed by queue name
- Includes golden test case with 26 queue entries sourced from Genie parser test data

Closes #281

## Test plan
- [x] Golden test passes (`tests/parsers/iosxe/show_control_cpu/001_basic/`)
- [x] `ruff check` and `ruff format` pass
- [x] `xenon --max-absolute B` complexity check passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)