### PR TITLE
feat(iosxe): show netconf session

### DIFF
--- a/changes/296.parser_added
+++ b/changes/296.parser_added
@@ -1,0 +1,1 @@
+Added IOS-XE parser for `show netconf session`.

--- a/src/muninn/parsers/iosxe/show_netconf_session.py
+++ b/src/muninn/parsers/iosxe/show_netconf_session.py
@@ -1,0 +1,54 @@
+"""Parser for 'show netconf session' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowNetconfSessionResult(TypedDict):
+    """Schema for 'show netconf session' parsed output."""
+
+    open_sessions: int
+    maximum_sessions: int
+
+
+_LINE_PATTERN = re.compile(
+    r"^Netconf Sessions:\s*(?P<open>\d+)\s+open,\s+maximum is\s+(?P<max>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+
+@register(OS.CISCO_IOSXE, "show netconf session")
+class ShowNetconfSessionParser(BaseParser[ShowNetconfSessionResult]):
+    """Parser for 'show netconf session' command."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowNetconfSessionResult:
+        """Parse 'show netconf session' output.
+
+        Args:
+            output: Raw CLI output from 'show netconf session'.
+
+        Returns:
+            Open and maximum NETCONF session counts.
+
+        Raises:
+            ValueError: If the summary line is missing.
+        """
+        for raw in output.splitlines():
+            line = raw.strip()
+            match = _LINE_PATTERN.match(line)
+            if match:
+                return ShowNetconfSessionResult(
+                    open_sessions=int(match.group("open")),
+                    maximum_sessions=int(match.group("max")),
+                )
+
+        msg = "Netconf session summary line not found in output"
+        raise ValueError(msg)

--- a/tests/parsers/iosxe/show_netconf_session/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_netconf_session/001_basic/expected.json
@@ -1,0 +1,4 @@
+{
+    "open_sessions": 0,
+    "maximum_sessions": 4
+}

--- a/tests/parsers/iosxe/show_netconf_session/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_netconf_session/001_basic/input.txt
@@ -1,0 +1,1 @@
+Netconf Sessions: 0 open, maximum is 4

--- a/tests/parsers/iosxe/show_netconf_session/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_netconf_session/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: NETCONF session count and maximum (issue #296)
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
Closes #296

Adds parser, golden test (raw CLI from Genie), and towncrier fragment.

- Parser: `src/muninn/parsers/iosxe/show_netconf_session.py`
- Tests: `tests/parsers/iosxe/show_netconf_session/`
- `changes/296.parser_added`

Made with [Cursor](https://cursor.com)