### PR TITLE
feat(cisco_iosxr): add parser for `show inventory`

### DIFF
--- a/changes/+cisco-iosxr-show-inventory.parser_added
+++ b/changes/+cisco-iosxr-show-inventory.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show inventory` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_inventory.py
+++ b/src/muninn/parsers/cisco_iosxr/show_inventory.py
@@ -1,0 +1,112 @@
+"""Parser for 'show inventory' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class InventoryItem(TypedDict):
+    """Schema for a single inventory entry."""
+
+    description: NotRequired[str]
+    pid: NotRequired[str]
+    vid: NotRequired[str]
+    sn: NotRequired[str]
+
+
+class ShowInventoryResult(TypedDict):
+    """Schema for 'show inventory' parsed output.
+
+    Dict keyed by inventory item NAME.
+    """
+
+
+# Sentinel values that mean "no data" in IOS-XR inventory output.
+_NA_SENTINELS = frozenset({"N/A", "n/a", "NA", ""})
+
+
+@register(OS.CISCO_IOSXR, "show inventory")
+class ShowInventoryParser(BaseParser[dict[str, InventoryItem]]):
+    """Parser for 'show inventory' command on Cisco IOS-XR.
+
+    Produces a dict keyed by inventory item NAME. Each value contains
+    the non-empty fields: description, pid, vid, sn.
+    Fields whose raw value is empty or "N/A" are omitted.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INVENTORY})
+
+    _NAME_DESCR_PATTERN = re.compile(
+        r'^NAME:\s+"(?P<name>[^"]+)"'
+        r',\s+DESCR:\s+"(?P<descr>[^"]*)"'
+    )
+    _PID_VID_SN_PATTERN = re.compile(
+        r"^PID:\s*(?P<pid>[^,]*?)\s*"
+        r",\s*VID:\s*(?P<vid>[^,]*?)\s*"
+        r",\s*SN:\s*(?P<sn>.*?)\s*$"
+    )
+
+    @classmethod
+    def _parse_pid_vid_sn(cls, line: str, item: InventoryItem) -> None:
+        """Extract PID, VID, and SN fields from a PID line into *item*.
+
+        Fields whose value is empty or a known sentinel are omitted.
+        """
+        pid_match = cls._PID_VID_SN_PATTERN.match(line)
+        if not pid_match:
+            return
+
+        for field, group in (("pid", "pid"), ("vid", "vid"), ("sn", "sn")):
+            value = pid_match.group(group).strip()
+            if value and value not in _NA_SENTINELS:
+                item[field] = value  # type: ignore[literal-required]
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, InventoryItem]:
+        """Parse 'show inventory' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by inventory item NAME.
+
+        Raises:
+            ValueError: If no inventory entries are found.
+        """
+        result: dict[str, InventoryItem] = {}
+        lines = output.splitlines()
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx].rstrip()
+            name_match = cls._NAME_DESCR_PATTERN.match(line)
+            if name_match:
+                name = name_match.group("name")
+                descr = name_match.group("descr").strip()
+                item: InventoryItem = {}
+
+                if descr and descr not in _NA_SENTINELS:
+                    item["description"] = descr
+
+                # Next non-blank line should be PID/VID/SN
+                idx += 1
+                while idx < len(lines) and not lines[idx].strip():
+                    idx += 1
+
+                if idx < len(lines):
+                    cls._parse_pid_vid_sn(lines[idx].rstrip(), item)
+
+                result[name] = item
+
+            idx += 1
+
+        if not result:
+            msg = "No inventory entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_inventory/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_inventory/001_basic/expected.json
@@ -1,0 +1,36 @@
+{
+    "module 0/RSP0/CPU0": {
+        "description": "ASR9K Route Switch Processor with 440G/slot Fabric and 6GB",
+        "pid": "A9K-RSP440-TR",
+        "vid": "V05",
+        "sn": "FOC1808NEND"
+    },
+    "module 0/RSP1/CPU0": {
+        "description": "ASR9K Route Switch Processor with 440G/slot Fabric and 6GB",
+        "pid": "A9K-RSP440-TR",
+        "vid": "V05",
+        "sn": "FOC1808NEP5"
+    },
+    "module 0/0/CPU0": {
+        "description": "80G Modular Linecard, Service Edge Optimized",
+        "pid": "A9K-MOD80-SE",
+        "vid": "V06",
+        "sn": "FOC1821NEET"
+    },
+    "module 0/0/0": {
+        "description": "ASR 9000 20-port 1GE Modular Port Adapter",
+        "pid": "A9K-MPA-20X1GE",
+        "vid": "V02",
+        "sn": "FOC1811N49J"
+    },
+    "module mau 0/0/0/0": {
+        "description": "Unknown or Unsupported CPAK Module",
+        "pid": "GLC-T",
+        "sn": "00000MTC160107LP"
+    },
+    "module mau 0/0/0/1": {
+        "description": "Unknown or Unsupported CPAK Module",
+        "pid": "GLC-T",
+        "sn": "00000MTC17150731"
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_inventory/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_inventory/001_basic/input.txt
@@ -1,0 +1,18 @@
+
+NAME: "module 0/RSP0/CPU0", DESCR: "ASR9K Route Switch Processor with 440G/slot Fabric and 6GB"
+PID: A9K-RSP440-TR, VID: V05, SN: FOC1808NEND
+
+NAME: "module 0/RSP1/CPU0", DESCR: "ASR9K Route Switch Processor with 440G/slot Fabric and 6GB"
+PID: A9K-RSP440-TR, VID: V05, SN: FOC1808NEP5
+
+NAME: "module 0/0/CPU0", DESCR: "80G Modular Linecard, Service Edge Optimized"
+PID: A9K-MOD80-SE, VID: V06, SN: FOC1821NEET
+
+NAME: "module 0/0/0", DESCR: "ASR 9000 20-port 1GE Modular Port Adapter"
+PID: A9K-MPA-20X1GE, VID: V02, SN: FOC1811N49J
+
+NAME: "module mau 0/0/0/0", DESCR: "Unknown or Unsupported CPAK Module"
+PID: GLC-T               , VID: N/A, SN: 00000MTC160107LP
+
+NAME: "module mau 0/0/0/1", DESCR: "Unknown or Unsupported CPAK Module"
+PID: GLC-T               , VID: N/A, SN: 00000MTC17150731

--- a/tests/parsers/cisco_iosxr/show_inventory/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_inventory/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "ASR9K inventory with RSP, linecards, and SFP modules including N/A VID entries"
+platform: "ASR 9006"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show inventory` on Cisco IOS-XR
- Produces a dict-of-dicts keyed by inventory item NAME with fields: description, pid, vid, sn
- Fields with empty or "N/A" values are omitted (NotRequired) rather than carried as placeholder strings
- Test fixture uses real ASR9K output including entries with N/A VID values

## Test plan
- [x] Parser test passes: `uv run pytest tests/parsers/test_parsers.py -k "cisco_iosxr/show_inventory"`
- [x] Placeholder sentinel tests pass: no N/A, empty string, or hyphen values in expected.json
- [x] Ruff lint and format clean
- [x] Xenon complexity within bounds (max-absolute B)
- [x] Bandit security scan clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)