### PR TITLE
fix: align pre-commit xenon thresholds with CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,7 @@ repos:
         types: [python]
       - id: xenon
         name: xenon
-        entry: uv run xenon --max-absolute=C --max-modules=B --max-average=B
+        entry: uv run xenon --max-absolute=B --max-modules=B --max-average=A src/
         language: system
-        types: [python]
+        pass_filenames: false
+        always_run: true

--- a/changes/541.internal
+++ b/changes/541.internal
@@ -1,0 +1,1 @@
+Aligned pre-commit xenon thresholds with CI (``--max-absolute B --max-average A``) and scoped to ``src/``.


### PR DESCRIPTION
## Summary
- Pre-commit hook used `--max-absolute=C --max-average=B` while CI used `--max-absolute B --max-average A`, allowing code to pass locally but fail in CI
- Aligned pre-commit to match CI: `--max-absolute=B --max-modules=B --max-average=A`
- Scoped pre-commit xenon hook to `src/` to match CI's target directory

## Test plan
- [x] `uv run pre-commit run xenon --all-files` passes
- [x] All pre-commit hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)