### PR TITLE
refactor(nxos): nest show mac address-table as mac_table dict

### DIFF
--- a/changes/601.breaking
+++ b/changes/601.breaking
@@ -1,0 +1,1 @@
+NX-OS `show mac address-table` now returns `mac_table` as `vlan_key -> mac_address -> row` (with `kind: unicast` on each row) instead of a flat list of entries.

--- a/src/muninn/parsers/nxos/show_mac_address_table.py
+++ b/src/muninn/parsers/nxos/show_mac_address_table.py
@@ -1,7 +1,7 @@
 """Parser for 'show mac address-table' command on NX-OS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, Literal, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -26,11 +26,7 @@ _INTERFACE_PORT_PATTERN = re.compile(r"^(?:Eth|Po|Lo|Vlan|mgmt|nve|Tu|Fa|Gi|Te)\
 
 
 class MacTableEntry(TypedDict):
-    """Schema for a single MAC address table entry.
-
-    Optional fields (vlan, age, entry_flag) are omitted when not applicable
-    rather than set to null, following the project convention.
-    """
+    """Intermediate row from the CLI line (includes keys used only for nesting)."""
 
     mac_address: str
     type: str
@@ -43,10 +39,57 @@ class MacTableEntry(TypedDict):
     entry_flag: NotRequired[str]
 
 
+class MacTableRow(TypedDict, total=False):
+    """Leaf under ``mac_table[vlan_key][mac_key]``."""
+
+    kind: Literal["unicast"]
+    type: str
+    secure: bool
+    ntfy: bool
+    port: str
+    is_routed: bool
+    age: NotRequired[int]
+    entry_flag: NotRequired[str]
+
+
 class ShowMacAddressTableResult(TypedDict):
     """Schema for 'show mac address-table' parsed output."""
 
-    mac_table: list[MacTableEntry]
+    mac_table: dict[str, dict[str, MacTableRow]]
+
+
+def _vlan_segment_key(entry: MacTableEntry) -> str:
+    """Outer key: numeric VLAN id, or ``none`` when VLAN is absent (``-`` column)."""
+    if "vlan" not in entry:
+        return "none"
+    return str(entry["vlan"])
+
+
+def _row_from_entry(entry: MacTableEntry) -> MacTableRow:
+    """Strip ``vlan`` / ``mac_address``; they appear only as parent keys."""
+    row: MacTableRow = {
+        "kind": "unicast",
+        "type": entry["type"],
+        "secure": entry["secure"],
+        "ntfy": entry["ntfy"],
+        "port": entry["port"],
+        "is_routed": entry["is_routed"],
+    }
+    if "age" in entry:
+        row["age"] = entry["age"]
+    if "entry_flag" in entry:
+        row["entry_flag"] = entry["entry_flag"]
+    return row
+
+
+def _nest_mac_table(entries: list[MacTableEntry]) -> dict[str, dict[str, MacTableRow]]:
+    """Build ``vlan -> mac -> row`` (last row wins on duplicate keys)."""
+    mac_table: dict[str, dict[str, MacTableRow]] = {}
+    for entry in entries:
+        vk = _vlan_segment_key(entry)
+        mk = entry["mac_address"]
+        mac_table.setdefault(vk, {})[mk] = _row_from_entry(entry)
+    return mac_table
 
 
 @register(OS.CISCO_NXOS, "show mac address-table")
@@ -135,12 +178,12 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed MAC address table with list of entries.
+            Parsed MAC address table with nested ``mac_table``.
 
         Raises:
-            ValueError: If no MAC table entries found.
+            ValueError: If no MAC table entries found in output.
         """
-        mac_table: list[MacTableEntry] = []
+        entries: list[MacTableEntry] = []
 
         for line in output.splitlines():
             line = line.strip()
@@ -149,10 +192,10 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
 
             match = cls._ENTRY_PATTERN.match(line)
             if match:
-                mac_table.append(cls._parse_entry(match))
+                entries.append(cls._parse_entry(match))
 
-        if not mac_table:
+        if not entries:
             msg = "No MAC address table entries found in output"
             raise ValueError(msg)
 
-        return ShowMacAddressTableResult(mac_table=mac_table)
+        return ShowMacAddressTableResult(mac_table=_nest_mac_table(entries))

--- a/tests/parsers/nxos/show_mac_address-table/001_mixed_static_entries/expected.json
+++ b/tests/parsers/nxos/show_mac_address-table/001_mixed_static_entries/expected.json
@@ -1,118 +1,120 @@
 {
-    "mac_table": [
-        {
-            "vlan": 10,
-            "mac_address": "aaaa.bbff.8888",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "Ethernet1/2",
-            "entry_flag": "primary",
-            "is_routed": false
+    "mac_table": {
+        "10": {
+            "aaaa.bbff.8888": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "Ethernet1/2",
+                "is_routed": false,
+                "entry_flag": "primary"
+            }
         },
-        {
-            "vlan": 20,
-            "mac_address": "aaaa.bbff.8888",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "Drop",
-            "entry_flag": "primary",
-            "is_routed": false
+        "20": {
+            "aaaa.bbff.8888": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "Drop",
+                "is_routed": false,
+                "entry_flag": "primary"
+            }
         },
-        {
-            "vlan": 30,
-            "mac_address": "aaaa.bbff.8888",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "Drop",
-            "entry_flag": "primary",
-            "is_routed": false
+        "30": {
+            "aaaa.bbff.8888": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "Drop",
+                "is_routed": false,
+                "entry_flag": "primary"
+            }
         },
-        {
-            "mac_address": "0000.deff.6c9d",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "none": {
+            "0000.deff.6c9d": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            },
+            "5e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R) (Lo0)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         },
-        {
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "(R)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "100": {
+            "5e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         },
-        {
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R) (Lo0)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "101": {
+            "5e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         },
-        {
-            "vlan": 100,
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "102": {
+            "5e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         },
-        {
-            "vlan": 101,
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "2000": {
+            "7e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "vPC Peer-Link(R)",
+                "is_routed": true
+            }
         },
-        {
-            "vlan": 102,
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "3000": {
+            "5e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true
+            }
         },
-        {
-            "vlan": 2000,
-            "mac_address": "7e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "vPC Peer-Link(R)",
-            "is_routed": true
-        },
-        {
-            "vlan": 3000,
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "is_routed": true
-        },
-        {
-            "vlan": 4000,
-            "mac_address": "5e00.c0ff.0007",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "is_routed": true
+        "4000": {
+            "5e00.c0ff.0007": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true
+            }
         }
-    ]
+    }
 }

--- a/tests/parsers/nxos/show_mac_address-table/002_dynamic_vpc_entries/expected.json
+++ b/tests/parsers/nxos/show_mac_address-table/002_dynamic_vpc_entries/expected.json
@@ -1,103 +1,96 @@
 {
-    "mac_table": [
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.e5a5",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel113",
-            "entry_flag": "primary",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.1446",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel103",
-            "entry_flag": "vpc_peer_link",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.d708",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel115",
-            "entry_flag": "vpc_peer_link",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.fd77",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel116",
-            "entry_flag": "primary",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.d0fc",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel127",
-            "entry_flag": "primary",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.037d",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel133",
-            "entry_flag": "primary",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.061e",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel132",
-            "entry_flag": "vpc_peer_link",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.1e9c",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel124",
-            "entry_flag": "primary",
-            "is_routed": false
-        },
-        {
-            "vlan": 390,
-            "mac_address": "000f.53ff.1f1d",
-            "type": "dynamic",
-            "age": 0,
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel125",
-            "entry_flag": "vpc_peer_link",
-            "is_routed": false
+    "mac_table": {
+        "390": {
+            "000f.53ff.e5a5": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel113",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "primary"
+            },
+            "000f.53ff.1446": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel103",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "vpc_peer_link"
+            },
+            "000f.53ff.d708": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel115",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "vpc_peer_link"
+            },
+            "000f.53ff.fd77": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel116",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "primary"
+            },
+            "000f.53ff.d0fc": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel127",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "primary"
+            },
+            "000f.53ff.037d": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel133",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "primary"
+            },
+            "000f.53ff.061e": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel132",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "vpc_peer_link"
+            },
+            "000f.53ff.1e9c": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel124",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "primary"
+            },
+            "000f.53ff.1f1d": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel125",
+                "is_routed": false,
+                "age": 0,
+                "entry_flag": "vpc_peer_link"
+            }
         }
-    ]
+    }
 }

--- a/tests/parsers/nxos/show_mac_address-table/003_na_age_mixed_flags/expected.json
+++ b/tests/parsers/nxos/show_mac_address-table/003_na_age_mixed_flags/expected.json
@@ -1,61 +1,60 @@
 {
-    "mac_table": [
-        {
-            "vlan": 100,
-            "mac_address": "0000.0000.1111",
-            "type": "dynamic",
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel100",
-            "entry_flag": "vpc_peer_link",
-            "is_routed": false
+    "mac_table": {
+        "100": {
+            "0000.0000.1111": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel100",
+                "is_routed": false,
+                "entry_flag": "vpc_peer_link"
+            },
+            "0000.0000.1112": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel100",
+                "is_routed": false
+            },
+            "0000.0000.1113": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel100",
+                "is_routed": false
+            },
+            "0000.0000.111a": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel100",
+                "is_routed": false,
+                "entry_flag": "vpc_peer_link"
+            },
+            "0010.9400.0002": {
+                "kind": "unicast",
+                "type": "dynamic",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel100",
+                "is_routed": false,
+                "entry_flag": "primary"
+            }
         },
-        {
-            "vlan": 100,
-            "mac_address": "0000.0000.1112",
-            "type": "dynamic",
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel100",
-            "is_routed": false
-        },
-        {
-            "vlan": 100,
-            "mac_address": "0000.0000.1113",
-            "type": "dynamic",
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel100",
-            "is_routed": false
-        },
-        {
-            "vlan": 100,
-            "mac_address": "0000.0000.111a",
-            "type": "dynamic",
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel100",
-            "entry_flag": "vpc_peer_link",
-            "is_routed": false
-        },
-        {
-            "vlan": 100,
-            "mac_address": "0010.9400.0002",
-            "type": "dynamic",
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel100",
-            "entry_flag": "primary",
-            "is_routed": false
-        },
-        {
-            "mac_address": "44ae.2502.a907",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "entry_flag": "gateway",
-            "is_routed": true
+        "none": {
+            "44ae.2502.a907": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         }
-    ]
+    }
 }

--- a/tests/parsers/nxos/show_mac_address-table/004_vlan_bd_with_drop_and_subinterface/expected.json
+++ b/tests/parsers/nxos/show_mac_address-table/004_vlan_bd_with_drop_and_subinterface/expected.json
@@ -1,42 +1,46 @@
 {
-    "mac_table": [
-        {
-            "mac_address": "0000.eeef.f113",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R) (Po90.275)",
-            "is_routed": true,
-            "entry_flag": "gateway"
+    "mac_table": {
+        "none": {
+            "0000.eeef.f113": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R) (Po90.275)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            },
+            "0000.eeef.f118": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "Drop (Eth17/3.280)",
+                "is_routed": false,
+                "entry_flag": "primary"
+            }
         },
-        {
-            "mac_address": "0000.eeef.f118",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "Drop (Eth17/3.280)",
-            "is_routed": false,
-            "entry_flag": "primary"
+        "301": {
+            "0000.eeef.f12d": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         },
-        {
-            "mac_address": "0000.eeef.f12d",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "is_routed": true,
-            "vlan": 301,
-            "entry_flag": "gateway"
-        },
-        {
-            "mac_address": "0000.eeef.f1b8",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "vPC Peer-Link(R)",
-            "is_routed": true,
-            "vlan": 440,
-            "entry_flag": "gateway"
+        "440": {
+            "0000.eeef.f1b8": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "vPC Peer-Link(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         }
-    ]
+    }
 }

--- a/tests/parsers/nxos/show_mac_address-table/005_ntc_gateway_static_drop/expected.json
+++ b/tests/parsers/nxos/show_mac_address-table/005_ntc_gateway_static_drop/expected.json
@@ -1,34 +1,35 @@
 {
-    "mac_table": [
-        {
-            "mac_address": "5087.89a1.de75",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "sup-eth1(R)",
-            "is_routed": true,
-            "vlan": 100,
-            "entry_flag": "gateway"
+    "mac_table": {
+        "100": {
+            "5087.89a1.de75": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "sup-eth1(R)",
+                "is_routed": true,
+                "entry_flag": "gateway"
+            }
         },
-        {
-            "mac_address": "000a.000a.000a",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "Drop",
-            "is_routed": false,
-            "vlan": 145,
-            "entry_flag": "primary"
-        },
-        {
-            "mac_address": "000e.000e.000e",
-            "type": "static",
-            "secure": false,
-            "ntfy": false,
-            "port": "Port-channel10",
-            "is_routed": false,
-            "vlan": 145,
-            "entry_flag": "primary"
+        "145": {
+            "000a.000a.000a": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "Drop",
+                "is_routed": false,
+                "entry_flag": "primary"
+            },
+            "000e.000e.000e": {
+                "kind": "unicast",
+                "type": "static",
+                "secure": false,
+                "ntfy": false,
+                "port": "Port-channel10",
+                "is_routed": false,
+                "entry_flag": "primary"
+            }
         }
-    ]
+    }
 }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -186,11 +186,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "nxos/show_ipv6_route/001_multi_vrf_mixed_protocols/expected.json",
         "nxos/show_ipv6_route/002_vxlan_overlay/expected.json",
         "nxos/show_ipv6_route/003_eigrp_subinterfaces/expected.json",
-        "nxos/show_mac_address-table/001_mixed_static_entries/expected.json",
-        "nxos/show_mac_address-table/002_dynamic_vpc_entries/expected.json",
-        "nxos/show_mac_address-table/003_na_age_mixed_flags/expected.json",
-        "nxos/show_mac_address-table/004_vlan_bd_with_drop_and_subinterface/expected.json",
-        "nxos/show_mac_address-table/005_ntc_gateway_static_drop/expected.json",
     }
 )
 


### PR DESCRIPTION
Aligns NX-OS output with the nested `mac_table` shape (`kind: unicast` on each row). Updates fixtures and exemptions.

Closes #601

Made with [Cursor](https://cursor.com)