### PR TITLE
feat(cisco_iosxr): add parser for show ip interface brief

### DIFF
--- a/changes/+cisco-iosxr-show-ip-interface-brief.parser_added
+++ b/changes/+cisco-iosxr-show-ip-interface-brief.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ip interface brief` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_ip_interface_brief.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ip_interface_brief.py
@@ -1,0 +1,90 @@
+"""Parser for 'show ip interface brief' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class IpInterfaceBriefEntry(TypedDict):
+    """Schema for a single interface entry in 'show ip interface brief' output."""
+
+    ip_address: str
+    interface_status: str
+    protocol_status: str
+    vrf_name: str
+
+
+class ShowIpInterfaceBriefResult(TypedDict):
+    """Schema for 'show ip interface brief' parsed output.
+
+    Dict-of-dicts keyed by interface name.
+    """
+
+    interfaces: dict[str, IpInterfaceBriefEntry]
+
+
+@register(OS.CISCO_IOSXR, "show ip interface brief")
+class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
+    """Parser for 'show ip interface brief' command on Cisco IOS-XR.
+
+    Parses the tabular IP interface summary output into a dict-of-dicts
+    keyed by interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+        }
+    )
+
+    # Matches a data line in the IP interface brief table.
+    # Columns: Interface  IP-Address  Status  Protocol  Vrf-Name
+    _INTF_LINE = re.compile(
+        r"^\s*(?P<name>\S+)"
+        r"\s+(?P<ip_address>\S+)"
+        r"\s+(?P<status>Up|Down|Shutdown)"
+        r"\s+(?P<protocol>Up|Down)"
+        r"\s+(?P<vrf>\S+)"
+        r"\s*$",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpInterfaceBriefResult:
+        """Parse 'show ip interface brief' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IP interface brief information keyed by interface name.
+
+        Raises:
+            ValueError: If no interface entries can be parsed from the output.
+        """
+        interfaces: dict[str, IpInterfaceBriefEntry] = {}
+
+        for line in output.splitlines():
+            match = cls._INTF_LINE.match(line)
+            if not match:
+                continue
+
+            name = canonical_interface_name(match.group("name"), os=OS.CISCO_IOSXR)
+            entry = IpInterfaceBriefEntry(
+                ip_address=match.group("ip_address"),
+                interface_status=match.group("status").capitalize(),
+                protocol_status=match.group("protocol").capitalize(),
+                vrf_name=match.group("vrf"),
+            )
+            interfaces[name] = entry
+
+        if not interfaces:
+            msg = "No interface entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpInterfaceBriefResult, {"interfaces": interfaces})

--- a/src/muninn/parsers/cisco_iosxr/show_ip_interface_brief.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ip_interface_brief.py
@@ -5,6 +5,7 @@ from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
@@ -46,7 +47,7 @@ class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
     # Columns: Interface  IP-Address  Status  Protocol  Vrf-Name
     _INTF_LINE = re.compile(
         r"^\s*(?P<name>\S+)"
-        r"\s+(?P<ip_address>\S+)"
+        rf"\s+(?P<ip_address>{IPV4_ADDRESS}|unassigned)"
         r"\s+(?P<status>Up|Down|Shutdown)"
         r"\s+(?P<protocol>Up|Down)"
         r"\s+(?P<vrf>\S+)"

--- a/tests/parsers/cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces/expected.json
+++ b/tests/parsers/cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces/expected.json
@@ -1,0 +1,40 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/0/1/18": {
+            "ip_address": "unassigned",
+            "interface_status": "Shutdown",
+            "protocol_status": "Down",
+            "vrf_name": "default"
+        },
+        "GigabitEthernet0/0/1/19": {
+            "ip_address": "unassigned",
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf_name": "default"
+        },
+        "GigabitEthernet0/0/1/19.2003": {
+            "ip_address": "10.79.255.0",
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf_name": "WAG:OOB"
+        },
+        "TenGigE0/0/2/0": {
+            "ip_address": "unassigned",
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf_name": "default"
+        },
+        "TenGigE0/0/2/0.2396": {
+            "ip_address": "10.79.255.96",
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf_name": "WAG:123"
+        },
+        "TenGigE0/0/2/0.2397": {
+            "ip_address": "10.79.255.80",
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf_name": "WAG:ABC"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces/input.txt
+++ b/tests/parsers/cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces/input.txt
@@ -1,0 +1,7 @@
+Interface                      IP-Address      Status          Protocol Vrf-Name
+GigabitEthernet0/0/1/18        unassigned      Shutdown        Down     default
+GigabitEthernet0/0/1/19        unassigned      Up              Up       default
+GigabitEthernet0/0/1/19.2003   10.79.255.0     Up              Up       WAG:OOB
+TenGigE0/0/2/0                 unassigned      Up              Up       default
+TenGigE0/0/2/0.2396            10.79.255.96    Up              Up       WAG:123
+TenGigE0/0/2/0.2397            10.79.255.80    Up              Up       WAG:ABC

--- a/tests/parsers/cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Mixed GigabitEthernet and TenGigE interfaces with subinterfaces and multiple VRFs"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show ip interface brief` on Cisco IOS-XR
- Extracts interface name, IP address, interface/protocol status, and VRF name into a dict-of-dicts keyed by interface name
- Includes test fixture with mixed GigabitEthernet/TenGigE interfaces, subinterfaces, and multiple VRFs (sourced from ntc-templates real device output)

## Test plan
- [x] Parser test passes: `cisco_iosxr/show_ip_interface_brief/001_mixed_interfaces`
- [x] ruff check and format clean
- [x] bandit security scan clean
- [x] xenon complexity check passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)