### PR TITLE
fix(iosxe): omit NA auth/acct in show radius statistics (#637)

### DIFF
--- a/changes/637.parser_updated
+++ b/changes/637.parser_updated
@@ -1,0 +1,1 @@
+IOS-XE `show radius statistics`: omit `auth` / `acct` keys when the device prints `NA` for non-applicable counters (see #637).

--- a/src/muninn/parsers/iosxe/show_radius_statistics.py
+++ b/src/muninn/parsers/iosxe/show_radius_statistics.py
@@ -10,11 +10,15 @@ from muninn.tags import ParserTag
 
 
 class RadiusTripleCounter(TypedDict):
-    """Three-column auth/acct/both counter."""
+    """Three-column auth/acct/both counter.
 
-    auth: str
-    acct: str
+    IOS-XE prints ``NA`` in the auth and/or acct columns when that counter does
+    not apply; those keys are omitted instead of carrying the literal token.
+    """
+
     both: str
+    auth: NotRequired[str]
+    acct: NotRequired[str]
 
 
 class ShowRadiusStatisticsResult(TypedDict):
@@ -38,6 +42,21 @@ _ELAPSED_RE = re.compile(
     r"^Elapsed time since counters last cleared\s*:\s*(.+)$",
     re.I,
 )
+
+
+def _omit_na_auth_acct_column(value: str) -> bool:
+    """Return True if the CLI uses NA / N/A for a non-applicable auth or acct cell."""
+    return value.strip().upper() in {"NA", "N/A"}
+
+
+def _triple_row(auth: str, acct: str, both: str) -> RadiusTripleCounter:
+    """Build a triple counter row, dropping auth/acct when the device printed NA."""
+    row: RadiusTripleCounter = {"both": both}
+    if not _omit_na_auth_acct_column(auth):
+        row["auth"] = auth
+    if not _omit_na_auth_acct_column(acct):
+        row["acct"] = acct
+    return row
 
 
 class _RadiusAcc:
@@ -77,11 +96,7 @@ class _RadiusAcc:
         name = m3.group(1).strip()
         if name.lower().startswith("access "):
             return True
-        self.triple[name] = RadiusTripleCounter(
-            auth=m3.group(2),
-            acct=m3.group(3),
-            both=m3.group(4),
-        )
+        self.triple[name] = _triple_row(m3.group(2), m3.group(3), m3.group(4))
         return True
 
     def _feed_single(self, s: str) -> bool:

--- a/tests/parsers/iosxe/show_radius_statistics/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_radius_statistics/001_basic/expected.json
@@ -1,18 +1,12 @@
 {
     "triple_counters": {
         "Maximum inQ length": {
-            "auth": "NA",
-            "acct": "NA",
             "both": "0"
         },
         "Maximum waitQ length": {
-            "auth": "NA",
-            "acct": "NA",
             "both": "2"
         },
         "Maximum doneQ length": {
-            "auth": "NA",
-            "acct": "NA",
             "both": "0"
         },
         "Total responses seen": {

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -51,7 +51,6 @@ _NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "iosxe/show_platform_nat_translations_active/001_basic/expected.json",
         "iosxe/show_power_inline_priority/002_with_oper_priority/expected.json",
         "iosxe/show_pppatm_session/001_basic/expected.json",
-        "iosxe/show_radius_statistics/001_basic/expected.json",
     }
 )
 


### PR DESCRIPTION
## Summary

IOS-XE `show radius statistics` prints `NA` in the auth and/or acct columns when those counters do not apply (e.g. queue depth metrics). Muninn now omits those keys instead of propagating the CLI placeholder string.

## Schema

- `RadiusTripleCounter`: `both` remains required; `auth` and `acct` are `NotRequired`.
- NA / N/A matching is case-insensitive on the stripped cell value.

## Tests

- Updated `001_basic/expected.json` for the three NA rows.
- Removed the legacy NA exemption from `test_fixture_placeholder_sentinels.py`.

Refs #637

Made with [Cursor](https://cursor.com)