### PR TITLE
fix(types): resolve `invalid-assignment` ty violations (#677)

### DIFF
--- a/changes/677.internal
+++ b/changes/677.internal
@@ -1,0 +1,1 @@
+Fix `invalid-assignment` ty violations and re-enable the rule.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,6 @@ missing-typed-dict-key = "ignore"  # #673 — parsers build TypedDicts increment
 invalid-return-type = "ignore"     # #674 — dict returned where TypedDict expected
 invalid-key = "ignore"             # #675 — dynamic key subscript on TypedDict
 invalid-argument-type = "ignore"   # #676 — type narrows not yet recognized
-invalid-assignment = "ignore"      # #677 — assignments to TypedDict fields via dynamic keys
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/muninn/parsers/ios/show_ip_route_summary.py
+++ b/src/muninn/parsers/ios/show_ip_route_summary.py
@@ -1,7 +1,7 @@
 """Parser for 'show ip route summary' command on IOS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -190,7 +190,7 @@ def _process_data_row(
     if source == "Total":
         return source, entry  # type: ignore[return-value]
 
-    route_sources[source] = entry  # type: ignore[assignment]
+    route_sources[source] = cast(RouteSourceEntry, entry)
     return source, None
 
 

--- a/src/muninn/parsers/ios/show_lldp_neighbors_detail.py
+++ b/src/muninn/parsers/ios/show_lldp_neighbors_detail.py
@@ -1,7 +1,7 @@
 """Parser for 'show lldp neighbors detail' command on IOS."""
 
 import re
-from typing import ClassVar, Literal, NotRequired, TypedDict
+from typing import ClassVar, Literal, NotRequired, TypedDict, cast
 
 from netutils.interface import canonical_interface_name
 
@@ -116,7 +116,7 @@ def _build_entry(
 
     mgmt = fields.get("management_addresses")
     if mgmt:
-        entry["management_addresses"] = mgmt  # type: ignore[assignment]
+        entry["management_addresses"] = cast(list[str], mgmt)
 
     return entry
 

--- a/src/muninn/parsers/iosxe/show_ip_eigrp_interfaces_detail.py
+++ b/src/muninn/parsers/iosxe/show_ip_eigrp_interfaces_detail.py
@@ -5,7 +5,7 @@ Also handles 'show ipv6 eigrp interfaces detail'.
 
 import re
 from collections.abc import Callable
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -283,7 +283,7 @@ class ShowIpEigrpInterfacesDetailParser(
                 iface = canonical_interface_name(
                     row_match.group("interface"), os=OS.CISCO_IOSXE
                 )
-                interfaces[iface] = current_entry  # type: ignore[assignment]
+                interfaces[iface] = cast(EigrpInterfaceDetailEntry, current_entry)
                 continue
 
             if current_entry is not None:

--- a/src/muninn/parsers/iosxe/show_platform_packet-trace_statistics.py
+++ b/src/muninn/parsers/iosxe/show_platform_packet-trace_statistics.py
@@ -206,8 +206,9 @@ def _build_summary(
         raise ValueError(msg)
 
     summary = PacketsSummary(traced=counters["traced"])
-    if counters.get("matched") is not None:
-        summary["matched"] = counters["matched"]  # type: ignore[assignment]
+    matched = counters.get("matched")
+    if matched is not None:
+        summary["matched"] = matched
     return summary
 
 

--- a/src/muninn/parsers/iosxe/show_policy-map_interface.py
+++ b/src/muninn/parsers/iosxe/show_policy-map_interface.py
@@ -1,7 +1,7 @@
 """Parser for 'show policy-map interface' command on IOS-XE."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -648,7 +648,7 @@ def _handle_priority_line(
 
     prio_lvl_m = _PRIORITY_LEVEL_RE.match(stripped)
     if prio_lvl_m:
-        prio_entry: PriorityEntry = class_entry.get("priority", {})  # type: ignore[assignment]
+        prio_entry = cast(PriorityEntry, class_entry.get("priority", {}))
         prio_entry["level"] = int(prio_lvl_m.group(1))
         class_entry["priority"] = prio_entry
         return True

--- a/src/muninn/parsers/nxos/show_interface.py
+++ b/src/muninn/parsers/nxos/show_interface.py
@@ -1,7 +1,7 @@
 """Parser for 'show interface' command on NX-OS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -463,12 +463,12 @@ def _parse_rx_tx_counters(
     if rx_lines:
         parsed_rx = _parse_counter_values(rx_lines, _RX_FIELD_MAP)
         if parsed_rx:
-            rx_counters = parsed_rx  # type: ignore[assignment]
+            rx_counters = cast(RxCountersEntry, parsed_rx)
 
     if tx_lines:
         parsed_tx = _parse_counter_values(tx_lines, _TX_FIELD_MAP)
         if parsed_tx:
-            tx_counters = parsed_tx  # type: ignore[assignment]
+            tx_counters = cast(TxCountersEntry, parsed_tx)
 
     return rx_counters, tx_counters
 

--- a/src/muninn/parsers/nxos/show_lldp_neighbors_detail.py
+++ b/src/muninn/parsers/nxos/show_lldp_neighbors_detail.py
@@ -2,7 +2,7 @@
 
 import re
 from collections.abc import Callable
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -159,7 +159,7 @@ class ShowLldpNeighborsDetailParser(BaseParser[ShowLldpNeighborsDetailResult]):
     ) -> None:
         """Save a completed entry into the neighbors dict if valid."""
         if local_port and entry.get("chassis_id"):
-            neighbors[local_port] = entry  # type: ignore[assignment]
+            neighbors[local_port] = cast(LldpNeighborDetailEntry, entry)
 
     @classmethod
     def _try_match_field(cls, stripped: str, entry: dict[str, str | int]) -> bool:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -822,4 +822,4 @@ class TestParserTags:
             source="built_in",
         )
         with pytest.raises(AttributeError):
-            info.os = OS.CISCO_IOSXE  # type: ignore[misc]
+            info.os = OS.CISCO_IOSXE  # type: ignore[misc]  # ty: ignore[invalid-assignment]


### PR DESCRIPTION
## Summary

- Fix 9 `invalid-assignment` ty type checker violations across parser and test files
- Use `cast()` for structurally-compatible dict-to-TypedDict assignments where ty cannot prove correctness (7 sites)
- Use type narrowing via intermediate variable for nullable counter lookup (1 site)
- Add `# ty: ignore[invalid-assignment]` for intentional read-only property test (1 site)
- Re-enable the `invalid-assignment` rule in `pyproject.toml` (changed from `"ignore"` to `"error"`)

Closes #677

## Test plan

- [x] `uv run ty check .` passes with zero errors
- [x] `uv run pytest tests/ -x -q` passes (4783 tests)
- [x] `uv run ruff check --fix . && uv run ruff format .` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)