### PR TITLE
fix(ios): complete issue #197 — show spanning-tree root schema + tests

### DIFF
--- a/src/muninn/parsers/ios/show_spanning-tree_root.py
+++ b/src/muninn/parsers/ios/show_spanning-tree_root.py
@@ -5,45 +5,50 @@ from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import MAC_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
 
-# --- Column header pattern ---
-_HEADER_RE = re.compile(r"^Vlan\s+Root\s+ID\s+Cost\s+Time\s+Age\s+Dly\s+Root\s+Port")
 
-# Data line: VLAN, priority, address, cost, hello, max age, fwd dly, port
-_DATA_RE = re.compile(
-    r"^(?P<vlan>\S+)\s+"
-    r"(?P<priority>\d+)\s+"
-    r"(?P<address>[0-9a-f]{4}\.[0-9a-f]{4}\.[0-9a-f]{4})\s+"
-    r"(?P<cost>\d+)\s+"
-    r"(?P<hello>\d+)\s+"
-    r"(?P<max_age>\d+)\s+"
-    r"(?P<fwd_delay>\d+)"
-    r"(?:\s+(?P<root_port>\S+))?\s*$"
-)
-
-
-class RootBridgeEntry(TypedDict):
-    """Schema for the root bridge identification."""
+class RootId(TypedDict):
+    """Schema for the root bridge identifier."""
 
     priority: int
     address: str
 
 
-class VlanRootEntry(TypedDict):
-    """Schema for a single VLAN's spanning-tree root information."""
+class SpanningTreeRootEntry(TypedDict):
+    """Schema for a single VLAN spanning-tree root entry."""
 
-    root_id: RootBridgeEntry
+    vlan_id: int
+    root_id: RootId
     root_cost: int
     hello_time: int
     max_age: int
     forward_delay: int
     root_port: NotRequired[str]
+    is_root: NotRequired[bool]
 
 
-ShowSpanningTreeRootResult = dict[str, VlanRootEntry]
+class ShowSpanningTreeRootResult(TypedDict):
+    """Schema for 'show spanning-tree root' parsed output on IOS."""
+
+    vlans: dict[str, SpanningTreeRootEntry]
+
+
+# Data line: VLAN name, priority, MAC, cost, hello, max age, fwd dly, optional root port
+_DATA_RE = re.compile(
+    r"^(?P<vlan>VLAN\d+)\s+"
+    r"(?P<priority>\d+)\s+"
+    rf"(?P<address>{MAC_ADDRESS})\s+"
+    r"(?P<cost>\d+)\s+"
+    r"(?P<hello>\d+)\s+"
+    r"(?P<max_age>\d+)\s+"
+    r"(?P<fwd_delay>\d+)"
+    r"(?:\s+(?P<root_port>\S+))?\s*$",
+    re.IGNORECASE,
+)
 
 
 @register(OS.CISCO_IOS, "show spanning-tree root")
@@ -75,44 +80,51 @@ class ShowSpanningTreeRootParser(BaseParser[ShowSpanningTreeRootResult]):
             output: Raw CLI output from 'show spanning-tree root' command.
 
         Returns:
-            Dict keyed by VLAN ID with root bridge information.
+            Parsed spanning-tree root entries keyed by VLAN ID string (digits
+            from the ``VLAN####`` name, preserving leading zeros).
 
         Raises:
-            ValueError: If a data line cannot be parsed.
+            ValueError: If no spanning-tree root entries found in output.
         """
-        result: ShowSpanningTreeRootResult = {}
+        vlans: dict[str, SpanningTreeRootEntry] = {}
 
         for line in output.splitlines():
-            match = _DATA_RE.match(line)
+            match = _DATA_RE.match(line.strip())
             if not match:
                 continue
 
             vlan_name = match.group("vlan")
-            # Extract numeric VLAN ID from names like "VLAN0001"
-            vlan_match = re.match(r"VLAN(\d+)", vlan_name, re.IGNORECASE)
-            if not vlan_match:
+            vlan_digits = re.match(r"VLAN(?P<vid>\d+)", vlan_name, re.IGNORECASE)
+            if not vlan_digits:
                 msg = f"Cannot extract VLAN ID from: {vlan_name}"
                 raise ValueError(msg)
 
-            vlan_id = str(int(vlan_match.group(1)))
+            vlan_id_str = vlan_digits.group("vid")
 
-            entry: VlanRootEntry = {
-                "root_id": {
-                    "priority": int(match.group("priority")),
-                    "address": match.group("address"),
-                },
+            entry: SpanningTreeRootEntry = {
+                "vlan_id": int(vlan_id_str),
+                "root_id": RootId(
+                    priority=int(match.group("priority")),
+                    address=match.group("address").lower(),
+                ),
                 "root_cost": int(match.group("cost")),
                 "hello_time": int(match.group("hello")),
                 "max_age": int(match.group("max_age")),
                 "forward_delay": int(match.group("fwd_delay")),
             }
 
-            root_port = match.group("root_port")
-            if root_port:
+            root_port_raw = match.group("root_port")
+            if root_port_raw:
                 entry["root_port"] = canonical_interface_name(
-                    root_port, os=OS.CISCO_IOS
+                    root_port_raw, os=OS.CISCO_IOS
                 )
+            else:
+                entry["is_root"] = True
 
-            result[vlan_id] = entry
+            vlans[vlan_id_str] = entry
 
-        return result
+        if not vlans:
+            msg = "No spanning-tree root entries found in output"
+            raise ValueError(msg)
+
+        return ShowSpanningTreeRootResult(vlans=vlans)

--- a/tests/parsers/ios/show_spanning-tree_root/001_basic/expected.json
+++ b/tests/parsers/ios/show_spanning-tree_root/001_basic/expected.json
@@ -1,33 +1,40 @@
 {
-    "1": {
-        "root_id": {
-            "priority": 11175,
-            "address": "5c6e.f0a7.a0b0"
+    "vlans": {
+        "0001": {
+            "vlan_id": 1,
+            "root_id": {
+                "priority": 11175,
+                "address": "5c6e.f0a7.a0b0"
+            },
+            "root_cost": 0,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 15,
+            "is_root": true
         },
-        "root_cost": 0,
-        "hello_time": 2,
-        "max_age": 20,
-        "forward_delay": 15
-    },
-    "2": {
-        "root_id": {
-            "priority": 11185,
-            "address": "5c6e.f0a7.a0b0"
+        "0002": {
+            "vlan_id": 2,
+            "root_id": {
+                "priority": 11185,
+                "address": "5c6e.f0a7.a0b0"
+            },
+            "root_cost": 0,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 15,
+            "is_root": true
         },
-        "root_cost": 0,
-        "hello_time": 2,
-        "max_age": 20,
-        "forward_delay": 15
-    },
-    "3": {
-        "root_id": {
-            "priority": 11195,
-            "address": "5c6e.f0a7.a0b0"
-        },
-        "root_cost": 0,
-        "hello_time": 2,
-        "max_age": 20,
-        "forward_delay": 15,
-        "root_port": "Port-channel34"
+        "0003": {
+            "vlan_id": 3,
+            "root_id": {
+                "priority": 11195,
+                "address": "5c6e.f0a7.a0b0"
+            },
+            "root_cost": 0,
+            "hello_time": 2,
+            "max_age": 20,
+            "forward_delay": 15,
+            "root_port": "Port-channel34"
+        }
     }
 }

--- a/tests/parsers/ios/show_spanning-tree_root/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_spanning-tree_root/001_basic/metadata.yaml
@@ -1,3 +1,9 @@
-description: Multiple VLANs with root bridge info, mix of root bridge and non-root with root port
-platform: Unknown
-software_version: Unknown
+description: >
+  Spanning-tree root table with local-root VLANs and one VLAN with a port-channel
+  root port.
+platform: Cisco Catalyst (IOS)
+software_version: IOS sample
+source: >
+  CLI fixture derived from ntc-templates
+  tests/cisco_ios/show_spanning-tree_root/cisco_ios_show_spanning_tree_root.raw
+  (Apache-2.0).


### PR DESCRIPTION
## Summary

Resolves [issue #197](https://github.com/ChartinoLabs/Muninn/issues/197) by aligning the Cisco IOS `show spanning-tree root` parser with the documented NX-OS shape and tightening the implementation.

## Changes

- **Output schema**: Top-level `vlans` dict (keys preserve VLAN digits, e.g. `0001`), each entry includes `vlan_id`, `root_id` (`priority`, `address`), timers, `root_cost`, optional `root_port` (canonical IOS name), and `is_root` when the **Root Port** column is blank (IOS does not print *This bridge is root* like NX-OS).
- **Parsing**: Shared `MAC_ADDRESS` pattern, case-insensitive VLAN line match, `ValueError` when no data rows parse (consistent with NX-OS).
- **Tests**: Updated `expected.json` and `metadata.yaml`; fixture CLI sample attributed to [ntc-templates](https://github.com/networktocode/ntc-templates) (`tests/cisco_ios/show_spanning-tree_root/…`).

## Verification

- `uv run pytest`
- `uv run ruff check`, `ruff format`
- `uv run ty check src/muninn/parsers/ios/show_spanning-tree_root.py`
- `uv run bandit -r` (targeted in CI for `src/`)

Closes https://github.com/ChartinoLabs/Muninn/issues/197

Made with [Cursor](https://cursor.com)