### PR TITLE
fix(iosxe): omit N/A slot state for empty show platform modules (#633)

### DIFF
--- a/changes/633.parser_updated
+++ b/changes/633.parser_updated
@@ -1,0 +1,1 @@
+IOS/IOS-XE ``show platform``: omit ``state`` when the device reports ``N/A`` for an empty module bay (unknown or blank slot type).

--- a/src/muninn/parsers/ios/show_platform.py
+++ b/src/muninn/parsers/ios/show_platform.py
@@ -21,14 +21,14 @@ class SubslotEntry(TypedDict):
     """Schema for a subslot within a chassis slot."""
 
     type: str
-    state: str
+    state: NotRequired[str]
     insert_time: str
 
 
 class SlotEntry(TypedDict):
     """Schema for a chassis slot entry."""
 
-    state: str
+    state: NotRequired[str]
     type: NotRequired[str]
     insert_time: NotRequired[str]
     cpld_version: NotRequired[str]
@@ -116,6 +116,19 @@ _CURRENT_HEADER_RE = re.compile(r"^\s*Current\s*$")
 _NA_VALUE = "N/A"
 
 
+def _omit_na_state_for_empty_module(slot_type: str, state: str) -> bool:
+    """Whether to drop ``state`` when the CLI prints N/A for an absent module.
+
+    Cisco uses type *Unknown* (or a blank type) with state *N/A* for empty
+    power/module bays; we omit ``state`` so fixtures avoid placeholder literals
+    (issue #633). Real modules keep ``state`` even if unusual.
+    """
+    if state != _NA_VALUE:
+        return False
+    normalized = slot_type.strip().lower()
+    return not normalized or normalized == "unknown"
+
+
 def _parse_chassis_type(lines: list[str]) -> str | None:
     """Extract chassis type from output lines."""
     for line in lines:
@@ -156,9 +169,10 @@ def _add_subslot(
     _, sub_type, sub_state, sub_insert = _parse_slot_row(line, cols)
     subslot_entry: SubslotEntry = {
         "type": sub_type,
-        "state": sub_state,
         "insert_time": sub_insert,
     }
+    if not _omit_na_state_for_empty_module(sub_type, sub_state):
+        subslot_entry["state"] = sub_state
     if parent_num in slots:
         current_parent = parent_num
     if current_parent and current_parent in slots:
@@ -186,7 +200,9 @@ def _parse_slot_table(lines: list[str], cols: _SlotColumns) -> dict[str, SlotEnt
         if not slot_name or not state:
             continue
 
-        entry: SlotEntry = {"state": state}
+        entry: SlotEntry = {}
+        if not _omit_na_state_for_empty_module(slot_type, state):
+            entry["state"] = state
         if slot_type:
             entry["type"] = slot_type
         if insert_time:

--- a/tests/parsers/iosxe/show_platform/003_asr903_chassis/expected.json
+++ b/tests/parsers/iosxe/show_platform/003_asr903_chassis/expected.json
@@ -20,7 +20,6 @@
             "insert_time": "1w4d"
         },
         "P1": {
-            "state": "N/A",
             "type": "Unknown",
             "insert_time": "never"
         },

--- a/tests/parsers/iosxe/show_platform/003_asr903_chassis/metadata.yaml
+++ b/tests/parsers/iosxe/show_platform/003_asr903_chassis/metadata.yaml
@@ -1,3 +1,3 @@
-description: ASR-903 chassis with empty F0 type, N/A state, orphaned subslot, and blank lines between rows
+description: ASR-903 chassis with empty F0 type, empty P1 bay (Unknown/N/A omitted from output), orphaned subslot, and blank lines between rows
 platform: ASR-903
 software_version: "15.6(42r)S"

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -47,7 +47,6 @@ _NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "ios/show_ip_nat_translations/001_basic/expected.json",
         "iosxe/show_endpoint_tracker_records/001_basic/expected.json",
         "iosxe/show_network_clocks_synchronization/001_basic/expected.json",
-        "iosxe/show_platform/003_asr903_chassis/expected.json",
         "iosxe/show_platform_nat_translations_active/001_basic/expected.json",
         "iosxe/show_power_inline_priority/002_with_oper_priority/expected.json",
         "iosxe/show_pppatm_session/001_basic/expected.json",


### PR DESCRIPTION
## Summary

Resolves #633.

- **Parser** (`show_platform.py`): When the slot **State** column is `N/A` and the **Type** is blank or `Unknown` (empty module bay, e.g. ASR-903 `P1`), omit the `state` key instead of emitting the CLI placeholder string. Subslots use the same rule.
- **Fixture**: Updated `003_asr903_chassis/expected.json` so `P1` no longer carries `"state": "N/A"`.
- **Tests**: Removed the NA-like placeholder exemption for this expected file from `test_fixture_placeholder_sentinels.py`.
- **Changelog**: `changes/633.parser_updated`.

## Verification

- `uv run pytest`
- `uv run ruff check` / format
- `uv run ty check src/muninn/parsers/ios/show_platform.py`

Made with [Cursor](https://cursor.com)