### PR TITLE
feat: add parser for 'show interface status' on IOS-XE / IOS

### DIFF
--- a/changes/539.parser_added
+++ b/changes/539.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interface status` on IOS-XE and IOS.

--- a/src/muninn/parsers/iosxe/show_interface_status.py
+++ b/src/muninn/parsers/iosxe/show_interface_status.py
@@ -1,11 +1,12 @@
 """Parser for 'show interface status' command on IOS-XE."""
 
 import re
-from typing import NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
+from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
 
 
@@ -40,6 +41,8 @@ class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
         Gi1/0/2   AccessPoint   connected    8      a-full a-1000
         Po1       ethchl        connected    trunk  a-full a-1000
     """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
 
     # IOS-XE status values.  The base status word may be followed by a colon
     # and optional additional text (e.g. "notconnect: TD", "connected: TDR").
@@ -146,9 +149,10 @@ class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
                 continue
 
             port = canonical_interface_name(match.group("port"), os=OS.CISCO_IOSXE)
-            status = parsed["status"]
-            duplex = parsed["duplex"]
-            speed = parsed["speed"]
+            # status, duplex, speed are always str from regex matches
+            status = str(parsed["status"])
+            duplex = str(parsed["duplex"])
+            speed = str(parsed["speed"])
             name = cls._normalize_value(parsed.get("name"))
             vlan = cls._normalize_value(parsed.get("vlan"))
             intf_type = cls._normalize_value(parsed.get("type"))

--- a/src/muninn/parsers/iosxe/show_interface_status.py
+++ b/src/muninn/parsers/iosxe/show_interface_status.py
@@ -1,0 +1,175 @@
+"""Parser for 'show interface status' command on IOS-XE."""
+
+import re
+from typing import NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.utils import canonical_interface_name
+
+
+class InterfaceStatusEntry(TypedDict):
+    """Schema for a single interface status entry."""
+
+    status: str
+    duplex: str
+    speed: str
+    name: NotRequired[str]
+    vlan: NotRequired[str]
+    type: NotRequired[str]
+
+
+class ShowInterfaceStatusResult(TypedDict):
+    """Schema for 'show interface status' parsed output."""
+
+    interfaces: dict[str, InterfaceStatusEntry]
+
+
+@register(OS.CISCO_IOSXE, "show interface status")
+@register(OS.CISCO_IOS, "show interface status")
+class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
+    """Parser for 'show interface status' command on IOS-XE / IOS.
+
+    Parses interface status including description, VLAN, duplex, speed, and type.
+
+    Example output::
+
+        Port      Name          Status       Vlan   Duplex  Speed Type
+        Gi1/0/1                 notconnect   1        auto   auto
+        Gi1/0/2   AccessPoint   connected    8      a-full a-1000
+        Po1       ethchl        connected    trunk  a-full a-1000
+    """
+
+    # IOS-XE status values.  The base status word may be followed by a colon
+    # and optional additional text (e.g. "notconnect: TD", "connected: TDR").
+    _STATUS_VALUES = (
+        "connected",
+        "notconnect",
+        "suspended",
+        "err-disabled",
+        "disabled",
+        "monitoring",
+        "inactive",
+    )
+
+    _STATUS_RE = re.compile(
+        r"(?P<status>" + "|".join(_STATUS_VALUES) + r")" r"(?::\s*[A-Za-z]*)?",
+    )
+
+    # Structured fields that follow the status (and any colon suffix).
+    # Matches: vlan  duplex  speed  [type]
+    _FIELDS_RE = re.compile(
+        r"(?P<vlan>\d+|trunk|routed|unassigned)\s+"
+        r"(?P<duplex>a-full|a-half|full|half|auto)\s+"
+        r"(?P<speed>\S+)"
+        r"(?:\s+(?P<type>.+))?$",
+    )
+
+    # Column-position based parsing.  IOS-XE output uses fixed-width columns
+    # but widths vary across platforms, so we match on known tokens instead.
+    _INTERFACE_PATTERN = re.compile(
+        r"^(?P<port>(?:Gi|Te|Tw|Fo|Fa|Po|Tu|Lo|Vl|Se|Ap|Hu)\S*)\s+"
+        r"(?P<rest>.+)$"
+    )
+
+    @classmethod
+    def _parse_rest(cls, rest: str) -> dict[str, str | None]:
+        """Parse everything after the port column.
+
+        Finds the status token, then matches the structured fields
+        (vlan, duplex, speed, type) from the remainder.  Everything
+        before the status token is the interface description.
+        """
+        status_match = cls._STATUS_RE.search(rest)
+        if not status_match:
+            return {}
+
+        status = status_match.group("status")
+        name_part = rest[: status_match.start()].strip()
+
+        # Search for structured fields after the status
+        after_status = rest[status_match.end() :]
+        fields_match = cls._FIELDS_RE.search(after_status)
+        if not fields_match:
+            return {}
+
+        return {
+            "name": name_part or None,
+            "status": status,
+            "vlan": fields_match.group("vlan"),
+            "duplex": fields_match.group("duplex"),
+            "speed": fields_match.group("speed"),
+            "type": (fields_match.group("type") or "").strip() or None,
+        }
+
+    @classmethod
+    def _normalize_value(cls, value: str | None) -> str | None:
+        """Normalize a field value, converting -- to None."""
+        if value is None:
+            return None
+        value = value.strip()
+        if not value or value == "--":
+            return None
+        return value
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfaceStatusResult:
+        """Parse 'show interface status' output on IOS-XE / IOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed interface status data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interfaces found.
+        """
+        interfaces: dict[str, InterfaceStatusEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if (
+                not stripped
+                or stripped.startswith("Port")
+                or stripped.startswith("---")
+            ):
+                continue
+
+            match = cls._INTERFACE_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            parsed = cls._parse_rest(match.group("rest"))
+            if not parsed:
+                continue
+
+            port = canonical_interface_name(match.group("port"), os=OS.CISCO_IOSXE)
+            status = parsed["status"]
+            duplex = parsed["duplex"]
+            speed = parsed["speed"]
+            name = cls._normalize_value(parsed.get("name"))
+            vlan = cls._normalize_value(parsed.get("vlan"))
+            intf_type = cls._normalize_value(parsed.get("type"))
+
+            entry: InterfaceStatusEntry = {
+                "status": status,
+                "duplex": duplex,
+                "speed": speed,
+            }
+
+            if name:
+                entry["name"] = name
+            if vlan:
+                entry["vlan"] = vlan
+            if intf_type:
+                entry["type"] = intf_type
+
+            interfaces[port] = entry
+
+        if not interfaces:
+            msg = "No interfaces found in output"
+            raise ValueError(msg)
+
+        return ShowInterfaceStatusResult(interfaces=interfaces)

--- a/src/muninn/parsers/iosxe/show_interface_status.py
+++ b/src/muninn/parsers/iosxe/show_interface_status.py
@@ -117,6 +117,33 @@ class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
         return value
 
     @classmethod
+    def _build_entry(cls, parsed: dict[str, str | None]) -> InterfaceStatusEntry:
+        """Build an InterfaceStatusEntry from parsed field values."""
+        entry: InterfaceStatusEntry = {
+            "status": str(parsed["status"]),
+            "duplex": str(parsed["duplex"]),
+            "speed": str(parsed["speed"]),
+        }
+
+        name = cls._normalize_value(parsed.get("name"))
+        vlan = cls._normalize_value(parsed.get("vlan"))
+        intf_type = cls._normalize_value(parsed.get("type"))
+
+        if name:
+            entry["name"] = name
+        if vlan:
+            entry["vlan"] = vlan
+        if intf_type:
+            entry["type"] = intf_type
+
+        return entry
+
+    @classmethod
+    def _is_header_or_empty(cls, line: str) -> bool:
+        """Return True if line is a header, separator, or empty."""
+        return not line or line.startswith("Port") or line.startswith("---")
+
+    @classmethod
     def parse(cls, output: str) -> ShowInterfaceStatusResult:
         """Parse 'show interface status' output on IOS-XE / IOS.
 
@@ -133,11 +160,7 @@ class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
 
         for line in output.splitlines():
             stripped = line.strip()
-            if (
-                not stripped
-                or stripped.startswith("Port")
-                or stripped.startswith("---")
-            ):
+            if cls._is_header_or_empty(stripped):
                 continue
 
             match = cls._INTERFACE_PATTERN.match(stripped)
@@ -149,28 +172,7 @@ class ShowInterfaceStatusParser(BaseParser[ShowInterfaceStatusResult]):
                 continue
 
             port = canonical_interface_name(match.group("port"), os=OS.CISCO_IOSXE)
-            # status, duplex, speed are always str from regex matches
-            status = str(parsed["status"])
-            duplex = str(parsed["duplex"])
-            speed = str(parsed["speed"])
-            name = cls._normalize_value(parsed.get("name"))
-            vlan = cls._normalize_value(parsed.get("vlan"))
-            intf_type = cls._normalize_value(parsed.get("type"))
-
-            entry: InterfaceStatusEntry = {
-                "status": status,
-                "duplex": duplex,
-                "speed": speed,
-            }
-
-            if name:
-                entry["name"] = name
-            if vlan:
-                entry["vlan"] = vlan
-            if intf_type:
-                entry["type"] = intf_type
-
-            interfaces[port] = entry
+            interfaces[port] = cls._build_entry(parsed)
 
         if not interfaces:
             msg = "No interfaces found in output"

--- a/tests/parsers/iosxe/show_interface_status/001_basic_statuses/expected.json
+++ b/tests/parsers/iosxe/show_interface_status/001_basic_statuses/expected.json
@@ -1,0 +1,43 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/1": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/2": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "name": "AccessPoint",
+            "vlan": "8",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "name": "John's Office",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/4": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-100",
+            "name": "SingleName",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/5": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "name": "Dashed-Name",
+            "vlan": "1000",
+            "type": "10/100/1000BaseTX"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interface_status/001_basic_statuses/input.txt
+++ b/tests/parsers/iosxe/show_interface_status/001_basic_statuses/input.txt
@@ -1,0 +1,6 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/1                      notconnect   1            auto   auto 10/100/1000BaseTX
+Gi1/0/2   AccessPoint        connected    8          a-full a-1000 10/100/1000BaseTX
+Gi1/0/3   John's Office      notconnect   1            auto   auto 10/100/1000BaseTX
+Gi1/0/4   SingleName         connected    1          a-full  a-100 10/100/1000BaseTX
+Gi1/0/5   Dashed-Name        connected    1000       a-full a-1000 10/100/1000BaseTX

--- a/tests/parsers/iosxe/show_interface_status/001_basic_statuses/metadata.yaml
+++ b/tests/parsers/iosxe/show_interface_status/001_basic_statuses/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic interface status with connected and notconnect ports
+platform: Catalyst 3750
+software_version: Unknown

--- a/tests/parsers/iosxe/show_interface_status/002_with_descriptions/expected.json
+++ b/tests/parsers/iosxe/show_interface_status/002_with_descriptions/expected.json
@@ -1,0 +1,36 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/6": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-100",
+            "name": "Spaced Example",
+            "vlan": "8",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/7": {
+            "status": "suspended",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "name": "Trunk Example",
+            "vlan": "trunk",
+            "type": "1000BaseSX SFP"
+        },
+        "GigabitEthernet1/0/8": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "name": "SFP Not Present",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet1/0/10": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "name": "Management",
+            "vlan": "routed",
+            "type": "10/100BaseTX"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interface_status/002_with_descriptions/input.txt
+++ b/tests/parsers/iosxe/show_interface_status/002_with_descriptions/input.txt
@@ -1,0 +1,5 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/6   Spaced Example     connected    8          a-full  a-100 10/100/1000BaseTX
+Gi1/0/7   Trunk Example      suspended    trunk      a-full a-1000 1000BaseSX SFP
+Gi1/0/8   SFP Not Present    notconnect   1            auto   auto Not Present
+Gi1/0/10  Management         notconnect   routed       auto   auto 10/100BaseTX

--- a/tests/parsers/iosxe/show_interface_status/002_with_descriptions/metadata.yaml
+++ b/tests/parsers/iosxe/show_interface_status/002_with_descriptions/metadata.yaml
@@ -1,0 +1,3 @@
+description: Interfaces with multi-word descriptions and SFP types
+platform: Catalyst 3850
+software_version: Unknown

--- a/tests/parsers/iosxe/show_interface_status/003_trunk_and_special_vlans/expected.json
+++ b/tests/parsers/iosxe/show_interface_status/003_trunk_and_special_vlans/expected.json
@@ -1,0 +1,44 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/11": {
+            "status": "notconnect",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "2960S Port",
+            "vlan": "16",
+            "type": "10/100BaseTX"
+        },
+        "GigabitEthernet1/0/12": {
+            "status": "notconnect",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "Half Duplex 2950",
+            "vlan": "16",
+            "type": "10/100BaseTX"
+        },
+        "GigabitEthernet1/0/13": {
+            "status": "notconnect",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "Half Duplex 2950-S",
+            "vlan": "16",
+            "type": "10/100BaseTX"
+        },
+        "GigabitEthernet1/0/14": {
+            "status": "notconnect",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "Half Duplex 2950-S",
+            "vlan": "16",
+            "type": "Not Present"
+        },
+        "GigabitEthernet1/0/15": {
+            "status": "notconnect",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "Multi Space to the",
+            "vlan": "16",
+            "type": "10/100BaseTX"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interface_status/003_trunk_and_special_vlans/input.txt
+++ b/tests/parsers/iosxe/show_interface_status/003_trunk_and_special_vlans/input.txt
@@ -1,0 +1,6 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/11  2960S Port         notconnect   16         a-half   auto 10/100BaseTX
+Gi1/0/12  Half Duplex 2950   notconnect   16         a-half   auto 10/100BaseTX
+Gi1/0/13  Half Duplex 2950-S notconnect   16         a-half   auto 10/100BaseTX
+Gi1/0/14  Half Duplex 2950-S notconnect   16         a-half   auto Not Present
+Gi1/0/15  Multi Space to the notconnect   16         a-half   auto 10/100BaseTX

--- a/tests/parsers/iosxe/show_interface_status/003_trunk_and_special_vlans/metadata.yaml
+++ b/tests/parsers/iosxe/show_interface_status/003_trunk_and_special_vlans/metadata.yaml
@@ -1,0 +1,3 @@
+description: Half duplex ports and unassigned VLAN
+platform: Catalyst 2960S
+software_version: Unknown

--- a/tests/parsers/iosxe/show_interface_status/004_err_disabled_and_monitoring/expected.json
+++ b/tests/parsers/iosxe/show_interface_status/004_err_disabled_and_monitoring/expected.json
@@ -1,0 +1,36 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/16": {
+            "status": "err-disabled",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "Multi Space to the",
+            "vlan": "16",
+            "type": "10/100BaseTX"
+        },
+        "GigabitEthernet1/0/17": {
+            "status": "disabled",
+            "duplex": "a-half",
+            "speed": "auto",
+            "name": "Multi Space",
+            "vlan": "16",
+            "type": "10/100BaseTX"
+        },
+        "GigabitEthernet1/0/18": {
+            "status": "monitoring",
+            "duplex": "a-full",
+            "speed": "auto",
+            "name": "Monitoring Port",
+            "vlan": "routed",
+            "type": "10/100/1000BaseT"
+        },
+        "GigabitEthernet1/0/21": {
+            "status": "monitoring",
+            "duplex": "a-full",
+            "speed": "auto",
+            "name": "Monitoring Port",
+            "vlan": "unassigned",
+            "type": "10/100/1000BaseT"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interface_status/004_err_disabled_and_monitoring/input.txt
+++ b/tests/parsers/iosxe/show_interface_status/004_err_disabled_and_monitoring/input.txt
@@ -1,0 +1,5 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/16  Multi Space to the err-disabled 16         a-half   auto 10/100BaseTX
+Gi1/0/17  Multi Space        disabled     16         a-half   auto 10/100BaseTX
+Gi1/0/18  Monitoring Port    monitoring   routed     a-full   auto 10/100/1000BaseT
+Gi1/0/21  Monitoring Port    monitoring   unassigned     a-full   auto 10/100/1000BaseT

--- a/tests/parsers/iosxe/show_interface_status/004_err_disabled_and_monitoring/metadata.yaml
+++ b/tests/parsers/iosxe/show_interface_status/004_err_disabled_and_monitoring/metadata.yaml
@@ -1,0 +1,3 @@
+description: Err-disabled, disabled, and monitoring status ports
+platform: Catalyst 3850
+software_version: Unknown

--- a/tests/parsers/iosxe/show_interface_status/005_status_with_colon_suffix/expected.json
+++ b/tests/parsers/iosxe/show_interface_status/005_status_with_colon_suffix/expected.json
@@ -1,0 +1,36 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/19": {
+            "status": "notconnect",
+            "duplex": "a-full",
+            "speed": "a-100",
+            "name": "No Description",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/20": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-100",
+            "name": "No Description",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/22": {
+            "status": "notconnect",
+            "duplex": "a-full",
+            "speed": "a-100",
+            "name": "addl status text",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/23": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-100",
+            "name": "addl status text",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interface_status/005_status_with_colon_suffix/input.txt
+++ b/tests/parsers/iosxe/show_interface_status/005_status_with_colon_suffix/input.txt
@@ -1,0 +1,5 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/19  No Description     notconnect:    1         a-full  a-100 10/100/1000BaseTX
+Gi1/0/20  No Description     connected:     1         a-full  a-100 10/100/1000BaseTX
+Gi1/0/22  addl status text   notconnect: TD 1         a-full  a-100 10/100/1000BaseTX
+Gi1/0/23  addl status text   connected: TDR 1         a-full  a-100 10/100/1000BaseTX

--- a/tests/parsers/iosxe/show_interface_status/005_status_with_colon_suffix/metadata.yaml
+++ b/tests/parsers/iosxe/show_interface_status/005_status_with_colon_suffix/metadata.yaml
@@ -1,0 +1,3 @@
+description: Status values with colon and additional text (e.g. TDR diagnostics)
+platform: Catalyst 3750
+software_version: Unknown

--- a/tests/parsers/iosxe/show_interface_status/006_port_channel_no_type/expected.json
+++ b/tests/parsers/iosxe/show_interface_status/006_port_channel_no_type/expected.json
@@ -1,0 +1,19 @@
+{
+    "interfaces": {
+        "FastEthernet1/6": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "name": "test",
+            "vlan": "1",
+            "type": "10/100BaseTX"
+        },
+        "Port-channel1": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "name": "ethchl",
+            "vlan": "trunk"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interface_status/006_port_channel_no_type/input.txt
+++ b/tests/parsers/iosxe/show_interface_status/006_port_channel_no_type/input.txt
@@ -1,0 +1,3 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Fa1/6     test               notconnect   1            auto    auto 10/100BaseTX
+Po1       ethchl             connected    trunk      a-full a-1000

--- a/tests/parsers/iosxe/show_interface_status/006_port_channel_no_type/metadata.yaml
+++ b/tests/parsers/iosxe/show_interface_status/006_port_channel_no_type/metadata.yaml
@@ -1,0 +1,3 @@
+description: Port-channel and FastEthernet interfaces, some without type field
+platform: Catalyst 3750
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds a new parser for the `show interface status` command on IOS-XE and IOS platforms
- Handles IOS-XE specific quirks: status colon suffixes (`: TD`, `: TDR`), multi-word type fields (`1000BaseSX SFP`, `Not Present`), and `unassigned` VLAN values
- Also registered for `cisco_ios` since the output format is identical
- 6 test cases covering connected/notconnect, descriptions, half-duplex, err-disabled/monitoring, colon suffixes, and port-channels

## Test data source
Test data derived from [ntc-templates](https://github.com/networktocode/ntc-templates) reference samples for `cisco_ios_show_interfaces_status`.

## Test plan
- [x] All 6 new test cases pass
- [x] Full test suite passes (1456 tests)
- [x] Pre-commit hooks pass (ruff, xenon, etc.)
- [ ] Review parser handles edge cases in production CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)