### PR TITLE
fix(nxos): keyed dicts for show cdp neighbors detail

### DIFF
--- a/changes/+nxos-cdp-neighbors-detail-keyed.breaking
+++ b/changes/+nxos-cdp-neighbors-detail-keyed.breaking
@@ -1,0 +1,1 @@
+NX-OS `show cdp neighbors detail` now returns per-local-interface neighbors as a mapping keyed by `device_id` (with a `device_id|port_id` suffix when the same device appears twice on one interface) instead of a list.

--- a/src/muninn/parsers/nxos/show_cdp_neighbors_detail.py
+++ b/src/muninn/parsers/nxos/show_cdp_neighbors_detail.py
@@ -48,7 +48,7 @@ class CdpNeighborDetailEntry(TypedDict):
 class ShowCdpNeighborsDetailResult(TypedDict):
     """Schema for 'show cdp neighbors detail' parsed output."""
 
-    neighbors: dict[str, list[CdpNeighborDetailEntry]]
+    neighbors: dict[str, dict[str, CdpNeighborDetailEntry]]
 
 
 # Required fields that must be present to build a valid entry
@@ -86,7 +86,7 @@ _OPTIONAL_LIST_FIELDS: tuple[OptionalListField, ...] = (
 class _ParseState:
     """Mutable state for the detail parser's line-by-line loop."""
 
-    neighbors: dict[str, list[CdpNeighborDetailEntry]] = field(
+    neighbors: dict[str, dict[str, CdpNeighborDetailEntry]] = field(
         default_factory=dict,
     )
     fields: dict[str, object] = field(default_factory=dict)
@@ -243,9 +243,11 @@ class ShowCdpNeighborsDetailParser(
         if entry is None:
             return
         intf = state.local_intf
-        if intf not in state.neighbors:
-            state.neighbors[intf] = []
-        state.neighbors[intf].append(entry)
+        by_device = state.neighbors.setdefault(intf, {})
+        key = entry["device_id"]
+        if key in by_device:
+            key = f"{entry['device_id']}|{entry['port_id']}"
+        by_device[key] = entry
 
     @classmethod
     def _handle_record_boundary(

--- a/src/muninn/parsers/nxos/show_cdp_neighbors_detail.py
+++ b/src/muninn/parsers/nxos/show_cdp_neighbors_detail.py
@@ -48,7 +48,7 @@ class CdpNeighborDetailEntry(TypedDict):
 class ShowCdpNeighborsDetailResult(TypedDict):
     """Schema for 'show cdp neighbors detail' parsed output."""
 
-    neighbors: dict[str, dict[str, CdpNeighborDetailEntry]]
+    neighbors: dict[str, dict[str, dict[str, CdpNeighborDetailEntry]]]
 
 
 # Required fields that must be present to build a valid entry
@@ -86,7 +86,7 @@ _OPTIONAL_LIST_FIELDS: tuple[OptionalListField, ...] = (
 class _ParseState:
     """Mutable state for the detail parser's line-by-line loop."""
 
-    neighbors: dict[str, dict[str, CdpNeighborDetailEntry]] = field(
+    neighbors: dict[str, dict[str, dict[str, CdpNeighborDetailEntry]]] = field(
         default_factory=dict,
     )
     fields: dict[str, object] = field(default_factory=dict)
@@ -243,11 +243,11 @@ class ShowCdpNeighborsDetailParser(
         if entry is None:
             return
         intf = state.local_intf
-        by_device = state.neighbors.setdefault(intf, {})
-        key = entry["device_id"]
-        if key in by_device:
-            key = f"{entry['device_id']}|{entry['port_id']}"
-        by_device[key] = entry
+        device_id = entry["device_id"]
+        port_key = entry["port_id"]
+        by_local = state.neighbors.setdefault(intf, {})
+        by_device = by_local.setdefault(device_id, {})
+        by_device[port_key] = entry
 
     @classmethod
     def _handle_record_boundary(

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/001_basic/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/001_basic/expected.json
@@ -2,110 +2,120 @@
     "neighbors": {
         "mgmt0": {
             "PERIMETER": {
-                "device_id": "PERIMETER",
-                "platform": "cisco WS-C3750-48TS",
-                "capabilities": "Router Switch IGMP Filtering",
-                "port_id": "FastEthernet1/0/32",
-                "hold_time": 134,
-                "version": "Cisco IOS Software, C3750 Software (C3750-IPBASEK9-M), Version 12.2(44)SE2, RELEASE SOFTWARE (fc2)\nCopyright (c) 1986-2008 by Cisco Systems, Inc.\nCompiled Thu 01-May-08 15:42 by antonino",
-                "advertisement_version": 2,
-                "duplex": "full",
-                "vtp_management_domain": "null",
-                "native_vlan": 100,
-                "interface_addresses": [
-                    "10.1.100.1"
-                ],
-                "mgmt_addresses": [
-                    "10.1.100.1"
-                ]
+                "FastEthernet1/0/32": {
+                    "device_id": "PERIMETER",
+                    "platform": "cisco WS-C3750-48TS",
+                    "capabilities": "Router Switch IGMP Filtering",
+                    "port_id": "FastEthernet1/0/32",
+                    "hold_time": 134,
+                    "version": "Cisco IOS Software, C3750 Software (C3750-IPBASEK9-M), Version 12.2(44)SE2, RELEASE SOFTWARE (fc2)\nCopyright (c) 1986-2008 by Cisco Systems, Inc.\nCompiled Thu 01-May-08 15:42 by antonino",
+                    "advertisement_version": 2,
+                    "duplex": "full",
+                    "vtp_management_domain": "null",
+                    "native_vlan": 100,
+                    "interface_addresses": [
+                        "10.1.100.1"
+                    ],
+                    "mgmt_addresses": [
+                        "10.1.100.1"
+                    ]
+                }
             }
         },
         "Ethernet1/1": {
             "dc-lf03(SAL19069XXX)": {
-                "device_id": "dc-lf03(SAL19069XXX)",
-                "platform": "N9K-C9372TX",
-                "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/1",
-                "hold_time": 157,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I5(1)",
-                "advertisement_version": 2,
-                "system_name": "dc-lf03",
-                "duplex": "full",
-                "physical_location": "snmplocation",
-                "native_vlan": 1,
-                "mtu": 1500,
-                "interface_addresses": [
-                    "10.1.100.226"
-                ],
-                "mgmt_addresses": [
-                    "10.1.100.226"
-                ]
+                "Ethernet1/1": {
+                    "device_id": "dc-lf03(SAL19069XXX)",
+                    "platform": "N9K-C9372TX",
+                    "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/1",
+                    "hold_time": 157,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I5(1)",
+                    "advertisement_version": 2,
+                    "system_name": "dc-lf03",
+                    "duplex": "full",
+                    "physical_location": "snmplocation",
+                    "native_vlan": 1,
+                    "mtu": 1500,
+                    "interface_addresses": [
+                        "10.1.100.226"
+                    ],
+                    "mgmt_addresses": [
+                        "10.1.100.226"
+                    ]
+                }
             }
         },
         "Ethernet1/3": {
             "dc-lf03(SAL1906XXXX)": {
-                "device_id": "dc-lf03(SAL1906XXXX)",
-                "platform": "N9K-C9372TX",
-                "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/3",
-                "hold_time": 157,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I5(1)",
-                "advertisement_version": 2,
-                "system_name": "dc-lf03",
-                "duplex": "full",
-                "physical_location": "snmplocation",
-                "native_vlan": 1,
-                "mtu": 1500,
-                "interface_addresses": [
-                    "10.1.100.226"
-                ],
-                "mgmt_addresses": [
-                    "10.1.100.226"
-                ]
+                "Ethernet1/3": {
+                    "device_id": "dc-lf03(SAL1906XXXX)",
+                    "platform": "N9K-C9372TX",
+                    "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/3",
+                    "hold_time": 157,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I5(1)",
+                    "advertisement_version": 2,
+                    "system_name": "dc-lf03",
+                    "duplex": "full",
+                    "physical_location": "snmplocation",
+                    "native_vlan": 1,
+                    "mtu": 1500,
+                    "interface_addresses": [
+                        "10.1.100.226"
+                    ],
+                    "mgmt_addresses": [
+                        "10.1.100.226"
+                    ]
+                }
             }
         },
         "Ethernet1/49": {
             "dc-sp01(SAL19069XXX)": {
-                "device_id": "dc-sp01(SAL19069XXX)",
-                "platform": "N9K-C9372TX",
-                "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/52",
-                "hold_time": 166,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I2(2d)",
-                "advertisement_version": 2,
-                "system_name": "dc-sp01",
-                "duplex": "full",
-                "physical_location": "NY-DC",
-                "native_vlan": 1,
-                "mtu": 1500,
-                "interface_addresses": [
-                    "10.1.1.1"
-                ],
-                "mgmt_addresses": [
-                    "10.1.100.222"
-                ]
+                "Ethernet1/52": {
+                    "device_id": "dc-sp01(SAL19069XXX)",
+                    "platform": "N9K-C9372TX",
+                    "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/52",
+                    "hold_time": 166,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I2(2d)",
+                    "advertisement_version": 2,
+                    "system_name": "dc-sp01",
+                    "duplex": "full",
+                    "physical_location": "NY-DC",
+                    "native_vlan": 1,
+                    "mtu": 1500,
+                    "interface_addresses": [
+                        "10.1.1.1"
+                    ],
+                    "mgmt_addresses": [
+                        "10.1.100.222"
+                    ]
+                }
             }
         },
         "Ethernet1/50": {
             "dc-sp02(SAL19069XXX)": {
-                "device_id": "dc-sp02(SAL19069XXX)",
-                "platform": "N9K-C9372TX",
-                "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/52",
-                "hold_time": 166,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I2(2d)",
-                "advertisement_version": 2,
-                "system_name": "dc-sp02",
-                "duplex": "full",
-                "physical_location": "NY-DC",
-                "native_vlan": 1,
-                "mtu": 1500,
-                "interface_addresses": [
-                    "10.1.1.9"
-                ],
-                "mgmt_addresses": [
-                    "10.1.100.223"
-                ]
+                "Ethernet1/52": {
+                    "device_id": "dc-sp02(SAL19069XXX)",
+                    "platform": "N9K-C9372TX",
+                    "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/52",
+                    "hold_time": 166,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(3)I2(2d)",
+                    "advertisement_version": 2,
+                    "system_name": "dc-sp02",
+                    "duplex": "full",
+                    "physical_location": "NY-DC",
+                    "native_vlan": 1,
+                    "mtu": 1500,
+                    "interface_addresses": [
+                        "10.1.1.9"
+                    ],
+                    "mgmt_addresses": [
+                        "10.1.100.223"
+                    ]
+                }
             }
         }
     }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/001_basic/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/001_basic/expected.json
@@ -1,7 +1,7 @@
 {
     "neighbors": {
-        "mgmt0": [
-            {
+        "mgmt0": {
+            "PERIMETER": {
                 "device_id": "PERIMETER",
                 "platform": "cisco WS-C3750-48TS",
                 "capabilities": "Router Switch IGMP Filtering",
@@ -19,9 +19,9 @@
                     "10.1.100.1"
                 ]
             }
-        ],
-        "Ethernet1/1": [
-            {
+        },
+        "Ethernet1/1": {
+            "dc-lf03(SAL19069XXX)": {
                 "device_id": "dc-lf03(SAL19069XXX)",
                 "platform": "N9K-C9372TX",
                 "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
@@ -41,9 +41,9 @@
                     "10.1.100.226"
                 ]
             }
-        ],
-        "Ethernet1/3": [
-            {
+        },
+        "Ethernet1/3": {
+            "dc-lf03(SAL1906XXXX)": {
                 "device_id": "dc-lf03(SAL1906XXXX)",
                 "platform": "N9K-C9372TX",
                 "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
@@ -63,9 +63,9 @@
                     "10.1.100.226"
                 ]
             }
-        ],
-        "Ethernet1/49": [
-            {
+        },
+        "Ethernet1/49": {
+            "dc-sp01(SAL19069XXX)": {
                 "device_id": "dc-sp01(SAL19069XXX)",
                 "platform": "N9K-C9372TX",
                 "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
@@ -85,9 +85,9 @@
                     "10.1.100.222"
                 ]
             }
-        ],
-        "Ethernet1/50": [
-            {
+        },
+        "Ethernet1/50": {
+            "dc-sp02(SAL19069XXX)": {
                 "device_id": "dc-sp02(SAL19069XXX)",
                 "platform": "N9K-C9372TX",
                 "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
@@ -107,6 +107,6 @@
                     "10.1.100.223"
                 ]
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/002_multiple_platforms/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/002_multiple_platforms/expected.json
@@ -1,7 +1,7 @@
 {
     "neighbors": {
-        "mgmt0": [
-            {
+        "mgmt0": {
+            "DC3P01SW01.test.co.nz": {
                 "device_id": "DC3P01SW01.test.co.nz",
                 "platform": "WS-C3560X-24",
                 "capabilities": "Switch IGMP Filtering",
@@ -18,9 +18,9 @@
                     "10.115.143.251"
                 ]
             }
-        ],
-        "Ethernet1/1": [
-            {
+        },
+        "Ethernet1/1": {
+            "DC3TESTW01-55.test.co.nz(SSI3707070J)": {
                 "device_id": "DC3TESTW01-55.test.co.nz(SSI3707070J)",
                 "platform": "N5K-C5548UP",
                 "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
@@ -39,9 +39,9 @@
                     "10.115.143.120"
                 ]
             }
-        ],
-        "Ethernet1/21": [
-            {
+        },
+        "Ethernet1/21": {
+            "DC3TESTW02.test.co.nz(SSI11111D2M)": {
                 "device_id": "DC3TESTW02.test.co.nz(SSI11111D2M)",
                 "platform": "N5K-C5020P-BF",
                 "capabilities": "Switch IGMP Filtering Supports-STP-Dispute",
@@ -60,9 +60,9 @@
                     "10.115.143.21"
                 ]
             }
-        ],
-        "Ethernet1/22": [
-            {
+        },
+        "Ethernet1/22": {
+            "DC3TESTW02.test.co.nz(SSI44444D2M)": {
                 "device_id": "DC3TESTW02.test.co.nz(SSI44444D2M)",
                 "platform": "N5K-C5020P-BF",
                 "capabilities": "Switch IGMP Filtering Supports-STP-Dispute",
@@ -81,6 +81,6 @@
                     "10.115.143.21"
                 ]
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/002_multiple_platforms/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/002_multiple_platforms/expected.json
@@ -2,84 +2,92 @@
     "neighbors": {
         "mgmt0": {
             "DC3P01SW01.test.co.nz": {
-                "device_id": "DC3P01SW01.test.co.nz",
-                "platform": "WS-C3560X-24",
-                "capabilities": "Switch IGMP Filtering",
-                "port_id": "GigabitEthernet0/20",
-                "hold_time": 134,
-                "version": "Cisco IOS Software, C3560E Software (C3560E-UNIVERSALK9-M), Version 12.2(55)SE5, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2012 by Cisco Systems, Inc.\nCompiled Thu 09-Feb-12 18:32 by prod_rel_team",
-                "advertisement_version": 2,
-                "duplex": "full",
-                "native_vlan": 143,
-                "interface_addresses": [
-                    "10.115.143.251"
-                ],
-                "mgmt_addresses": [
-                    "10.115.143.251"
-                ]
+                "GigabitEthernet0/20": {
+                    "device_id": "DC3P01SW01.test.co.nz",
+                    "platform": "WS-C3560X-24",
+                    "capabilities": "Switch IGMP Filtering",
+                    "port_id": "GigabitEthernet0/20",
+                    "hold_time": 134,
+                    "version": "Cisco IOS Software, C3560E Software (C3560E-UNIVERSALK9-M), Version 12.2(55)SE5, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2012 by Cisco Systems, Inc.\nCompiled Thu 09-Feb-12 18:32 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "duplex": "full",
+                    "native_vlan": 143,
+                    "interface_addresses": [
+                        "10.115.143.251"
+                    ],
+                    "mgmt_addresses": [
+                        "10.115.143.251"
+                    ]
+                }
             }
         },
         "Ethernet1/1": {
             "DC3TESTW01-55.test.co.nz(SSI3707070J)": {
-                "device_id": "DC3TESTW01-55.test.co.nz(SSI3707070J)",
-                "platform": "N5K-C5548UP",
-                "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/31",
-                "hold_time": 157,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 5.2(1)N1(4)",
-                "advertisement_version": 2,
-                "system_name": "DC3TESTW01-55",
-                "duplex": "full",
-                "physical_location": "DC3, Sydney DC Rack P1, RU36",
-                "native_vlan": 1,
-                "interface_addresses": [
-                    "10.115.17.253"
-                ],
-                "mgmt_addresses": [
-                    "10.115.143.120"
-                ]
+                "Ethernet1/31": {
+                    "device_id": "DC3TESTW01-55.test.co.nz(SSI3707070J)",
+                    "platform": "N5K-C5548UP",
+                    "capabilities": "Router Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/31",
+                    "hold_time": 157,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 5.2(1)N1(4)",
+                    "advertisement_version": 2,
+                    "system_name": "DC3TESTW01-55",
+                    "duplex": "full",
+                    "physical_location": "DC3, Sydney DC Rack P1, RU36",
+                    "native_vlan": 1,
+                    "interface_addresses": [
+                        "10.115.17.253"
+                    ],
+                    "mgmt_addresses": [
+                        "10.115.143.120"
+                    ]
+                }
             }
         },
         "Ethernet1/21": {
             "DC3TESTW02.test.co.nz(SSI11111D2M)": {
-                "device_id": "DC3TESTW02.test.co.nz(SSI11111D2M)",
-                "platform": "N5K-C5020P-BF",
-                "capabilities": "Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/21",
-                "hold_time": 157,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 5.2(1)N1(4)",
-                "advertisement_version": 2,
-                "system_name": "DC3TESTW02",
-                "duplex": "full",
-                "physical_location": "DC3 , Melbourne",
-                "native_vlan": 1,
-                "interface_addresses": [
-                    "10.115.143.21"
-                ],
-                "mgmt_addresses": [
-                    "10.115.143.21"
-                ]
+                "Ethernet1/21": {
+                    "device_id": "DC3TESTW02.test.co.nz(SSI11111D2M)",
+                    "platform": "N5K-C5020P-BF",
+                    "capabilities": "Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/21",
+                    "hold_time": 157,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 5.2(1)N1(4)",
+                    "advertisement_version": 2,
+                    "system_name": "DC3TESTW02",
+                    "duplex": "full",
+                    "physical_location": "DC3 , Melbourne",
+                    "native_vlan": 1,
+                    "interface_addresses": [
+                        "10.115.143.21"
+                    ],
+                    "mgmt_addresses": [
+                        "10.115.143.21"
+                    ]
+                }
             }
         },
         "Ethernet1/22": {
             "DC3TESTW02.test.co.nz(SSI44444D2M)": {
-                "device_id": "DC3TESTW02.test.co.nz(SSI44444D2M)",
-                "platform": "N5K-C5020P-BF",
-                "capabilities": "Switch IGMP Filtering Supports-STP-Dispute",
-                "port_id": "Ethernet1/22",
-                "hold_time": 157,
-                "version": "Cisco Nexus Operating System (NX-OS) Software, Version 5.2(1)N1(4)",
-                "advertisement_version": 2,
-                "system_name": "DC3TESTW02",
-                "duplex": "full",
-                "physical_location": "DC3 , Melbourne",
-                "native_vlan": 1,
-                "interface_addresses": [
-                    "10.115.143.21"
-                ],
-                "mgmt_addresses": [
-                    "10.115.143.21"
-                ]
+                "Ethernet1/22": {
+                    "device_id": "DC3TESTW02.test.co.nz(SSI44444D2M)",
+                    "platform": "N5K-C5020P-BF",
+                    "capabilities": "Switch IGMP Filtering Supports-STP-Dispute",
+                    "port_id": "Ethernet1/22",
+                    "hold_time": 157,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 5.2(1)N1(4)",
+                    "advertisement_version": 2,
+                    "system_name": "DC3TESTW02",
+                    "duplex": "full",
+                    "physical_location": "DC3 , Melbourne",
+                    "native_vlan": 1,
+                    "interface_addresses": [
+                        "10.115.143.21"
+                    ],
+                    "mgmt_addresses": [
+                        "10.115.143.21"
+                    ]
+                }
             }
         }
     }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/003_mikrotik/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/003_mikrotik/expected.json
@@ -1,7 +1,7 @@
 {
     "neighbors": {
-        "Ethernet1/1": [
-            {
+        "Ethernet1/1": {
+            "MKT1": {
                 "device_id": "MKT1",
                 "platform": "MikroTik",
                 "capabilities": "Router",
@@ -12,6 +12,6 @@
                 "local_interface_mac": "b1:81:d1:d1:a1:11",
                 "remote_interface_mac": "00:00:00:00:00:00"
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/003_mikrotik/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/003_mikrotik/expected.json
@@ -2,15 +2,17 @@
     "neighbors": {
         "Ethernet1/1": {
             "MKT1": {
-                "device_id": "MKT1",
-                "platform": "MikroTik",
-                "capabilities": "Router",
-                "port_id": "ether1",
-                "hold_time": 61,
-                "version": "6.47.10 (long-term)",
-                "advertisement_version": 1,
-                "local_interface_mac": "b1:81:d1:d1:a1:11",
-                "remote_interface_mac": "00:00:00:00:00:00"
+                "ether1": {
+                    "device_id": "MKT1",
+                    "platform": "MikroTik",
+                    "capabilities": "Router",
+                    "port_id": "ether1",
+                    "hold_time": 61,
+                    "version": "6.47.10 (long-term)",
+                    "advertisement_version": 1,
+                    "local_interface_mac": "b1:81:d1:d1:a1:11",
+                    "remote_interface_mac": "00:00:00:00:00:00"
+                }
             }
         }
     }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/004_no_separator/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/004_no_separator/expected.json
@@ -1,7 +1,7 @@
 {
     "neighbors": {
-        "Ethernet7/14": [
-            {
+        "Ethernet7/14": {
+            "redacted.test.com": {
                 "device_id": "redacted.test.com",
                 "platform": "C9300-48UXM",
                 "capabilities": "Switch IGMP Filtering",
@@ -19,9 +19,9 @@
                     "10.0.0.1"
                 ]
             }
-        ],
-        "Ethernet7/15": [
-            {
+        },
+        "Ethernet7/15": {
+            "redacted.test.com": {
                 "device_id": "redacted.test.com",
                 "platform": "C9300-48UXM",
                 "capabilities": "Switch IGMP Filtering",
@@ -39,6 +39,6 @@
                     "10.0.0.4"
                 ]
             }
-        ]
+        }
     }
 }

--- a/tests/parsers/nxos/show_cdp_neighbors_detail/004_no_separator/expected.json
+++ b/tests/parsers/nxos/show_cdp_neighbors_detail/004_no_separator/expected.json
@@ -2,42 +2,46 @@
     "neighbors": {
         "Ethernet7/14": {
             "redacted.test.com": {
-                "device_id": "redacted.test.com",
-                "platform": "C9300-48UXM",
-                "capabilities": "Switch IGMP Filtering",
-                "port_id": "TenGigabitEthernet1/1/7",
-                "hold_time": 133,
-                "version": "Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2019 by Cisco Systems, Inc.\nCompiled Thu 11-Apr-19 03:51 by mcpre",
-                "advertisement_version": 2,
-                "duplex": "full",
-                "vtp_management_domain": "brwn",
-                "native_vlan": 1000,
-                "interface_addresses": [
-                    "10.0.0.1"
-                ],
-                "mgmt_addresses": [
-                    "10.0.0.1"
-                ]
+                "TenGigabitEthernet1/1/7": {
+                    "device_id": "redacted.test.com",
+                    "platform": "C9300-48UXM",
+                    "capabilities": "Switch IGMP Filtering",
+                    "port_id": "TenGigabitEthernet1/1/7",
+                    "hold_time": 133,
+                    "version": "Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2019 by Cisco Systems, Inc.\nCompiled Thu 11-Apr-19 03:51 by mcpre",
+                    "advertisement_version": 2,
+                    "duplex": "full",
+                    "vtp_management_domain": "brwn",
+                    "native_vlan": 1000,
+                    "interface_addresses": [
+                        "10.0.0.1"
+                    ],
+                    "mgmt_addresses": [
+                        "10.0.0.1"
+                    ]
+                }
             }
         },
         "Ethernet7/15": {
             "redacted.test.com": {
-                "device_id": "redacted.test.com",
-                "platform": "C9300-48UXM",
-                "capabilities": "Switch IGMP Filtering",
-                "port_id": "TenGigabitEthernet1/1/8",
-                "hold_time": 136,
-                "version": "Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2019 by Cisco Systems, Inc.\nCompiled Thu 11-Apr-19 03:51 by mcpre",
-                "advertisement_version": 2,
-                "duplex": "full",
-                "vtp_management_domain": "brwn",
-                "native_vlan": 1000,
-                "interface_addresses": [
-                    "10.0.0.3"
-                ],
-                "mgmt_addresses": [
-                    "10.0.0.4"
-                ]
+                "TenGigabitEthernet1/1/8": {
+                    "device_id": "redacted.test.com",
+                    "platform": "C9300-48UXM",
+                    "capabilities": "Switch IGMP Filtering",
+                    "port_id": "TenGigabitEthernet1/1/8",
+                    "hold_time": 136,
+                    "version": "Cisco IOS Software [Everest], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 16.6.6, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2019 by Cisco Systems, Inc.\nCompiled Thu 11-Apr-19 03:51 by mcpre",
+                    "advertisement_version": 2,
+                    "duplex": "full",
+                    "vtp_management_domain": "brwn",
+                    "native_vlan": 1000,
+                    "interface_addresses": [
+                        "10.0.0.3"
+                    ],
+                    "mgmt_addresses": [
+                        "10.0.0.4"
+                    ]
+                }
             }
         }
     }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -166,10 +166,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         # --- NX-OS ---
         "nxos/show_bgp_all_dampening_flap-statistics/001_basic/expected.json",
         "nxos/show_bgp_vrf_all_all/001_basic/expected.json",
-        "nxos/show_cdp_neighbors_detail/001_basic/expected.json",
-        "nxos/show_cdp_neighbors_detail/002_multiple_platforms/expected.json",
-        "nxos/show_cdp_neighbors_detail/003_mikrotik/expected.json",
-        "nxos/show_cdp_neighbors_detail/004_no_separator/expected.json",
         "nxos/show_ip_bgp/001_basic_routes/expected.json",
         "nxos/show_ip_bgp/002_multi_vrf/expected.json",
         "nxos/show_ip_bgp/003_route_distinguisher/expected.json",


### PR DESCRIPTION
## Summary
- Per local interface, CDP neighbor details are now a mapping keyed by `device_id` (with `device_id|port_id` if the same device id appears twice on one interface).
- Drops the four `nxos/show_cdp_neighbors_detail/*` list-of-dicts exemptions in `test_fixture_json_conventions.py`.
- Breaking changelog fragment included.

Closes #597

Made with [Cursor](https://cursor.com)