### PR TITLE
feat(cisco_iosxr): add parser for `show version`

### DIFF
--- a/changes/698.parser_added
+++ b/changes/698.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show version` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_version.py
+++ b/src/muninn/parsers/cisco_iosxr/show_version.py
@@ -1,0 +1,343 @@
+"""Parser for 'show version' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class UptimeInfo(TypedDict):
+    """Schema for uptime information."""
+
+    years: NotRequired[int]
+    weeks: NotRequired[int]
+    days: NotRequired[int]
+    hours: NotRequired[int]
+    minutes: NotRequired[int]
+
+
+class BuildInfo(TypedDict):
+    """Schema for build information (IOS-XR 6.x+ format)."""
+
+    built_by: NotRequired[str]
+    built_on: NotRequired[str]
+    built_host: NotRequired[str]
+    workspace: NotRequired[str]
+    version: NotRequired[str]
+    location: NotRequired[str]
+    label: NotRequired[str]
+
+
+class ShowVersionResult(TypedDict):
+    """Schema for 'show version' parsed output on IOS-XR."""
+
+    # Software info (always present)
+    software_version: str
+
+    # Copyright year(s) (e.g. "2017" or "2013-2017")
+    copyright_years: NotRequired[str]
+
+    # ROM/bootstrap info
+    rom: NotRequired[str]
+
+    # Build info block (newer IOS-XR format)
+    build_info: NotRequired[BuildInfo]
+
+    # Device identification
+    device_name: NotRequired[str]
+    chassis: str
+    chassis_detail: NotRequired[str]
+    processor: NotRequired[str]
+    processor_speed: NotRequired[str]
+    memory: NotRequired[str]
+
+    # System image
+    image_file: NotRequired[str]
+
+    # Uptime
+    uptime: NotRequired[UptimeInfo]
+
+    # Configuration register
+    config_register: NotRequired[str]
+
+
+@register(OS.CISCO_IOSXR, "show version")
+class ShowVersionParser(BaseParser[ShowVersionResult]):
+    """Parser for 'show version' command on Cisco IOS-XR.
+
+    Parses system version, hardware, and uptime information.
+    Supports both classic (ASR9K/CRS) and modern (NCS/XRv9000) output formats.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INVENTORY,
+            ParserTag.SYSTEM,
+        }
+    )
+
+    # Software version line — strip optional [Default] suffix
+    _SOFTWARE_VERSION = re.compile(
+        r"^Cisco IOS XR Software,\s+Version\s+"
+        r"(?P<version>[^\s\[]+)(?:\[Default\])?"
+        r"(?:\s+(?P<extra>\S+))?$",
+        re.I,
+    )
+
+    # Copyright line
+    _COPYRIGHT = re.compile(
+        r"^Copyright \(c\)\s+(?P<years>\d+(?:-\d+)?)\s+by Cisco Systems",
+        re.I,
+    )
+
+    # ROM line
+    _ROM = re.compile(
+        r"^ROM:\s+(?P<rom>.+?),?\s*$",
+        re.I,
+    )
+
+    # Build info fields
+    _BUILD_BUILT_BY = re.compile(r"^\s+Built By\s+:\s+(?P<value>\S+)", re.I)
+    _BUILD_BUILT_ON = re.compile(r"^\s+Built On\s+:\s+(?P<value>.+?)\s*$", re.I)
+    _BUILD_BUILT_HOST = re.compile(
+        r"^\s+(?:Build|Built) Host\s+:\s+(?P<value>\S+)", re.I
+    )
+    _BUILD_WORKSPACE = re.compile(r"^\s+Workspace\s+:\s+(?P<value>\S+)", re.I)
+    _BUILD_VERSION = re.compile(r"^\s+Version\s+:\s+(?P<value>\S+)", re.I)
+    _BUILD_LOCATION = re.compile(r"^\s+Location\s+:\s+(?P<value>\S+)", re.I)
+    _BUILD_LABEL = re.compile(r"^\s+Label\s+:\s+(?P<value>\S+)", re.I)
+
+    # Device name and uptime in format: "<hostname> uptime is ..."
+    _DEVICE_UPTIME = re.compile(
+        r"^(?P<hostname>\S+)\s+uptime\s+is\s+(?P<uptime>.+)$",
+        re.I,
+    )
+
+    # System uptime (no hostname prefix)
+    _SYSTEM_UPTIME = re.compile(
+        r"^System uptime is\s+(?P<uptime>.+)$",
+        re.I,
+    )
+
+    # System image file
+    _IMAGE_FILE = re.compile(
+        r'^System image file is\s+"(?P<file>[^"]+)"',
+        re.I,
+    )
+
+    # Chassis line: "cisco <model> (<processor>) processor with <memory>"
+    _CHASSIS_WITH_MEMORY = re.compile(
+        r"^cisco\s+(?P<chassis>.+?)\s+\((?P<processor>[^)]+)\)\s+processor"
+        r"\s+with\s+(?P<memory>\S+\s+\S+)\s+of\s+memory",
+        re.I,
+    )
+
+    # Chassis line without memory: "cisco <model> (<processor>) processor"
+    _CHASSIS_PROCESSOR = re.compile(
+        r"^cisco\s+(?P<chassis>.+?)\s+\((?P<processor>[^)]*)\)\s+processor",
+        re.I,
+    )
+
+    # Processor speed line: "<processor> at <speed>, Revision ..."
+    _PROCESSOR_SPEED = re.compile(
+        r"^(?P<processor>.+?)\s+(?:at|@)\s+(?P<speed>\d+\S*Hz)",
+        re.I,
+    )
+
+    # Chassis detail line (standalone, e.g. "ASR 9006 4 Line Card Slot Chassis ...")
+    # or "IOS XRv Chassis" or "CRS 16 Slots ..."
+    _CHASSIS_DETAIL = re.compile(
+        r"^(?P<detail>(?:ASR|CRS|NCS|IOS XRv|Cisco)\s+.*(?:Chassis|Slot).*)$",
+        re.I,
+    )
+
+    # Configuration register
+    _CONFIG_REGISTER = re.compile(
+        r"^Configuration register on node \S+ is (?P<value>\S+)",
+        re.I,
+    )
+
+    # Uptime duration components
+    _UPTIME_YEARS = re.compile(r"(\d+)\s+year", re.I)
+    _UPTIME_WEEKS = re.compile(r"(\d+)\s+week", re.I)
+    _UPTIME_DAYS = re.compile(r"(\d+)\s+day", re.I)
+    _UPTIME_HOURS = re.compile(r"(\d+)\s+hour", re.I)
+    _UPTIME_MINUTES = re.compile(r"(\d+)\s+minute", re.I)
+
+    @classmethod
+    def _parse_uptime_string(cls, uptime_str: str) -> UptimeInfo:
+        """Parse an uptime string into an UptimeInfo dict.
+
+        Handles formats like:
+            "5 hours, 14 minutes"
+            "5 days, 25 minutes"
+            "1 week, 1 day, 5 hours, 47 minutes"
+            "1 minute"
+            "23 hours 3 minutes"
+        """
+        info: UptimeInfo = {}
+
+        if match := cls._UPTIME_YEARS.search(uptime_str):
+            info["years"] = int(match.group(1))
+        if match := cls._UPTIME_WEEKS.search(uptime_str):
+            info["weeks"] = int(match.group(1))
+        if match := cls._UPTIME_DAYS.search(uptime_str):
+            info["days"] = int(match.group(1))
+        if match := cls._UPTIME_HOURS.search(uptime_str):
+            info["hours"] = int(match.group(1))
+        if match := cls._UPTIME_MINUTES.search(uptime_str):
+            info["minutes"] = int(match.group(1))
+
+        return info
+
+    @classmethod
+    def _parse_software(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse software version, copyright, and ROM lines."""
+        if match := cls._SOFTWARE_VERSION.match(line):
+            version = match.group("version")
+            extra = match.group("extra")
+            if extra:
+                version = f"{version} {extra}"
+            result["software_version"] = version
+            return True
+
+        if match := cls._COPYRIGHT.match(line):
+            result["copyright_years"] = match.group("years")
+            return True
+
+        if match := cls._ROM.match(line):
+            result["rom"] = match.group("rom").rstrip(",").strip()
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_build_info(cls, line: str, build_info: BuildInfo) -> bool:
+        """Parse build information block fields."""
+        if match := cls._BUILD_BUILT_BY.match(line):
+            build_info["built_by"] = match.group("value")
+            return True
+        if match := cls._BUILD_BUILT_ON.match(line):
+            build_info["built_on"] = match.group("value")
+            return True
+        if match := cls._BUILD_BUILT_HOST.match(line):
+            build_info["built_host"] = match.group("value")
+            return True
+        if match := cls._BUILD_WORKSPACE.match(line):
+            build_info["workspace"] = match.group("value")
+            return True
+        if match := cls._BUILD_VERSION.match(line):
+            build_info["version"] = match.group("value")
+            return True
+        if match := cls._BUILD_LOCATION.match(line):
+            build_info["location"] = match.group("value")
+            return True
+        if match := cls._BUILD_LABEL.match(line):
+            build_info["label"] = match.group("value")
+            return True
+        return False
+
+    @classmethod
+    def _parse_uptime(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse uptime lines (system uptime or device-name uptime)."""
+        # System uptime (no hostname) — check before device uptime
+        if match := cls._SYSTEM_UPTIME.match(line):
+            result["uptime"] = cls._parse_uptime_string(match.group("uptime"))
+            return True
+
+        # Device name + uptime (e.g. "PE1 uptime is 5 hours, 14 minutes")
+        if match := cls._DEVICE_UPTIME.match(line):
+            result["device_name"] = match.group("hostname")
+            result["uptime"] = cls._parse_uptime_string(match.group("uptime"))
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_hardware(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse chassis, processor, memory, and config register lines."""
+        if match := cls._IMAGE_FILE.match(line):
+            result["image_file"] = match.group("file")
+            return True
+
+        if match := cls._CHASSIS_WITH_MEMORY.match(line):
+            result["chassis"] = f"cisco {match.group('chassis')}"
+            processor = match.group("processor").strip()
+            if processor:
+                result["processor"] = processor
+            result["memory"] = match.group("memory")
+            return True
+
+        if match := cls._CHASSIS_PROCESSOR.match(line):
+            if "chassis" not in result:
+                result["chassis"] = f"cisco {match.group('chassis')}"
+                processor = match.group("processor").strip()
+                if processor:
+                    result["processor"] = processor
+            return True
+
+        if match := cls._PROCESSOR_SPEED.match(line):
+            result["processor_speed"] = match.group("speed")
+            return True
+
+        if match := cls._CHASSIS_DETAIL.match(line):
+            result["chassis_detail"] = match.group("detail").strip()
+            return True
+
+        if match := cls._CONFIG_REGISTER.match(line):
+            result["config_register"] = match.group("value")
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_line(
+        cls,
+        line: str,
+        result: dict[str, object],
+        build_info: BuildInfo,
+    ) -> bool:
+        """Dispatch a single line to the appropriate sub-parser."""
+        return (
+            cls._parse_software(line, result)
+            or cls._parse_build_info(line, build_info)
+            or cls._parse_uptime(line, result)
+            or cls._parse_hardware(line, result)
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVersionResult:
+        """Parse 'show version' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed version information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result: dict[str, object] = {}
+        build_info: BuildInfo = {}
+
+        for line in output.splitlines():
+            stripped = line.rstrip()
+            if stripped:
+                cls._parse_line(stripped, result, build_info)
+
+        # Add build_info if any fields were parsed
+        if build_info:
+            result["build_info"] = build_info
+
+        # Validate required fields
+        required = ["software_version", "chassis"]
+        missing = [f for f in required if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return cast(ShowVersionResult, result)

--- a/tests/parsers/cisco_iosxr/show_version/001_asr9k_classic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_version/001_asr9k_classic/expected.json
@@ -1,0 +1,17 @@
+{
+    "software_version": "6.1.4.10I",
+    "copyright_years": "2017",
+    "rom": "System Bootstrap, Version 0.75(c) 1994-2012 by Cisco Systems,  Inc.",
+    "device_name": "PE1",
+    "chassis": "cisco ASR9K Series",
+    "processor": "Intel 686 F6M14S4",
+    "memory": "6291456K bytes",
+    "processor_speed": "2134MHz",
+    "chassis_detail": "ASR 9006 4 Line Card Slot Chassis with V2 AC PEM",
+    "image_file": "disk0:asr9k-os-mbi-6.1.4.10I/0x100305/mbiasr9k-rsp3.vm",
+    "uptime": {
+        "hours": 5,
+        "minutes": 14
+    },
+    "config_register": "0x1922"
+}

--- a/tests/parsers/cisco_iosxr/show_version/001_asr9k_classic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_version/001_asr9k_classic/input.txt
@@ -1,0 +1,24 @@
+
+Cisco IOS XR Software, Version 6.1.4.10I[Default]
+Copyright (c) 2017 by Cisco Systems, Inc.
+
+ROM: System Bootstrap, Version 0.75(c) 1994-2012 by Cisco Systems,  Inc.
+
+PE1 uptime is 5 hours, 14 minutes
+System image file is "disk0:asr9k-os-mbi-6.1.4.10I/0x100305/mbiasr9k-rsp3.vm"
+
+cisco ASR9K Series (Intel 686 F6M14S4) processor with 6291456K bytes of memory.
+Intel 686 F6M14S4 processor at 2134MHz, Revision 2.174
+ASR 9006 4 Line Card Slot Chassis with V2 AC PEM
+
+2 FastEthernet
+4 Management Ethernet
+20 GigabitEthernet
+503k bytes of non-volatile configuration memory.
+6271M bytes of hard disk.
+12510192k bytes of disk0: (Sector size 512 bytes).
+12510192k bytes of disk1: (Sector size 512 bytes).
+
+Configuration register on node 0/RSP0/CPU0 is 0x1922
+Boot device on node 0/RSP0/CPU0 is disk0:
+Package active on node 0/RSP0/CPU0:

--- a/tests/parsers/cisco_iosxr/show_version/001_asr9k_classic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_version/001_asr9k_classic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Classic ASR9K format with ROM, image file, and config register"
+platform: "ASR 9006"
+software_version: "6.1.4.10I"

--- a/tests/parsers/cisco_iosxr/show_version/002_iosxrv_virtual/expected.json
+++ b/tests/parsers/cisco_iosxr/show_version/002_iosxrv_virtual/expected.json
@@ -1,0 +1,17 @@
+{
+    "software_version": "6.2.1.23I",
+    "copyright_years": "2016",
+    "rom": "GRUB, Version 1.99(0), DEV RELEASE",
+    "device_name": "iosxrvuut",
+    "chassis": "cisco IOS XRv Series",
+    "processor": "Pentium Celeron Stepping 3",
+    "memory": "4193911K bytes",
+    "processor_speed": "2931MHz",
+    "chassis_detail": "IOS XRv Chassis",
+    "image_file": "bootflash:disk0/xrvr-os-mbi-6.2.1.23I/mbixrvr-rp.vm",
+    "uptime": {
+        "days": 5,
+        "minutes": 25
+    },
+    "config_register": "0x1"
+}

--- a/tests/parsers/cisco_iosxr/show_version/002_iosxrv_virtual/input.txt
+++ b/tests/parsers/cisco_iosxr/show_version/002_iosxrv_virtual/input.txt
@@ -1,0 +1,22 @@
+
+Cisco IOS XR Software, Version 6.2.1.23I[Default]
+Copyright (c) 2016 by Cisco Systems, Inc.
+
+ROM: GRUB, Version 1.99(0), DEV RELEASE
+
+iosxrvuut uptime is 5 days, 25 minutes
+System image file is "bootflash:disk0/xrvr-os-mbi-6.2.1.23I/mbixrvr-rp.vm"
+
+cisco IOS XRv Series (Pentium Celeron Stepping 3) processor with 4193911K bytes of memory.
+Pentium Celeron Stepping 3 processor at 2931MHz, Revision 2.174
+IOS XRv Chassis
+
+1 Management Ethernet
+7 GigabitEthernet
+97070k bytes of non-volatile configuration memory.
+866M bytes of hard disk.
+2321392k bytes of disk0: (Sector size 512 bytes).
+
+Configuration register on node 0/0/CPU0 is 0x1
+Boot device on node 0/0/CPU0 is disk0:
+Package active on node 0/0/CPU0:

--- a/tests/parsers/cisco_iosxr/show_version/002_iosxrv_virtual/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_version/002_iosxrv_virtual/metadata.yaml
@@ -1,0 +1,3 @@
+description: "IOS-XRv virtual router with GRUB ROM"
+platform: "IOS XRv"
+software_version: "6.2.1.23I"

--- a/tests/parsers/cisco_iosxr/show_version/003_crs16_chassis/expected.json
+++ b/tests/parsers/cisco_iosxr/show_version/003_crs16_chassis/expected.json
@@ -1,0 +1,17 @@
+{
+    "software_version": "6.4.2",
+    "copyright_years": "2019",
+    "rom": "System Bootstrap, Version 2.12(20170128:070504) [CRS ROMMON]",
+    "device_name": "tcore3-rohan",
+    "chassis": "cisco CRS-16/S-B",
+    "processor": "Intel 686 F6M14S4",
+    "memory": "12582912K bytes",
+    "processor_speed": "2127Mhz",
+    "chassis_detail": "CRS 16 Slots Line Card Chassis for CRS-16/S-B",
+    "image_file": "disk0:hfr-os-mbi-6.4.2.CSCvm85739-1.0.0/0x100008/mbihfr-rp-x86e.vm",
+    "uptime": {
+        "days": 4,
+        "hours": 5,
+        "minutes": 46
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_version/003_crs16_chassis/input.txt
+++ b/tests/parsers/cisco_iosxr/show_version/003_crs16_chassis/input.txt
@@ -1,0 +1,37 @@
+Mon Oct 14 17:44:22.298 EDT
+
+Cisco IOS XR Software, Version 6.4.2[Default]
+Copyright (c) 2019 by Cisco Systems, Inc.
+
+ROM: System Bootstrap, Version 2.12(20170128:070504) [CRS ROMMON],
+
+
+tcore3-rohan uptime is 4 days, 5 hours, 46 minutes
+System image file is "disk0:hfr-os-mbi-6.4.2.CSCvm85739-1.0.0/0x100008/mbihfr-rp-x86e.vm"
+
+cisco CRS-16/S-B (Intel 686 F6M14S4) processor with 12582912K bytes of memory.
+Intel 686 F6M14S4 processor at 2127Mhz, Revision 2.174
+CRS 16 Slots Line Card Chassis for CRS-16/S-B
+
+2 Management Ethernet
+54 TenGigE
+59 DWDM controller(s)
+54 WANPHY controller(s)
+5 HundredGigE
+5 GigabitEthernet
+4 SONET/SDH
+4 Packet over SONET/SDH
+1019k bytes of non-volatile configuration memory.
+16726M bytes of hard disk.
+11881456k bytes of disk0: (Sector size 512 bytes).
+11881456k bytes of disk1: (Sector size 512 bytes).
+
+Boot device on node 0/0/CPU0 is lcdisk0:
+Package active on node 0/0/CPU0:
+iosxr-mpls-6.4.2.CSCvr26601, V 1.0.0[SMU], Cisco Systems, at disk0:iosxr-mpls-6.4.2.CSCvr26601-1.0.0
+    Built on Fri Oct  4 05:07:32 EDT 2019
+    By iox-lnx-smu2 in /san2/EFR/smu_r64x_6_4_2/workspace for pie
+
+hfr-px-6.4.2.CSCvr26601, V 1.0.0[SMU], Cisco Systems, at disk0:hfr-px-6.4.2.CSCvr26601-1.0.0
+    Built on Fri Oct  4 05:07:38 EDT 2019
+    By iox-lnx-smu2 in /san2/EFR/smu_r64x_6_4_2/workspace for pie

--- a/tests/parsers/cisco_iosxr/show_version/003_crs16_chassis/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_version/003_crs16_chassis/metadata.yaml
@@ -1,0 +1,3 @@
+description: "CRS-16/S-B chassis with SMU packages"
+platform: "CRS-16/S-B"
+software_version: "6.4.2"

--- a/tests/parsers/cisco_iosxr/show_version/004_ncs5500_build_info/expected.json
+++ b/tests/parsers/cisco_iosxr/show_version/004_ncs5500_build_info/expected.json
@@ -1,0 +1,19 @@
+{
+    "software_version": "6.1.4",
+    "copyright_years": "2013-2016",
+    "build_info": {
+        "built_by": "ahoang",
+        "built_on": "Thu Jun 29 15:31:09 PDT 2017",
+        "built_host": "iox-lnx-032",
+        "workspace": "/auto/srcarchive13/production/6.1.4/ncs5500/workspace",
+        "version": "6.1.4",
+        "location": "/opt/cisco/XR/packages/"
+    },
+    "chassis": "cisco NCS-5500",
+    "uptime": {
+        "weeks": 4,
+        "days": 6,
+        "hours": 1,
+        "minutes": 42
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_version/004_ncs5500_build_info/input.txt
+++ b/tests/parsers/cisco_iosxr/show_version/004_ncs5500_build_info/input.txt
@@ -1,0 +1,15 @@
+Wed Mar 14 12:31:28.607 UTC
+
+Cisco IOS XR Software, Version 6.1.4
+Copyright (c) 2013-2016 by Cisco Systems, Inc.
+
+Build Information:
+ Built By     : ahoang
+ Built On     : Thu Jun 29 15:31:09 PDT 2017
+ Build Host   : iox-lnx-032
+ Workspace    : /auto/srcarchive13/production/6.1.4/ncs5500/workspace
+ Version      : 6.1.4
+ Location     : /opt/cisco/XR/packages/
+
+cisco NCS-5500 () processor
+System uptime is 4 weeks, 6 days, 1 hour, 42 minutes

--- a/tests/parsers/cisco_iosxr/show_version/004_ncs5500_build_info/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_version/004_ncs5500_build_info/metadata.yaml
@@ -1,0 +1,3 @@
+description: "NCS-5500 with build info block and no ROM line"
+platform: "NCS-5500"
+software_version: "6.1.4"


### PR DESCRIPTION
## Summary

- Adds `show version` parser for Cisco IOS-XR (`cisco_iosxr` platform)
- Supports classic format (ASR9K, CRS) and modern format (NCS-5500, XRv9000)
- 4 test cases sourced from genieparser and ntc-templates real device output

Closes #698 (epic #691)

## Test plan

- [x] 4 test cases: ASR9K, IOS-XRv, CRS-16, NCS-5500
- [x] `uv run pytest tests/parsers/cisco_iosxr/ -v` passes
- [x] ruff check/format clean
- [x] Pre-commit hooks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)