### PR TITLE
refactor(ios): key show object-group entries by stable identity

### DIFF
--- a/changes/589.breaking
+++ b/changes/589.breaking
@@ -1,0 +1,1 @@
+IOS ``show object-group`` parser now returns each group's ``entries`` as a mapping of stable entry keys to entry dicts instead of a list.

--- a/src/muninn/parsers/ios/show_object_group.py
+++ b/src/muninn/parsers/ios/show_object_group.py
@@ -1,7 +1,7 @@
 """Parser for 'show object-group' command on IOS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -40,7 +40,7 @@ class ObjectGroup(TypedDict):
 
     group_type: str
     description: NotRequired[str]
-    entries: list[NetworkEntry | ServiceEntry]
+    entries: dict[str, NetworkEntry | ServiceEntry]
 
 
 class ShowObjectGroupResult(TypedDict):
@@ -182,6 +182,68 @@ def _parse_service_entry(line: str, group_type: str) -> ServiceEntry | None:
     return entry
 
 
+def _network_entry_key(entry: NetworkEntry) -> str:
+    """Stable key for a network or V6-network object-group entry."""
+    if entry.get("any"):
+        return "any"
+    if "host" in entry:
+        return f"host:{entry['host']}"
+    if "range_start" in entry:
+        return f"range:{entry['range_start']}-{entry['range_end']}"
+    if "group_object" in entry:
+        return f"group-object:{entry['group_object']}"
+    if "network" in entry:
+        return f"network:{entry['network']}/{entry['mask']}"
+    msg = f"Unsupported network object-group entry: {entry!r}"
+    raise ValueError(msg)
+
+
+def _service_entry_key(entry: ServiceEntry) -> str:
+    """Stable key for a service or V6-service object-group entry."""
+    if "group_object" in entry:
+        return f"group-object:{entry['group_object']}"
+
+    proto = entry.get("protocol", "")
+    if proto == "icmp":
+        if "icmp_type" in entry:
+            return f"icmp:{entry['icmp_type']}"
+        return "icmp"
+
+    port_match = entry.get("port_match")
+    if port_match == "range":
+        return f"{proto}:range:{entry['port_range_start']}:{entry['port_range_end']}"
+    if port_match in ("eq", "lt", "gt"):
+        return f"{proto}:{port_match}:{entry['port']}"
+    if port_match is None:
+        return proto
+
+    msg = f"Unsupported service object-group entry: {entry!r}"
+    raise ValueError(msg)
+
+
+def _object_group_entry_base_key(entry: NetworkEntry | ServiceEntry) -> str:
+    """Return a stable key for an object-group entry (may collide on duplicates)."""
+    gtype = entry["type"]
+    if "Network" in gtype:
+        return _network_entry_key(cast(NetworkEntry, entry))
+    return _service_entry_key(cast(ServiceEntry, entry))
+
+
+def _insert_entry(
+    entries: dict[str, NetworkEntry | ServiceEntry],
+    entry: NetworkEntry | ServiceEntry,
+) -> None:
+    """Insert *entry* under a unique key derived from its semantic identity."""
+    base = _object_group_entry_base_key(entry)
+    if base not in entries:
+        entries[base] = entry
+        return
+    n = 2
+    while f"{base}#{n}" in entries:
+        n += 1
+    entries[f"{base}#{n}"] = entry
+
+
 def _parse_entry(line: str, group_type: str) -> NetworkEntry | ServiceEntry | None:
     """Parse an object-group entry line based on group type.
 
@@ -214,7 +276,7 @@ def _process_header(
     group_type = header_match.group("type")
     # Avoid overwriting entries if the group was already created.
     if name not in object_groups:
-        object_groups[name] = {"group_type": group_type, "entries": []}
+        object_groups[name] = {"group_type": group_type, "entries": {}}
     return name, group_type
 
 
@@ -232,7 +294,7 @@ def _process_body_line(
 
     entry = _parse_entry(line, current_type)
     if entry:
-        object_groups[current_name]["entries"].append(entry)
+        _insert_entry(object_groups[current_name]["entries"], entry)
 
 
 def _parse_object_groups(output: str) -> dict[str, ObjectGroup]:
@@ -300,7 +362,8 @@ class ShowObjectGroupParser(BaseParser[ShowObjectGroupResult]):
             output: Raw CLI output from 'show object-group' command.
 
         Returns:
-            Parsed data with object groups keyed by name.
+            Parsed data with object groups keyed by name. Each group's ``entries``
+            maps a stable entry identity string to that entry's fields.
 
         Raises:
             ValueError: If no object groups found in output.

--- a/tests/parsers/ios/show_object-group/001_basic/expected.json
+++ b/tests/parsers/ios/show_object-group/001_basic/expected.json
@@ -2,150 +2,150 @@
     "object_groups": {
         "NNNN": {
             "group_type": "Network",
-            "entries": []
+            "entries": {}
         },
         "SSSS": {
             "group_type": "Service",
-            "entries": []
+            "entries": {}
         },
         "TEST-SVC-OGR": {
             "group_type": "Service",
-            "description": "! Test Service Group !",
-            "entries": [
-                {
+            "entries": {
+                "icmp:echo-reply": {
                     "type": "Service",
                     "protocol": "icmp",
                     "icmp_type": "echo-reply"
                 },
-                {
+                "tcp:eq:smtp": {
                     "type": "Service",
                     "protocol": "tcp",
                     "port_match": "eq",
                     "port": "smtp"
                 },
-                {
+                "udp:eq:tacacs": {
                     "type": "Service",
                     "protocol": "udp",
                     "port_match": "eq",
                     "port": "tacacs"
                 },
-                {
+                "udp:range:tacacs:50": {
                     "type": "Service",
                     "protocol": "udp",
                     "port_match": "range",
                     "port_range_start": "tacacs",
                     "port_range_end": "50"
                 },
-                {
+                "tcp:range:79:www": {
                     "type": "Service",
                     "protocol": "tcp",
                     "port_match": "range",
                     "port_range_start": "79",
                     "port_range_end": "www"
                 },
-                {
+                "tcp:eq:www": {
                     "type": "Service",
                     "protocol": "tcp",
                     "port_match": "eq",
                     "port": "www"
                 },
-                {
+                "tcp:eq:81": {
                     "type": "Service",
                     "protocol": "tcp",
                     "port_match": "eq",
                     "port": "81"
                 },
-                {
+                "udp:lt:999": {
                     "type": "Service",
                     "protocol": "udp",
                     "port_match": "lt",
                     "port": "999"
                 },
-                {
+                "udp:gt:97": {
                     "type": "Service",
                     "protocol": "udp",
                     "port_match": "gt",
                     "port": "97"
                 },
-                {
+                "tcp-udp:range:12200:12700": {
                     "type": "Service",
                     "protocol": "tcp-udp",
                     "port_match": "range",
                     "port_range_start": "12200",
                     "port_range_end": "12700"
                 },
-                {
+                "icmp": {
                     "type": "Service",
                     "protocol": "icmp"
                 },
-                {
+                "tcp": {
                     "type": "Service",
                     "protocol": "tcp"
                 },
-                {
+                "udp": {
                     "type": "Service",
                     "protocol": "udp"
                 },
-                {
+                "tcp-udp:range:0:65535": {
                     "type": "Service",
                     "protocol": "tcp-udp",
                     "port_match": "range",
                     "port_range_start": "0",
                     "port_range_end": "65535"
                 },
-                {
+                "group-object:SSSS": {
                     "type": "Service",
                     "group_object": "SSSS"
                 },
-                {
+                "ip": {
                     "type": "Service",
                     "protocol": "ip"
                 },
-                {
+                "ipinip": {
                     "type": "Service",
                     "protocol": "ipinip"
                 },
-                {
+                "99": {
                     "type": "Service",
                     "protocol": "99"
                 }
-            ]
+            },
+            "description": "! Test Service Group !"
         },
         "TEST_NET_OGR": {
             "group_type": "Network",
-            "description": "###TEST NETWORK OGR###",
-            "entries": [
-                {
+            "entries": {
+                "any": {
                     "type": "Network",
                     "any": true
                 },
-                {
+                "host:1.1.1.1": {
                     "type": "Network",
                     "host": "1.1.1.1"
                 },
-                {
+                "range:2.2.2.2-3.3.3.3": {
                     "type": "Network",
                     "range_start": "2.2.2.2",
                     "range_end": "3.3.3.3"
                 },
-                {
+                "group-object:NNNN": {
                     "type": "Network",
                     "group_object": "NNNN"
                 },
-                {
+                "network:1.1.1.0/255.255.255.0": {
                     "type": "Network",
                     "network": "1.1.1.0",
                     "mask": "255.255.255.0"
                 }
-            ]
+            },
+            "description": "###TEST NETWORK OGR###"
         },
         "XXXX": {
             "group_type": "Network",
-            "entries": []
+            "entries": {}
         },
         "YYYY": {
             "group_type": "Network",
-            "entries": []
+            "entries": {}
         }
     }
 }

--- a/tests/parsers/ios/show_object-group/002_ipv6/expected.json
+++ b/tests/parsers/ios/show_object-group/002_ipv6/expected.json
@@ -2,41 +2,41 @@
     "object_groups": {
         "TEST-v6-obj": {
             "group_type": "V6-Network",
-            "entries": [
-                {
+            "entries": {
+                "host:2001:db8::1:1111": {
                     "type": "V6-Network",
                     "host": "2001:db8::1:1111"
                 },
-                {
+                "host:2001:db8::2:2222": {
                     "type": "V6-Network",
                     "host": "2001:db8::2:2222"
                 },
-                {
+                "network:2001:db8:111:1::/48": {
                     "type": "V6-Network",
                     "network": "2001:db8:111:1::",
                     "mask": "48"
                 },
-                {
+                "network:2001:db8:222:2::/48": {
                     "type": "V6-Network",
                     "network": "2001:db8:222:2::",
                     "mask": "48"
                 }
-            ]
+            }
         },
         "TEST-v6-icmp": {
             "group_type": "V6-Service",
-            "entries": [
-                {
+            "entries": {
+                "icmp:echo-request": {
                     "type": "V6-Service",
                     "protocol": "icmp",
                     "icmp_type": "echo-request"
                 },
-                {
+                "icmp:echo-reply": {
                     "type": "V6-Service",
                     "protocol": "icmp",
                     "icmp_type": "echo-reply"
                 }
-            ]
+            }
         }
     }
 }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -92,8 +92,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "ios/show_mac_address-table/008_extended_multi_supervisor/expected.json",
         "ios/show_mac_address-table/009_unicast_multicast_static_switch/expected.json",
         "ios/show_mac_address-table/010_standard_simple_vlan_svi/expected.json",
-        "ios/show_object-group/001_basic/expected.json",
-        "ios/show_object-group/002_ipv6/expected.json",
         "ios/show_processes_memory/001_basic/expected.json",
         "ios/show_processes_memory_sorted/001_basic/expected.json",
         "ios/show_processes_memory_sorted/002_single_pool/expected.json",


### PR DESCRIPTION
## Summary

- Replace `entries` list-of-dicts with a `dict[str, ...]` keyed by stable identity strings (e.g. `network:1.1.1.0/255.255.255.0`, `tcp:eq:smtp`, `icmp:echo-reply`). Duplicate semantics append `#2`, `#3`, …
- Update `001_basic` and `002_ipv6` `expected.json`; remove list-of-dicts exemptions in `test_fixture_json_conventions.py`.
- Add Towncrier `changes/589.breaking`.

Closes #589

Made with [Cursor](https://cursor.com)