### PR TITLE
test: drop stale show standby brief list-of-dicts exemption

### DIFF
--- a/changes/+standby-brief-exemption.internal
+++ b/changes/+standby-brief-exemption.internal
@@ -1,0 +1,1 @@
+Remove stale list-of-dicts exemption for `show standby brief` (fixture already nested dicts).

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -113,7 +113,6 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         "ios/show_processes_memory/001_basic/expected.json",
         "ios/show_processes_memory_sorted/001_basic/expected.json",
         "ios/show_processes_memory_sorted/002_single_pool/expected.json",
-        "ios/show_standby_brief/001_mixed_states_and_interfaces/expected.json",
         "ios/show_version/001_c3750x_switch/expected.json",
         # --- IOS-XE ---
         "iosxe/show_bgp_all/001_basic/expected.json",


### PR DESCRIPTION
Removes a mistaken exemption reintroduced after #612; the fixture already satisfies the nested-dict convention.

Closes #595

Made with [Cursor](https://cursor.com)