### PR TITLE
refactor(iosxe): SVL link ports as nested dicts

### DIFF
--- a/changes/+svl-link-ports-dict.breaking
+++ b/changes/+svl-link-ports-dict.breaking
@@ -1,0 +1,1 @@
+`show stackwise-virtual link` parser now returns per-switch `ports` as a mapping of interface name to status instead of a list.

--- a/src/muninn/parsers/iosxe/show_stackwise_virtual_link.py
+++ b/src/muninn/parsers/iosxe/show_stackwise_virtual_link.py
@@ -11,9 +11,8 @@ from muninn.utils import canonical_interface_name
 
 
 class SVLLinkPortStatus(TypedDict):
-    """Per-port link and protocol status on an SVL."""
+    """Link and protocol status for one port on an SVL."""
 
-    port: str
     link_status: str
     protocol_status: str
 
@@ -22,7 +21,7 @@ class SVLLinkSwitchEntry(TypedDict):
     """SVL link rows for one switch."""
 
     svl: str
-    ports: list[SVLLinkPortStatus]
+    ports: dict[str, SVLLinkPortStatus]
 
 
 class ShowStackwiseVirtualLinkResult(TypedDict):
@@ -85,14 +84,12 @@ def _parse_link_table(lines: list[str]) -> dict[str, SVLLinkSwitchEntry]:
             if sw not in switches:
                 switches[sw] = SVLLinkSwitchEntry(
                     svl=m.group("svl"),
-                    ports=[],
+                    ports={},
                 )
-            switches[sw]["ports"].append(
-                SVLLinkPortStatus(
-                    port=_canon(m.group("port")),
-                    link_status=m.group("link_st"),
-                    protocol_status=m.group("proto_st"),
-                ),
+            port_name = _canon(m.group("port"))
+            switches[sw]["ports"][port_name] = SVLLinkPortStatus(
+                link_status=m.group("link_st"),
+                protocol_status=m.group("proto_st"),
             )
             continue
 
@@ -100,12 +97,10 @@ def _parse_link_table(lines: list[str]) -> dict[str, SVLLinkSwitchEntry]:
             continue
 
         if m := _CONT.match(line):
-            switches[current_switch]["ports"].append(
-                SVLLinkPortStatus(
-                    port=_canon(m.group("port")),
-                    link_status=m.group("link_st"),
-                    protocol_status=m.group("proto_st"),
-                ),
+            port_name = _canon(m.group("port"))
+            switches[current_switch]["ports"][port_name] = SVLLinkPortStatus(
+                link_status=m.group("link_st"),
+                protocol_status=m.group("proto_st"),
             )
 
     return switches

--- a/tests/parsers/iosxe/show_stackwise-virtual_link/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_stackwise-virtual_link/001_basic/expected.json
@@ -2,33 +2,29 @@
     "switches": {
         "1": {
             "svl": "1",
-            "ports": [
-                {
-                    "port": "HundredGigabitEthernet1/0/1",
+            "ports": {
+                "HundredGigabitEthernet1/0/1": {
                     "link_status": "U",
                     "protocol_status": "P"
                 },
-                {
-                    "port": "HundredGigabitEthernet1/0/6",
+                "HundredGigabitEthernet1/0/6": {
                     "link_status": "U",
                     "protocol_status": "P"
                 }
-            ]
+            }
         },
         "2": {
             "svl": "1",
-            "ports": [
-                {
-                    "port": "HundredGigabitEthernet2/0/1",
+            "ports": {
+                "HundredGigabitEthernet2/0/1": {
                     "link_status": "U",
                     "protocol_status": "P"
                 },
-                {
-                    "port": "HundredGigabitEthernet2/0/6",
+                "HundredGigabitEthernet2/0/6": {
                     "link_status": "U",
                     "protocol_status": "P"
                 }
-            ]
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Updates the `show stackwise-virtual link` parser so each switch\u2019s `ports` field is a **mapping** from canonical interface name to link/protocol status, instead of a **list** of objects that each carried a `port` key.

## Motivation

Nested keys are easier to look up by interface and align with other Muninn patterns that index by interface name.

## Breaking change

Consumers must use `ports.items()` (or key lookup) instead of iterating a list of `{"port": ...}` entries.

## Testing

- `uv run pytest tests/parsers/test_parsers.py -k virtual_link`
- `uv run ty check src/muninn/parsers/iosxe/show_stackwise_virtual_link.py`

Made with [Cursor](https://cursor.com)