### PR TITLE
fix(iosxe): omit N/A placeholders in show endpoint-tracker records (#631)

### DIFF
--- a/changes/631.parser_fixed
+++ b/changes/631.parser_fixed
@@ -1,0 +1,1 @@
+IOS-XE ``show endpoint-tracker records`` omits ``endpoint_type``, ``threshold_ms``, ``multiplier``, and ``interval_s`` when the CLI prints ``NA`` / ``N/A`` / ``n/a`` as empty placeholders (e.g. tracker-group rows).

--- a/src/muninn/parsers/iosxe/show_endpoint_tracker_records.py
+++ b/src/muninn/parsers/iosxe/show_endpoint_tracker_records.py
@@ -1,12 +1,15 @@
 """Parser for 'show endpoint-tracker records' command on IOS-XE."""
 
 import re
-from typing import ClassVar, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+
+# CLI prints these in numeric/type columns when a tracker-group row has no value.
+_NA_LIKE_PLACEHOLDERS: frozenset[str] = frozenset({"NA", "N/A", "n/a"})
 
 
 class EndpointTrackerRecordRow(TypedDict):
@@ -14,11 +17,11 @@ class EndpointTrackerRecordRow(TypedDict):
 
     record_name: str
     endpoint: str
-    endpoint_type: str
-    threshold_ms: str
-    multiplier: str
-    interval_s: str
     tracker_type: str
+    endpoint_type: NotRequired[str]
+    threshold_ms: NotRequired[str]
+    multiplier: NotRequired[str]
+    interval_s: NotRequired[str]
 
 
 class ShowEndpointTrackerRecordsResult(TypedDict):
@@ -32,6 +35,23 @@ def _split_record_line(line: str) -> list[str] | None:
     if len(parts) < 7:
         return None
     return parts
+
+
+def _row_from_record_parts(parts: list[str]) -> EndpointTrackerRecordRow:
+    row: EndpointTrackerRecordRow = {
+        "record_name": parts[0],
+        "endpoint": parts[1],
+        "tracker_type": parts[6],
+    }
+    if parts[2] not in _NA_LIKE_PLACEHOLDERS:
+        row["endpoint_type"] = parts[2]
+    if parts[3] not in _NA_LIKE_PLACEHOLDERS:
+        row["threshold_ms"] = parts[3]
+    if parts[4] not in _NA_LIKE_PLACEHOLDERS:
+        row["multiplier"] = parts[4]
+    if parts[5] not in _NA_LIKE_PLACEHOLDERS:
+        row["interval_s"] = parts[5]
+    return row
 
 
 @register(OS.CISCO_IOSXE, "show endpoint-tracker records")
@@ -53,15 +73,7 @@ class ShowEndpointTrackerRecordsParser(BaseParser[ShowEndpointTrackerRecordsResu
             parts = _split_record_line(line)
             if not parts:
                 continue
-            row = EndpointTrackerRecordRow(
-                record_name=parts[0],
-                endpoint=parts[1],
-                endpoint_type=parts[2],
-                threshold_ms=parts[3],
-                multiplier=parts[4],
-                interval_s=parts[5],
-                tracker_type=parts[6],
-            )
+            row = _row_from_record_parts(parts)
             rows[row["record_name"]] = row
         if not rows:
             msg = "No endpoint-tracker records parsed"

--- a/tests/parsers/iosxe/show_endpoint_tracker_records/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_endpoint_tracker_records/001_basic/expected.json
@@ -3,10 +3,6 @@
         "group-udp-tcp-10001": {
             "record_name": "group-udp-tcp-10001",
             "endpoint": "tcp-10002 OR udp-10002",
-            "endpoint_type": "N/A",
-            "threshold_ms": "N/A",
-            "multiplier": "N/A",
-            "interval_s": "N/A",
             "tracker_type": "tracker-group"
         },
         "nat-dia-tracker-4351": {

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -45,7 +45,6 @@ _NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "ios/show_access-session/002_with_flags_and_unauth/expected.json",
         "ios/show_authentication_sessions/002_with_session_count/expected.json",
         "ios/show_ip_nat_translations/001_basic/expected.json",
-        "iosxe/show_endpoint_tracker_records/001_basic/expected.json",
         "iosxe/show_network_clocks_synchronization/001_basic/expected.json",
         "iosxe/show_platform/003_asr903_chassis/expected.json",
         "iosxe/show_platform_nat_translations_active/001_basic/expected.json",


### PR DESCRIPTION
## Summary

- IOS-XE `show endpoint-tracker records`: omit `endpoint_type`, `threshold_ms`, `multiplier`, and `interval_s` when the CLI prints `NA` / `N/A` / `n/a` as empty placeholders (e.g. tracker-group rows).
- Model those fields as `NotRequired` on `EndpointTrackerRecordRow`; helper `_row_from_record_parts` keeps xenon complexity in range.
- Update `001_basic/expected.json` and remove the NA-like exemption from `test_fixture_placeholder_sentinels.py`.

Closes #631.

Made with [Cursor](https://cursor.com)