### PR TITLE
refactor(iosxe): key stackwise-virtual neighbors by local port

### DIFF
--- a/changes/+iosxe-stackwise-virtual-neighbors-ports.breaking
+++ b/changes/+iosxe-stackwise-virtual-neighbors-ports.breaking
@@ -1,0 +1,1 @@
+IOS-XE `show stackwise-virtual neighbors` parser now returns per-switch `ports` as a mapping of local interface name to `{ "remote_port": ... }` instead of a `port_pairs` list.

--- a/src/muninn/parsers/iosxe/show_stackwise_virtual_neighbors.py
+++ b/src/muninn/parsers/iosxe/show_stackwise_virtual_neighbors.py
@@ -10,10 +10,9 @@ from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
 
 
-class NeighborPortPair(TypedDict):
-    """Local and optional remote SVL neighbor port."""
+class NeighborPortRemote(TypedDict):
+    """Remote SVL neighbor port for a local interface."""
 
-    local_port: str
     remote_port: str
 
 
@@ -21,7 +20,7 @@ class NeighborSwitchEntry(TypedDict):
     """SVL neighbor information for one switch."""
 
     svl: str
-    port_pairs: list[NeighborPortPair]
+    ports: dict[str, NeighborPortRemote]
 
 
 class ShowStackwiseVirtualNeighborsResult(TypedDict):
@@ -73,13 +72,11 @@ def _parse_neighbors_table(lines: list[str]) -> dict[str, NeighborSwitchEntry]:
             if sw not in switches:
                 switches[sw] = NeighborSwitchEntry(
                     svl=m.group("svl"),
-                    port_pairs=[],
+                    ports={},
                 )
-            switches[sw]["port_pairs"].append(
-                NeighborPortPair(
-                    local_port=_canon(m.group("local")),
-                    remote_port=_canon(m.group("remote")),
-                ),
+            local = _canon(m.group("local"))
+            switches[sw]["ports"][local] = NeighborPortRemote(
+                remote_port=_canon(m.group("remote")),
             )
             continue
 
@@ -87,18 +84,14 @@ def _parse_neighbors_table(lines: list[str]) -> dict[str, NeighborSwitchEntry]:
             continue
 
         if m := _CONT_TWO.match(line):
-            switches[current_switch]["port_pairs"].append(
-                NeighborPortPair(
-                    local_port=_canon(m.group("local")),
-                    remote_port=_canon(m.group("remote")),
-                ),
+            local = _canon(m.group("local"))
+            switches[current_switch]["ports"][local] = NeighborPortRemote(
+                remote_port=_canon(m.group("remote")),
             )
         elif m := _CONT_ONE.match(line):
-            switches[current_switch]["port_pairs"].append(
-                NeighborPortPair(
-                    local_port=_canon(m.group("local")),
-                    remote_port="",
-                ),
+            local = _canon(m.group("local"))
+            switches[current_switch]["ports"][local] = NeighborPortRemote(
+                remote_port="",
             )
 
     return switches

--- a/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_stackwise-virtual_neighbors/001_basic/expected.json
@@ -2,37 +2,31 @@
     "switches": {
         "1": {
             "svl": "1",
-            "port_pairs": [
-                {
-                    "local_port": "HundredGigabitEthernet1/1/0/19",
+            "ports": {
+                "HundredGigabitEthernet1/1/0/19": {
                     "remote_port": "HundredGigabitEthernet2/1/0/23"
                 },
-                {
-                    "local_port": "HundredGigabitEthernet1/5/0/17",
+                "HundredGigabitEthernet1/5/0/17": {
                     "remote_port": "HundredGigabitEthernet2/1/0/24"
                 },
-                {
-                    "local_port": "FiftyGigabitEthernet1/6/0/33",
+                "FiftyGigabitEthernet1/6/0/33": {
                     "remote_port": ""
                 }
-            ]
+            }
         },
         "2": {
             "svl": "1",
-            "port_pairs": [
-                {
-                    "local_port": "HundredGigabitEthernet2/1/0/23",
+            "ports": {
+                "HundredGigabitEthernet2/1/0/23": {
                     "remote_port": "HundredGigabitEthernet1/1/0/19"
                 },
-                {
-                    "local_port": "HundredGigabitEthernet2/1/0/24",
+                "HundredGigabitEthernet2/1/0/24": {
                     "remote_port": "HundredGigabitEthernet1/5/0/17"
                 },
-                {
-                    "local_port": "FiftyGigabitEthernet2/6/0/29",
+                "FiftyGigabitEthernet2/6/0/29": {
                     "remote_port": ""
                 }
-            ]
+            }
         }
     }
 }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -152,7 +152,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "iosxe/show_processes_memory/001_live_device/expected.json",
         "iosxe/show_processes_memory/003_sorted_two_pools_with_total_line/expected.json",
         "iosxe/show_processes_memory_sorted/001_live_device/expected.json",
-        "iosxe/show_stackwise-virtual_neighbors/001_basic/expected.json",
         "iosxe/show_standby_brief/001_multiple_active_groups/expected.json",
         "iosxe/show_standby_brief/002_ipv6_and_continuation_lines/expected.json",
         "iosxe/show_standby_brief/003_single_init_no_preempt/expected.json",


### PR DESCRIPTION
## Summary
- `port_pairs` → `ports`: `dict[local_interface, { remote_port }]` per switch.
- Fixture + exemption cleanup; breaking towncrier fragment.

**Closes #594** (epic #606).

Made with [Cursor](https://cursor.com)