### PR TITLE
fix(iosxe): omit NA-like ESMC placeholders in show network-clocks synchronization

### DIFF
--- a/changes/632.parser_fixed
+++ b/changes/632.parser_fixed
@@ -1,0 +1,1 @@
+IOS-XE ``show network-clocks synchronization`` omits ``esmc_tx`` / ``esmc_rx`` when the CLI prints ``NA`` / ``N/A`` / ``n/a`` as empty placeholders (in addition to ``-``); ``sig_type`` still preserves ``NA`` where it is the Cisco SigType value.

--- a/src/muninn/parsers/iosxe/show_network_clocks_synchronization.py
+++ b/src/muninn/parsers/iosxe/show_network_clocks_synchronization.py
@@ -1,7 +1,7 @@
 """Parser for 'show network-clocks synchronization' command on IOS-XE."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict, cast
+from typing import ClassVar, Final, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -35,6 +35,15 @@ _ROW_RE = re.compile(
     r"(?P<prio>\d+)\s+(?P<ql>\S+)\s+(?P<tx>\S+)\s+(?P<rx>\S+)\s*$"
 )
 
+# ESMC Tx/Rx use "-" or NA-like tokens for “no value”; SigType "NA" is a separate enum.
+_ESMC_ABSENT_CASEFOLD: Final[frozenset[str]] = frozenset({"na", "n/a"})
+
+
+def _esmc_column_has_value(token: str) -> bool:
+    if token == "-":
+        return False
+    return token.casefold() not in _ESMC_ABSENT_CASEFOLD
+
 
 def _parse_ncs_kv_line(line: str) -> tuple[str, str] | None:
     if ":" not in line:
@@ -62,9 +71,9 @@ def _parse_interface_row(line: str) -> NetworkClockInterfaceRow | None:
         "prio": int(m.group("prio")),
         "ql_in": m.group("ql"),
     }
-    if tx != "-":
+    if _esmc_column_has_value(tx):
         row["esmc_tx"] = tx
-    if rx != "-":
+    if _esmc_column_has_value(rx):
         row["esmc_rx"] = rx
     return row
 

--- a/src/muninn/parsers/iosxe/show_network_clocks_synchronization.py
+++ b/src/muninn/parsers/iosxe/show_network_clocks_synchronization.py
@@ -40,7 +40,7 @@ _ESMC_ABSENT_CASEFOLD: Final[frozenset[str]] = frozenset({"na", "n/a"})
 
 
 def _esmc_column_has_value(token: str) -> bool:
-    if token == "-":
+    if token == "-":  # nosec B105
         return False
     return token.casefold() not in _ESMC_ABSENT_CASEFOLD
 

--- a/tests/parsers/iosxe/show_network_clocks_synchronization/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_network_clocks_synchronization/001_basic/expected.json
@@ -19,9 +19,7 @@
             "sig_type": "NA",
             "mode_ql": "NA/Dis",
             "prio": 251,
-            "ql_in": "QL-SEC",
-            "esmc_tx": "NA",
-            "esmc_rx": "NA"
+            "ql_in": "QL-SEC"
         },
         "GigabitEthernet0/0/2": {
             "interface": "GigabitEthernet0/0/2",

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -5,7 +5,9 @@ omitting the key (or using ``null`` if the schema uses optional fields) instead 
 carrying strings like ``-`` or ``---`` through to structured output.
 
 Some tokens are ambiguous: Cisco often prints ``NA`` / ``N/A`` as *meaningful*
-labels (e.g. network-clocks ``SigType``, RADIUS statistics). Legacy fixtures that
+labels (e.g. network-clocks ``SigType`` as the literal ``NA`` enum, or RADIUS
+statistics). ESMC Tx/Rx columns treat ``NA`` / ``N/A`` / ``n/a`` like ``-`` and
+omit those keys. Legacy fixtures that
 still mirror those literals are listed below; **new** test cases are not exempt
 unless their path is added explicitly (so new work does not silently reintroduce
 placeholders).


### PR DESCRIPTION
## Summary
- Treat `NA` / `N/A` / `n/a` in **ESMC Tx/Rx** columns like `-` and omit `esmc_tx` / `esmc_rx` when they are empty placeholders.
- Leave **SigType** `NA` unchanged: it is a real Cisco enum value in this command (see issue discussion).
- Update the `001_basic` fixture accordingly.

## Fixture exemption (#621)
`tests/parsers/iosxe/show_network_clocks_synchronization/001_basic/expected.json` stays in `_NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES` because the test flags any string leaf equal to `NA` / `N/A` / `n/a`, and `sig_type` still carries the literal `NA`.

## Issue
Related to #632 (does not close: `sig_type` `NA` remains intentional per vendor semantics).

Made with [Cursor](https://cursor.com)