### PR TITLE
fix(ios): omit VLAN placeholder in show mac address-table (#622)

### DIFF
--- a/changes/+622-placeholder-mac.parser_updated
+++ b/changes/+622-placeholder-mac.parser_updated
@@ -1,0 +1,1 @@
+Omit VLAN field in IOS/IOS-XE `show mac address-table` output when the CLI uses dash placeholders instead of a VLAN id.

--- a/src/muninn/parsers/ios/show_mac_address_table.py
+++ b/src/muninn/parsers/ios/show_mac_address_table.py
@@ -1,7 +1,7 @@
 """Parser for 'show mac address-table' command on IOS/IOS-XE."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, Final, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -83,6 +83,9 @@ _CONTINUATION_RE = re.compile(r"^\s{10,}(.+?)\s*$")
 _UNICAST_HEADER_RE = re.compile(r"^Unicast Entries", re.IGNORECASE)
 _MULTICAST_HEADER_RE = re.compile(r"^Multicast Entries", re.IGNORECASE)
 
+# VLAN column placeholders (no numeric VLAN / not applicable) — omit key in output
+_VLAN_PLACEHOLDER_VALUES: Final[frozenset[str]] = frozenset({"-", "---"})
+
 # Special port values that should not be normalized as interfaces
 _SPECIAL_PORTS = frozenset(
     {
@@ -97,7 +100,7 @@ _SPECIAL_PORTS = frozenset(
 class MacEntry(TypedDict):
     """Schema for a single MAC address table entry."""
 
-    vlan: str
+    vlan: NotRequired[str]
     mac_address: str
     type: str
     ports: list[str]
@@ -122,6 +125,13 @@ class ShowMacAddressTableResult(TypedDict):
     entries: list[MacEntry]
     multicast_entries: NotRequired[list[MulticastEntry]]
     total_mac_addresses: NotRequired[int]
+
+
+def _vlan_value_or_omit(raw: str) -> str | None:
+    """Return VLAN id text, or None when the CLI printed a dash placeholder."""
+    if raw in _VLAN_PLACEHOLDER_VALUES:
+        return None
+    return raw
 
 
 def _normalize_port(port: str) -> str:
@@ -178,11 +188,13 @@ def _parse_standard_entries(lines: list[str]) -> list[MacEntry]:
             continue
 
         entry: MacEntry = {
-            "vlan": m.group(2),
             "mac_address": m.group(3),
             "type": m.group(4).lower(),
             "ports": _parse_port_list(m.group(5) or ""),
         }
+        vlan_val = _vlan_value_or_omit(m.group(2))
+        if vlan_val is not None:
+            entry["vlan"] = vlan_val
         if m.group(1) == "*":
             entry["primary"] = True
 
@@ -195,12 +207,14 @@ def _parse_extended_entry(m: re.Match[str]) -> MacEntry:
     """Build a MacEntry from an extended-format regex match."""
     age_raw = m.group(6)
     entry: MacEntry = {
-        "vlan": m.group(2),
         "mac_address": m.group(3),
         "type": m.group(4).lower(),
         "learn": m.group(5).lower() == "yes",
         "ports": _parse_port_list(m.group(7) or ""),
     }
+    vlan_val = _vlan_value_or_omit(m.group(2))
+    if vlan_val is not None:
+        entry["vlan"] = vlan_val
     if age_raw != "-":
         entry["age"] = int(age_raw)
     if m.group(1) == "*":

--- a/tests/parsers/ios/show_mac_address-table/002_extended/expected.json
+++ b/tests/parsers/ios/show_mac_address-table/002_extended/expected.json
@@ -72,7 +72,6 @@
             ]
         },
         {
-            "vlan": "---",
             "mac_address": "0000.0000.0000",
             "type": "static",
             "learn": false,

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -30,7 +30,6 @@ _PLACEHOLDER_NA_LIKE: Final[frozenset[str]] = frozenset({"NA", "N/A", "n/a"})
 # Legacy fixtures still using hyphen / em-dash placeholders as string *values*.
 _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
     {
-        "ios/show_mac_address-table/002_extended/expected.json",
         "ios/show_snmp_user/001_basic/expected.json",
         "iosxe/show_vpdn/001_basic/expected.json",
         "nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json",


### PR DESCRIPTION
## Summary
Resolves #622 by omitting the `vlan` key when IOS/IOS-XE prints `-` or `---` in the VLAN column of `show mac address-table` (extended/standard formats), consistent with other parsers that drop hyphen sentinels instead of echoing them as strings.

## Changes
- Parser: `_vlan_value_or_omit()` + conditional `vlan` on entries; `MacEntry.vlan` is `NotRequired[str]`.
- Fixture `ios/show_mac_address-table/002_extended/expected.json`: removed `vlan` for the null-MAC / Router row.
- Dropped full-file exemption from `test_fixture_placeholder_sentinels.py`.
- Towncrier: `changes/+622-placeholder-mac.parser_updated`.

## Testing
`uv run pytest tests/parsers/test_parsers.py -k "show_mac_address-table"`
`uv run pytest tests/parsers/test_fixture_placeholder_sentinels.py`

Made with [Cursor](https://cursor.com)