### PR TITLE
feat(iosxe): show netconf-yang datastores

### DIFF
--- a/changes/297.parser_added
+++ b/changes/297.parser_added
@@ -1,0 +1,1 @@
+Added IOS-XE parser for `show netconf-yang datastores`.

--- a/src/muninn/parsers/iosxe/show_netconf_yang_datastores.py
+++ b/src/muninn/parsers/iosxe/show_netconf_yang_datastores.py
@@ -1,0 +1,56 @@
+"""Parser for 'show netconf-yang datastores' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowNetconfYangDatastoresResult(TypedDict):
+    """Schema for 'show netconf-yang datastores' parsed output."""
+
+    datastores: list[str]
+
+
+_DATASTORE_PATTERN = re.compile(
+    r"^Datastore Name\s*:\s*(?P<name>\S+)\s*$",
+    re.IGNORECASE,
+)
+
+# Echoed command / hostname lines (e.g. "cedge#show netconf-yang datastores")
+_PROMPT_LINE_PATTERN = re.compile(r"^\S+#.*$")
+
+
+@register(OS.CISCO_IOSXE, "show netconf-yang datastores")
+class ShowNetconfYangDatastoresParser(BaseParser[ShowNetconfYangDatastoresResult]):
+    """Parser for 'show netconf-yang datastores' command."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowNetconfYangDatastoresResult:
+        """Parse 'show netconf-yang datastores' output.
+
+        Args:
+            output: Raw CLI output from 'show netconf-yang datastores'.
+
+        Returns:
+            List of datastore names; echoed hostname lines are ignored.
+        """
+        names: list[str] = []
+
+        for raw in output.splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            if _PROMPT_LINE_PATTERN.match(line):
+                continue
+
+            match = _DATASTORE_PATTERN.match(line)
+            if match:
+                names.append(match.group("name"))
+
+        return ShowNetconfYangDatastoresResult(datastores=names)

--- a/tests/parsers/iosxe/show_netconf-yang_datastores/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_netconf-yang_datastores/001_basic/expected.json
@@ -1,0 +1,6 @@
+{
+    "datastores": [
+        "running",
+        "candidate"
+    ]
+}

--- a/tests/parsers/iosxe/show_netconf-yang_datastores/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_netconf-yang_datastores/001_basic/input.txt
@@ -1,0 +1,5 @@
+cedge#show netconf-yang datastores
+Datastore Name             : running
+Datastore Name             : candidate
+
+cedge#

--- a/tests/parsers/iosxe/show_netconf-yang_datastores/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_netconf-yang_datastores/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: NETCONF-YANG datastore names (issue #297)
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
Closes #297

Adds parser, golden test (raw CLI from Genie), and towncrier fragment.

- Parser: `src/muninn/parsers/iosxe/show_netconf_yang_datastores.py`
- Tests: `tests/parsers/iosxe/show_netconf-yang_datastores/`
- `changes/297.parser_added`

Made with [Cursor](https://cursor.com)