### PR TITLE
feat(iosxe): show netconf-yang sessions

### DIFF
--- a/changes/298.parser_added
+++ b/changes/298.parser_added
@@ -1,0 +1,1 @@
+Added IOS-XE parser for `show netconf-yang sessions`.

--- a/src/muninn/parsers/iosxe/show_netconf_yang_sessions.py
+++ b/src/muninn/parsers/iosxe/show_netconf_yang_sessions.py
@@ -1,0 +1,90 @@
+"""Parser for 'show netconf-yang sessions' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NetconfYangSessionEntry(TypedDict):
+    """One NETCONF-YANG management session."""
+
+    session_id: str
+    transport: str
+    username: str
+    source_host: str
+    global_lock: str
+
+
+class ShowNetconfYangSessionsResult(TypedDict):
+    """Schema for 'show netconf-yang sessions' parsed output."""
+
+    session_count: int
+    sessions: list[NetconfYangSessionEntry]
+
+
+_SESSION_COUNT_PATTERN = re.compile(
+    r"^Number of sessions\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+_SESSION_ROW_PATTERN = re.compile(
+    r"^(?P<id>\d+)\s+"
+    r"(?P<transport>\S+)\s+"
+    r"(?P<username>\S+)\s+"
+    r"(?P<source>\S+)\s+"
+    r"(?P<lock>\S+)\s*$"
+)
+
+
+@register(OS.CISCO_IOSXE, "show netconf-yang sessions")
+class ShowNetconfYangSessionsParser(BaseParser[ShowNetconfYangSessionsResult]):
+    """Parser for 'show netconf-yang sessions' command."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowNetconfYangSessionsResult:
+        """Parse 'show netconf-yang sessions' output.
+
+        Args:
+            output: Raw CLI output from 'show netconf-yang sessions'.
+
+        Returns:
+            Session count and session rows from the table.
+        """
+        session_count = 0
+        sessions: list[NetconfYangSessionEntry] = []
+
+        for raw in output.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+
+            count_match = _SESSION_COUNT_PATTERN.match(line)
+            if count_match:
+                session_count = int(count_match.group("count"))
+                continue
+
+            if line.startswith("-") or "session-id" in line.lower():
+                continue
+
+            row_match = _SESSION_ROW_PATTERN.match(line)
+            if row_match:
+                sessions.append(
+                    NetconfYangSessionEntry(
+                        session_id=row_match.group("id"),
+                        transport=row_match.group("transport"),
+                        username=row_match.group("username"),
+                        source_host=row_match.group("source"),
+                        global_lock=row_match.group("lock"),
+                    )
+                )
+
+        return ShowNetconfYangSessionsResult(
+            session_count=session_count,
+            sessions=sessions,
+        )

--- a/tests/parsers/iosxe/show_netconf-yang_sessions/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_netconf-yang_sessions/001_basic/expected.json
@@ -1,0 +1,12 @@
+{
+    "session_count": 1,
+    "sessions": [
+        {
+            "session_id": "24",
+            "transport": "netconf-ssh",
+            "username": "admin",
+            "source_host": "10.69.35.35",
+            "global_lock": "None"
+        }
+    ]
+}

--- a/tests/parsers/iosxe/show_netconf-yang_sessions/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_netconf-yang_sessions/001_basic/input.txt
@@ -1,0 +1,9 @@
+R: Global-lock on running datastore
+C: Global-lock on candidate datastore
+S: Global-lock on startup datastore
+
+Number of sessions : 1
+
+session-id  transport    username             source-host            global-lock
+--------------------------------------------------------------------------------
+24          netconf-ssh  admin                10.69.35.35             None

--- a/tests/parsers/iosxe/show_netconf-yang_sessions/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_netconf-yang_sessions/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: NETCONF-YANG management sessions list (issue #298)
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
Closes #298

Adds parser, golden test (raw CLI from Genie), and towncrier fragment.

- Parser: `src/muninn/parsers/iosxe/show_netconf_yang_sessions.py`
- Tests: `tests/parsers/iosxe/show_netconf-yang_sessions/`
- `changes/298.parser_added`

Made with [Cursor](https://cursor.com)