### PR TITLE
refactor(ios): key show vlan private_vlans by secondary ID

### DIFF
--- a/changes/592.breaking
+++ b/changes/592.breaking
@@ -1,0 +1,1 @@
+`show vlan` on IOS/IOS-XE now returns `private_vlans` as a mapping of secondary VLAN ID (string) to association details instead of a list.

--- a/src/muninn/parsers/ios/show_vlan.py
+++ b/src/muninn/parsers/ios/show_vlan.py
@@ -47,7 +47,7 @@ class ShowVlanResult(TypedDict):
 
     vlans: dict[str, VlanEntry]
     remote_span_vlans: NotRequired[list[int]]
-    private_vlans: NotRequired[list[PrivateVlanEntry]]
+    private_vlans: NotRequired[dict[str, PrivateVlanEntry]]
 
 
 # Section header patterns
@@ -307,9 +307,9 @@ def _parse_private_vlan_line(
 
 def _parse_private_vlans(
     lines: list[str],
-) -> list[PrivateVlanEntry]:
-    """Parse Private VLAN associations table."""
-    entries: list[PrivateVlanEntry] = []
+) -> dict[str, PrivateVlanEntry]:
+    """Parse Private VLAN associations table (keyed by secondary VLAN ID)."""
+    entries: dict[str, PrivateVlanEntry] = {}
 
     header_idx = -1
     for i, line in enumerate(lines):
@@ -333,7 +333,7 @@ def _parse_private_vlans(
 
         entry = _parse_private_vlan_line(line, pri_col, sec_col, type_col, ports_col)
         if entry is not None:
-            entries.append(entry)
+            entries[str(entry["secondary"])] = entry
 
     return entries
 

--- a/tests/parsers/ios/show_vlan/002_remote_span_and_private_vlans/expected.json
+++ b/tests/parsers/ios/show_vlan/002_remote_span_and_private_vlans/expected.json
@@ -107,8 +107,30 @@
         27,
         102
     ],
-    "private_vlans": [
-        {
+    "private_vlans": {
+        "10": {
+            "secondary": 10,
+            "type": "community",
+            "ports": []
+        },
+        "105": {
+            "primary": 20,
+            "secondary": 105,
+            "type": "isolated",
+            "ports": []
+        },
+        "151": {
+            "primary": 100,
+            "secondary": 151,
+            "type": "non-operational",
+            "ports": []
+        },
+        "202": {
+            "secondary": 202,
+            "type": "community",
+            "ports": []
+        },
+        "301": {
             "primary": 2,
             "secondary": 301,
             "type": "community",
@@ -117,44 +139,22 @@
                 "FastEthernet5/25"
             ]
         },
-        {
+        "302": {
             "primary": 2,
             "secondary": 302,
             "type": "community",
             "ports": []
         },
-        {
-            "secondary": 10,
-            "type": "community",
-            "ports": []
-        },
-        {
-            "primary": 20,
-            "secondary": 105,
-            "type": "isolated",
-            "ports": []
-        },
-        {
-            "primary": 100,
-            "secondary": 151,
-            "type": "non-operational",
-            "ports": []
-        },
-        {
-            "secondary": 202,
-            "type": "community",
-            "ports": []
-        },
-        {
+        "303": {
             "secondary": 303,
             "type": "community",
             "ports": []
         },
-        {
+        "402": {
             "primary": 101,
             "secondary": 402,
             "type": "non-operational",
             "ports": []
         }
-    ]
+    }
 }

--- a/tests/parsers/ios/show_vlan/003_token_ring/expected.json
+++ b/tests/parsers/ios/show_vlan/003_token_ring/expected.json
@@ -71,12 +71,12 @@
             "trans2": 0
         }
     },
-    "private_vlans": [
-        {
+    "private_vlans": {
+        "2": {
             "primary": 1,
             "secondary": 2,
             "type": "community",
             "ports": []
         }
-    ]
+    }
 }

--- a/tests/parsers/iosxe/show_vlan/002_all_statuses_remote_span_private_vlans/expected.json
+++ b/tests/parsers/iosxe/show_vlan/002_all_statuses_remote_span_private_vlans/expected.json
@@ -115,8 +115,30 @@
         27,
         102
     ],
-    "private_vlans": [
-        {
+    "private_vlans": {
+        "10": {
+            "secondary": 10,
+            "type": "community",
+            "ports": []
+        },
+        "105": {
+            "secondary": 105,
+            "type": "isolated",
+            "ports": [],
+            "primary": 20
+        },
+        "151": {
+            "secondary": 151,
+            "type": "non-operational",
+            "ports": [],
+            "primary": 100
+        },
+        "202": {
+            "secondary": 202,
+            "type": "community",
+            "ports": []
+        },
+        "301": {
             "secondary": 301,
             "type": "community",
             "ports": [
@@ -125,44 +147,22 @@
             ],
             "primary": 2
         },
-        {
+        "302": {
             "secondary": 302,
             "type": "community",
             "ports": [],
             "primary": 2
         },
-        {
-            "secondary": 10,
-            "type": "community",
-            "ports": []
-        },
-        {
-            "secondary": 105,
-            "type": "isolated",
-            "ports": [],
-            "primary": 20
-        },
-        {
-            "secondary": 151,
-            "type": "non-operational",
-            "ports": [],
-            "primary": 100
-        },
-        {
-            "secondary": 202,
-            "type": "community",
-            "ports": []
-        },
-        {
+        "303": {
             "secondary": 303,
             "type": "community",
             "ports": []
         },
-        {
+        "402": {
             "secondary": 402,
             "type": "non-operational",
             "ports": [],
             "primary": 101
         }
-    ]
+    }
 }

--- a/tests/parsers/iosxe/show_vlan/004_wrapped_name_arehops_trbrf/expected.json
+++ b/tests/parsers/iosxe/show_vlan/004_wrapped_name_arehops_trbrf/expected.json
@@ -86,12 +86,12 @@
             "stp": "ibm"
         }
     },
-    "private_vlans": [
-        {
+    "private_vlans": {
+        "2": {
             "secondary": 2,
             "type": "community",
             "ports": [],
             "primary": 1
         }
-    ]
+    }
 }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -100,8 +100,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "ios/show_standby/002_multiple_groups_with_tracks/expected.json",
         "ios/show_standby_brief/001_mixed_states_and_interfaces/expected.json",
         "ios/show_version/001_c3750x_switch/expected.json",
-        "ios/show_vlan/002_remote_span_and_private_vlans/expected.json",
-        "ios/show_vlan/003_token_ring/expected.json",
         # --- IOS-XE ---
         "iosxe/show_bgp_all/001_basic/expected.json",
         "iosxe/show_bgp_all/001_live_device/expected.json",
@@ -161,8 +159,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "iosxe/show_track/002_multiple_track_types/expected.json",
         "iosxe/show_version/001_c3850_stack/expected.json",
         "iosxe/show_version/003_c9300_switch/expected.json",
-        "iosxe/show_vlan/002_all_statuses_remote_span_private_vlans/expected.json",
-        "iosxe/show_vlan/004_wrapped_name_arehops_trbrf/expected.json",
         # --- NX-OS ---
         "nxos/show_bgp_all_dampening_flap-statistics/001_basic/expected.json",
         "nxos/show_bgp_vrf_all_all/001_basic/expected.json",


### PR DESCRIPTION
Returns `private_vlans` as a mapping keyed by secondary VLAN ID (string), per design-principles keyed-dict preference. Updates IOS fixtures 002–003 and matching IOS-XE `show_vlan` fixtures; removes list-of-dicts exemptions.

Closes #592

Made with [Cursor](https://cursor.com)