### PR TITLE
feat(cisco_iosxr): add parser for show ipv6 neighbors

### DIFF
--- a/changes/+cisco-iosxr-show-ipv6-neighbors.parser_added
+++ b/changes/+cisco-iosxr-show-ipv6-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ipv6 neighbors` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
@@ -1,0 +1,103 @@
+"""Parser for 'show ipv6 neighbors' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import MAC_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class Ipv6NeighborEntry(TypedDict):
+    """Schema for a single IPv6 neighbor (NDP) entry."""
+
+    age: str
+    link_layer_address: str
+    state: str
+    interface: str
+    location: NotRequired[str]
+
+
+class ShowIpv6NeighborsResult(TypedDict):
+    """Schema for 'show ipv6 neighbors' parsed output on IOS-XR.
+
+    Keyed by IPv6 address. Multicast adjacency entries (``[Mcast adjacency]``)
+    are excluded because they lack a meaningful unique key and represent
+    internal platform state rather than real neighbor relationships.
+    """
+
+    neighbors: dict[str, Ipv6NeighborEntry]
+
+
+# IPv6 neighbor table row pattern for IOS-XR.
+# Columns: IPv6 Address, Age, Link-layer Addr, State, Interface, Location.
+# Age can be a number (seconds) or ``-`` for multicast adjacencies.
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<ipv6_address>\S+)\s+"
+    r"(?P<age>\d+)\s+"
+    rf"(?P<link_layer_address>{MAC_ADDRESS})\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<interface>\S+)"
+    r"(?:\s+(?P<location>\S+))?\s*$"
+)
+
+
+@register(OS.CISCO_IOSXR, "show ipv6 neighbors")
+class ShowIpv6NeighborsParser(BaseParser["ShowIpv6NeighborsResult"]):
+    """Parser for 'show ipv6 neighbors' on Cisco IOS-XR.
+
+    Parses the IPv6 neighbor discovery (NDP) table. Entries are keyed
+    by IPv6 address. Multicast adjacency rows are skipped.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ARP})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowIpv6NeighborsResult":
+        """Parse 'show ipv6 neighbors' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed neighbor entries keyed by IPv6 address.
+
+        Raises:
+            ValueError: If no neighbor entries found in output.
+        """
+        neighbors: dict[str, Ipv6NeighborEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = _NEIGHBOR_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            ipv6_address = match.group("ipv6_address")
+            interface_raw = match.group("interface")
+            interface = canonical_interface_name(interface_raw, os=OS.CISCO_IOSXR)
+
+            entry: Ipv6NeighborEntry = {
+                "age": match.group("age"),
+                "link_layer_address": match.group("link_layer_address").lower(),
+                "state": match.group("state").upper(),
+                "interface": interface,
+            }
+
+            location = match.group("location")
+            if location:
+                entry["location"] = location
+
+            neighbors[ipv6_address] = entry
+
+        if not neighbors:
+            msg = "No IPv6 neighbor entries found in output"
+            raise ValueError(msg)
+
+        return cast("ShowIpv6NeighborsResult", {"neighbors": neighbors})

--- a/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ipv6_neighbors.py
@@ -12,9 +12,13 @@ from muninn.utils import canonical_interface_name
 
 
 class Ipv6NeighborEntry(TypedDict):
-    """Schema for a single IPv6 neighbor (NDP) entry."""
+    """Schema for a single IPv6 neighbor (NDP) entry.
 
-    age: str
+    The ``age_minutes`` field reflects the IOS-XR ``Age`` column, which
+    represents time since last reachability confirmation in minutes.
+    """
+
+    age_minutes: int
     link_layer_address: str
     state: str
     interface: str
@@ -84,7 +88,7 @@ class ShowIpv6NeighborsParser(BaseParser["ShowIpv6NeighborsResult"]):
             interface = canonical_interface_name(interface_raw, os=OS.CISCO_IOSXR)
 
             entry: Ipv6NeighborEntry = {
-                "age": match.group("age"),
+                "age_minutes": int(match.group("age")),
                 "link_layer_address": match.group("link_layer_address").lower(),
                 "state": match.group("state").upper(),
                 "interface": interface,

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
@@ -1,56 +1,56 @@
 {
     "neighbors": {
         "2001:db8:ffff::12:2": {
-            "age": "110",
+            "age_minutes": 110,
             "link_layer_address": "0c07.a11a.b801",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/0",
             "location": "0/0/CPU0"
         },
         "fe80::e07:a1ff:fe1a:b801": {
-            "age": "99",
+            "age_minutes": 99,
             "link_layer_address": "0c07.a11a.b801",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/0",
             "location": "0/0/CPU0"
         },
         "2001:db8:1000:beef::1": {
-            "age": "105",
+            "age_minutes": 105,
             "link_layer_address": "ca01.0ff1.0008",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/3",
             "location": "0/0/CPU0"
         },
         "2001:db8:1000:beef::2": {
-            "age": "108",
+            "age_minutes": 108,
             "link_layer_address": "ca02.0fff.0008",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/3",
             "location": "0/0/CPU0"
         },
         "2001:db8:1000:beef::3": {
-            "age": "105",
+            "age_minutes": 105,
             "link_layer_address": "ca03.100d.0008",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/3",
             "location": "0/0/CPU0"
         },
         "fe80::c801:fff:fef1:8": {
-            "age": "89",
+            "age_minutes": 89,
             "link_layer_address": "ca01.0ff1.0008",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/3",
             "location": "0/0/CPU0"
         },
         "fe80::c802:fff:feff:8": {
-            "age": "105",
+            "age_minutes": 105,
             "link_layer_address": "ca02.0fff.0008",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/3",
             "location": "0/0/CPU0"
         },
         "fe80::c803:10ff:fe0d:8": {
-            "age": "91",
+            "age_minutes": 91,
             "link_layer_address": "ca03.100d.0008",
             "state": "REACH",
             "interface": "GigabitEthernet0/0/0/3",

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/expected.json
@@ -1,0 +1,60 @@
+{
+    "neighbors": {
+        "2001:db8:ffff::12:2": {
+            "age": "110",
+            "link_layer_address": "0c07.a11a.b801",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/0",
+            "location": "0/0/CPU0"
+        },
+        "fe80::e07:a1ff:fe1a:b801": {
+            "age": "99",
+            "link_layer_address": "0c07.a11a.b801",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/0",
+            "location": "0/0/CPU0"
+        },
+        "2001:db8:1000:beef::1": {
+            "age": "105",
+            "link_layer_address": "ca01.0ff1.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "2001:db8:1000:beef::2": {
+            "age": "108",
+            "link_layer_address": "ca02.0fff.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "2001:db8:1000:beef::3": {
+            "age": "105",
+            "link_layer_address": "ca03.100d.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "fe80::c801:fff:fef1:8": {
+            "age": "89",
+            "link_layer_address": "ca01.0ff1.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "fe80::c802:fff:feff:8": {
+            "age": "105",
+            "link_layer_address": "ca02.0fff.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        },
+        "fe80::c803:10ff:fe0d:8": {
+            "age": "91",
+            "link_layer_address": "ca03.100d.0008",
+            "state": "REACH",
+            "interface": "GigabitEthernet0/0/0/3",
+            "location": "0/0/CPU0"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/input.txt
@@ -1,0 +1,14 @@
+Fri Oct 11 02:35:25.149 UTC
+IPv6 Address                              Age Link-layer Addr State Interface            Location
+2001:db8:ffff::12:2                      110  0c07.a11a.b801 REACH Gi0/0/0/0            0/0/CPU0
+fe80::e07:a1ff:fe1a:b801                 99   0c07.a11a.b801 REACH Gi0/0/0/0            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/0            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/1            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/2            0/0/CPU0
+2001:db8:1000:beef::1                    105  ca01.0ff1.0008 REACH Gi0/0/0/3            0/0/CPU0
+2001:db8:1000:beef::2                    108  ca02.0fff.0008 REACH Gi0/0/0/3            0/0/CPU0
+2001:db8:1000:beef::3                    105  ca03.100d.0008 REACH Gi0/0/0/3            0/0/CPU0
+fe80::c801:fff:fef1:8                    89   ca01.0ff1.0008 REACH Gi0/0/0/3            0/0/CPU0
+fe80::c802:fff:feff:8                    105  ca02.0fff.0008 REACH Gi0/0/0/3            0/0/CPU0
+fe80::c803:10ff:fe0d:8                   91   ca03.100d.0008 REACH Gi0/0/0/3            0/0/CPU0
+[Mcast adjacency]                           - 0000.0000.0000 REACH Gi0/0/0/3            0/0/CPU0

--- a/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_ipv6_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Basic IPv6 neighbor table with unicast and multicast adjacency entries"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add parser for `show ipv6 neighbors` on Cisco IOS-XR
- Parses IPv6 NDP table entries keyed by IPv6 address, extracting age, link-layer address, state, interface, and location
- Multicast adjacency rows (`[Mcast adjacency]`) are skipped as they lack meaningful unique keys
- Tagged with `ParserTag.ARP`

## Test plan
- [x] `001_basic` fixture with real device output covering unicast and multicast adjacency entries across multiple interfaces
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] Ruff lint and format clean
- [x] Xenon complexity check passes
- [x] Bandit security scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)