### PR TITLE
fix(iosxe): omit unset admin_priority for show power inline priority (#635)

### DIFF
--- a/changes/635.parser_updated
+++ b/changes/635.parser_updated
@@ -1,0 +1,1 @@
+IOS-XE `show power inline priority`: omit `admin_priority` when the CLI prints `NA` / `N/A` / `n/a` (unset), instead of passing those strings through.

--- a/src/muninn/parsers/iosxe/show_power_inline_priority.py
+++ b/src/muninn/parsers/iosxe/show_power_inline_priority.py
@@ -1,7 +1,7 @@
 """Parser for 'show power inline priority' command on IOS-XE."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, Final, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -16,7 +16,7 @@ class PowerInlinePriorityEntry(TypedDict):
 
     admin_state: str
     oper_state: str
-    admin_priority: str
+    admin_priority: NotRequired[str]
     oper_priority: NotRequired[str]
 
 
@@ -45,6 +45,13 @@ _HEADER_KEYWORDS = frozenset({"interface", "admin", "oper", "state", "priority"}
 
 _SEPARATOR_PATTERN = SEPARATOR_DASH_SPACE_RE
 
+# CLI uses NA / N/A / n/a when admin priority is not configured (not an enum value).
+_ADMIN_PRIORITY_UNSET_NORMALIZED: Final[frozenset[str]] = frozenset({"na", "n/a"})
+
+
+def _admin_priority_is_unset(raw: str) -> bool:
+    return raw.strip().casefold() in _ADMIN_PRIORITY_UNSET_NORMALIZED
+
 
 def _is_header_or_separator(line: str) -> bool:
     """Return True if the line is a table header or separator."""
@@ -52,6 +59,22 @@ def _is_header_or_separator(line: str) -> bool:
     if all(word in _HEADER_KEYWORDS for word in lower.split()):
         return True
     return bool(_SEPARATOR_PATTERN.match(line))
+
+
+def _entry_from_row_match(m: re.Match[str]) -> tuple[str, PowerInlinePriorityEntry]:
+    """Build an interface entry from a row regex match."""
+    name = canonical_interface_name(m.group("interface"))
+    entry: PowerInlinePriorityEntry = {
+        "admin_state": m.group("admin_state"),
+        "oper_state": m.group("oper_state"),
+    }
+    admin_priority = m.group("admin_priority")
+    if not _admin_priority_is_unset(admin_priority):
+        entry["admin_priority"] = admin_priority
+    oper_priority = m.group("oper_priority")
+    if oper_priority is not None:
+        entry["oper_priority"] = oper_priority
+    return name, entry
 
 
 @register(OS.CISCO_IOSXE, "show power inline priority")
@@ -98,15 +121,7 @@ class ShowPowerInlinePriorityParser(BaseParser[ShowPowerInlinePriorityResult]):
                 continue
 
             if m := _ROW_PATTERN.match(line):
-                name = canonical_interface_name(m.group("interface"))
-                entry: PowerInlinePriorityEntry = {
-                    "admin_state": m.group("admin_state"),
-                    "oper_state": m.group("oper_state"),
-                    "admin_priority": m.group("admin_priority"),
-                }
-                oper_priority = m.group("oper_priority")
-                if oper_priority is not None:
-                    entry["oper_priority"] = oper_priority
+                name, entry = _entry_from_row_match(m)
                 interfaces[name] = entry
 
         if not interfaces:

--- a/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/expected.json
+++ b/tests/parsers/iosxe/show_power_inline_priority/002_with_oper_priority/expected.json
@@ -1,7 +1,6 @@
 {
     "interfaces": {
         "TenGigabitEthernet2/0/1": {
-            "admin_priority": "n/a",
             "admin_state": "auto",
             "oper_priority": "1",
             "oper_state": "off"

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -49,7 +49,6 @@ _NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "iosxe/show_network_clocks_synchronization/001_basic/expected.json",
         "iosxe/show_platform/003_asr903_chassis/expected.json",
         "iosxe/show_platform_nat_translations_active/001_basic/expected.json",
-        "iosxe/show_power_inline_priority/002_with_oper_priority/expected.json",
         "iosxe/show_pppatm_session/001_basic/expected.json",
         "iosxe/show_radius_statistics/001_basic/expected.json",
     }


### PR DESCRIPTION
## Summary

Resolves #635.

When `show power inline priority` prints `NA` / `N/A` / `n/a` in the Admin Priority column, that indicates no configured priority—not a literal enum value. The parser now omits `admin_priority` in that case (same pattern as optional `oper_priority`).

## Changes

- `PowerInlinePriorityEntry.admin_priority` is `NotRequired[str]`.
- Fixture `002_with_oper_priority` updated; removed full-file exemption from `_NA_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES`.

## Testing

- `uv run pytest`
- `uv run ruff check .` / `ruff format --check .`
- `uv run towncrier check --compare-with origin/main`

Made with [Cursor](https://cursor.com)