### PR TITLE
fix(types): resolve `call-non-callable` ty violations (#679)

### DIFF
--- a/changes/679.internal
+++ b/changes/679.internal
@@ -1,0 +1,1 @@
+Fix `call-non-callable` ty violations and re-enable the rule.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ invalid-return-type = "ignore"     # #674 — dict returned where TypedDict expe
 invalid-key = "ignore"             # #675 — dynamic key subscript on TypedDict
 invalid-argument-type = "ignore"   # #676 — type narrows not yet recognized
 invalid-assignment = "ignore"      # #677 — assignments to TypedDict fields via dynamic keys
-call-non-callable = "ignore"       # #679 — false positives on TypedDict value callables
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/muninn/parsers/nxos/show_lldp_neighbors_detail.py
+++ b/src/muninn/parsers/nxos/show_lldp_neighbors_detail.py
@@ -1,6 +1,7 @@
 """Parser for 'show lldp neighbors detail' command on NX-OS."""
 
 import re
+from collections.abc import Callable
 from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
@@ -10,6 +11,9 @@ from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
 
 _NOT_ADVERTISED = "not advertised"
+
+_Transform = Callable[[str], str | int]
+_FieldSpec = tuple[re.Pattern[str], str, _Transform]
 
 
 class LldpNeighborDetailEntry(TypedDict):
@@ -82,7 +86,7 @@ class ShowLldpNeighborsDetailParser(BaseParser[ShowLldpNeighborsDetailResult]):
     # Table-driven field patterns: (pattern, field_name, transform)
     # Transform is a callable that converts the matched value string.
     # A transform returning None means the field should be omitted.
-    _FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str, object], ...] = (
+    _FIELD_PATTERNS: tuple[_FieldSpec, ...] = (
         (
             re.compile(r"^Port\s+Description:\s+(?P<value>.+)$", re.I),
             "port_description",
@@ -116,7 +120,7 @@ class ShowLldpNeighborsDetailParser(BaseParser[ShowLldpNeighborsDetailResult]):
     )
 
     # Fields that use "not advertised" sentinel and should be omitted when so
-    _OPTIONAL_ADDR_PATTERNS: tuple[tuple[re.Pattern[str], str, object], ...] = (
+    _OPTIONAL_ADDR_PATTERNS: tuple[_FieldSpec, ...] = (
         (
             re.compile(r"^Management\s+Address\s+IPV6:\s+(?P<value>.+)$", re.I),
             "management_address_ipv6",
@@ -163,7 +167,7 @@ class ShowLldpNeighborsDetailParser(BaseParser[ShowLldpNeighborsDetailResult]):
         for pattern, field, transform in cls._FIELD_PATTERNS:
             match = pattern.match(stripped)
             if match:
-                entry[field] = transform(match.group("value"))  # type: ignore[operator]
+                entry[field] = transform(match.group("value"))
                 return True
         return False
 
@@ -177,7 +181,7 @@ class ShowLldpNeighborsDetailParser(BaseParser[ShowLldpNeighborsDetailResult]):
             if match:
                 value = match.group("value").strip()
                 if value.lower() != _NOT_ADVERTISED:
-                    entry[field] = transform(value)  # type: ignore[operator]
+                    entry[field] = transform(value)
                 return True
         return False
 


### PR DESCRIPTION
## Summary

- Added proper `Callable[[str], str | int]` type annotations to the transform functions in `_FIELD_PATTERNS` and `_OPTIONAL_ADDR_PATTERNS` tuples (previously typed as `object`), so `ty` can verify the transforms are callable
- Introduced `_Transform` and `_FieldSpec` type aliases to keep line lengths within ruff limits
- Removed now-unnecessary `# type: ignore[operator]` comments on the call sites
- Re-enabled `call-non-callable` as `"error"` in `pyproject.toml` `[tool.ty.rules]`

Closes #679

## Test plan

- [x] `uv run ty check .` passes with zero diagnostics
- [x] `uv run pytest tests/ -x -q` passes (4783 tests)
- [x] `uv run ruff check --fix . && uv run ruff format .` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)