### PR TITLE
feat: add multi-vendor OS definitions and parser scaffolding

### DIFF
--- a/changes/+multi-vendor-os-scaffolding.core_added
+++ b/changes/+multi-vendor-os-scaffolding.core_added
@@ -1,0 +1,1 @@
+Added OS definitions and parser scaffolding for Arista EOS, Juniper Junos, Palo Alto PAN-OS, Nokia SR OS, and Linux platforms.

--- a/src/muninn/os.py
+++ b/src/muninn/os.py
@@ -47,6 +47,41 @@ class CiscoIOS(OperatingSystem):
     aliases = ("ios", "cisco_ios")
 
 
+class AristaEOS(OperatingSystem):
+    """Arista EOS (data center and campus switches)."""
+
+    name = "arista_eos"
+    aliases = ("arista_eos", "eos", "arista")
+
+
+class JuniperJunos(OperatingSystem):
+    """Juniper Junos (MX, QFX, EX, SRX, PTX)."""
+
+    name = "juniper_junos"
+    aliases = ("juniper_junos", "junos", "juniper")
+
+
+class PaloAltoPanOS(OperatingSystem):
+    """Palo Alto PAN-OS (next-generation firewalls)."""
+
+    name = "paloalto_panos"
+    aliases = ("paloalto_panos", "panos", "paloalto", "pan-os", "pan_os")
+
+
+class NokiaSROS(OperatingSystem):
+    """Nokia SR OS (7750 SR, 7210 SAS, 7450 ESS)."""
+
+    name = "nokia_sros"
+    aliases = ("nokia_sros", "sros", "nokia", "sr-os", "sr_os")
+
+
+class Linux(OperatingSystem):
+    """Linux (including SONiC, Cumulus, FRR-based platforms)."""
+
+    name = "linux"
+    aliases = ("linux",)
+
+
 class OS(Enum):
     """Enumeration of supported operating systems.
 
@@ -63,6 +98,11 @@ class OS(Enum):
     CISCO_IOSXE = CiscoIOSXE
     CISCO_IOSXR = CiscoIOSXR
     CISCO_IOS = CiscoIOS
+    ARISTA_EOS = AristaEOS
+    JUNIPER_JUNOS = JuniperJunos
+    PALOALTO_PANOS = PaloAltoPanOS
+    NOKIA_SROS = NokiaSROS
+    LINUX = Linux
 
 
 # Build lookup table: alias -> OS enum member

--- a/src/muninn/parsers/arista_eos/__init__.py
+++ b/src/muninn/parsers/arista_eos/__init__.py
@@ -1,0 +1,1 @@
+"""Arista EOS parsers."""

--- a/src/muninn/parsers/cisco_iosxr/__init__.py
+++ b/src/muninn/parsers/cisco_iosxr/__init__.py
@@ -1,0 +1,1 @@
+"""Cisco IOS-XR parsers."""

--- a/src/muninn/parsers/juniper_junos/__init__.py
+++ b/src/muninn/parsers/juniper_junos/__init__.py
@@ -1,0 +1,1 @@
+"""Juniper Junos parsers."""

--- a/src/muninn/parsers/linux/__init__.py
+++ b/src/muninn/parsers/linux/__init__.py
@@ -1,0 +1,1 @@
+"""Linux parsers."""

--- a/src/muninn/parsers/nokia_sros/__init__.py
+++ b/src/muninn/parsers/nokia_sros/__init__.py
@@ -1,0 +1,1 @@
+"""Nokia SR OS parsers."""

--- a/src/muninn/parsers/paloalto_panos/__init__.py
+++ b/src/muninn/parsers/paloalto_panos/__init__.py
@@ -1,0 +1,1 @@
+"""Palo Alto PAN-OS parsers."""


### PR DESCRIPTION
## Summary

- Registers 5 new operating systems in `os.py`: Arista EOS, Juniper Junos, Palo Alto PAN-OS, Nokia SR OS, and Linux (IOS-XR was already registered)
- Creates empty parser package directories for all 6 new platforms
- Adds changelog fragment

This lays the groundwork for parser development tracked in #691, #692, #693, #694, #695, #696.

## Test plan

- [x] All 14 OS alias resolutions verified (new + existing)
- [x] Full test suite passes (4783 tests)
- [x] Pre-commit hooks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)