### PR TITLE
refactor(ios): keyed port-channel members in show interfaces

### DIFF
--- a/changes/588.breaking
+++ b/changes/588.breaking
@@ -1,0 +1,1 @@
+IOS/IOS-XE ``show interfaces`` parser: ``port_channel.members`` is now a dict keyed by canonical interface name; each value holds ``duplex`` and ``speed`` only (the redundant ``interface`` field is removed).

--- a/src/muninn/parsers/ios/show_interfaces.py
+++ b/src/muninn/parsers/ios/show_interfaces.py
@@ -68,9 +68,8 @@ class CountersEntry(TypedDict):
 
 
 class PortChannelMemberEntry(TypedDict):
-    """Schema for a port-channel member."""
+    """Per-member duplex and speed (see ``PortChannelInfo.members`` keys)."""
 
-    interface: str
     duplex: str
     speed: str
 
@@ -79,7 +78,7 @@ class PortChannelInfo(TypedDict):
     """Schema for port-channel information."""
 
     active_members: int
-    members: list[PortChannelMemberEntry]
+    members: dict[str, PortChannelMemberEntry]
     pf_jumbo_members: NotRequired[int]
 
 
@@ -617,7 +616,8 @@ def _parse_tunnel(lines: list[str]) -> TunnelInfo:
 
 def _parse_port_channel(lines: list[str]) -> PortChannelInfo:
     """Parse port-channel specific lines."""
-    pc: PortChannelInfo = {"active_members": 0, "members": []}
+    members: dict[str, PortChannelMemberEntry] = {}
+    pc: PortChannelInfo = {"active_members": 0, "members": members}
     for line in lines:
         m = _PC_ACTIVE_RE.match(line)
         if m:
@@ -626,13 +626,11 @@ def _parse_port_channel(lines: list[str]) -> PortChannelInfo:
 
         m = _PC_MEMBER_RE.match(line)
         if m:
-            pc["members"].append(
-                {
-                    "interface": canonical_interface_name(m.group(1), os=OS.CISCO_IOS),
-                    "duplex": m.group(2).strip(),
-                    "speed": m.group(3),
-                }
-            )
+            if_name = canonical_interface_name(m.group(1), os=OS.CISCO_IOS)
+            members[if_name] = {
+                "duplex": m.group(2).strip(),
+                "speed": m.group(3),
+            }
             continue
 
         m = _PC_JUMBO_RE.match(line)
@@ -645,14 +643,9 @@ def _parse_port_channel(lines: list[str]) -> PortChannelInfo:
             # "Members in this channel: Gi1/0/2" — short form without duplex/speed
             member_str = m.group(1).strip()
             for name in member_str.split():
-                pc["members"].append(
-                    {
-                        "interface": canonical_interface_name(name, os=OS.CISCO_IOS),
-                        "duplex": "",
-                        "speed": "",
-                    }
-                )
-            pc["active_members"] = len(pc["members"])
+                canon = canonical_interface_name(name, os=OS.CISCO_IOS)
+                members[canon] = {"duplex": "", "speed": ""}
+            pc["active_members"] = len(members)
             continue
 
     return pc

--- a/tests/parsers/ios/show_interfaces/003_port_channel_members/expected.json
+++ b/tests/parsers/ios/show_interfaces/003_port_channel_members/expected.json
@@ -78,18 +78,16 @@
             },
             "port_channel": {
                 "active_members": 2,
-                "members": [
-                    {
-                        "interface": "TenGigabitEthernet0/0/0",
+                "members": {
+                    "TenGigabitEthernet0/0/0": {
                         "duplex": "Full-duplex",
                         "speed": "10000Mb/s"
                     },
-                    {
-                        "interface": "TenGigabitEthernet0/0/1",
+                    "TenGigabitEthernet0/0/1": {
                         "duplex": "Full-duplex",
                         "speed": "10000Mb/s"
                     }
-                ],
+                },
                 "pf_jumbo_members": 2
             }
         },

--- a/tests/parsers/iosxe/show_interfaces/002_mixed_types/expected.json
+++ b/tests/parsers/iosxe/show_interfaces/002_mixed_types/expected.json
@@ -447,13 +447,12 @@
             },
             "port_channel": {
                 "active_members": 1,
-                "members": [
-                    {
-                        "interface": "GigabitEthernet1/0/2",
+                "members": {
+                    "GigabitEthernet1/0/2": {
                         "duplex": "",
                         "speed": ""
                     }
-                ]
+                }
             }
         },
         "GigabitEthernet0/0/4": {

--- a/tests/parsers/iosxe/show_interfaces/004_port_channel_802q/expected.json
+++ b/tests/parsers/iosxe/show_interfaces/004_port_channel_802q/expected.json
@@ -75,18 +75,16 @@
             },
             "port_channel": {
                 "active_members": 2,
-                "members": [
-                    {
-                        "interface": "GigabitEthernet0/0/0",
+                "members": {
+                    "GigabitEthernet0/0/0": {
                         "duplex": "Full-duplex",
                         "speed": "1000Mb/s"
                     },
-                    {
-                        "interface": "GigabitEthernet0/0/1",
+                    "GigabitEthernet0/0/1": {
                         "duplex": "Full-duplex",
                         "speed": "1000Mb/s"
                     }
-                ],
+                },
                 "pf_jumbo_members": 2
             }
         }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -61,7 +61,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "ios/show_cdp_neighbors_detail/002_single_neighbor/expected.json",
         "ios/show_crypto_session_detail/001_basic/expected.json",
         "ios/show_dot1x_all/002_with_clients/expected.json",
-        "ios/show_interfaces/003_port_channel_members/expected.json",
         "ios/show_ip_eigrp_topology/001_basic/expected.json",
         "ios/show_ip_eigrp_topology/002_multiple_as/expected.json",
         "ios/show_ip_ospf_database/001_basic/expected.json",


### PR DESCRIPTION
## Summary
- `port_channel.members` is now `dict[str, PortChannelMemberEntry]` keyed by canonical interface name; each entry has `duplex` and `speed` only.
- Updated IOS fixture `003_port_channel_members` and shared IOS-XE `show interfaces` fixtures that embed the same structure; removed the list-of-dicts convention exemption for the IOS fixture.
- Changelog: `changes/588.breaking`.

Closes #588

Made with [Cursor](https://cursor.com)