### PR TITLE
feat(nokia_sros): add parser for `show port`

### DIFF
--- a/changes/702.parser_added
+++ b/changes/702.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show port` on Nokia SR OS.

--- a/src/muninn/parsers/nokia_sros/show_port.py
+++ b/src/muninn/parsers/nokia_sros/show_port.py
@@ -1,0 +1,209 @@
+"""Parser for 'show port' command on Nokia SR OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PortEntry(TypedDict):
+    """Schema for a single port entry."""
+
+    admin_state: str
+    link_state: str
+    port_state: str
+    cfg_mtu: NotRequired[int]
+    oper_mtu: NotRequired[int]
+    lag_id: NotRequired[str]
+    port_mode: NotRequired[str]
+    port_encap: NotRequired[str]
+    port_type: str
+    transceiver: NotRequired[str]
+
+
+# Top-level result is a dict keyed by port ID
+ShowPortResult = dict[str, PortEntry]
+
+
+@register(OS.NOKIA_SROS, "show port")
+class ShowPortParser(BaseParser[ShowPortResult]):
+    """Parser for 'show port' command on Nokia SR OS.
+
+    Parses the tabular port summary output, returning a dict keyed
+    by port ID with each value containing port attributes.
+
+    Handles both standard port rows (with full columns) and connector
+    port rows (sparse columns with port type 'conn').
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+        }
+    )
+
+    # Separator lines used to delimit table sections
+    _SEPARATOR = re.compile(r"^[=\-]{10,}$")
+
+    # Header line identifying column headers (used to skip)
+    _HEADER = re.compile(r"^\s*Port\s+Admin\s+Link\s+Port", re.I)
+    _HEADER_CONT = re.compile(r"^\s*Id\s+State\s+State", re.I)
+
+    # Section header like "Ports on Slot 1" or "Ports on Satellite esat-1"
+    _SECTION_HEADER = re.compile(r"^\s*Ports on\s+", re.I)
+
+    # Footnote line
+    _FOOTNOTE = re.compile(r"^\s*\*\s+indicates\s+that\s+", re.I)
+
+    # Pattern to collapse multiple spaces in transceiver values
+    _MULTI_SPACE = re.compile(r"\s{2,}")
+
+    # Connector port row: port_id, admin_state, port_state (may be
+    # "Link Up" / "Down"), port_type is "conn", plus optional transceiver
+    _CONNECTOR_ROW = re.compile(
+        r"^(?P<port_id>\S+)\s+"
+        r"(?P<admin_state>Up|Down)\s+"
+        r"(?P<port_state>Link Up|Down)\s+"
+        r"conn"
+        r"(?:\s+(?P<transceiver>\S+.*))?$"
+    )
+
+    # Standard port row with all columns present
+    _PORT_ROW = re.compile(
+        r"^(?P<port_id>\S+)\s+"
+        r"(?P<admin_state>Up|Down)\s+"
+        r"(?P<link_state>Yes|No)\s+"
+        r"(?P<port_state>\S+(?:\s+Up)?)\s+"
+        r"(?P<cfg_mtu>\d+)\s+"
+        r"(?P<oper_mtu>\d+)\s+"
+        r"(?P<lag>\S+)\s+"
+        r"(?P<port_mode>\S+)\s+"
+        r"(?P<port_encap>\S+)\s+"
+        r"(?P<port_type>\S+)"
+        r"(?:\s+(?P<transceiver>\S+.*))?$"
+    )
+
+    @classmethod
+    def _is_skip_line(cls, line: str) -> bool:
+        """Return True for lines that are not data rows."""
+        stripped = line.strip()
+        if not stripped:
+            return True
+        if cls._SEPARATOR.match(stripped):
+            return True
+        if cls._HEADER.match(stripped):
+            return True
+        if cls._HEADER_CONT.match(stripped):
+            return True
+        if cls._SECTION_HEADER.match(stripped):
+            return True
+        if cls._FOOTNOTE.match(stripped):
+            return True
+        return False
+
+    @classmethod
+    def _parse_connector_row(cls, line: str) -> tuple[str, PortEntry] | None:
+        """Try to parse a connector port row.
+
+        Connector rows have sparse columns: port_id, admin_state,
+        port_state, 'conn' as type, and optional transceiver info.
+
+        Returns:
+            Tuple of (port_id, PortEntry) or None if not a connector row.
+        """
+        match = cls._CONNECTOR_ROW.match(line.strip())
+        if not match:
+            return None
+
+        port_id = match.group("port_id")
+        transceiver_raw = match.group("transceiver")
+        transceiver = cls._normalize_transceiver(transceiver_raw)
+
+        entry: PortEntry = {
+            "admin_state": match.group("admin_state"),
+            "link_state": "",
+            "port_state": match.group("port_state"),
+            "port_type": "conn",
+        }
+        if transceiver:
+            entry["transceiver"] = transceiver
+
+        return port_id, entry
+
+    @classmethod
+    def _normalize_transceiver(cls, raw: str | None) -> str:
+        """Normalize transceiver string by collapsing whitespace runs."""
+        if not raw:
+            return ""
+        value = raw.strip()
+        return cls._MULTI_SPACE.sub(" ", value)
+
+    @classmethod
+    def _parse_port_row(cls, line: str) -> tuple[str, PortEntry] | None:
+        """Try to parse a standard port row.
+
+        Returns:
+            Tuple of (port_id, PortEntry) or None if not a port row.
+        """
+        match = cls._PORT_ROW.match(line.strip())
+        if not match:
+            return None
+
+        port_id = match.group("port_id")
+        lag_raw = match.group("lag")
+        lag_id = lag_raw if lag_raw != "-" else ""
+        transceiver_raw = match.group("transceiver")
+        transceiver = cls._normalize_transceiver(transceiver_raw)
+
+        entry: PortEntry = {
+            "admin_state": match.group("admin_state"),
+            "link_state": match.group("link_state"),
+            "port_state": match.group("port_state"),
+            "cfg_mtu": int(match.group("cfg_mtu")),
+            "oper_mtu": int(match.group("oper_mtu")),
+            "port_mode": match.group("port_mode"),
+            "port_encap": match.group("port_encap"),
+            "port_type": match.group("port_type"),
+        }
+        if lag_id:
+            entry["lag_id"] = lag_id
+        if transceiver:
+            entry["transceiver"] = transceiver
+
+        return port_id, entry
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPortResult:
+        """Parse 'show port' output on Nokia SR OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by port ID, each value a PortEntry dict.
+
+        Raises:
+            ValueError: If no port entries can be parsed.
+        """
+        result: dict[str, PortEntry] = {}
+
+        for line in output.splitlines():
+            if cls._is_skip_line(line):
+                continue
+
+            # Try connector row first (more specific pattern)
+            parsed = cls._parse_connector_row(line)
+            if parsed is None:
+                parsed = cls._parse_port_row(line)
+            if parsed is not None:
+                port_id, entry = parsed
+                result[port_id] = entry
+
+        if not result:
+            msg = "No port entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowPortResult, result)

--- a/tests/parsers/nokia_sros/show_port/001_mixed_slots_and_satellites/expected.json
+++ b/tests/parsers/nokia_sros/show_port/001_mixed_slots_and_satellites/expected.json
@@ -1,0 +1,1913 @@
+{
+    "1/1/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "hybr",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/2": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/1/3": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/1/4": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "lag_id": "1",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/5": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/6": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/7": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/1/8": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/1/9": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/10": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/11": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/1/12": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9000,
+        "oper_mtu": 9000,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/1/13": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/14": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/1/15": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9000,
+        "oper_mtu": 9000,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/1/16": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/17": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/1/18": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/1/19": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/1/20": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "hybr",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/1/21": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/22": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/1/23": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/1/24": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/1": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-SX"
+    },
+    "1/2/2": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/2/3": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/2/4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/5": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "hybr",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/6": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9022,
+        "oper_mtu": 9022,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/7": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/8": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "1/2/9": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "lag_id": "99",
+        "transceiver": "GIGE-SX"
+    },
+    "1/2/10": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/2/11": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/2/12": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/13": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/14": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/15": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1570,
+        "oper_mtu": 1570,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/16": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9022,
+        "oper_mtu": 9022,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/17": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1538,
+        "oper_mtu": 1538,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/18": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/19": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/20": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "1/2/21": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "1/2/22": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/23": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "1/2/24": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "lag_id": "7",
+        "transceiver": "GIGE-SX"
+    },
+    "A/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste",
+        "transceiver": "MDI"
+    },
+    "A/4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste"
+    },
+    "B/1": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste"
+    },
+    "B/4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste"
+    },
+    "esat-1/1/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "lag_id": "5",
+        "transceiver": "MDI GIGE-T"
+    },
+    "esat-1/1/2": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "esat-1/1/3": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1518,
+        "oper_mtu": 1518,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "esat-1/1/4": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1538,
+        "oper_mtu": 1538,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "esat-1/1/5": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9022,
+        "oper_mtu": 9022,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDX GIGE-T"
+    },
+    "esat-1/1/6": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "esat-1/1/7": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9022,
+        "oper_mtu": 9022,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "MDI GIGE-T"
+    },
+    "esat-1/1/8": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9022,
+        "oper_mtu": 9022,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "xcme",
+        "transceiver": "GIGE-T"
+    },
+    "esat-1/1/9": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/10": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/11": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/12": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/13": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/14": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/15": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/16": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/17": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/18": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/19": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/20": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/21": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/22": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/23": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/24": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/25": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/26": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/27": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/28": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/29": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/30": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/31": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/32": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/33": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/34": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/35": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/36": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/37": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/38": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/39": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/40": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/41": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/42": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/43": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/44": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/45": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/46": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/47": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/48": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-1/1/u1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige",
+        "transceiver": "10GBASE-LR *"
+    },
+    "esat-1/1/u2": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "esat-1/1/u3": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "esat-1/1/u4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "esat-2/1/1": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/2": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/3": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/4": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/5": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/6": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/7": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/8": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/9": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/10": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/11": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/12": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/13": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/14": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/15": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/16": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/17": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/18": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/19": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/20": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/21": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/22": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/23": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/24": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/25": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/26": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/27": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/28": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/29": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/30": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/31": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/32": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/33": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/34": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/35": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/36": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/37": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/38": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/39": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/40": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/41": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/42": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/43": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/44": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/45": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/46": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/47": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/48": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9208,
+        "oper_mtu": 9208,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "xcme"
+    },
+    "esat-2/1/u1": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "esat-2/1/u2": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "esat-2/1/u3": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "esat-2/1/u4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Ghost",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "accs",
+        "port_encap": "dotq",
+        "port_type": "xgige"
+    },
+    "10/2/c1": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c1/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "10"
+    },
+    "10/2/c2": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c2/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "10"
+    },
+    "10/2/c3": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c3/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "10"
+    },
+    "10/2/c4": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c5": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c6": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c7": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c7/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "15"
+    },
+    "10/2/c8": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c8/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "30"
+    },
+    "10/2/c9": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c10": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c10/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "24"
+    },
+    "10/2/c11": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c12": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c13": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c13/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "14"
+    },
+    "10/2/c14": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c14/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Link Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "14"
+    },
+    "10/2/c15": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c15/1": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige"
+    },
+    "10/2/c16": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c17": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c18": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c19": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c19/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "7"
+    },
+    "10/2/c20": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c20/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "3"
+    },
+    "10/2/c21": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c21/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9212,
+        "oper_mtu": 9212,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "7"
+    },
+    "10/2/c22": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c23": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c24": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    }
+}

--- a/tests/parsers/nokia_sros/show_port/001_mixed_slots_and_satellites/input.txt
+++ b/tests/parsers/nokia_sros/show_port/001_mixed_slots_and_satellites/input.txt
@@ -1,0 +1,237 @@
+
+===============================================================================
+Ports on Slot 1
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+1/1/1         Up    Yes  Up      9212 9212    - hybr dotq xcme   GIGE-SX
+1/1/2         Up    Yes  Up      1518 1518    - accs dotq xcme   MDI GIGE-T
+1/1/3         Up    Yes  Up      1518 1518    - accs dotq xcme   MDX GIGE-T
+1/1/4         Up    Yes  Up      9212 9212    1 netw null xcme   GIGE-SX
+1/1/5         Up    Yes  Up      9212 9212    - netw null xcme   GIGE-SX
+1/1/6         Up    Yes  Up      9212 9212    - netw null xcme   GIGE-SX
+1/1/7         Up    Yes  Up      1518 1518    - accs dotq xcme   MDX GIGE-T
+1/1/8         Up    Yes  Up      1514 1514    - accs null xcme   MDX GIGE-T
+1/1/9         Up    Yes  Up      9212 9212    - netw null xcme   GIGE-SX
+1/1/10        Up    No   Down    1518 1518    - accs dotq xcme   GIGE-SX
+1/1/11        Up    No   Down    1518 1518    - accs dotq xcme   GIGE-T
+1/1/12        Up    Yes  Up      9000 9000    - accs null xcme   MDX GIGE-T
+1/1/13        Up    Yes  Up      1514 1514    - accs null xcme   GIGE-SX
+1/1/14        Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/1/15        Up    Yes  Up      9000 9000    - accs null xcme   MDI GIGE-T
+1/1/16        Up    Yes  Up      1514 1514    - accs null xcme   GIGE-SX
+1/1/17        Up    No   Down    1518 1518    - accs dotq xcme   GIGE-T
+1/1/18        Up    Yes  Up      1518 1518    - accs dotq xcme   MDI GIGE-T
+1/1/19        Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/1/20        Up    Yes  Up      9212 9212    - hybr dotq xcme   MDX GIGE-T
+1/1/21        Up    Yes  Up      1518 1518    - accs dotq xcme   GIGE-SX
+1/1/22        Up    Yes  Up      1518 1518    - accs dotq xcme   GIGE-SX
+1/1/23        Up    Yes  Up      1518 1518    - accs dotq xcme   MDI GIGE-T
+1/1/24        Up    Yes  Up      1518 1518    - accs dotq xcme   MDX GIGE-T
+1/2/1         Up    No   Down    1518 1518    - accs dotq xcme   GIGE-SX
+1/2/2         Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/2/3         Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/2/4         Up    No   Down    1514 1514    - accs null xcme   GIGE-T
+1/2/5         Up    Yes  Up      9212 9212    - hybr dotq xcme   MDX GIGE-T
+1/2/6         Up    No   Down    9022 9022    - accs null xcme   GIGE-T
+1/2/7         Up    Yes  Up      1514 1514    - accs null xcme   MDX GIGE-T
+1/2/8         Up    No   Down    1514 1514    - accs null xcme
+1/2/9         Up    No   Down    1518 1518   99 accs dotq xcme   GIGE-SX
+1/2/10        Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/2/11        Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/2/12        Up    No   Down    1514 1514    - accs null xcme   GIGE-T
+1/2/13        Up    Yes  Up      1514 1514    - accs null xcme   MDX GIGE-T
+1/2/14        Up    No   Down    1514 1514    - accs null xcme   GIGE-T
+1/2/15        Up    No   Down    1570 1570    - accs dotq xcme   GIGE-T
+1/2/16        Up    Yes  Up      9022 9022    - accs null xcme   MDX GIGE-T
+1/2/17        Up    Yes  Up      1538 1538    - accs dotq xcme   MDX GIGE-T
+1/2/18        Up    No   Down    1514 1514    - accs null xcme   GIGE-T
+1/2/19        Up    No   Down    1518 1518    - accs dotq xcme   GIGE-T
+1/2/20        Up    No   Down    1514 1514    - accs null xcme   GIGE-T
+1/2/21        Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+1/2/22        Up    Yes  Up      1518 1518    - accs dotq xcme   MDX GIGE-T
+1/2/23        Up    Yes  Up      1518 1518    - accs dotq xcme   MDX GIGE-T
+1/2/24        Up    Yes  Up      9212 9212    7 netw null xcme   GIGE-SX
+
+===============================================================================
+Ports on Slot A
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+A/1           Up    Yes  Up      1514 1514    - netw null faste  MDI
+A/4           Up    No   Down    1514 1514    - netw null faste
+
+===============================================================================
+Ports on Slot B
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+B/1           Up    No   Down    1514 1514    - netw null faste
+B/4           Up    No   Down    1514 1514    - netw null faste
+
+
+===============================================================================
+Ports on Satellite esat-1
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+esat-1/1/1    Up    Yes  Up      1518 1518    5 accs dotq xcme   MDI GIGE-T
+esat-1/1/2    Up    Yes  Up      1518 1518    - accs dotq xcme   MDI GIGE-T
+esat-1/1/3    Up    Yes  Up      1518 1518    - accs dotq xcme   MDX GIGE-T
+esat-1/1/4    Up    Yes  Up      1538 1538    - accs dotq xcme   MDX GIGE-T
+esat-1/1/5    Up    Yes  Up      9022 9022    - accs null xcme   MDX GIGE-T
+esat-1/1/6    Up    Yes  Up      1514 1514    - accs null xcme   MDI GIGE-T
+esat-1/1/7    Up    Yes  Up      9022 9022    - accs null xcme   MDI GIGE-T
+esat-1/1/8    Up    No   Down    9022 9022    - accs null xcme   GIGE-T
+esat-1/1/9    Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/10   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/11   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/12   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/13   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/14   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/15   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/16   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/17   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/18   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/19   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/20   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/21   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/22   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/23   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/24   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/25   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/26   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/27   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/28   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/29   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/30   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/31   Up    No   Down    9208 9208    - netw null xcme
+esat-1/1/32   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/33   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/34   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/35   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/36   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/37   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/38   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/39   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/40   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/41   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/42   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/43   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/44   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/45   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/46   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/47   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/48   Down  No   Down    9208 9208    - netw null xcme
+esat-1/1/u1   Up    Yes  Up      9212 9212    - accs dotq xgige  10GBASE-LR  *
+esat-1/1/u2   Up    No   Down    9212 9212    - accs dotq xgige
+esat-1/1/u3   Up    No   Down    9212 9212    - accs dotq xgige
+esat-1/1/u4   Up    No   Down    9212 9212    - accs dotq xgige
+
+===============================================================================
+Ports on Satellite esat-2
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+esat-2/1/1    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/2    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/3    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/4    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/5    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/6    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/7    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/8    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/9    Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/10   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/11   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/12   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/13   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/14   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/15   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/16   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/17   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/18   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/19   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/20   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/21   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/22   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/23   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/24   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/25   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/26   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/27   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/28   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/29   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/30   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/31   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/32   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/33   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/34   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/35   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/36   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/37   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/38   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/39   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/40   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/41   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/42   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/43   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/44   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/45   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/46   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/47   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/48   Down  No   Ghost   9208 9208    - netw null xcme
+esat-2/1/u1   Up    No   Ghost   9212 9212    - accs dotq xgige
+esat-2/1/u2   Up    No   Ghost   9212 9212    - accs dotq xgige
+esat-2/1/u3   Up    No   Ghost   9212 9212    - accs dotq xgige
+esat-2/1/u4   Up    No   Ghost   9212 9212    - accs dotq xgige
+
+===============================================================================
+Ports on Slot 10
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+10/2/c1       Up         Link Up                          conn   100GBASE-LR4*
+10/2/c1/1     Up    Yes  Up      9192 9192   10 accs null cgige
+10/2/c2       Up         Link Up                          conn   100GBASE-LR4*
+10/2/c2/1     Up    Yes  Up      9192 9192   10 accs null cgige
+10/2/c3       Up         Link Up                          conn   100GBASE-LR4*
+10/2/c3/1     Up    Yes  Up      9192 9192   10 accs null cgige
+10/2/c4       Down       Down                             conn   100GBASE-LR4*
+10/2/c5       Down       Down                             conn
+10/2/c6       Down       Down                             conn
+10/2/c7       Up         Link Up                          conn   100GBASE-LR4*
+10/2/c7/1     Up    Yes  Up      9192 9192   15 accs null cgige
+10/2/c8       Up         Link Up                          conn   100GBASE-LR4*
+10/2/c8/1     Up    Yes  Up      9192 9192   30 accs null cgige
+10/2/c9       Down       Down                             conn   100GBASE-LR4*
+10/2/c10      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c10/1    Up    Yes  Up      9192 9192   24 accs null cgige
+10/2/c11      Down       Down                             conn
+10/2/c12      Down       Down                             conn
+10/2/c13      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c13/1    Up    Yes  Up      9192 9192   14 accs null cgige
+10/2/c14      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c14/1    Up    Yes  Link Up 9192 9192   14 accs null cgige
+10/2/c15      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c15/1    Down  No   Down    9192 9192    - accs null cgige
+10/2/c16      Down       Down                             conn   100GBASE-LR4*
+10/2/c17      Down       Down                             conn
+10/2/c18      Down       Down                             conn
+10/2/c19      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c19/1    Up    Yes  Up      9212 9212    7 netw null cgige
+10/2/c20      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c20/1    Up    Yes  Up      9212 9212    3 netw null cgige
+10/2/c21      Up         Link Up                          conn   100GBASE-LR4*
+10/2/c21/1    Up    Yes  Up      9212 9212    7 netw null cgige
+10/2/c22      Down       Down                             conn
+10/2/c23      Down       Down                             conn
+10/2/c24      Down       Down                             conn
+===============================================================================
+* indicates that the corresponding row element may have been truncated.

--- a/tests/parsers/nokia_sros/show_port/001_mixed_slots_and_satellites/metadata.yaml
+++ b/tests/parsers/nokia_sros/show_port/001_mixed_slots_and_satellites/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed output with physical slots, management slots, satellite ports, and connector ports
+platform: Nokia 7750 SR
+software_version: SR OS

--- a/tests/parsers/nokia_sros/show_port/002_management_ports_only/expected.json
+++ b/tests/parsers/nokia_sros/show_port/002_management_ports_only/expected.json
@@ -1,0 +1,43 @@
+{
+    "A/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste",
+        "transceiver": "MDI"
+    },
+    "A/4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste"
+    },
+    "B/1": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste"
+    },
+    "B/4": {
+        "admin_state": "Up",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 1514,
+        "oper_mtu": 1514,
+        "port_mode": "netw",
+        "port_encap": "null",
+        "port_type": "faste"
+    }
+}

--- a/tests/parsers/nokia_sros/show_port/002_management_ports_only/input.txt
+++ b/tests/parsers/nokia_sros/show_port/002_management_ports_only/input.txt
@@ -1,0 +1,18 @@
+
+===============================================================================
+Ports on Slot A
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+A/1           Up    Yes  Up      1514 1514    - netw null faste  MDI
+A/4           Up    No   Down    1514 1514    - netw null faste
+
+===============================================================================
+Ports on Slot B
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+B/1           Up    No   Down    1514 1514    - netw null faste
+B/4           Up    No   Down    1514 1514    - netw null faste

--- a/tests/parsers/nokia_sros/show_port/002_management_ports_only/metadata.yaml
+++ b/tests/parsers/nokia_sros/show_port/002_management_ports_only/metadata.yaml
@@ -1,0 +1,3 @@
+description: Management ports only from Slot A and Slot B
+platform: Nokia 7750 SR
+software_version: SR OS

--- a/tests/parsers/nokia_sros/show_port/003_connector_ports/expected.json
+++ b/tests/parsers/nokia_sros/show_port/003_connector_ports/expected.json
@@ -1,0 +1,54 @@
+{
+    "10/2/c1": {
+        "admin_state": "Up",
+        "link_state": "",
+        "port_state": "Link Up",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c1/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "10"
+    },
+    "10/2/c4": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn",
+        "transceiver": "100GBASE-LR4*"
+    },
+    "10/2/c5": {
+        "admin_state": "Down",
+        "link_state": "",
+        "port_state": "Down",
+        "port_type": "conn"
+    },
+    "10/2/c14/1": {
+        "admin_state": "Up",
+        "link_state": "Yes",
+        "port_state": "Link Up",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige",
+        "lag_id": "14"
+    },
+    "10/2/c15/1": {
+        "admin_state": "Down",
+        "link_state": "No",
+        "port_state": "Down",
+        "cfg_mtu": 9192,
+        "oper_mtu": 9192,
+        "port_mode": "accs",
+        "port_encap": "null",
+        "port_type": "cgige"
+    }
+}

--- a/tests/parsers/nokia_sros/show_port/003_connector_ports/input.txt
+++ b/tests/parsers/nokia_sros/show_port/003_connector_ports/input.txt
@@ -1,0 +1,15 @@
+
+===============================================================================
+Ports on Slot 10
+===============================================================================
+Port          Admin Link Port    Cfg  Oper LAG/ Port Port Port   C/QS/S/XFP/
+Id            State      State   MTU  MTU  Bndl Mode Encp Type   MDIMDX
+-------------------------------------------------------------------------------
+10/2/c1       Up         Link Up                          conn   100GBASE-LR4*
+10/2/c1/1     Up    Yes  Up      9192 9192   10 accs null cgige
+10/2/c4       Down       Down                             conn   100GBASE-LR4*
+10/2/c5       Down       Down                             conn
+10/2/c14/1    Up    Yes  Link Up 9192 9192   14 accs null cgige
+10/2/c15/1    Down  No   Down    9192 9192    - accs null cgige
+===============================================================================
+* indicates that the corresponding row element may have been truncated.

--- a/tests/parsers/nokia_sros/show_port/003_connector_ports/metadata.yaml
+++ b/tests/parsers/nokia_sros/show_port/003_connector_ports/metadata.yaml
@@ -1,0 +1,3 @@
+description: Connector ports with sub-ports on Slot 10
+platform: Nokia 7750 SR
+software_version: SR OS


### PR DESCRIPTION
## Summary

- Adds `show port` parser for Nokia SR OS (`nokia_sros` platform)
- Parses tabular port status output with dict-of-dicts keyed by port ID
- Handles standard ports, connector ports, management slots (A/B), and satellite ports (esat-*)
- 3 test cases sourced from ntc-templates real device output

Closes #702 (epic #695)

## Test plan

- [x] 3 test cases: mixed slots/satellites (192 ports), management-only, connector ports
- [x] `uv run pytest tests/parsers/nokia_sros/ -v` passes
- [x] ruff check/format clean
- [x] Pre-commit hooks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)