### PR TITLE
fix(nxos): omit OSPF neighbor up_time for hyphen placeholder (#626)

### DIFF
--- a/changes/626.parser_updated
+++ b/changes/626.parser_updated
@@ -1,0 +1,1 @@
+Omit `up_time` on NX-OS `show ip ospf neighbor` when the CLI prints a hyphen placeholder.

--- a/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
+++ b/src/muninn/parsers/nxos/show_ip_ospf_neighbor.py
@@ -16,8 +16,8 @@ class OspfNeighborEntry(TypedDict):
 
     priority: int
     state: str
-    up_time: str
     address: str
+    up_time: NotRequired[str]
     role: NotRequired[str]
 
 
@@ -158,9 +158,12 @@ class ShowIpOspfNeighborParser(BaseParser[ShowIpOspfNeighborResult]):
         entry: OspfNeighborEntry = {
             "priority": int(match.group("priority")),
             "state": state,
-            "up_time": match.group("up_time"),
             "address": match.group("address"),
         }
+
+        up_time = match.group("up_time")
+        if up_time not in {"-", "---"}:
+            entry["up_time"] = up_time
 
         if role and role != "-":
             entry["role"] = role

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json
@@ -61,8 +61,7 @@
                                 "address": "77.77.77.77",
                                 "priority": 1,
                                 "role": "DROTHER",
-                                "state": "INIT",
-                                "up_time": "-"
+                                "state": "INIT"
                             }
                         }
                     }

--- a/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/metadata.yaml
+++ b/tests/parsers/nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/metadata.yaml
@@ -1,3 +1,3 @@
-description: Multiple VRFs with DROTHER role and dash up_time
+description: Multiple VRFs with DROTHER role and omitted up_time when CLI shows dash
 platform: Unknown
 software_version: Unknown

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -34,7 +34,6 @@ _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "ios/show_snmp_user/001_basic/expected.json",
         "iosxe/show_vpdn/001_basic/expected.json",
         "nxos/show_ip_arp_detail_vrf_all/002_incomplete_and_static/expected.json",
-        "nxos/show_ip_ospf_neighbor/002_multi_vrf_with_roles/expected.json",
         "nxos/show_vpc/001_basic/expected.json",
     }
 )


### PR DESCRIPTION
Closes #626.

When NX-OS prints `-` (or `---`) in the Up Time column of `show ip ospf neighbor`, the parser now omits `up_time` instead of copying the CLI sentinel. `OspfNeighborEntry.up_time` is `NotRequired[str]`.

- Updated `002_multi_vrf_with_roles` expected output and fixture description
- Removed that expected file from `_HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES` since it no longer contains hyphen placeholders

Made with [Cursor](https://cursor.com)