### PR TITLE
fix(nxos): omit physical_interface when ARP detail Physical Interface is '-'

### DIFF
--- a/changes/625.parser_updated
+++ b/changes/625.parser_updated
@@ -1,0 +1,1 @@
+NX-OS ``show ip arp detail vrf all`` omits ``physical_interface`` when the CLI prints ``-`` (no resolved L2 interface).

--- a/src/muninn/parsers/nxos/show_ip_arp_detail_vrf_all.py
+++ b/src/muninn/parsers/nxos/show_ip_arp_detail_vrf_all.py
@@ -15,7 +15,7 @@ class ArpDetailEntry(TypedDict):
     """Schema for a single detailed ARP entry."""
 
     interface: str
-    physical_interface: str
+    physical_interface: NotRequired[str]
     age: NotRequired[str]
     mac_address: NotRequired[str]
     flags: NotRequired[str]
@@ -45,10 +45,12 @@ def _build_entry(match: re.Match[str]) -> ArpDetailEntry:
         "interface": canonical_interface_name(
             match.group("interface"), os=OS.CISCO_NXOS
         ),
-        "physical_interface": canonical_interface_name(
-            match.group("physical_interface"), os=OS.CISCO_NXOS
-        ),
     }
+    raw_physical = match.group("physical_interface")
+    if raw_physical != "-":
+        entry["physical_interface"] = canonical_interface_name(
+            raw_physical, os=OS.CISCO_NXOS
+        )
 
     age_str = match.group("age")
     if age_str != "-":

--- a/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json
+++ b/tests/parsers/nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json
@@ -20,8 +20,7 @@
         },
         "172.16.10.1": {
             "interface": "Vlan393",
-            "mac_address": "0000.0cff.9129",
-            "physical_interface": "-"
+            "mac_address": "0000.0cff.9129"
         }
     }
 }

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -33,7 +33,6 @@ _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "ios/show_mac_address-table/002_extended/expected.json",
         "ios/show_snmp_user/001_basic/expected.json",
         "iosxe/show_vpdn/001_basic/expected.json",
-        "nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json",
         "nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json",
         "nxos/show_vpc/001_basic/expected.json",
     }


### PR DESCRIPTION
## Summary

Resolves [#625](https://github.com/ChartinoLabs/Muninn/issues/625).

When `show ip arp detail vrf all` prints `-` in the **Physical Interface** column, NX-OS means there is no resolved L2 interface for that ARP row. Muninn already omits other fields for CLI sentinels (e.g. age `-`); this change applies the same convention to `physical_interface` so we do not propagate the hyphen as a string value.

## Changes

- `physical_interface` is optional on `ArpDetailEntry`; omitted when the CLI field is `-`.
- Updated `002_incomplete_and_static` expected JSON accordingly.
- Removed the placeholder-sentinel exemption for that fixture (`tests/parsers/test_fixture_placeholder_sentinels.py`).

## Testing

- `uv run pytest`
- `uv run ruff check` / `ruff format` (pre-commit)

Made with [Cursor](https://cursor.com)