### PR TITLE
feat(iosxe): show stackwise-virtual neighbors

### DIFF
--- a/changes/318.parser_added
+++ b/changes/318.parser_added
@@ -1,0 +1,1 @@
+Added IOS-XE parser for `show stackwise-virtual neighbors`.

--- a/src/muninn/parsers/iosxe/show_stackwise_virtual_neighbors.py
+++ b/src/muninn/parsers/iosxe/show_stackwise_virtual_neighbors.py
@@ -1,0 +1,123 @@
+"""Parser for 'show stackwise-virtual neighbors' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class NeighborPortPair(TypedDict):
+    """Local and optional remote SVL neighbor port."""
+
+    local_port: str
+    remote_port: str
+
+
+class NeighborSwitchEntry(TypedDict):
+    """SVL neighbor information for one switch."""
+
+    svl: str
+    port_pairs: list[NeighborPortPair]
+
+
+class ShowStackwiseVirtualNeighborsResult(TypedDict):
+    """Schema for 'show stackwise-virtual neighbors' parsed output."""
+
+    switches: dict[str, NeighborSwitchEntry]
+
+
+_FULL_ROW = re.compile(
+    r"^(?P<switch>\d+)\s+"
+    r"(?P<svl>\d+)\s+"
+    r"(?P<local>\S+)\s+"
+    r"(?P<remote>\S+)\s*$",
+)
+_CONT_TWO = re.compile(r"^\s+(?P<local>\S+)\s+(?P<remote>\S+)\s*$")
+_CONT_ONE = re.compile(r"^\s+(?P<local>\S+)\s*$")
+
+_TABLE_HEADER = re.compile(
+    r"^Switch\s+SVL\s+Local\s+Port",
+    re.IGNORECASE,
+)
+
+
+def _canon(name: str) -> str:
+    return canonical_interface_name(name, os=OS.CISCO_IOSXE)
+
+
+def _skip_neighbors_preamble(stripped: str) -> bool:
+    if stripped.startswith("---") or _TABLE_HEADER.match(stripped):
+        return True
+    return stripped.startswith("Stackwise Virtual Link")
+
+
+def _parse_neighbors_table(lines: list[str]) -> dict[str, NeighborSwitchEntry]:
+    switches: dict[str, NeighborSwitchEntry] = {}
+    current_switch: str | None = None
+
+    for raw in lines:
+        line = raw.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _skip_neighbors_preamble(stripped):
+            continue
+
+        if m := _FULL_ROW.match(stripped):
+            sw = m.group("switch")
+            current_switch = sw
+            if sw not in switches:
+                switches[sw] = NeighborSwitchEntry(
+                    svl=m.group("svl"),
+                    port_pairs=[],
+                )
+            switches[sw]["port_pairs"].append(
+                NeighborPortPair(
+                    local_port=_canon(m.group("local")),
+                    remote_port=_canon(m.group("remote")),
+                ),
+            )
+            continue
+
+        if current_switch is None:
+            continue
+
+        if m := _CONT_TWO.match(line):
+            switches[current_switch]["port_pairs"].append(
+                NeighborPortPair(
+                    local_port=_canon(m.group("local")),
+                    remote_port=_canon(m.group("remote")),
+                ),
+            )
+        elif m := _CONT_ONE.match(line):
+            switches[current_switch]["port_pairs"].append(
+                NeighborPortPair(
+                    local_port=_canon(m.group("local")),
+                    remote_port="",
+                ),
+            )
+
+    return switches
+
+
+@register(OS.CISCO_IOSXE, "show stackwise-virtual neighbors")
+class ShowStackwiseVirtualNeighborsParser(
+    BaseParser[ShowStackwiseVirtualNeighborsResult],
+):
+    """Parser for 'show stackwise-virtual neighbors' command."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowStackwiseVirtualNeighborsResult:
+        """Parse 'show stackwise-virtual neighbors' output."""
+        switches = _parse_neighbors_table(output.splitlines())
+        if not switches:
+            msg = "No SVL neighbor data found in output"
+            raise ValueError(msg)
+
+        return ShowStackwiseVirtualNeighborsResult(switches=switches)

--- a/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/expected.json
@@ -1,0 +1,38 @@
+{
+    "switches": {
+        "1": {
+            "svl": "1",
+            "port_pairs": [
+                {
+                    "local_port": "HundredGigabitEthernet1/1/0/19",
+                    "remote_port": "HundredGigabitEthernet2/1/0/23"
+                },
+                {
+                    "local_port": "HundredGigabitEthernet1/5/0/17",
+                    "remote_port": "HundredGigabitEthernet2/1/0/24"
+                },
+                {
+                    "local_port": "FiftyGigabitEthernet1/6/0/33",
+                    "remote_port": ""
+                }
+            ]
+        },
+        "2": {
+            "svl": "1",
+            "port_pairs": [
+                {
+                    "local_port": "HundredGigabitEthernet2/1/0/23",
+                    "remote_port": "HundredGigabitEthernet1/1/0/19"
+                },
+                {
+                    "local_port": "HundredGigabitEthernet2/1/0/24",
+                    "remote_port": "HundredGigabitEthernet1/5/0/17"
+                },
+                {
+                    "local_port": "FiftyGigabitEthernet2/6/0/29",
+                    "remote_port": ""
+                }
+            ]
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/input.txt
@@ -1,0 +1,10 @@
+Stackwise Virtual Link(SVL) Neighbors Information:
+--------------------------------------------------
+Switch  SVL     Local Port                         Remote Port
+------  ---     ----------                         -----------
+1       1       HundredGigE1/1/0/19                HundredGigE2/1/0/23
+                HundredGigE1/5/0/17                HundredGigE2/1/0/24
+                FiftyGigE1/6/0/33
+2       1       HundredGigE2/1/0/23                HundredGigE1/1/0/19
+                HundredGigE2/1/0/24                HundredGigE1/5/0/17
+                FiftyGigE2/6/0/29

--- a/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: SVL neighbors table with continuation rows and local-only port
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
Closes #318

Adds parser, golden test (raw CLI from Genie), and towncrier fragment.

- Parser: `src/muninn/parsers/iosxe/show_stackwise_virtual_neighbors.py`
- Tests: `tests/parsers/iosxe/show_stackwise-virtual_neighbors/`
- `changes/318.parser_added`