### PR TITLE
fix(iosxe): omit show vpdn interface when CLI shows hyphen

### DIFF
--- a/changes/624.parser_updated
+++ b/changes/624.parser_updated
@@ -1,0 +1,1 @@
+Omit `interface` on IOS-XE `show vpdn` sessions when the CLI prints `-` (no interface).

--- a/src/muninn/parsers/iosxe/show_vpdn.py
+++ b/src/muninn/parsers/iosxe/show_vpdn.py
@@ -29,7 +29,7 @@ class VpdnSessionEntry(TypedDict):
     remote_id: int
     tunnel_id: int
     username: str
-    interface: str
+    interface: NotRequired[str]
     state: str
     last_change: str
     unique_id: int
@@ -104,16 +104,18 @@ def _build_session_entry(match: re.Match[str]) -> tuple[str, VpdnSessionEntry]:
         Tuple of (local_id_str, session_entry).
     """
     local_id = match.group("local_id")
+    intf = match.group("intf")
     entry = VpdnSessionEntry(
         local_id=int(local_id),
         remote_id=int(match.group("remote_id")),
         tunnel_id=int(match.group("tunnel_id")),
         username=match.group("username"),
-        interface=match.group("intf"),
         state=match.group("state"),
         last_change=match.group("last_chg"),
         unique_id=int(match.group("uniq_id")),
     )
+    if intf != "-":
+        entry["interface"] = intf
     return local_id, entry
 
 
@@ -133,6 +135,9 @@ class ShowVpdnParser(BaseParser[ShowVpdnResult]):
          LocID      RemID      TunID      Username, Intf/      State  Last Chg Uniq ID
                                           Vcid, Circuit
          3542       56774      7658       lns@cisco.com, -     est    00:10:09 645
+
+    A hyphen in the interface column means no interface; the ``interface`` key is
+    omitted (rather than set to ``"-"``).
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.VPN})

--- a/tests/parsers/iosxe/show_vpdn/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vpdn/001_basic/expected.json
@@ -27,7 +27,6 @@
             "remote_id": 56774,
             "tunnel_id": 7658,
             "username": "lns@cisco.com",
-            "interface": "-",
             "state": "est",
             "last_change": "00:10:09",
             "unique_id": 645
@@ -37,7 +36,6 @@
             "remote_id": 3791,
             "tunnel_id": 11479,
             "username": "lns@cisco.com",
-            "interface": "-",
             "state": "est",
             "last_change": "00:10:08",
             "unique_id": 645

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -32,7 +32,6 @@ _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
     {
         "ios/show_mac_address-table/002_extended/expected.json",
         "ios/show_snmp_user/001_basic/expected.json",
-        "iosxe/show_vpdn/001_basic/expected.json",
         "nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json",
         "nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json",
         "nxos/show_vpc/001_basic/expected.json",


### PR DESCRIPTION
Fixes #624

- Treat `-` in the session interface column as “no interface” and omit the `interface` key (same pattern as `esmc_tx` / `esmc_rx` in `show network-clocks synchronization`).
- `VpdnSessionEntry.interface` is now `NotRequired[str]`.
- Drop the `show_vpdn` hyphen-placeholder exemption from fixture guard tests.

Made with [Cursor](https://cursor.com)