### PR TITLE
refactor(ios): key show dot1x all clients by session_id

### DIFF
--- a/changes/602.breaking
+++ b/changes/602.breaking
@@ -1,0 +1,1 @@
+IOS `show dot1x all` now maps `clients` by `session_id` (dict) instead of a list; `session_id` is not duplicated inside each client row.

--- a/src/muninn/parsers/ios/show_dot1x_all.py
+++ b/src/muninn/parsers/ios/show_dot1x_all.py
@@ -11,11 +11,10 @@ from muninn.utils import canonical_interface_name
 
 
 class Dot1xClientEntry(TypedDict):
-    """Schema for a single dot1x client (supplicant) entry."""
+    """Schema for a single dot1x client (supplicant), keyed by ``session_id``."""
 
     eap_method: str
     mac_address: str
-    session_id: str
     auth_sm_state: NotRequired[str]
     auth_bend_sm_state: NotRequired[str]
 
@@ -44,7 +43,7 @@ class Dot1xInterfaceEntry(TypedDict):
     max_start: NotRequired[int]
     credentials_profile: NotRequired[str]
     eap_profile: NotRequired[str]
-    clients: NotRequired[list[Dot1xClientEntry]]
+    clients: NotRequired[dict[str, Dot1xClientEntry]]
 
 
 class ShowDot1xAllResult(TypedDict):
@@ -192,15 +191,27 @@ _CLIENT_FIELD_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 ]
 
 
-def _flush_client(clients: list[Dot1xClientEntry], current: dict | None) -> None:
-    """Append the current client to the list if it has a MAC address."""
-    if current is not None and "mac_address" in current:
-        clients.append(current)  # type: ignore[arg-type]
+def _flush_client(clients: dict[str, Dot1xClientEntry], current: dict | None) -> None:
+    """Store the current client under ``session_id`` when complete."""
+    if current is None or "mac_address" not in current:
+        return
+    sid = current.get("session_id")
+    if not sid:
+        return
+    row: Dot1xClientEntry = {
+        "eap_method": current["eap_method"],
+        "mac_address": current["mac_address"],
+    }
+    if "auth_sm_state" in current:
+        row["auth_sm_state"] = current["auth_sm_state"]
+    if "auth_bend_sm_state" in current:
+        row["auth_bend_sm_state"] = current["auth_bend_sm_state"]
+    clients[sid] = row
 
 
-def _parse_clients(lines: list[str]) -> list[Dot1xClientEntry]:
+def _parse_clients(lines: list[str]) -> dict[str, Dot1xClientEntry]:
     """Parse dot1x client entries from interface block lines."""
-    clients: list[Dot1xClientEntry] = []
+    clients: dict[str, Dot1xClientEntry] = {}
     current: dict | None = None
 
     for line in lines:
@@ -294,9 +305,9 @@ def _parse_interface_block(raw_name: str, block: str) -> Dot1xInterfaceEntry:
     if client_start is not None and not _CLIENT_LIST_EMPTY_RE.match(
         block_lines[client_start].strip()
     ):
-        clients = _parse_clients(block_lines[client_start:])
-        if clients:
-            entry["clients"] = clients
+        client_map = _parse_clients(block_lines[client_start:])
+        if client_map:
+            entry["clients"] = client_map
 
     return entry  # type: ignore[return-value]
 

--- a/tests/parsers/ios/show_dot1x_all/001_basic/expected.json
+++ b/tests/parsers/ios/show_dot1x_all/001_basic/expected.json
@@ -1,42 +1,42 @@
 {
-    "critical_eapol": "Disabled",
-    "critical_recovery_delay": 100,
     "interfaces": {
         "Ethernet1/0": {
-            "control_direction": "Both",
-            "host_mode": "SINGLE_HOST",
             "interface": "Ethernet1/0",
-            "max_req": 2,
             "pae": "AUTHENTICATOR",
             "port_control": "AUTO",
-            "quiet_period": 60,
-            "rate_limit_period": 0,
-            "re_auth_max": 2,
-            "re_auth_period": 3600,
-            "re_auth_period_source": "Locally configured",
+            "control_direction": "Both",
+            "host_mode": "SINGLE_HOST",
             "re_authentication": "Disabled",
+            "quiet_period": 60,
             "server_timeout": 30,
             "supp_timeout": 30,
-            "tx_period": 30
+            "re_auth_period": 3600,
+            "re_auth_period_source": "Locally configured",
+            "re_auth_max": 2,
+            "max_req": 2,
+            "tx_period": 30,
+            "rate_limit_period": 0
         },
         "Ethernet1/2": {
-            "control_direction": "Both",
-            "host_mode": "SINGLE_HOST",
             "interface": "Ethernet1/2",
-            "max_req": 2,
             "pae": "AUTHENTICATOR",
             "port_control": "AUTO",
-            "quiet_period": 60,
-            "rate_limit_period": 0,
-            "re_auth_max": 2,
-            "re_auth_period": 3600,
-            "re_auth_period_source": "Locally configured",
+            "control_direction": "Both",
+            "host_mode": "SINGLE_HOST",
             "re_authentication": "Disabled",
+            "quiet_period": 60,
             "server_timeout": 30,
             "supp_timeout": 30,
-            "tx_period": 30
+            "re_auth_period": 3600,
+            "re_auth_period_source": "Locally configured",
+            "re_auth_max": 2,
+            "max_req": 2,
+            "tx_period": 30,
+            "rate_limit_period": 0
         }
     },
+    "sysauthcontrol": "Disabled",
     "protocol_version": 2,
-    "sysauthcontrol": "Disabled"
+    "critical_recovery_delay": 100,
+    "critical_eapol": "Disabled"
 }

--- a/tests/parsers/ios/show_dot1x_all/002_with_clients/expected.json
+++ b/tests/parsers/ios/show_dot1x_all/002_with_clients/expected.json
@@ -1,39 +1,37 @@
 {
     "interfaces": {
         "FastEthernet7/1": {
-            "clients": [
-                {
-                    "auth_bend_sm_state": "IDLE",
-                    "auth_sm_state": "HELD",
-                    "eap_method": "MD5",
-                    "mac_address": "fa16.3eff.c0c3",
-                    "session_id": "000000000000000E00110F79"
-                },
-                {
-                    "auth_bend_sm_state": "IDLE",
-                    "auth_sm_state": "AUTHENTICATED",
-                    "eap_method": "MD5",
-                    "mac_address": "fa16.3eff.40c7",
-                    "session_id": "000000000000000C00108250"
-                }
-            ],
-            "control_direction": "Both",
-            "host_mode": "SINGLE_HOST",
             "interface": "FastEthernet7/1",
-            "max_req": 2,
             "pae": "AUTHENTICATOR",
             "port_control": "AUTO",
-            "quiet_period": 60,
-            "rate_limit_period": 0,
-            "re_auth_max": 2,
-            "re_auth_period": 3600,
-            "re_auth_period_source": "Locally configured",
+            "control_direction": "Both",
+            "host_mode": "SINGLE_HOST",
             "re_authentication": "Disabled",
+            "quiet_period": 60,
             "server_timeout": 30,
             "supp_timeout": 30,
-            "tx_period": 30
+            "re_auth_period": 3600,
+            "re_auth_period_source": "Locally configured",
+            "re_auth_max": 2,
+            "max_req": 2,
+            "tx_period": 30,
+            "rate_limit_period": 0,
+            "clients": {
+                "000000000000000E00110F79": {
+                    "eap_method": "MD5",
+                    "mac_address": "fa16.3eff.c0c3",
+                    "auth_sm_state": "HELD",
+                    "auth_bend_sm_state": "IDLE"
+                },
+                "000000000000000C00108250": {
+                    "eap_method": "MD5",
+                    "mac_address": "fa16.3eff.40c7",
+                    "auth_sm_state": "AUTHENTICATED",
+                    "auth_bend_sm_state": "IDLE"
+                }
+            }
         }
     },
-    "protocol_version": 3,
-    "sysauthcontrol": "Enabled"
+    "sysauthcontrol": "Enabled",
+    "protocol_version": 3
 }

--- a/tests/parsers/ios/show_dot1x_all/003_supplicant/expected.json
+++ b/tests/parsers/ios/show_dot1x_all/003_supplicant/expected.json
@@ -1,16 +1,16 @@
 {
     "interfaces": {
         "GigabitEthernet1/0/9": {
-            "auth_period": 30,
-            "credentials_profile": "switch4",
-            "eap_profile": "EAP-METH",
-            "held_period": 60,
             "interface": "GigabitEthernet1/0/9",
-            "max_start": 3,
             "pae": "SUPPLICANT",
-            "start_period": 30
+            "start_period": 30,
+            "auth_period": 30,
+            "held_period": 60,
+            "max_start": 3,
+            "credentials_profile": "switch4",
+            "eap_profile": "EAP-METH"
         }
     },
-    "protocol_version": 3,
-    "sysauthcontrol": "Enabled"
+    "sysauthcontrol": "Enabled",
+    "protocol_version": 3
 }

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -82,7 +82,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
     {
         # --- IOS ---
         "ios/show_crypto_session_detail/001_basic/expected.json",
-        "ios/show_dot1x_all/002_with_clients/expected.json",
         "ios/show_ip_eigrp_topology/001_basic/expected.json",
         "ios/show_ip_eigrp_topology/002_multiple_as/expected.json",
         "ios/show_ip_ospf_database/001_basic/expected.json",


### PR DESCRIPTION
Replaces `clients` list with a dict keyed by `session_id`; omits duplicate `session_id` in row values.

Closes #602

Made with [Cursor](https://cursor.com)