### PR TITLE
refactor(ios): key CDP neighbor detail by local interface

### DIFF
--- a/changes/+ios-cdp-neighbors-detail-keyed.breaking
+++ b/changes/+ios-cdp-neighbors-detail-keyed.breaking
@@ -1,0 +1,1 @@
+IOS/IOS-XE `show cdp neighbors detail` parser now returns `neighbors` as a mapping keyed by canonical local interface name instead of a list.

--- a/changes/+ios-cdp-neighbors-detail-keyed.breaking
+++ b/changes/+ios-cdp-neighbors-detail-keyed.breaking
@@ -1,1 +1,1 @@
-IOS/IOS-XE `show cdp neighbors detail` parser now returns `neighbors` as a mapping keyed by canonical local interface name instead of a list.
+IOS/IOS-XE `show cdp neighbors detail` now nests `neighbors` as local interface → CDP device_id → outgoing port_id → entry (replacing both the prior list shape and a flat per-local-interface map). Each neighbor entry no longer repeats `local_interface`; use the top-level key path instead.

--- a/src/muninn/parsers/ios/show_cdp_neighbors_detail.py
+++ b/src/muninn/parsers/ios/show_cdp_neighbors_detail.py
@@ -19,7 +19,6 @@ class CdpNeighborDetailEntry(TypedDict):
     entry_addresses: list[str]
     platform: str
     capabilities: str
-    local_interface: str
     port_id: str
     hold_time: int
     version: str
@@ -33,7 +32,7 @@ class CdpNeighborDetailEntry(TypedDict):
 class ShowCdpNeighborsDetailResult(TypedDict):
     """Schema for 'show cdp neighbors detail' parsed output."""
 
-    neighbors: dict[str, CdpNeighborDetailEntry]
+    neighbors: dict[str, dict[str, dict[str, CdpNeighborDetailEntry]]]
     total_entries: NotRequired[int]
 
 
@@ -226,8 +225,8 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
             entry["management_addresses"] = mgmt_addresses
 
     @classmethod
-    def _parse_block(cls, block: str) -> CdpNeighborDetailEntry | None:
-        """Parse a single neighbor block into a structured entry."""
+    def _parse_block(cls, block: str) -> tuple[str, CdpNeighborDetailEntry] | None:
+        """Parse a single neighbor block into (local interface key, entry)."""
         device_match = cls._DEVICE_ID_PATTERN.search(block)
         if not device_match:
             return None
@@ -239,19 +238,21 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
         platform, capabilities = cls._extract_platform_capabilities(block)
         hold_match = cls._HOLDTIME_PATTERN.search(block)
 
+        local_interface = canonical_interface_name(intf_match.group(1))
+        port_id = canonical_interface_name(intf_match.group(2))
+
         entry: CdpNeighborDetailEntry = {
             "device_id": device_match.group(1).strip(),
             "entry_addresses": cls._extract_addresses(block, cls._ENTRY_ADDR_HEADER),
             "platform": platform,
             "capabilities": capabilities,
-            "local_interface": canonical_interface_name(intf_match.group(1)),
-            "port_id": canonical_interface_name(intf_match.group(2)),
+            "port_id": port_id,
             "hold_time": int(hold_match.group(1)) if hold_match else 0,
             "version": cls._extract_version(block),
         }
 
         cls._add_optional_fields(entry, block)
-        return entry
+        return local_interface, entry
 
     @classmethod
     def parse(cls, output: str) -> ShowCdpNeighborsDetailResult:
@@ -261,18 +262,27 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed CDP neighbor details keyed by canonical local interface name.
+            Parsed CDP neighbor details nested as
+            ``local interface → device_id → port_id (outgoing) → entry``.
+            Multiple neighbors on the same local interface are distinct under
+            ``device_id`` and ``port_id``.
 
         Raises:
             ValueError: If no neighbors found.
         """
         blocks = cls._split_into_blocks(output)
-        neighbors: dict[str, CdpNeighborDetailEntry] = {}
+        neighbors: dict[str, dict[str, dict[str, CdpNeighborDetailEntry]]] = {}
 
         for block in blocks:
-            entry = cls._parse_block(block)
-            if entry is not None:
-                neighbors[entry["local_interface"]] = entry
+            parsed = cls._parse_block(block)
+            if parsed is None:
+                continue
+            local_if, entry = parsed
+            device_id = entry["device_id"]
+            port_key = entry["port_id"]
+            by_local = neighbors.setdefault(local_if, {})
+            by_device = by_local.setdefault(device_id, {})
+            by_device[port_key] = entry
 
         if not neighbors:
             msg = "No CDP neighbor details found in output"

--- a/src/muninn/parsers/ios/show_cdp_neighbors_detail.py
+++ b/src/muninn/parsers/ios/show_cdp_neighbors_detail.py
@@ -33,7 +33,7 @@ class CdpNeighborDetailEntry(TypedDict):
 class ShowCdpNeighborsDetailResult(TypedDict):
     """Schema for 'show cdp neighbors detail' parsed output."""
 
-    neighbors: list[CdpNeighborDetailEntry]
+    neighbors: dict[str, CdpNeighborDetailEntry]
     total_entries: NotRequired[int]
 
 
@@ -261,18 +261,18 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed CDP neighbor details as a list of entries.
+            Parsed CDP neighbor details keyed by canonical local interface name.
 
         Raises:
             ValueError: If no neighbors found.
         """
         blocks = cls._split_into_blocks(output)
-        neighbors: list[CdpNeighborDetailEntry] = []
+        neighbors: dict[str, CdpNeighborDetailEntry] = {}
 
         for block in blocks:
             entry = cls._parse_block(block)
             if entry is not None:
-                neighbors.append(entry)
+                neighbors[entry["local_interface"]] = entry
 
         if not neighbors:
             msg = "No CDP neighbor details found in output"

--- a/tests/parsers/ios/show_cdp_neighbors_detail/001_multiple_neighbors/expected.json
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/001_multiple_neighbors/expected.json
@@ -1,65 +1,77 @@
 {
     "neighbors": {
         "GigabitEthernet1/0/16": {
-            "device_id": "desktop-switch",
-            "entry_addresses": [
-                "10.1.1.2"
-            ],
-            "platform": "cisco WS-C2960-8TC-L",
-            "capabilities": "Switch IGMP",
-            "local_interface": "GigabitEthernet1/0/16",
-            "port_id": "GigabitEthernet0/1",
-            "hold_time": 164,
-            "version": "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2014 by Cisco Systems, Inc.\nCompiled Mon 03-Mar-14 22:53 by prod_rel_team",
-            "advertisement_version": 2,
-            "native_vlan": 1,
-            "duplex": "full",
-            "vtp_management_domain": "",
-            "management_addresses": [
-                "10.1.1.2"
-            ]
+            "desktop-switch": {
+                "GigabitEthernet0/1": {
+                    "device_id": "desktop-switch",
+                    "entry_addresses": [
+                        "10.1.1.2"
+                    ],
+                    "platform": "cisco WS-C2960-8TC-L",
+                    "capabilities": "Switch IGMP",
+                    "port_id": "GigabitEthernet0/1",
+                    "hold_time": 164,
+                    "version": "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2014 by Cisco Systems, Inc.\nCompiled Mon 03-Mar-14 22:53 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "native_vlan": 1,
+                    "duplex": "full",
+                    "vtp_management_domain": "",
+                    "management_addresses": [
+                        "10.1.1.2"
+                    ]
+                }
+            }
         },
         "GigabitEthernet1/0/22": {
-            "device_id": "ce-router",
-            "entry_addresses": [
-                "10.1.1.1"
-            ],
-            "platform": "Cisco 3825",
-            "capabilities": "Router Switch IGMP",
-            "local_interface": "GigabitEthernet1/0/22",
-            "port_id": "GigabitEthernet0/0",
-            "hold_time": 156,
-            "version": "Cisco IOS Software, 3800 Software (C3825-ADVENTERPRISEK9-M), Version 12.4(24)T1, RELEASE SOFTWARE (fc3)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2009 by Cisco Systems, Inc.\nCompiled Fri 19-Jun-09 18:40 by prod_rel_team",
-            "advertisement_version": 2,
-            "duplex": "full",
-            "vtp_management_domain": ""
+            "ce-router": {
+                "GigabitEthernet0/0": {
+                    "device_id": "ce-router",
+                    "entry_addresses": [
+                        "10.1.1.1"
+                    ],
+                    "platform": "Cisco 3825",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "GigabitEthernet0/0",
+                    "hold_time": 156,
+                    "version": "Cisco IOS Software, 3800 Software (C3825-ADVENTERPRISEK9-M), Version 12.4(24)T1, RELEASE SOFTWARE (fc3)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2009 by Cisco Systems, Inc.\nCompiled Fri 19-Jun-09 18:40 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "duplex": "full",
+                    "vtp_management_domain": ""
+                }
+            }
         },
         "GigabitEthernet1/0/19": {
-            "device_id": "server",
-            "entry_addresses": [
-                "10.1.1.232"
-            ],
-            "platform": "VMware",
-            "capabilities": "Host",
-            "local_interface": "GigabitEthernet1/0/19",
-            "port_id": "Ethernet0",
-            "hold_time": 145,
-            "version": "Linux 2.6.32-431.20.3.el6.x86_64 #1 SMP Fri Jun 6 18:30:54 EDT 2014 CCM:10.5.2.10000-5.i386",
-            "advertisement_version": 2,
-            "duplex": "full"
+            "server": {
+                "Ethernet0": {
+                    "device_id": "server",
+                    "entry_addresses": [
+                        "10.1.1.232"
+                    ],
+                    "platform": "VMware",
+                    "capabilities": "Host",
+                    "port_id": "Ethernet0",
+                    "hold_time": 145,
+                    "version": "Linux 2.6.32-431.20.3.el6.x86_64 #1 SMP Fri Jun 6 18:30:54 EDT 2014 CCM:10.5.2.10000-5.i386",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
         },
         "GigabitEthernet0/3": {
-            "device_id": "vIOS-L2-1",
-            "entry_addresses": [],
-            "platform": "Cisco",
-            "capabilities": "Router Switch IGMP",
-            "local_interface": "GigabitEthernet0/3",
-            "port_id": "GigabitEthernet0/3",
-            "hold_time": 173,
-            "version": "Cisco IOS Software, vios_l2 Software (vios_l2-ADVENTERPRISEK9-M), Version 15.2(CML_NIGHTLY_20150414)FLO_DSGS7, EARLY DEPLOYMENT DEVELOPMENT BUILD, synced to  DSGS_PI5_POSTCOLLAPSE_TEAM_TRACK_CLONE\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Wed 15-Apr-15 00:42 by mmen",
-            "advertisement_version": 2,
-            "native_vlan": 1,
-            "duplex": "full"
+            "vIOS-L2-1": {
+                "GigabitEthernet0/3": {
+                    "device_id": "vIOS-L2-1",
+                    "entry_addresses": [],
+                    "platform": "Cisco",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "GigabitEthernet0/3",
+                    "hold_time": 173,
+                    "version": "Cisco IOS Software, vios_l2 Software (vios_l2-ADVENTERPRISEK9-M), Version 15.2(CML_NIGHTLY_20150414)FLO_DSGS7, EARLY DEPLOYMENT DEVELOPMENT BUILD, synced to  DSGS_PI5_POSTCOLLAPSE_TEAM_TRACK_CLONE\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Wed 15-Apr-15 00:42 by mmen",
+                    "advertisement_version": 2,
+                    "native_vlan": 1,
+                    "duplex": "full"
+                }
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_cdp_neighbors_detail/001_multiple_neighbors/expected.json
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/001_multiple_neighbors/expected.json
@@ -1,6 +1,6 @@
 {
-    "neighbors": [
-        {
+    "neighbors": {
+        "GigabitEthernet1/0/16": {
             "device_id": "desktop-switch",
             "entry_addresses": [
                 "10.1.1.2"
@@ -19,7 +19,7 @@
                 "10.1.1.2"
             ]
         },
-        {
+        "GigabitEthernet1/0/22": {
             "device_id": "ce-router",
             "entry_addresses": [
                 "10.1.1.1"
@@ -34,7 +34,7 @@
             "duplex": "full",
             "vtp_management_domain": ""
         },
-        {
+        "GigabitEthernet1/0/19": {
             "device_id": "server",
             "entry_addresses": [
                 "10.1.1.232"
@@ -48,7 +48,7 @@
             "advertisement_version": 2,
             "duplex": "full"
         },
-        {
+        "GigabitEthernet0/3": {
             "device_id": "vIOS-L2-1",
             "entry_addresses": [],
             "platform": "Cisco",
@@ -61,5 +61,5 @@
             "native_vlan": 1,
             "duplex": "full"
         }
-    ]
+    }
 }

--- a/tests/parsers/ios/show_cdp_neighbors_detail/002_single_neighbor/expected.json
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/002_single_neighbor/expected.json
@@ -1,6 +1,6 @@
 {
-    "neighbors": [
-        {
+    "neighbors": {
+        "GigabitEthernet0/3": {
             "device_id": "switchxxxxx",
             "entry_addresses": [
                 "1.1.1.1"
@@ -19,5 +19,5 @@
                 "1.1.1.1"
             ]
         }
-    ]
+    }
 }

--- a/tests/parsers/ios/show_cdp_neighbors_detail/002_single_neighbor/expected.json
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/002_single_neighbor/expected.json
@@ -1,23 +1,26 @@
 {
     "neighbors": {
         "GigabitEthernet0/3": {
-            "device_id": "switchxxxxx",
-            "entry_addresses": [
-                "1.1.1.1"
-            ],
-            "platform": "cisco WS-C3560X-24P",
-            "capabilities": "Switch IGMP",
-            "local_interface": "GigabitEthernet0/3",
-            "port_id": "GigabitEthernet0/8",
-            "hold_time": 154,
-            "version": "Cisco IOS Software, C3560E Software (C3560E-UNIVERSALK9-M), Version 12.2(55)SE10, RELEASE SOFTWARE (fc2)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Wed 11-Feb-15 11:28 by prod_rel_team",
-            "advertisement_version": 2,
-            "native_vlan": 1,
-            "duplex": "full",
-            "vtp_management_domain": "",
-            "management_addresses": [
-                "1.1.1.1"
-            ]
+            "switchxxxxx": {
+                "GigabitEthernet0/8": {
+                    "device_id": "switchxxxxx",
+                    "entry_addresses": [
+                        "1.1.1.1"
+                    ],
+                    "platform": "cisco WS-C3560X-24P",
+                    "capabilities": "Switch IGMP",
+                    "port_id": "GigabitEthernet0/8",
+                    "hold_time": 154,
+                    "version": "Cisco IOS Software, C3560E Software (C3560E-UNIVERSALK9-M), Version 12.2(55)SE10, RELEASE SOFTWARE (fc2)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Wed 11-Feb-15 11:28 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "native_vlan": 1,
+                    "duplex": "full",
+                    "vtp_management_domain": "",
+                    "management_addresses": [
+                        "1.1.1.1"
+                    ]
+                }
+            }
         }
     }
 }

--- a/tests/parsers/ios/show_cdp_neighbors_detail/003_two_neighbors_same_local_interface/expected.json
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/003_two_neighbors_same_local_interface/expected.json
@@ -1,0 +1,36 @@
+{
+    "neighbors": {
+        "GigabitEthernet1/0/16": {
+            "upstream-core": {
+                "GigabitEthernet0/1": {
+                    "device_id": "upstream-core",
+                    "entry_addresses": [
+                        "10.0.0.1"
+                    ],
+                    "platform": "cisco WS-C2960-8TC-L",
+                    "capabilities": "Switch IGMP",
+                    "port_id": "GigabitEthernet0/1",
+                    "hold_time": 120,
+                    "version": "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            },
+            "access-switch": {
+                "GigabitEthernet0/2": {
+                    "device_id": "access-switch",
+                    "entry_addresses": [
+                        "10.0.0.2"
+                    ],
+                    "platform": "cisco WS-C2960-8TC-L",
+                    "capabilities": "Switch IGMP",
+                    "port_id": "GigabitEthernet0/2",
+                    "hold_time": 121,
+                    "version": "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_cdp_neighbors_detail/003_two_neighbors_same_local_interface/input.txt
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/003_two_neighbors_same_local_interface/input.txt
@@ -1,0 +1,27 @@
+-------------------------
+Device ID: upstream-core
+Entry address(es):
+  IP address: 10.0.0.1
+Platform: cisco WS-C2960-8TC-L,  Capabilities: Switch IGMP
+Interface: GigabitEthernet1/0/16,  Port ID (outgoing port): GigabitEthernet0/1
+Holdtime : 120 sec
+
+Version :
+Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: access-switch
+Entry address(es):
+  IP address: 10.0.0.2
+Platform: cisco WS-C2960-8TC-L,  Capabilities: Switch IGMP
+Interface: GigabitEthernet1/0/16,  Port ID (outgoing port): GigabitEthernet0/2
+Holdtime : 121 sec
+
+Version :
+Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 12.2(55)SE9, RELEASE SOFTWARE (fc1)
+
+advertisement version: 2
+Duplex: full

--- a/tests/parsers/ios/show_cdp_neighbors_detail/003_two_neighbors_same_local_interface/metadata.yaml
+++ b/tests/parsers/ios/show_cdp_neighbors_detail/003_two_neighbors_same_local_interface/metadata.yaml
@@ -1,0 +1,3 @@
+platform: Cisco IOS
+software_version: Unknown
+description: Two CDP neighbors on the same local interface (different remote devices and ports).

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -57,8 +57,6 @@ PARSERS_TEST_DIR = Path(__file__).parent
 _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
     {
         # --- IOS ---
-        "ios/show_cdp_neighbors_detail/001_multiple_neighbors/expected.json",
-        "ios/show_cdp_neighbors_detail/002_single_neighbor/expected.json",
         "ios/show_crypto_session_detail/001_basic/expected.json",
         "ios/show_dot1x_all/002_with_clients/expected.json",
         "ios/show_interfaces/003_port_channel_members/expected.json",


### PR DESCRIPTION
## Summary

Implements **hierarchical keyed output** for `show cdp neighbors detail` on **IOS and IOS-XE** (shared parser), per [design principles §4](https://github.com/ChartinoLabs/Muninn/blob/main/docs/01-design-principles.md) (prefer nested dicts over encoding multiple dimensions in a single key).

### Schema

- `neighbors` is a **three-level** mapping: **`canonical local interface → CDP device_id → outgoing port_id → CdpNeighborDetailEntry`**.
- This supports **multiple CDP neighbors on the same local interface** (distinct under `device_id` and/or remote `port_id`). A flat `dict[str, CdpNeighborDetailEntry]` keyed only by local interface could not represent that.
- Each entry **no longer includes** `local_interface`; it is implied by the first key in the path.

### Tests and tooling

- Updated IOS fixtures; removed paths from `_LIST_OF_DICTS_EXEMPT_EXPECTED_FILES`.
- Added `003_two_neighbors_same_local_interface` to lock in two neighbors on one local interface.
- Towncrier **breaking** fragment updated.

**Closes #586** (child of epic #606).

Made with [Cursor](https://cursor.com)
