### PR TITLE
feat(cisco_iosxr): add parser for `show interfaces description`

### DIFF
--- a/changes/+cisco-iosxr-show-interfaces-description.parser_added
+++ b/changes/+cisco-iosxr-show-interfaces-description.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interfaces description` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_interfaces_description.py
+++ b/src/muninn/parsers/cisco_iosxr/show_interfaces_description.py
@@ -1,0 +1,91 @@
+"""Parser for 'show interfaces description' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class InterfaceDescriptionEntry(TypedDict):
+    """Schema for a single interface entry in 'show interfaces description' output."""
+
+    status: str
+    protocol: str
+    description: NotRequired[str]
+
+
+class ShowInterfacesDescriptionResult(TypedDict):
+    """Schema for 'show interfaces description' parsed output.
+
+    Dict-of-dicts keyed by interface name.
+    """
+
+    interfaces: dict[str, InterfaceDescriptionEntry]
+
+
+@register(OS.CISCO_IOSXR, "show interfaces description")
+class ShowInterfacesDescriptionParser(BaseParser[ShowInterfacesDescriptionResult]):
+    """Parser for 'show interfaces description' command on Cisco IOS-XR.
+
+    Parses the tabular interface description output into a dict-of-dicts
+    keyed by canonical interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+        }
+    )
+
+    # Matches a data line in the interface description table.
+    # Columns: Interface  Status  Protocol  Description (optional)
+    # The description column may be absent when empty.
+    _INTF_LINE = re.compile(
+        r"^\s*(?P<name>\S+)"
+        r"\s+(?P<status>up|down|admin-down|deleted)"
+        r"\s+(?P<protocol>up|down|admin-down|deleted)"
+        r"(?:\s+(?P<description>.+?))?"
+        r"\s*$",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesDescriptionResult:
+        """Parse 'show interfaces description' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed interface description information keyed by interface name.
+
+        Raises:
+            ValueError: If no interface entries can be parsed from the output.
+        """
+        interfaces: dict[str, InterfaceDescriptionEntry] = {}
+
+        for line in output.splitlines():
+            match = cls._INTF_LINE.match(line)
+            if not match:
+                continue
+
+            name = canonical_interface_name(match.group("name"), os=OS.CISCO_IOSXR)
+            entry = InterfaceDescriptionEntry(
+                status=match.group("status"),
+                protocol=match.group("protocol"),
+            )
+            description = match.group("description")
+            if description:
+                entry["description"] = description
+
+            interfaces[name] = entry
+
+        if not interfaces:
+            msg = "No interface entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowInterfacesDescriptionResult, {"interfaces": interfaces})

--- a/tests/parsers/cisco_iosxr/show_interfaces_description/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_interfaces_description/001_basic/expected.json
@@ -1,0 +1,91 @@
+{
+    "interfaces": {
+        "BE100": {
+            "status": "up",
+            "protocol": "up",
+            "description": "Ligacao -SAT01 | 10G | (satellite100)"
+        },
+        "Loopback0": {
+            "status": "up",
+            "protocol": "up",
+            "description": "Endereco de Acesso ao Roteador"
+        },
+        "Loopback10": {
+            "status": "up",
+            "protocol": "up",
+            "description": "SPB | BGP | ASN 123456"
+        },
+        "Loopback20": {
+            "status": "up",
+            "protocol": "up",
+            "description": "*** Management Loopback ***"
+        },
+        "Null0": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "GigabitEthernet100/0/0/0": {
+            "status": "up",
+            "protocol": "up",
+            "description": "LINK ETHERNET"
+        },
+        "GigabitEthernet100/0/0/0.10": {
+            "status": "up",
+            "protocol": "up",
+            "description": "MULTIPLANNING"
+        },
+        "GigabitEthernet100/0/0/0.150012": {
+            "status": "admin-down",
+            "protocol": "admin-down",
+            "description": "ADMIN DOWN"
+        },
+        "GigabitEthernet100/0/0/2": {
+            "status": "admin-down",
+            "protocol": "admin-down"
+        },
+        "GigabitEthernet100/0/0/9": {
+            "status": "deleted",
+            "protocol": "deleted",
+            "description": "DELETED"
+        },
+        "nG100/0/0/42": {
+            "status": "deleted",
+            "protocol": "deleted"
+        },
+        "nG100/0/0/43": {
+            "status": "down",
+            "protocol": "down"
+        },
+        "nT100/0/0/47": {
+            "status": "up",
+            "protocol": "up"
+        },
+        "PT0/RSP0/CPU0/0": {
+            "status": "admin-down",
+            "protocol": "admin-down"
+        },
+        "MgmtEth0/RSP1/CPU0/0": {
+            "status": "admin-down",
+            "protocol": "admin-down"
+        },
+        "MgmtEth0/RSP1/CPU0/1": {
+            "status": "admin-down",
+            "protocol": "admin-down"
+        },
+        "TenGigabitEthernet0/3/0/0": {
+            "status": "up",
+            "protocol": "up",
+            "description": "Ligacao | 10G | 10G/061 | (ten0/4/0/1/0)"
+        },
+        "TenGigabitEthernet0/4/0/0": {
+            "status": "up",
+            "protocol": "up",
+            "description": "Ligacao | 10G | 10G/062 | (ten0/3/0/1/7)"
+        },
+        "TenGigabitEthernet0/5/0/3": {
+            "status": "up",
+            "protocol": "up",
+            "description": "Ligacao -SAT04 | 10G | (satellite400)"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_interfaces_description/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_interfaces_description/001_basic/input.txt
@@ -1,0 +1,23 @@
+Tue Sep 24 10:49:25.293 BRA
+
+Interface          Status      Protocol    Description
+--------------------------------------------------------------------------------
+BE100              up          up          Ligacao -SAT01 | 10G | (satellite100)
+Lo0                up          up          Endereco de Acesso ao Roteador
+Lo10               up          up          SPB | BGP | ASN 123456
+Lo20               up          up          *** Management Loopback ***
+Nu0                up          up
+Gi100/0/0/0        up          up          LINK ETHERNET
+Gi100/0/0/0.10     up          up          MULTIPLANNING
+Gi100/0/0/0.150012 admin-down  admin-down  ADMIN DOWN
+Gi100/0/0/2        admin-down  admin-down
+Gi100/0/0/9        deleted     deleted     DELETED
+nG100/0/0/42       deleted     deleted
+nG100/0/0/43       down        down
+nT100/0/0/47       up          up
+PT0/RSP0/CPU0/0    admin-down  admin-down
+Mg0/RSP1/CPU0/0    admin-down  admin-down
+Mg0/RSP1/CPU0/1    admin-down  admin-down
+Te0/3/0/0          up          up          Ligacao | 10G | 10G/061 | (ten0/4/0/1/0)
+Te0/4/0/0          up          up          Ligacao | 10G | 10G/062 | (ten0/3/0/1/7)
+Te0/5/0/3          up          up          Ligacao -SAT04 | 10G | (satellite400)

--- a/tests/parsers/cisco_iosxr/show_interfaces_description/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_interfaces_description/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Mixed interface types with descriptions, admin-down, deleted, and empty descriptions"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show interfaces description` on Cisco IOS-XR
- Parses tabular output into dict-of-dicts keyed by canonical interface name
- Handles all status values: up, down, admin-down, deleted
- Omits the `description` key when the field is blank (uses `NotRequired` in TypedDict)
- Includes test fixture with 19 interfaces covering subinterfaces, management, loopback, null, bundle-ether, and ten-gig interfaces

## Test plan
- [x] Parser test passes against real device output fixture
- [x] Placeholder sentinel tests pass (no empty strings, hyphens, or NA values)
- [x] JSON convention tests pass (no list-of-dicts, no pipe in keys)
- [x] ruff check and format clean
- [x] xenon complexity check passes
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)