### PR TITLE
feat(arista_eos): add parser for `show version`

### DIFF
--- a/changes/699.parser_added
+++ b/changes/699.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show version` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_version.py
+++ b/src/muninn/parsers/arista_eos/show_version.py
@@ -1,0 +1,259 @@
+"""Parser for 'show version' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class UptimeInfo(TypedDict):
+    """Schema for uptime information."""
+
+    weeks: NotRequired[int]
+    days: int
+    hours: int
+    minutes: int
+
+
+class ShowVersionResult(TypedDict):
+    """Schema for 'show version' parsed output on Arista EOS."""
+
+    # Model / hardware
+    model: str
+    hardware_version: NotRequired[str]
+    serial_number: NotRequired[str]
+    hardware_mac_address: NotRequired[str]
+    system_mac_address: str
+
+    # Software
+    software_image_version: str
+    architecture: str
+    internal_build_version: str
+    internal_build_id: str
+    image_format_version: NotRequired[str]
+    image_optimization: NotRequired[str]
+
+    # cEOS-specific
+    ceos_tools_version: NotRequired[str]
+    kernel_version: NotRequired[str]
+
+    # Uptime
+    uptime: UptimeInfo
+
+    # Memory
+    total_memory_kb: int
+    free_memory_kb: int
+
+
+@register(OS.ARISTA_EOS, "show version")
+class ShowVersionParser(BaseParser[ShowVersionResult]):
+    """Parser for 'show version' command on Arista EOS.
+
+    Parses system version, hardware, and uptime information.
+    Supports physical hardware, vEOS, and cEOS variants.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INVENTORY,
+            ParserTag.SYSTEM,
+        }
+    )
+
+    # First line: model identifier
+    _MODEL = re.compile(r"^Arista\s+(?P<model>.+)$")
+
+    # Hardware info
+    _HARDWARE_VERSION = re.compile(r"^Hardware version:\s*(?P<version>.+)$")
+    _SERIAL_NUMBER = re.compile(r"^Serial number:\s*(?P<serial>.+)$")
+    _HARDWARE_MAC = re.compile(r"^Hardware MAC address:\s*(?P<mac>\S+)", re.I)
+    _SYSTEM_MAC = re.compile(r"^System MAC address:\s*(?P<mac>\S+)", re.I)
+
+    # Software info
+    _SOFTWARE_VERSION = re.compile(r"^Software image version:\s*(?P<version>.+)$")
+    _ARCHITECTURE = re.compile(r"^Architecture:\s*(?P<arch>\S+)")
+    _INTERNAL_BUILD_VERSION = re.compile(r"^Internal build version:\s*(?P<version>.+)$")
+    _INTERNAL_BUILD_ID = re.compile(r"^Internal build ID:\s*(?P<id>\S+)")
+    _IMAGE_FORMAT_VERSION = re.compile(r"^Image format version:\s*(?P<version>.+)$")
+    _IMAGE_OPTIMIZATION = re.compile(r"^Image optimization:\s*(?P<opt>.+)$")
+
+    # cEOS-specific
+    _CEOS_TOOLS_VERSION = re.compile(r"^cEOS tools version:\s*(?P<version>.+)$")
+    _KERNEL_VERSION = re.compile(r"^Kernel version:\s*(?P<version>.+)$")
+
+    # Uptime
+    _UPTIME = re.compile(r"^Uptime:\s*(?P<uptime>.+)$")
+    _UPTIME_WEEKS = re.compile(r"(?P<weeks>\d+)\s+weeks?")
+    _UPTIME_DAYS = re.compile(r"(?P<days>\d+)\s+days?")
+    _UPTIME_HOURS = re.compile(r"(?P<hours>\d+)\s+hours?")
+    _UPTIME_MINUTES = re.compile(r"(?P<minutes>\d+)\s+minutes?")
+
+    # Memory
+    _TOTAL_MEMORY = re.compile(r"^Total memory:\s*(?P<memory>\d+)\s+kB")
+    _FREE_MEMORY = re.compile(r"^Free memory:\s*(?P<memory>\d+)\s+kB")
+
+    @classmethod
+    def _parse_uptime_string(cls, uptime_str: str) -> UptimeInfo:
+        """Parse an Arista EOS uptime string.
+
+        Args:
+            uptime_str: Raw uptime string from CLI output.
+
+        Returns:
+            UptimeInfo dict with parsed components.
+        """
+        result: dict[str, int] = {}
+
+        if match := cls._UPTIME_WEEKS.search(uptime_str):
+            result["weeks"] = int(match.group("weeks"))
+
+        days_match = cls._UPTIME_DAYS.search(uptime_str)
+        result["days"] = int(days_match.group("days")) if days_match else 0
+
+        hours_match = cls._UPTIME_HOURS.search(uptime_str)
+        result["hours"] = int(hours_match.group("hours")) if hours_match else 0
+
+        minutes_match = cls._UPTIME_MINUTES.search(uptime_str)
+        result["minutes"] = int(minutes_match.group("minutes")) if minutes_match else 0
+
+        return cast(UptimeInfo, result)
+
+    @classmethod
+    def _parse_hardware(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse hardware-related fields from a single line."""
+        if match := cls._MODEL.match(line):
+            result["model"] = match.group("model").strip()
+            return True
+
+        if match := cls._HARDWARE_VERSION.match(line):
+            version = match.group("version").strip()
+            if version:
+                result["hardware_version"] = version
+            return True
+
+        if match := cls._SERIAL_NUMBER.match(line):
+            serial = match.group("serial").strip()
+            if serial:
+                result["serial_number"] = serial
+            return True
+
+        if match := cls._HARDWARE_MAC.match(line):
+            result["hardware_mac_address"] = match.group("mac")
+            return True
+
+        if match := cls._SYSTEM_MAC.match(line):
+            result["system_mac_address"] = match.group("mac")
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_software(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse software-related fields from a single line."""
+        if match := cls._SOFTWARE_VERSION.match(line):
+            result["software_image_version"] = match.group("version").strip()
+            return True
+
+        if match := cls._ARCHITECTURE.match(line):
+            result["architecture"] = match.group("arch")
+            return True
+
+        if match := cls._INTERNAL_BUILD_VERSION.match(line):
+            result["internal_build_version"] = match.group("version").strip()
+            return True
+
+        if match := cls._INTERNAL_BUILD_ID.match(line):
+            result["internal_build_id"] = match.group("id")
+            return True
+
+        if match := cls._IMAGE_FORMAT_VERSION.match(line):
+            result["image_format_version"] = match.group("version").strip()
+            return True
+
+        if match := cls._IMAGE_OPTIMIZATION.match(line):
+            result["image_optimization"] = match.group("opt").strip()
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_ceos(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse cEOS-specific fields from a single line."""
+        if match := cls._CEOS_TOOLS_VERSION.match(line):
+            result["ceos_tools_version"] = match.group("version").strip()
+            return True
+
+        if match := cls._KERNEL_VERSION.match(line):
+            result["kernel_version"] = match.group("version").strip()
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_system(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse uptime and memory fields from a single line."""
+        if match := cls._UPTIME.match(line):
+            result["uptime"] = cls._parse_uptime_string(match.group("uptime"))
+            return True
+
+        if match := cls._TOTAL_MEMORY.match(line):
+            result["total_memory_kb"] = int(match.group("memory"))
+            return True
+
+        if match := cls._FREE_MEMORY.match(line):
+            result["free_memory_kb"] = int(match.group("memory"))
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_line(cls, line: str, result: dict[str, object]) -> bool:
+        """Dispatch a single line to the appropriate sub-parser."""
+        return (
+            cls._parse_hardware(line, result)
+            or cls._parse_software(line, result)
+            or cls._parse_ceos(line, result)
+            or cls._parse_system(line, result)
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVersionResult:
+        """Parse 'show version' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed version information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result: dict[str, object] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped:
+                cls._parse_line(stripped, result)
+
+        # Validate required fields
+        required_fields = [
+            "model",
+            "system_mac_address",
+            "software_image_version",
+            "architecture",
+            "internal_build_version",
+            "internal_build_id",
+            "uptime",
+            "total_memory_kb",
+            "free_memory_kb",
+        ]
+        missing = [f for f in required_fields if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return cast(ShowVersionResult, result)

--- a/tests/parsers/arista_eos/show_version/001_veos/expected.json
+++ b/tests/parsers/arista_eos/show_version/001_veos/expected.json
@@ -1,0 +1,15 @@
+{
+    "model": "vEOS",
+    "system_mac_address": "2803.829a.1347",
+    "software_image_version": "4.14.7M",
+    "architecture": "i386",
+    "internal_build_version": "4.14.7M-2384414.4147M",
+    "internal_build_id": "92a53fad-f853-42a5-9f57-c3c4ea3c26b3",
+    "uptime": {
+        "days": 0,
+        "hours": 1,
+        "minutes": 5
+    },
+    "total_memory_kb": 2028860,
+    "free_memory_kb": 301240
+}

--- a/tests/parsers/arista_eos/show_version/001_veos/input.txt
+++ b/tests/parsers/arista_eos/show_version/001_veos/input.txt
@@ -1,0 +1,13 @@
+Arista vEOS
+Hardware version:
+Serial number:
+System MAC address:  2803.829a.1347
+
+Software image version: 4.14.7M
+Architecture:           i386
+Internal build version: 4.14.7M-2384414.4147M
+Internal build ID:      92a53fad-f853-42a5-9f57-c3c4ea3c26b3
+
+Uptime:                 1 hour and 5 minutes
+Total memory:           2028860 kB
+Free memory:            301240 kB

--- a/tests/parsers/arista_eos/show_version/001_veos/metadata.yaml
+++ b/tests/parsers/arista_eos/show_version/001_veos/metadata.yaml
@@ -1,0 +1,3 @@
+description: vEOS virtual appliance with minimal hardware info
+platform: vEOS
+software_version: "4.14.7M"

--- a/tests/parsers/arista_eos/show_version/002_physical_switch/expected.json
+++ b/tests/parsers/arista_eos/show_version/002_physical_switch/expected.json
@@ -1,0 +1,21 @@
+{
+    "model": "CCS-720XP-24ZY4-F",
+    "hardware_version": "11.00",
+    "serial_number": "JPE11400249",
+    "hardware_mac_address": "fcbd.67c7.ffe7",
+    "system_mac_address": "fcbd.67c7.ffe7",
+    "software_image_version": "4.27.6M",
+    "architecture": "i686",
+    "internal_build_version": "4.27.6M-28481162.4276M",
+    "internal_build_id": "f62c8154-2e05-4650-be1e-c30774deec7e",
+    "image_format_version": "2.0",
+    "image_optimization": "DEFAULT",
+    "uptime": {
+        "weeks": 134,
+        "days": 5,
+        "hours": 23,
+        "minutes": 44
+    },
+    "total_memory_kb": 3982820,
+    "free_memory_kb": 1807180
+}

--- a/tests/parsers/arista_eos/show_version/002_physical_switch/input.txt
+++ b/tests/parsers/arista_eos/show_version/002_physical_switch/input.txt
@@ -1,0 +1,16 @@
+Arista CCS-720XP-24ZY4-F
+Hardware version: 11.00
+Serial number: JPE11400249
+Hardware MAC address: fcbd.67c7.ffe7
+System MAC address: fcbd.67c7.ffe7
+
+Software image version: 4.27.6M
+Architecture: i686
+Internal build version: 4.27.6M-28481162.4276M
+Internal build ID: f62c8154-2e05-4650-be1e-c30774deec7e
+Image format version: 2.0
+Image optimization: DEFAULT
+
+Uptime: 134 weeks, 5 days, 23 hours and 44 minutes
+Total memory: 3982820 kB
+Free memory: 1807180 kB

--- a/tests/parsers/arista_eos/show_version/002_physical_switch/metadata.yaml
+++ b/tests/parsers/arista_eos/show_version/002_physical_switch/metadata.yaml
@@ -1,0 +1,3 @@
+description: Physical CCS-720XP campus switch with long uptime
+platform: CCS-720XP-24ZY4-F
+software_version: "4.27.6M"

--- a/tests/parsers/arista_eos/show_version/003_physical_switch_dcs7010t/expected.json
+++ b/tests/parsers/arista_eos/show_version/003_physical_switch_dcs7010t/expected.json
@@ -1,0 +1,21 @@
+{
+    "model": "DCS-7010T-48-R",
+    "hardware_version": "12.03",
+    "serial_number": "JPE18523609",
+    "hardware_mac_address": "985d.82b8.faf5",
+    "system_mac_address": "985d.82b8.faf5",
+    "software_image_version": "4.28.9M",
+    "architecture": "i686",
+    "internal_build_version": "4.28.9M-33818481.4289M",
+    "internal_build_id": "ecbeee98-6249-4e05-84e6-60b46a08f83e",
+    "image_format_version": "3.0",
+    "image_optimization": "Strata-4GB",
+    "uptime": {
+        "weeks": 3,
+        "days": 0,
+        "hours": 20,
+        "minutes": 45
+    },
+    "total_memory_kb": 3982456,
+    "free_memory_kb": 2076700
+}

--- a/tests/parsers/arista_eos/show_version/003_physical_switch_dcs7010t/input.txt
+++ b/tests/parsers/arista_eos/show_version/003_physical_switch_dcs7010t/input.txt
@@ -1,0 +1,16 @@
+Arista DCS-7010T-48-R
+Hardware version: 12.03
+Serial number: JPE18523609
+Hardware MAC address: 985d.82b8.faf5
+System MAC address: 985d.82b8.faf5
+
+Software image version: 4.28.9M
+Architecture: i686
+Internal build version: 4.28.9M-33818481.4289M
+Internal build ID: ecbeee98-6249-4e05-84e6-60b46a08f83e
+Image format version: 3.0
+Image optimization: Strata-4GB
+
+Uptime: 3 weeks, 0 days, 20 hours and 45 minutes
+Total memory: 3982456 kB
+Free memory: 2076700 kB

--- a/tests/parsers/arista_eos/show_version/003_physical_switch_dcs7010t/metadata.yaml
+++ b/tests/parsers/arista_eos/show_version/003_physical_switch_dcs7010t/metadata.yaml
@@ -1,0 +1,3 @@
+description: Physical DCS-7010T data center switch
+platform: DCS-7010T-48-R
+software_version: "4.28.9M"

--- a/tests/parsers/arista_eos/show_version/004_ceos_lab/expected.json
+++ b/tests/parsers/arista_eos/show_version/004_ceos_lab/expected.json
@@ -1,0 +1,21 @@
+{
+    "model": "cEOSLab",
+    "serial_number": "35BA12C16E793CAD48DE0EEC072CFD74",
+    "hardware_mac_address": "001c.73cd.2352",
+    "system_mac_address": "001c.73cd.2352",
+    "software_image_version": "4.31.6M-39953990.4316M (engineering build)",
+    "architecture": "x86_64",
+    "internal_build_version": "4.31.6M-39953990.4316M",
+    "internal_build_id": "27a18095-d8a6-4dcf-a74c-c9ad0f655faf",
+    "image_format_version": "1.0",
+    "image_optimization": "None",
+    "ceos_tools_version": "(unknown)",
+    "kernel_version": "6.8.0-60-generic",
+    "uptime": {
+        "days": 2,
+        "hours": 15,
+        "minutes": 56
+    },
+    "total_memory_kb": 43138472,
+    "free_memory_kb": 27548760
+}

--- a/tests/parsers/arista_eos/show_version/004_ceos_lab/input.txt
+++ b/tests/parsers/arista_eos/show_version/004_ceos_lab/input.txt
@@ -1,0 +1,19 @@
+Arista cEOSLab
+Hardware version:
+Serial number: 35BA12C16E793CAD48DE0EEC072CFD74
+Hardware MAC address: 001c.73cd.2352
+System MAC address: 001c.73cd.2352
+
+Software image version: 4.31.6M-39953990.4316M (engineering build)
+Architecture: x86_64
+Internal build version: 4.31.6M-39953990.4316M
+Internal build ID: 27a18095-d8a6-4dcf-a74c-c9ad0f655faf
+Image format version: 1.0
+Image optimization: None
+
+cEOS tools version: (unknown)
+Kernel version: 6.8.0-60-generic
+
+Uptime: 2 days, 15 hours and 56 minutes
+Total memory: 43138472 kB
+Free memory: 27548760 kB

--- a/tests/parsers/arista_eos/show_version/004_ceos_lab/metadata.yaml
+++ b/tests/parsers/arista_eos/show_version/004_ceos_lab/metadata.yaml
@@ -1,0 +1,3 @@
+description: cEOS-Lab container with engineering build and cEOS tools
+platform: cEOSLab
+software_version: "4.31.6M"

--- a/tests/parsers/arista_eos/show_version/005_ceos_clab/expected.json
+++ b/tests/parsers/arista_eos/show_version/005_ceos_clab/expected.json
@@ -1,0 +1,19 @@
+{
+    "model": "cEOSLab",
+    "system_mac_address": "001c.7312.b056",
+    "hardware_mac_address": "001c.7312.b056",
+    "software_image_version": "4.32.1F-37265360.4321F (engineering build)",
+    "architecture": "x86_64",
+    "internal_build_version": "4.32.1F-37265360.4321F",
+    "internal_build_id": "5cc97ff0-08f5-438e-9b7c-c94dea3f44a6",
+    "image_format_version": "1.0",
+    "image_optimization": "None",
+    "kernel_version": "6.6.87.2-microsoft-standard-WSL2",
+    "uptime": {
+        "days": 0,
+        "hours": 1,
+        "minutes": 16
+    },
+    "total_memory_kb": 16378596,
+    "free_memory_kb": 8609248
+}

--- a/tests/parsers/arista_eos/show_version/005_ceos_clab/input.txt
+++ b/tests/parsers/arista_eos/show_version/005_ceos_clab/input.txt
@@ -1,0 +1,18 @@
+Arista cEOSLab
+Hardware version:
+Serial number:
+Hardware MAC address: 001c.7312.b056
+System MAC address: 001c.7312.b056
+
+Software image version: 4.32.1F-37265360.4321F (engineering build)
+Architecture: x86_64
+Internal build version: 4.32.1F-37265360.4321F
+Internal build ID: 5cc97ff0-08f5-438e-9b7c-c94dea3f44a6
+Image format version: 1.0
+Image optimization: None
+
+Kernel version: 6.6.87.2-microsoft-standard-WSL2
+
+Uptime: 1 hour and 16 minutes
+Total memory: 16378596 kB
+Free memory: 8609248 kB

--- a/tests/parsers/arista_eos/show_version/005_ceos_clab/metadata.yaml
+++ b/tests/parsers/arista_eos/show_version/005_ceos_clab/metadata.yaml
@@ -1,0 +1,3 @@
+description: cEOS-Lab container on WSL2 without serial number or cEOS tools
+platform: cEOSLab
+software_version: "4.32.1F"


### PR DESCRIPTION
## Summary

- Adds `show version` parser for Arista EOS (`arista_eos` platform)
- Handles vEOS, physical switches (DCS-7050, DCS-7010T), and cEOS/cEOSLab variants
- 5 test cases sourced from ntc-templates real device output

Closes #699 (epic #692)

## Test plan

- [x] 5 test cases: vEOS, two physical switches, cEOS lab, cEOS clab
- [x] `uv run pytest tests/parsers/arista_eos/ -v` passes
- [x] ruff check/format clean
- [x] Pre-commit hooks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)