### PR TITLE
feat(iosxe): register IOS for show ip dhcp snooping binding

### DIFF
--- a/changes/293.parser_added
+++ b/changes/293.parser_added
@@ -1,0 +1,1 @@
+Registered `show ip dhcp snooping binding` for Cisco IOS (shared parser with IOS-XE).

--- a/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_binding.py
+++ b/src/muninn/parsers/iosxe/show_ip_dhcp_snooping_binding.py
@@ -33,6 +33,7 @@ class ShowIpDhcpSnoopingBindingResult(TypedDict):
 
 
 @register(OS.CISCO_IOSXE, "show ip dhcp snooping binding")
+@register(OS.CISCO_IOS, "show ip dhcp snooping binding")
 class ShowIpDhcpSnoopingBindingParser(BaseParser[ShowIpDhcpSnoopingBindingResult]):
     """Parser for 'show ip dhcp snooping binding' command."""
 


### PR DESCRIPTION
Closes #293

Adds parser, golden test (Genie CLI sample), and towncrier fragment `changes/293.parser_added`.