### PR TITLE
feat(cisco_iosxr): add parser for `show ipv6 neighbors`

### DIFF
--- a/changes/+cisco-iosxr-show-ipv6-neighbors.parser_added
+++ b/changes/+cisco-iosxr-show-ipv6-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ipv6 neighbors` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
@@ -1,0 +1,103 @@
+"""Parser for 'show ipv6 neighbors' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import MAC_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class Ipv6NeighborEntry(TypedDict):
+    """Schema for a single IPv6 neighbor (NDP) entry."""
+
+    age: str
+    link_layer_address: str
+    state: str
+    interface: str
+    location: NotRequired[str]
+
+
+class ShowIpv6NeighborsResult(TypedDict):
+    """Schema for 'show ipv6 neighbors' parsed output on IOS-XR.
+
+    Keyed by IPv6 address. Multicast adjacency entries (``[Mcast adjacency]``)
+    are excluded because they lack a meaningful unique key and represent
+    internal platform state rather than real neighbor relationships.
+    """
+
+    neighbors: dict[str, Ipv6NeighborEntry]
+
+
+# IPv6 neighbor table row pattern for IOS-XR.
+# Columns: IPv6 Address, Age, Link-layer Addr, State, Interface, Location.
+# Age can be a number (seconds) or ``-`` for multicast adjacencies.
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<ipv6_address>\S+)\s+"
+    r"(?P<age>\d+)\s+"
+    rf"(?P<link_layer_address>{MAC_ADDRESS})\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<interface>\S+)"
+    r"(?:\s+(?P<location>\S+))?\s*$"
+)
+
+
+@register(OS.CISCO_IOSXR, "show ipv6 neighbors")
+class ShowIpv6NeighborsParser(BaseParser["ShowIpv6NeighborsResult"]):
+    """Parser for 'show ipv6 neighbors' on Cisco IOS-XR.
+
+    Parses the IPv6 neighbor discovery (NDP) table. Entries are keyed
+    by IPv6 address. Multicast adjacency rows are skipped.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ARP})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowIpv6NeighborsResult":
+        """Parse 'show ipv6 neighbors' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed neighbor entries keyed by IPv6 address.
+
+        Raises:
+            ValueError: If no neighbor entries found in output.
+        """
+        neighbors: dict[str, Ipv6NeighborEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = _NEIGHBOR_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            ipv6_address = match.group("ipv6_address")
+            interface_raw = match.group("interface")
+            interface = canonical_interface_name(interface_raw, os=OS.CISCO_IOSXR)
+
+            entry: Ipv6NeighborEntry = {
+                "age": match.group("age"),
+                "link_layer_address": match.group("link_layer_address").lower(),
+                "state": match.group("state").upper(),
+                "interface": interface,
+            }
+
+            location = match.group("location")
+            if location:
+                entry["location"] = location
+
+            neighbors[ipv6_address] = entry
+
+        if not neighbors:
+            msg = "No IPv6 neighbor entries found in output"
+            raise ValueError(msg)
+
+        return cast("ShowIpv6NeighborsResult", {"neighbors": neighbors})

--- a/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
@@ -12,29 +12,32 @@ from muninn.utils import canonical_interface_name
 
 
 class Ipv6NeighborEntry(TypedDict):
-    """Schema for a single IPv6 neighbor (NDP) entry."""
+    """Schema for a single IPv6 neighbor (NDP) entry on a given interface."""
 
-    age: str
+    age: int
     link_layer_address: str
     state: str
-    interface: str
     location: NotRequired[str]
 
 
 class ShowIpv6NeighborsResult(TypedDict):
     """Schema for 'show ipv6 neighbors' parsed output on IOS-XR.
 
-    Keyed by IPv6 address. Multicast adjacency entries (``[Mcast adjacency]``)
-    are excluded because they lack a meaningful unique key and represent
-    internal platform state rather than real neighbor relationships.
+    Keyed by IPv6 address, then by canonical interface name. The nested
+    interface key is required because IPv6 link-local addresses
+    (``fe80::/10``) commonly appear on multiple interfaces and a flat
+    dict keyed solely by IPv6 address would silently overwrite entries.
+
+    Multicast adjacency entries (``[Mcast adjacency]``) are excluded
+    because they lack a meaningful unique key and represent internal
+    platform state rather than real neighbor relationships.
     """
 
-    neighbors: dict[str, Ipv6NeighborEntry]
+    neighbors: dict[str, dict[str, Ipv6NeighborEntry]]
 
 
 # IPv6 neighbor table row pattern for IOS-XR.
 # Columns: IPv6 Address, Age, Link-layer Addr, State, Interface, Location.
-# Age can be a number (seconds) or ``-`` for multicast adjacencies.
 _NEIGHBOR_PATTERN = re.compile(
     r"^(?P<ipv6_address>\S+)\s+"
     r"(?P<age>\d+)\s+"
@@ -50,7 +53,8 @@ class ShowIpv6NeighborsParser(BaseParser["ShowIpv6NeighborsResult"]):
     """Parser for 'show ipv6 neighbors' on Cisco IOS-XR.
 
     Parses the IPv6 neighbor discovery (NDP) table. Entries are keyed
-    by IPv6 address. Multicast adjacency rows are skipped.
+    by IPv6 address, then by canonical interface name. Multicast
+    adjacency rows are skipped.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ARP})
@@ -63,12 +67,12 @@ class ShowIpv6NeighborsParser(BaseParser["ShowIpv6NeighborsResult"]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed neighbor entries keyed by IPv6 address.
+            Parsed neighbor entries keyed by IPv6 address and interface.
 
         Raises:
             ValueError: If no neighbor entries found in output.
         """
-        neighbors: dict[str, Ipv6NeighborEntry] = {}
+        neighbors: dict[str, dict[str, Ipv6NeighborEntry]] = {}
 
         for line in output.splitlines():
             stripped = line.strip()
@@ -80,21 +84,23 @@ class ShowIpv6NeighborsParser(BaseParser["ShowIpv6NeighborsResult"]):
                 continue
 
             ipv6_address = match.group("ipv6_address")
-            interface_raw = match.group("interface")
-            interface = canonical_interface_name(interface_raw, os=OS.CISCO_IOSXR)
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.CISCO_IOSXR
+            )
 
             entry: Ipv6NeighborEntry = {
-                "age": match.group("age"),
+                "age": int(match.group("age")),
                 "link_layer_address": match.group("link_layer_address").lower(),
                 "state": match.group("state").upper(),
-                "interface": interface,
             }
 
             location = match.group("location")
             if location:
                 entry["location"] = location
 
-            neighbors[ipv6_address] = entry
+            if ipv6_address not in neighbors:
+                neighbors[ipv6_address] = {}
+            neighbors[ipv6_address][interface] = entry
 
         if not neighbors:
             msg = "No IPv6 neighbor entries found in output"

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
@@ -1,60 +1,68 @@
 {
     "neighbors": {
         "2001:db8:ffff::12:2": {
-            "age": "110",
-            "link_layer_address": "0c07.a11a.b801",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/0",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/0": {
+                "age": 110,
+                "link_layer_address": "0c07.a11a.b801",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "fe80::e07:a1ff:fe1a:b801": {
-            "age": "99",
-            "link_layer_address": "0c07.a11a.b801",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/0",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/0": {
+                "age": 99,
+                "link_layer_address": "0c07.a11a.b801",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "2001:db8:1000:beef::1": {
-            "age": "105",
-            "link_layer_address": "ca01.0ff1.0008",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/3",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/3": {
+                "age": 105,
+                "link_layer_address": "ca01.0ff1.0008",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "2001:db8:1000:beef::2": {
-            "age": "108",
-            "link_layer_address": "ca02.0fff.0008",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/3",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/3": {
+                "age": 108,
+                "link_layer_address": "ca02.0fff.0008",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "2001:db8:1000:beef::3": {
-            "age": "105",
-            "link_layer_address": "ca03.100d.0008",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/3",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/3": {
+                "age": 105,
+                "link_layer_address": "ca03.100d.0008",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "fe80::c801:fff:fef1:8": {
-            "age": "89",
-            "link_layer_address": "ca01.0ff1.0008",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/3",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/3": {
+                "age": 89,
+                "link_layer_address": "ca01.0ff1.0008",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "fe80::c802:fff:feff:8": {
-            "age": "105",
-            "link_layer_address": "ca02.0fff.0008",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/3",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/3": {
+                "age": 105,
+                "link_layer_address": "ca02.0fff.0008",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         },
         "fe80::c803:10ff:fe0d:8": {
-            "age": "91",
-            "link_layer_address": "ca03.100d.0008",
-            "state": "REACH",
-            "interface": "GigabitEthernet0/0/0/3",
-            "location": "0/0/CPU0"
+            "GigabitEthernet0/0/0/3": {
+                "age": 91,
+                "link_layer_address": "ca03.100d.0008",
+                "state": "REACH",
+                "location": "0/0/CPU0"
+            }
         }
     }
 }

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
@@ -1,0 +1,60 @@
+{
+    "neighbors": {
+        "2001:db8:ffff::12:2": {
+            "age": "110",
+            "link_layer_address": "0c07.a11a.b801",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/0",
+            "location": "0/0/CPU0"
+        },
+        "fe80::e07:a1ff:fe1a:b801": {
+            "age": "99",
+            "link_layer_address": "0c07.a11a.b801",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/0",
+            "location": "0/0/CPU0"
+        },
+        "2001:db8:1000:beef::1": {
+            "age": "105",
+            "link_layer_address": "ca01.0ff1.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "2001:db8:1000:beef::2": {
+            "age": "108",
+            "link_layer_address": "ca02.0fff.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "2001:db8:1000:beef::3": {
+            "age": "105",
+            "link_layer_address": "ca03.100d.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "fe80::c801:fff:fef1:8": {
+            "age": "89",
+            "link_layer_address": "ca01.0ff1.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "fe80::c802:fff:feff:8": {
+            "age": "105",
+            "link_layer_address": "ca02.0fff.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "fe80::c803:10ff:fe0d:8": {
+            "age": "91",
+            "link_layer_address": "ca03.100d.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/input.txt
@@ -1,0 +1,14 @@
+Fri Oct 11 02:35:25.149 UTC
+IPv6 Address                              Age Link-layer Addr State Interface            Location
+2001:db8:ffff::12:2                      110  0c07.a11a.b801 REACH Gi0/0/0/0            0/0/CPU0
+fe80::e07:a1ff:fe1a:b801                 99   0c07.a11a.b801 REACH Gi0/0/0/0            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/0            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/1            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/2            0/0/CPU0
+2001:db8:1000:beef::1                    105  ca01.0ff1.0008 REACH Gi0/0/0/3            0/0/CPU0
+2001:db8:1000:beef::2                    108  ca02.0fff.0008 REACH Gi0/0/0/3            0/0/CPU0
+2001:db8:1000:beef::3                    105  ca03.100d.0008 REACH Gi0/0/0/3            0/0/CPU0
+fe80::c801:fff:fef1:8                    89   ca01.0ff1.0008 REACH Gi0/0/0/3            0/0/CPU0
+fe80::c802:fff:feff:8                    105  ca02.0fff.0008 REACH Gi0/0/0/3            0/0/CPU0
+fe80::c803:10ff:fe0d:8                   91   ca03.100d.0008 REACH Gi0/0/0/3            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/3            0/0/CPU0

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple IPv6 neighbors across interfaces with multicast adjacency entries
+platform: Unknown
+software_version: IOS-XR


### PR DESCRIPTION
## Summary

- Add parser for `show ipv6 neighbors` on Cisco IOS-XR, parsing the IPv6 NDP neighbor table
- Returns dict-of-dicts keyed by IPv6 address with age, link-layer address, state, interface, and location fields
- Multicast adjacency rows (`[Mcast adjacency]`) are skipped as they lack meaningful unique keys and represent internal platform state

## Test plan

- [x] Test fixture `001_basic` with real device output covering multiple interfaces, global and link-local addresses
- [x] All pre-commit hooks pass (ruff, xenon, bandit, pretty-format-json)
- [x] `uv run pytest tests/parsers/ -k "show_ipv6_neighbors"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)