### PR TITLE
fix(ios): omit N/A method placeholder in auth/access session parsers (#629)

### DIFF
--- a/changes/629.parser_fixed
+++ b/changes/629.parser_fixed
@@ -1,0 +1,1 @@
+IOS ``show authentication sessions`` and ``show access-session`` omit the ``method`` field when the CLI prints ``NA`` / ``N/A`` / ``n/a`` as an empty placeholder (instead of echoing those strings).

--- a/src/muninn/parsers/ios/show_authentication_sessions.py
+++ b/src/muninn/parsers/ios/show_authentication_sessions.py
@@ -25,6 +25,9 @@ _DATA_RE = re.compile(
 )
 _SESSION_COUNT_RE = re.compile(r"^\s*Session\s+count\s*=\s*(\d+)", re.IGNORECASE)
 
+# Device prints these in the Method column when no method applies; omit the key.
+_NA_LIKE_METHOD_PLACEHOLDERS: frozenset[str] = frozenset({"NA", "N/A", "n/a"})
+
 
 class SessionTableEntry(TypedDict):
     """Normalized row parsed from an IOS session summary table."""
@@ -110,7 +113,7 @@ def _parse_session_table(
 class AuthSessionEntry(TypedDict):
     """Schema for a single authentication session entry."""
 
-    method: str
+    method: NotRequired[str]
     domain: str
     status: str
     session_id: str
@@ -160,11 +163,12 @@ class ShowAuthenticationSessionsParser(
             mac_address = entry["mac_address"]
 
             auth_entry: AuthSessionEntry = {
-                "method": entry["method"],
                 "domain": entry["domain"],
                 "status": entry["status"],
                 "session_id": entry["session_id"],
             }
+            if entry["method"] not in _NA_LIKE_METHOD_PLACEHOLDERS:
+                auth_entry["method"] = entry["method"]
             if "fg" in entry:
                 auth_entry["fg"] = entry["fg"]
 

--- a/tests/parsers/ios/show_access-session/002_with_flags_and_unauth/expected.json
+++ b/tests/parsers/ios/show_access-session/002_with_flags_and_unauth/expected.json
@@ -18,7 +18,6 @@
             },
             "005a.12cd.3567": {
                 "domain": "UNKNOWN",
-                "method": "N/A",
                 "session_id": "0A0A1DFE00001F8D160101FF",
                 "status": "Unauth"
             }

--- a/tests/parsers/ios/show_authentication_sessions/002_with_session_count/expected.json
+++ b/tests/parsers/ios/show_authentication_sessions/002_with_session_count/expected.json
@@ -26,7 +26,6 @@
             },
             "005a.12cd.3567": {
                 "domain": "UNKNOWN",
-                "method": "N/A",
                 "session_id": "0A0A1DFE00001F8D160101FF",
                 "status": "Unauth"
             }

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -42,8 +42,6 @@ _HYPHEN_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
 # Legacy fixtures where NA / N/A / n/a appear as CLI text (not always “null”).
 _NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
     {
-        "ios/show_access-session/002_with_flags_and_unauth/expected.json",
-        "ios/show_authentication_sessions/002_with_session_count/expected.json",
         "ios/show_ip_nat_translations/001_basic/expected.json",
         "iosxe/show_endpoint_tracker_records/001_basic/expected.json",
         "iosxe/show_network_clocks_synchronization/001_basic/expected.json",


### PR DESCRIPTION
## Summary

- Treat `NA` / `N/A` / `n/a` in the IOS session table **Method** column as semantically empty: omit the `method` key instead of passing the literal string through.
- `AuthSessionEntry.method` is now optional (`NotRequired`).
- Updated `show authentication sessions` and `show access-session` fixtures (shared parser) and removed both paths from `_NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES`.

Fixes #629
Closes #628


Made with [Cursor](https://cursor.com)