### PR TITLE
feat(docs): add schema and example views to parser library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/muninn/_version.py
 
 # Generated documentation artifacts
 docs/library/*.json
+docs/library/details/
 
 # MkDocs build output
 site/

--- a/changes/+parser-library-details.core_added
+++ b/changes/+parser-library-details.core_added
@@ -1,0 +1,1 @@
+Parser library now displays TypedDict schema and test fixture examples (CLI input and parsed output) for each parser, loaded on demand when a row is expanded.

--- a/docs/library.md
+++ b/docs/library.md
@@ -1,6 +1,6 @@
 # Parser Library
 
-Browse all parsers available in Muninn. Use the search box and filters to find parsers by command, OS, or feature tag.
+Browse all parsers available in Muninn. Use the search box and filters to find parsers by command, OS, or feature tag. Click any row to view its schema and example output.
 
 <div id="parser-catalog">
   <div class="catalog-controls">
@@ -21,6 +21,7 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   <table id="catalog-table">
     <thead>
       <tr>
+        <th class="expand-col"></th>
         <th data-sort="os">Platform</th>
         <th data-sort="command">Command</th>
         <th data-sort="tags">Tags</th>
@@ -36,6 +37,12 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
 </div>
 
 <style>
+  .md-sidebar--secondary {
+    display: none;
+  }
+  .md-main__inner.md-grid {
+    max-width: none;
+  }
   .catalog-controls {
     display: flex;
     gap: 0.75rem;
@@ -73,6 +80,7 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   #catalog-table {
     width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
   }
   #catalog-table th {
     cursor: pointer;
@@ -103,8 +111,41 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     border-bottom: 1px solid var(--md-default-fg-color--lightest);
     vertical-align: top;
   }
-  #catalog-table tr:hover td {
+  th.expand-col {
+    width: 2rem;
+    cursor: default;
+  }
+  th.expand-col::after {
+    content: none;
+  }
+  td.expand-cell {
+    width: 2rem;
+    text-align: center;
+    color: var(--md-default-fg-color--lighter);
+    font-size: 0.7rem;
+  }
+  td.expand-cell span {
+    display: inline-block;
+    transition: transform 0.2s ease;
+  }
+  tr.catalog-row.expanded td.expand-cell span {
+    transform: rotate(90deg);
+  }
+  tr.catalog-row {
+    cursor: pointer;
+  }
+  tr.catalog-row:hover td {
     background: var(--md-code-bg-color);
+  }
+  tr.catalog-row:hover td.expand-cell {
+    color: var(--md-accent-fg-color);
+  }
+  tr.catalog-row.expanded td {
+    background: var(--md-code-bg-color);
+    border-bottom: none;
+  }
+  tr.catalog-row.expanded td.expand-cell {
+    color: var(--md-accent-fg-color);
   }
   .tag-chip {
     display: inline-block;
@@ -126,14 +167,143 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     text-align: center;
     color: var(--md-default-fg-color--light);
   }
+
+  /* Detail panel */
+  tr.detail-row td {
+    padding: 0;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  }
+  .detail-panel {
+    padding: 1rem 1.5rem 1.5rem;
+    background: var(--md-code-bg-color);
+    overflow: hidden;
+    min-width: 0;
+  }
+  .detail-panel h4 {
+    margin: 0 0 0.5rem;
+    font-size: 0.95rem;
+    color: var(--md-default-fg-color);
+  }
+
+  /* Schema tree */
+  .schema-tree {
+    font-family: var(--md-code-font);
+    font-size: 0.82rem;
+    line-height: 1.6;
+    padding: 0.75rem 1rem;
+    background: var(--md-default-bg-color);
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 4px;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+  }
+  .schema-field-name {
+    color: var(--md-accent-fg-color);
+  }
+  .schema-type {
+    color: var(--md-default-fg-color--light);
+  }
+  .schema-optional {
+    color: var(--md-default-fg-color--lighter);
+    font-style: italic;
+    font-size: 0.78rem;
+  }
+
+  /* Example tabs */
+  .example-tabs {
+    margin-bottom: 1rem;
+  }
+  .example-tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 2px solid var(--md-default-fg-color--lightest);
+    margin-bottom: 0;
+    flex-wrap: wrap;
+  }
+  .example-tab-btn {
+    padding: 0.4rem 1rem;
+    border: none;
+    background: transparent;
+    color: var(--md-default-fg-color--light);
+    cursor: pointer;
+    font-size: 0.82rem;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    font-family: inherit;
+  }
+  .example-tab-btn:hover {
+    color: var(--md-default-fg-color);
+  }
+  .example-tab-btn.active {
+    color: var(--md-accent-fg-color);
+    border-bottom-color: var(--md-accent-fg-color);
+  }
+  .example-content {
+    display: none;
+  }
+  .example-content.active {
+    display: block;
+  }
+  .example-view-bar {
+    display: flex;
+    gap: 0;
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+  }
+  .example-view-btn {
+    padding: 0.35rem 0.9rem;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color--light);
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-family: inherit;
+  }
+  .example-view-btn:first-child {
+    border-radius: 4px 0 0 0;
+    border-right: none;
+  }
+  .example-view-btn:last-child {
+    border-radius: 0 4px 0 0;
+  }
+  .example-view-btn.active {
+    background: var(--md-accent-fg-color);
+    color: var(--md-accent-bg-color);
+    border-color: var(--md-accent-fg-color);
+  }
+  .example-pre {
+    margin: 0;
+    padding: 0.75rem;
+    background: var(--md-default-bg-color);
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+    font-size: 0.78rem;
+    line-height: 1.5;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+  }
+  .detail-loading {
+    padding: 1rem;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.85rem;
+  }
+  .detail-error {
+    padding: 1rem;
+    color: #e53935;
+    font-size: 0.85rem;
+  }
+  .no-data-msg {
+    color: var(--md-default-fg-color--lighter);
+    font-size: 0.85rem;
+    font-style: italic;
+  }
 </style>
 
 <script>
-// Use an IIFE instead of DOMContentLoaded — MkDocs Material's instant
-// navigation (XHR page swaps) never re-fires DOMContentLoaded, so the
-// catalog wouldn't initialise on first visit via an in-site link.
-// The inline script sits below the HTML it references, so the elements
-// already exist when this executes.
+// IIFE — see previous fix for why we avoid DOMContentLoaded with
+// MkDocs Material instant navigation.
 ;(function () {
   var versionSelect = document.getElementById("catalog-version");
   var search = document.getElementById("catalog-search");
@@ -147,8 +317,9 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   var currentParsers = [];
   var sortCol = "command";
   var sortDir = "asc";
+  var detailCache = {};
+  var expandedKey = null;
 
-  // Human-readable OS display names
   var osDisplayNames = {
     "cisco_ios": "Cisco IOS",
     "cisco_iosxe": "Cisco IOS-XE",
@@ -160,7 +331,20 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     return osDisplayNames[os] || os;
   }
 
-  // Load versions manifest
+  function parserKey(p) {
+    return p.os + "::" + p.command;
+  }
+
+  function setMessage(parent, className, text) {
+    while (parent.firstChild) parent.removeChild(parent.firstChild);
+    var div = document.createElement("div");
+    div.className = className;
+    div.textContent = text;
+    parent.appendChild(div);
+  }
+
+  // --- Version loading ---
+
   fetch("versions.json")
     .then(function (r) { return r.json(); })
     .then(function (manifest) { initVersions(manifest); })
@@ -172,10 +356,8 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
 
   function initVersions(manifest) {
-    // Clear loading placeholder
     versionSelect.textContent = "";
 
-    // Add released versions (newest first)
     manifest.versions.forEach(function (v) {
       var opt = document.createElement("option");
       opt.value = v.file;
@@ -183,28 +365,25 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       versionSelect.appendChild(opt);
     });
 
-    // Add main at the bottom
     var mainOpt = document.createElement("option");
     mainOpt.value = manifest.main.file;
     mainOpt.textContent = manifest.main.label;
     versionSelect.appendChild(mainOpt);
 
-    // Select the latest release by default
     var latestFile = manifest.versions.length > 0
       ? manifest.versions[0].file
       : manifest.main.file;
     versionSelect.value = latestFile;
-
-    // Load the default version
     loadVersion(latestFile);
 
-    // Switch versions on change
     versionSelect.addEventListener("change", function () {
       loadVersion(versionSelect.value);
     });
   }
 
   function loadVersion(file) {
+    expandedKey = null;
+    detailCache = {};
     fetch(file)
       .then(function (r) { return r.json(); })
       .then(function (parsers) {
@@ -220,11 +399,11 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       });
   }
 
+  // --- Filters ---
+
   function rebuildFilters() {
-    // Reset search
     search.value = "";
 
-    // Rebuild OS filter
     osFilter.textContent = "";
     var allOsOpt = document.createElement("option");
     allOsOpt.value = "";
@@ -243,7 +422,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       osFilter.appendChild(opt);
     });
 
-    // Rebuild tag filter
     tagFilter.textContent = "";
     var allTagOpt = document.createElement("option");
     allTagOpt.value = "";
@@ -265,6 +443,8 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
   }
 
+  // --- Rendering ---
+
   function createTagChip(tag) {
     var span = document.createElement("span");
     span.className = "tag-chip";
@@ -273,7 +453,17 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   }
 
   function createRow(p) {
+    var key = parserKey(p);
     var tr = document.createElement("tr");
+    tr.className = "catalog-row";
+    if (expandedKey === key) tr.classList.add("expanded");
+
+    var tdExpand = document.createElement("td");
+    tdExpand.className = "expand-cell";
+    var chevron = document.createElement("span");
+    chevron.textContent = "\u25B6";
+    tdExpand.appendChild(chevron);
+    tr.appendChild(tdExpand);
 
     var tdOs = document.createElement("td");
     tdOs.textContent = osLabel(p.os);
@@ -292,6 +482,10 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
     tr.appendChild(tdTags);
 
+    tr.addEventListener("click", function () {
+      toggleDetail(p, tr);
+    });
+
     return tr;
   }
 
@@ -307,7 +501,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       return true;
     });
 
-    // Sort
     filtered.sort(function (a, b) {
       var va = a[sortCol] || "";
       var vb = b[sortCol] || "";
@@ -318,21 +511,30 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       return sortDir === "asc" ? cmp : -cmp;
     });
 
-    // Clear existing rows
-    while (tbody.firstChild) {
-      tbody.removeChild(tbody.firstChild);
-    }
+    while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
 
-    // Build rows
     filtered.forEach(function (p) {
-      tbody.appendChild(createRow(p));
+      var row = createRow(p);
+      tbody.appendChild(row);
+
+      // Re-insert expanded detail row if this parser is expanded
+      if (expandedKey === parserKey(p)) {
+        var detailRow = createDetailRow();
+        tbody.appendChild(detailRow);
+        var panel = detailRow.querySelector(".detail-panel");
+        var data = detailCache[parserKey(p)];
+        if (data) {
+          renderDetailContent(panel, data);
+        } else {
+          loadDetail(p, panel);
+        }
+      }
     });
 
     stats.textContent = "Showing " + filtered.length + " of " + currentParsers.length + " parsers";
     empty.style.display = filtered.length === 0 ? "block" : "none";
     table.style.display = filtered.length === 0 ? "none" : "table";
 
-    // Update sort indicators
     table.querySelectorAll("th").forEach(function (th) {
       th.classList.remove("sort-asc", "sort-desc");
       if (th.dataset.sort === sortCol) {
@@ -341,7 +543,327 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
   }
 
-  // Event listeners
+  // --- Detail panel ---
+
+  function createDetailRow() {
+    var tr = document.createElement("tr");
+    tr.className = "detail-row";
+    var td = document.createElement("td");
+    td.colSpan = 4;
+    var panel = document.createElement("div");
+    panel.className = "detail-panel";
+    setMessage(panel, "detail-loading", "Loading details...");
+    td.appendChild(panel);
+    tr.appendChild(td);
+    return tr;
+  }
+
+  function toggleDetail(p, rowEl) {
+    var key = parserKey(p);
+
+    if (expandedKey === key) {
+      // Collapse
+      expandedKey = null;
+      rowEl.classList.remove("expanded");
+      var next = rowEl.nextElementSibling;
+      if (next && next.classList.contains("detail-row")) {
+        next.parentNode.removeChild(next);
+      }
+      return;
+    }
+
+    // Collapse any previously expanded row
+    var prevExpanded = tbody.querySelector("tr.catalog-row.expanded");
+    if (prevExpanded) {
+      prevExpanded.classList.remove("expanded");
+      var prevDetail = prevExpanded.nextElementSibling;
+      if (prevDetail && prevDetail.classList.contains("detail-row")) {
+        prevDetail.parentNode.removeChild(prevDetail);
+      }
+    }
+
+    // Expand this row
+    expandedKey = key;
+    rowEl.classList.add("expanded");
+
+    var detailRow = createDetailRow();
+    rowEl.parentNode.insertBefore(detailRow, rowEl.nextSibling);
+
+    var panel = detailRow.querySelector(".detail-panel");
+    var cached = detailCache[key];
+    if (cached) {
+      renderDetailContent(panel, cached);
+    } else {
+      loadDetail(p, panel);
+    }
+  }
+
+  function loadDetail(p, panel) {
+    var key = parserKey(p);
+    if (!p.detail_file) {
+      setMessage(panel, "detail-error", "No detail data available.");
+      return;
+    }
+    fetch(p.detail_file)
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        detailCache[key] = data;
+        if (expandedKey === key) {
+          renderDetailContent(panel, data);
+        }
+      })
+      .catch(function () {
+        if (expandedKey === key) {
+          setMessage(panel, "detail-error", "Failed to load parser details.");
+        }
+      });
+  }
+
+  function renderDetailContent(panel, data) {
+    while (panel.firstChild) panel.removeChild(panel.firstChild);
+
+    // Schema section
+    var schemaHeading = document.createElement("h4");
+    schemaHeading.textContent = "Schema";
+    panel.appendChild(schemaHeading);
+
+    if (data.schema) {
+      var schemaEl = document.createElement("pre");
+      schemaEl.className = "schema-tree";
+      schemaEl.textContent = renderSchemaText(data.schema);
+      panel.appendChild(schemaEl);
+    } else {
+      var noSchema = document.createElement("div");
+      noSchema.className = "no-data-msg";
+      noSchema.textContent = "No schema information available.";
+      panel.appendChild(noSchema);
+    }
+
+    // Examples section
+    var exHeading = document.createElement("h4");
+    exHeading.textContent = "Examples";
+    panel.appendChild(exHeading);
+
+    if (data.examples && data.examples.length > 0) {
+      panel.appendChild(renderExamples(data.examples));
+    } else {
+      var noEx = document.createElement("div");
+      noEx.className = "no-data-msg";
+      noEx.textContent = "No test fixture examples available.";
+      panel.appendChild(noEx);
+    }
+  }
+
+  // --- Schema rendering ---
+
+  function renderSchemaText(schema) {
+    var lines = [];
+    renderTypedDict(schema, 0, lines, false);
+    return lines.join("\n");
+  }
+
+  function indent(depth) {
+    var s = "";
+    for (var i = 0; i < depth; i++) s += "  ";
+    return s;
+  }
+
+  function renderTypedDict(td, depth, lines, omitBraces) {
+    if (!td || !td.fields) return;
+    var fields = td.fields;
+    var keys = Object.keys(fields);
+    if (!omitBraces) lines.push(indent(depth) + "{");
+    var inner = depth + 1;
+
+    keys.forEach(function (name, i) {
+      var field = fields[name];
+      var keyStr = field.required ? '"' + name + '"' : '"' + name + '"?';
+      var val = typeToJsonValue(field.type, inner, lines);
+      var comma = i < keys.length - 1 ? "," : "";
+
+      if (val.multiline) {
+        lines.push(indent(inner) + keyStr + ": " + val.open);
+        val.bodyFn();
+        lines.push(indent(inner) + val.close + comma);
+      } else {
+        lines.push(indent(inner) + keyStr + ": " + val.text + comma);
+      }
+    });
+
+    if (!omitBraces) lines.push(indent(depth) + "}");
+  }
+
+  function typeToJsonValue(t, depth, lines) {
+    if (typeof t === "string") {
+      return { text: "<" + t + ">", multiline: false };
+    }
+
+    if (!t) return { text: "<unknown>", multiline: false };
+
+    // TypedDict
+    if (t.fields && t.name) {
+      return {
+        multiline: true,
+        open: "{",
+        close: "}",
+        bodyFn: function () { renderTypedDict(t, depth, lines, true); }
+      };
+    }
+
+    if (t.type === "dict") {
+      var keyPlaceholder = "<" + scalarName(t.key) + ">";
+      var valResult = typeToJsonValue(t.value, depth + 1, lines);
+
+      if (valResult.multiline) {
+        return {
+          multiline: true,
+          open: "{",
+          close: "}",
+          bodyFn: function () {
+            lines.push(indent(depth + 1) + keyPlaceholder + ": " + valResult.open);
+            valResult.bodyFn();
+            lines.push(indent(depth + 1) + valResult.close);
+          }
+        };
+      }
+      return {
+        multiline: true,
+        open: "{",
+        close: "}",
+        bodyFn: function () {
+          lines.push(indent(depth + 1) + keyPlaceholder + ": " + valResult.text);
+        }
+      };
+    }
+
+    if (t.type === "list") {
+      var itemResult = typeToJsonValue(t.items, depth + 1, lines);
+      if (itemResult.multiline) {
+        return {
+          multiline: true,
+          open: "[",
+          close: "]",
+          bodyFn: function () {
+            lines.push(indent(depth + 1) + itemResult.open);
+            itemResult.bodyFn();
+            lines.push(indent(depth + 1) + itemResult.close);
+          }
+        };
+      }
+      return {
+        multiline: true,
+        open: "[",
+        close: "]",
+        bodyFn: function () {
+          lines.push(indent(depth + 1) + itemResult.text);
+        }
+      };
+    }
+
+    if (t.type === "literal") {
+      var vals = t.values.map(function (v) {
+        return typeof v === "string" ? '"' + v + '"' : String(v);
+      });
+      return { text: vals.join(" | "), multiline: false };
+    }
+
+    if (t.type === "union") {
+      var parts = t.options.map(function (o) { return scalarName(o); });
+      return { text: "<" + parts.join(" | ") + ">", multiline: false };
+    }
+
+    return { text: "<" + String(t.type || t) + ">", multiline: false };
+  }
+
+  function scalarName(t) {
+    if (typeof t === "string") return t;
+    if (t && t.name) return t.name;
+    if (t && t.type) return t.type;
+    return "unknown";
+  }
+
+  // --- Example rendering ---
+
+  function renderExamples(examples) {
+    var container = document.createElement("div");
+    container.className = "example-tabs";
+
+    var bar = document.createElement("div");
+    bar.className = "example-tab-bar";
+    container.appendChild(bar);
+
+    var panes = [];
+
+    examples.forEach(function (ex, idx) {
+      var btn = document.createElement("button");
+      btn.className = "example-tab-btn";
+      if (idx === 0) btn.classList.add("active");
+      btn.textContent = ex.name;
+      btn.addEventListener("click", function () {
+        bar.querySelectorAll(".example-tab-btn").forEach(function (b) {
+          b.classList.remove("active");
+        });
+        btn.classList.add("active");
+        panes.forEach(function (pane, j) {
+          pane.classList.toggle("active", j === idx);
+        });
+      });
+      bar.appendChild(btn);
+
+      var pane = document.createElement("div");
+      pane.className = "example-content";
+      if (idx === 0) pane.classList.add("active");
+
+      // View toggle: CLI Output / Parsed Result
+      var viewBar = document.createElement("div");
+      viewBar.className = "example-view-bar";
+
+      var cliBtn = document.createElement("button");
+      cliBtn.className = "example-view-btn active";
+      cliBtn.textContent = "CLI Output";
+      viewBar.appendChild(cliBtn);
+
+      var parsedBtn = document.createElement("button");
+      parsedBtn.className = "example-view-btn";
+      parsedBtn.textContent = "Parsed Result";
+      viewBar.appendChild(parsedBtn);
+
+      pane.appendChild(viewBar);
+
+      var cliPre = document.createElement("pre");
+      cliPre.className = "example-pre";
+      cliPre.textContent = ex.input;
+      pane.appendChild(cliPre);
+
+      var parsedPre = document.createElement("pre");
+      parsedPre.className = "example-pre";
+      parsedPre.style.display = "none";
+      parsedPre.textContent = JSON.stringify(ex.expected, null, 2);
+      pane.appendChild(parsedPre);
+
+      cliBtn.addEventListener("click", function () {
+        cliBtn.classList.add("active");
+        parsedBtn.classList.remove("active");
+        cliPre.style.display = "";
+        parsedPre.style.display = "none";
+      });
+
+      parsedBtn.addEventListener("click", function () {
+        parsedBtn.classList.add("active");
+        cliBtn.classList.remove("active");
+        parsedPre.style.display = "";
+        cliPre.style.display = "none";
+      });
+
+      container.appendChild(pane);
+      panes.push(pane);
+    });
+
+    return container;
+  }
+
+  // --- Event listeners ---
+
   search.addEventListener("input", render);
   osFilter.addEventListener("change", render);
   tagFilter.addEventListener("change", render);

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,7 +1,8 @@
 """Generate versioned parser catalog JSON files for the documentation site.
 
 Produces one catalog JSON file per git tag plus one for the main branch,
-along with a versions.json manifest. All output goes to docs/library/.
+along with a versions.json manifest and per-parser detail files containing
+TypedDict schemas and test fixture examples. All output goes to docs/library/.
 """
 
 import json
@@ -9,7 +10,9 @@ import logging
 import subprocess
 import sys
 import tempfile
+import typing
 from pathlib import Path
+from typing import Any
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -29,8 +32,235 @@ def get_git_tags() -> list[str]:
     return [tag.strip() for tag in result.stdout.splitlines() if tag.strip()]
 
 
-def generate_catalog_from_source(src_path: Path) -> list[dict[str, object]]:
-    """Import muninn from a source path and generate catalog entries."""
+# ---------------------------------------------------------------------------
+# TypedDict schema extraction
+# ---------------------------------------------------------------------------
+
+
+def _type_to_schema(t: Any, globalns: dict[str, object], seen: set[int]) -> object:  # noqa: ANN401
+    """Convert a type annotation to a JSON-serialisable schema representation."""
+    origin = typing.get_origin(t)
+    args = typing.get_args(t)
+
+    # NotRequired[X] → unwrap
+    if origin is typing.NotRequired:
+        return _type_to_schema(args[0], globalns, seen)
+
+    # TypedDict → recurse
+    if isinstance(t, type) and hasattr(t, "__required_keys__"):
+        return _typeddict_to_schema(t, globalns, seen)
+
+    # dict[K, V]
+    if origin is dict:
+        k, v = args if args else (str, object)
+        return {
+            "type": "dict",
+            "key": _type_to_schema(k, globalns, seen),
+            "value": _type_to_schema(v, globalns, seen),
+        }
+
+    # list[X]
+    if origin is list:
+        return {
+            "type": "list",
+            "items": _type_to_schema(args[0], globalns, seen) if args else "Any",
+        }
+
+    # Literal
+    if origin is typing.Literal:
+        return {"type": "literal", "values": list(args)}
+
+    # Union / Optional
+    if origin is typing.Union:
+        return {
+            "type": "union",
+            "options": [_type_to_schema(a, globalns, seen) for a in args],
+        }
+
+    # Scalars
+    simple = {str: "str", int: "int", float: "float", bool: "bool"}
+    if t in simple:
+        return simple[t]
+
+    return str(t)
+
+
+def _typeddict_to_schema(
+    td: Any,  # noqa: ANN401
+    globalns: dict[str, object],
+    seen: set[int] | None = None,
+) -> dict[str, object]:
+    """Recursively convert a TypedDict into a JSON-friendly schema dict."""
+    if seen is None:
+        seen = set()
+    if id(td) in seen:
+        return {"type": "ref", "name": td.__name__}
+    seen.add(id(td))
+
+    hints = typing.get_type_hints(td, globalns=globalns, include_extras=True)
+    required_keys = td.__required_keys__
+
+    fields: dict[str, object] = {}
+    for name, annotation in hints.items():
+        fields[name] = {
+            "type": _type_to_schema(annotation, globalns, seen),
+            "required": name in required_keys,
+        }
+
+    return {"name": td.__name__, "fields": fields}
+
+
+def extract_schema(
+    parser_cls: Any,  # noqa: ANN401
+    module_ns: dict[str, object],
+) -> dict[str, object] | None:
+    """Extract the TypedDict schema from a parser class's parse() return type."""
+    try:
+        hints = typing.get_type_hints(parser_cls.parse, globalns=module_ns)
+    except Exception:
+        return None
+
+    ret = hints.get("return")
+    if ret is None or not hasattr(ret, "__required_keys__"):
+        return None
+
+    return _typeddict_to_schema(ret, module_ns)
+
+
+# ---------------------------------------------------------------------------
+# Test fixture discovery
+# ---------------------------------------------------------------------------
+
+# Maps catalog OS names (e.g. "cisco_nxos") to test directory names ("nxos")
+_OS_TO_TEST_DIR: dict[str, str] = {}
+
+
+def _build_os_test_dir_map(tests_dir: Path) -> dict[str, str]:
+    """Build mapping from catalog OS name to test fixture directory name.
+
+    Scans the test directory for OS subdirectories and resolves their full
+    OS names via muninn's resolve_os.
+    """
+    if _OS_TO_TEST_DIR:
+        return _OS_TO_TEST_DIR
+
+    try:
+        from muninn.os import resolve_os
+    except ImportError:
+        return {}
+
+    for d in tests_dir.iterdir():
+        if d.is_dir() and not d.name.startswith("_"):
+            try:
+                full_name = resolve_os(d.name).value.name
+                _OS_TO_TEST_DIR[full_name] = d.name
+            except (ValueError, KeyError):
+                continue
+
+    return _OS_TO_TEST_DIR
+
+
+def _resolve_command_dir(
+    os_dir: Path,
+    command: str,
+) -> Path | None:
+    """Locate the test fixture directory for a command."""
+    command_dir = os_dir / command.replace(" ", "_")
+    if command_dir.is_dir():
+        return command_dir
+
+    # Fallback: scan for command.txt override
+    for candidate in os_dir.iterdir():
+        if not candidate.is_dir():
+            continue
+        override = candidate / "command.txt"
+        if override.exists() and override.read_text().strip() == command:
+            return candidate
+
+    return None
+
+
+def _load_fixture_description(test_case_dir: Path) -> str:
+    """Return fixture description from metadata or directory name."""
+    metadata_file = test_case_dir / "metadata.yaml"
+    if metadata_file.exists():
+        try:
+            import yaml
+
+            meta = yaml.safe_load(metadata_file.read_text())
+            if meta and meta.get("description"):
+                return meta["description"]
+        except Exception:
+            pass
+    return test_case_dir.name
+
+
+def discover_fixtures(
+    source_path: Path,
+    os_name: str,
+    command: str,
+) -> list[dict[str, str]]:
+    """Find test fixtures for a specific OS/command pair.
+
+    Returns a list of example dicts, each with 'name', 'input',
+    and 'expected'.
+    """
+    tests_dir = source_path / "tests" / "parsers"
+    if not tests_dir.exists():
+        return []
+
+    os_map = _build_os_test_dir_map(tests_dir)
+    os_dir_name = os_map.get(os_name)
+    if os_dir_name is None:
+        return []
+
+    command_dir = _resolve_command_dir(
+        tests_dir / os_dir_name,
+        command,
+    )
+    if command_dir is None:
+        return []
+
+    examples = []
+    for test_case_dir in sorted(command_dir.iterdir()):
+        if not test_case_dir.is_dir() or test_case_dir.name.startswith("_"):
+            continue
+
+        input_file = test_case_dir / "input.txt"
+        expected_file = test_case_dir / "expected.json"
+        if not input_file.exists() or not expected_file.exists():
+            continue
+
+        examples.append(
+            {
+                "name": _load_fixture_description(test_case_dir),
+                "input": input_file.read_text(),
+                "expected": json.loads(expected_file.read_text()),
+            }
+        )
+
+    return examples
+
+
+# ---------------------------------------------------------------------------
+# Catalog + detail generation
+# ---------------------------------------------------------------------------
+
+
+def _command_to_filename(command: str) -> str:
+    """Convert a command string to a safe filename (without extension)."""
+    return command.replace(" ", "_").replace("/", "_").replace("<", "").replace(">", "")
+
+
+def generate_catalog_from_source(
+    src_path: Path,
+) -> tuple[list[dict[str, object]], dict[tuple[str, str], dict[str, object]]]:
+    """Import muninn from a source path and generate catalog entries + details.
+
+    Returns:
+        A tuple of (catalog_entries, details_map) where details_map is keyed
+        by (os_name, command) and contains schema + examples for each parser.
+    """
     original_sys_path = sys.path[:]
     original_modules = {k: v for k, v in sys.modules.items() if k.startswith("muninn")}
 
@@ -39,6 +269,9 @@ def generate_catalog_from_source(src_path: Path) -> list[dict[str, object]]:
         if key.startswith("muninn"):
             del sys.modules[key]
 
+    # Reset OS test dir cache for fresh source path
+    _OS_TO_TEST_DIR.clear()
+
     sys.path.insert(0, str(src_path / "src"))
 
     try:
@@ -46,18 +279,40 @@ def generate_catalog_from_source(src_path: Path) -> list[dict[str, object]]:
 
         mn = Muninn()
         mn.load_builtin_parsers()
-        catalog = mn.registry.list_parser_catalog()
+        specs = mn.registry.list_command_specs()
 
         entries = []
-        for info in catalog:
+        details: dict[tuple[str, str], dict[str, object]] = {}
+
+        for spec in specs:
+            os_name = spec.os.value.name
+            command = spec.doc_template
+
+            detail_file = f"details/{os_name}/{_command_to_filename(command)}.json"
             entries.append(
                 {
-                    "os": info.os.value.name,
-                    "command": info.command_template,
-                    "tags": sorted(str(tag) for tag in info.tags),
-                    "source": info.source,
+                    "os": os_name,
+                    "command": command,
+                    "tags": sorted(str(tag) for tag in spec.tags),
+                    "source": spec.source,
+                    "detail_file": detail_file,
                 }
             )
+
+            # Extract schema
+            mod = sys.modules.get(spec.parser_cls.__module__)
+            module_ns = vars(mod) if mod else {}
+            schema = extract_schema(spec.parser_cls, module_ns)
+
+            # Discover test fixtures
+            examples = discover_fixtures(src_path, os_name, command)
+
+            details[(os_name, command)] = {
+                "os": os_name,
+                "command": command,
+                "schema": schema,
+                "examples": examples,
+            }
 
         # De-duplicate
         seen: set[tuple[str, str]] = set()
@@ -69,7 +324,7 @@ def generate_catalog_from_source(src_path: Path) -> list[dict[str, object]]:
                 unique.append(entry)
 
         unique.sort(key=lambda e: (str(e["os"]), str(e["command"])))
-        return unique
+        return unique, details
 
     finally:
         # Restore original state
@@ -80,8 +335,10 @@ def generate_catalog_from_source(src_path: Path) -> list[dict[str, object]]:
         sys.path[:] = original_sys_path
 
 
-def generate_catalog_for_tag(tag: str) -> list[dict[str, object]]:
-    """Check out a tag into a temp directory and generate its catalog."""
+def generate_for_tag(
+    tag: str,
+) -> tuple[list[dict[str, object]], dict[tuple[str, str], dict[str, object]]]:
+    """Check out a tag into a temp directory and generate its catalog + details."""
     with tempfile.TemporaryDirectory() as tmpdir:
         worktree_path = Path(tmpdir) / "worktree"
         subprocess.run(
@@ -107,9 +364,16 @@ def generate_catalog_for_tag(tag: str) -> list[dict[str, object]]:
             )
 
 
-def generate_catalog_for_main() -> list[dict[str, object]]:
-    """Generate catalog from the current working tree."""
+def generate_for_main() -> tuple[
+    list[dict[str, object]], dict[tuple[str, str], dict[str, object]]
+]:
+    """Generate catalog + details from the current working tree."""
     return generate_catalog_from_source(PROJECT_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
 
 
 def write_catalog(entries: list[dict[str, object]], filename: str) -> None:
@@ -118,6 +382,24 @@ def write_catalog(entries: list[dict[str, object]], filename: str) -> None:
     output_path = OUTPUT_DIR / filename
     output_path.write_text(json.dumps(entries, indent=2) + "\n")
     logger.info("Wrote %d parser entries to %s", len(entries), output_path)
+
+
+def write_details(
+    details: dict[tuple[str, str], dict[str, object]],
+) -> None:
+    """Write per-parser detail JSON files."""
+    count = 0
+    for (_os_name, command), detail in details.items():
+        os_name = str(detail["os"])
+        detail_dir = OUTPUT_DIR / "details" / os_name
+        detail_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = _command_to_filename(command) + ".json"
+        output_path = detail_dir / filename
+        output_path.write_text(json.dumps(detail, indent=2) + "\n")
+        count += 1
+
+    logger.info("Wrote %d parser detail files", count)
 
 
 def write_versions(tags: list[str]) -> None:
@@ -142,16 +424,18 @@ def main() -> None:
     tags = get_git_tags()
     logger.info("Found tags: %s", tags)
 
-    # Generate catalog for each tag
+    # Generate catalog + details for each tag
     for tag in tags:
         logger.info("Generating catalog for %s...", tag)
-        entries = generate_catalog_for_tag(tag)
+        entries, details = generate_for_tag(tag)
         write_catalog(entries, tag + ".json")
+        write_details(details)
 
-    # Generate catalog for main (current working tree)
+    # Generate catalog + details for main (current working tree)
     logger.info("Generating catalog for main...")
-    entries = generate_catalog_for_main()
+    entries, details = generate_for_main()
     write_catalog(entries, "main.json")
+    write_details(details)
 
     # Write versions manifest
     write_versions(tags)


### PR DESCRIPTION
## Summary

- Extends the parser library page with expandable detail panels for each parser, showing the TypedDict schema and test fixture examples
- Schema is rendered in a JSON-like format with `<type>` placeholders and `?` markers for optional fields
- Examples display raw CLI output and parsed result in a single pane with a toggle button to swap between views
- Detail data is generated as per-parser JSON files (`docs/library/details/`) and lazy-loaded on click to keep the initial page load fast
- Hides the unused right-side ToC sidebar on the library page to give the table more horizontal room

### Changes
- `scripts/generate_catalog.py` — TypedDict schema extraction, test fixture discovery, per-parser detail file generation
- `docs/library.md` — expandable rows with chevron indicator, schema viewer, example toggle UI, layout width improvements
- `.gitignore` — ignore generated `docs/library/details/` directory

## Test plan

- [ ] Run `uv run python scripts/generate_catalog.py` — verify catalog + detail files generate without errors
- [ ] Run `uv run mkdocs serve` and browse to Parser Library — verify table loads, rows are clickable
- [ ] Expand a parser row — verify schema displays in JSON-like format with correct indentation
- [ ] Toggle between CLI Output and Parsed Result in examples
- [ ] Switch versions in the dropdown — verify detail cache resets and new version data loads
- [ ] Verify the page works on first visit via instant navigation (not just on refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)