### PR TITLE
fix(nxos): omit dual_active_excluded_vlans when show vpc prints '-'

### DIFF
--- a/changes/627.parser_fixed
+++ b/changes/627.parser_fixed
@@ -1,0 +1,1 @@
+NX-OS ``show vpc`` omits ``dual_active_excluded_vlans`` when the device prints ``-`` (no VLANs excluded).

--- a/src/muninn/parsers/nxos/show_vpc.py
+++ b/src/muninn/parsers/nxos/show_vpc.py
@@ -30,7 +30,7 @@ class ShowVpcResult(TypedDict):
     vpc_role: str
     number_of_vpcs: int
     peer_gateway: str
-    dual_active_excluded_vlans: str
+    dual_active_excluded_vlans: NotRequired[str]
     graceful_consistency_check: str
     auto_recovery_status: str
     delay_restore_status: str
@@ -127,7 +127,13 @@ def _try_kv_match(stripped: str, result: dict[str, Any]) -> bool:
     for pattern, key, converter in _KV_PATTERNS:
         m = pattern.match(stripped)
         if m:
-            result[key] = converter(m.group(1))
+            raw = m.group(1)
+            if key == "dual_active_excluded_vlans":
+                val = raw.strip()
+                if val not in ("", "-"):
+                    result[key] = val
+                return True
+            result[key] = converter(raw)
             return True
     return False
 
@@ -182,7 +188,6 @@ class ShowVpcParser(BaseParser["ShowVpcResult"]):
             "vpc_role": "",
             "number_of_vpcs": 0,
             "peer_gateway": "",
-            "dual_active_excluded_vlans": "",
             "graceful_consistency_check": "",
             "auto_recovery_status": "",
             "delay_restore_status": "",

--- a/tests/parsers/nxos/show_vpc/001_basic/expected.json
+++ b/tests/parsers/nxos/show_vpc/001_basic/expected.json
@@ -7,7 +7,6 @@
     "vpc_role": "none established",
     "number_of_vpcs": 0,
     "peer_gateway": "Disabled",
-    "dual_active_excluded_vlans": "-",
     "graceful_consistency_check": "Disabled (due to peer configuration)",
     "auto_recovery_status": "Disabled",
     "delay_restore_status": "Timer is off.(timeout = 30s)",

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -35,7 +35,6 @@ _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "iosxe/show_vpdn/001_basic/expected.json",
         "nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json",
         "nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json",
-        "nxos/show_vpc/001_basic/expected.json",
     }
 )
 


### PR DESCRIPTION
## Summary

NX-OS `show vpc` reported `dual_active_excluded_vlans` as the literal string `-` when no VLANs are excluded. That CLI token means *none configured*; structured output now omits the key (NotRequired[str] in ShowVpcResult), consistent with `active_vlans` on peer-link rows and Muninn’s placeholder policy.

## Changes

- Parser: skip setting `dual_active_excluded_vlans` when the captured value is empty or `-`.
- Fixture: drop the key from `001_basic/expected.json`.
- Remove the hyphen-placeholder exemption for that fixture (`test_fixture_placeholder_sentinels.py`).

Closes #627