### PR TITLE
fix(ios): omit hyphen placeholders in show snmp user (#623)

### DIFF
--- a/changes/623.parser_updated
+++ b/changes/623.parser_updated
@@ -1,0 +1,1 @@
+Omit hyphen placeholder values for privacy protocol (and access-list) in IOS `show snmp user` output.

--- a/src/muninn/parsers/ios/show_snmp_user.py
+++ b/src/muninn/parsers/ios/show_snmp_user.py
@@ -15,7 +15,7 @@ class SnmpUserEntry(TypedDict):
     engine_id: str
     storage_type: str
     authentication_protocol: str
-    privacy_protocol: str
+    privacy_protocol: NotRequired[str]
     group_name: str
     access_list: NotRequired[str]
 
@@ -39,6 +39,9 @@ _PRIVACY_PROTOCOL_PATTERN = re.compile(
     r"^Privacy\s+Protocol:\s+(?P<privacy_protocol>\S+)"
 )
 _GROUP_NAME_PATTERN = re.compile(r"^Group-name:\s+(?P<group_name>\S+)")
+
+# IOS uses "-" / "---" for absent values; omit matching keys from structured output.
+_PLACEHOLDER_HYPHENS = frozenset({"-", "---"})
 
 
 @register(OS.CISCO_IOS, "show snmp user")
@@ -132,9 +135,13 @@ def _build_entry(raw: dict[str, str]) -> SnmpUserEntry:
         "engine_id": raw.get("engine_id", ""),
         "storage_type": raw.get("storage_type", ""),
         "authentication_protocol": raw.get("authentication_protocol", ""),
-        "privacy_protocol": raw.get("privacy_protocol", ""),
         "group_name": raw.get("group_name", ""),
     }
+    privacy = raw.get("privacy_protocol", "")
+    if privacy not in _PLACEHOLDER_HYPHENS:
+        entry["privacy_protocol"] = privacy
     if "access_list" in raw:
-        entry["access_list"] = raw["access_list"]
+        acl = raw["access_list"]
+        if acl not in _PLACEHOLDER_HYPHENS:
+            entry["access_list"] = acl
     return entry

--- a/tests/parsers/ios/show_snmp_user/001_basic/expected.json
+++ b/tests/parsers/ios/show_snmp_user/001_basic/expected.json
@@ -4,7 +4,6 @@
             "authentication_protocol": "None",
             "engine_id": "8000000903005E0000010000",
             "group_name": "test-group",
-            "privacy_protocol": "-",
             "storage_type": "nonvolatile"
         },
         "user_snmp1": {

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -31,7 +31,6 @@ _PLACEHOLDER_NA_LIKE: Final[frozenset[str]] = frozenset({"NA", "N/A", "n/a"})
 _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
     {
         "ios/show_mac_address-table/002_extended/expected.json",
-        "ios/show_snmp_user/001_basic/expected.json",
         "iosxe/show_vpdn/001_basic/expected.json",
         "nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json",
         "nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json",


### PR DESCRIPTION
## Summary
- Treat `-` and `---` from IOS `show snmp user` as absent values: omit `privacy_protocol` and `access_list` keys instead of passing CLI sentinels through to JSON.
- Update `001_basic` expected fixture and remove its hyphen-placeholder exemption in `test_fixture_placeholder_sentinels.py`.

Fixes #623

Made with [Cursor](https://cursor.com)