### PR TITLE
feat(cisco_iosxr): add parser for `show platform`

### DIFF
--- a/changes/+cisco-iosxr-show-platform.parser_added
+++ b/changes/+cisco-iosxr-show-platform.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show platform` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_platform.py
+++ b/src/muninn/parsers/cisco_iosxr/show_platform.py
@@ -5,6 +5,7 @@ from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_RE
 from muninn.registry import register
 from muninn.tags import ParserTag
 
@@ -29,7 +30,9 @@ class ShowPlatformParser(BaseParser[ShowPlatformResult]):
     and optional config state information.
     """
 
-    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.PLATFORM, ParserTag.SYSTEM}
+    )
 
     # Match lines like:
     # 0/RSP0/CPU0     A9K-RSP440-TR(Active)     IOS XR RUN       PWR,NSHUT,MON
@@ -42,9 +45,6 @@ class ShowPlatformParser(BaseParser[ShowPlatformResult]):
         r"(?P<state>.+?)"
         r"(?:\s{2,}(?P<config_state>\S+.*))?$"
     )
-
-    # Separator line of dashes
-    _SEPARATOR = re.compile(r"^-{5,}$")
 
     @classmethod
     def parse(cls, output: str) -> ShowPlatformResult:
@@ -68,7 +68,7 @@ class ShowPlatformParser(BaseParser[ShowPlatformResult]):
                 continue
 
             # Skip until we pass the separator line
-            if cls._SEPARATOR.match(stripped):
+            if SEPARATOR_DASH_RE.match(stripped):
                 past_header = True
                 continue
 

--- a/src/muninn/parsers/cisco_iosxr/show_platform.py
+++ b/src/muninn/parsers/cisco_iosxr/show_platform.py
@@ -1,0 +1,94 @@
+"""Parser for 'show platform' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowPlatformNodeEntry(TypedDict):
+    """Schema for a single node entry in 'show platform' output."""
+
+    type: str
+    state: str
+    config_state: NotRequired[str]
+
+
+# Dict keyed by node name (e.g. '0/RSP0/CPU0') -> node details.
+ShowPlatformResult = dict[str, ShowPlatformNodeEntry]
+
+
+@register(OS.CISCO_IOSXR, "show platform")
+class ShowPlatformParser(BaseParser[ShowPlatformResult]):
+    """Parser for 'show platform' command on Cisco IOS-XR.
+
+    Parses the tabular output of node/slot inventory with type, state,
+    and optional config state information.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    # Match lines like:
+    # 0/RSP0/CPU0     A9K-RSP440-TR(Active)     IOS XR RUN       PWR,NSHUT,MON
+    # 0/FT0/SP        ASR-9010-FAN-V2           READY
+    _NODE_LINE = re.compile(
+        r"^(?P<node>\d+\S+)"
+        r"\s+"
+        r"(?P<type>\S+)"
+        r"\s+"
+        r"(?P<state>.+?)"
+        r"(?:\s{2,}(?P<config_state>\S+.*))?$"
+    )
+
+    # Separator line of dashes
+    _SEPARATOR = re.compile(r"^-{5,}$")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPlatformResult:
+        """Parse 'show platform' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by node name with type, state, and config_state.
+
+        Raises:
+            ValueError: If no platform entries are found.
+        """
+        result: ShowPlatformResult = {}
+        past_header = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            # Skip until we pass the separator line
+            if cls._SEPARATOR.match(stripped):
+                past_header = True
+                continue
+
+            if not past_header:
+                continue
+
+            match = cls._NODE_LINE.match(stripped)
+            if match:
+                node = match.group("node")
+                config_state = match.group("config_state")
+                entry = ShowPlatformNodeEntry(
+                    type=match.group("type"),
+                    state=match.group("state").strip(),
+                )
+                if config_state and config_state.strip():
+                    entry["config_state"] = config_state.strip()
+                result[node] = entry
+
+        if not result:
+            msg = "No platform entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_platform/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_platform/001_basic/expected.json
@@ -1,0 +1,25 @@
+{
+    "0/RSP0/CPU0": {
+        "type": "A9K-RSP440-TR(Active)",
+        "state": "IOS XR RUN",
+        "config_state": "PWR,NSHUT,MON"
+    },
+    "0/RSP1/CPU0": {
+        "type": "A9K-RSP440-TR(Standby)",
+        "state": "IOS XR RUN",
+        "config_state": "PWR,NSHUT,MON"
+    },
+    "0/FT0/SP": {
+        "type": "ASR-9010-FAN-V2",
+        "state": "READY"
+    },
+    "0/FT1/SP": {
+        "type": "ASR-9010-FAN-V2",
+        "state": "READY"
+    },
+    "0/0/0": {
+        "type": "A9K-MPA-2X40GE",
+        "state": "OK",
+        "config_state": "PWR,NSHUT,MON"
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_platform/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_platform/001_basic/input.txt
@@ -1,0 +1,8 @@
+Tue Mar  7 14:29:29.338 EST
+Node            Type                      State            Config State
+-----------------------------------------------------------------------------
+0/RSP0/CPU0     A9K-RSP440-TR(Active)     IOS XR RUN       PWR,NSHUT,MON
+0/RSP1/CPU0     A9K-RSP440-TR(Standby)    IOS XR RUN       PWR,NSHUT,MON
+0/FT0/SP        ASR-9010-FAN-V2           READY
+0/FT1/SP        ASR-9010-FAN-V2           READY
+0/0/0           A9K-MPA-2X40GE            OK               PWR,NSHUT,MON

--- a/tests/parsers/cisco_iosxr/show_platform/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_platform/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "ASR 9010 with RSP, fan trays, and MPA modules"
+platform: "ASR 9010"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show platform` on Cisco IOS-XR
- Returns dict-of-dicts keyed by node name (e.g. `0/RSP0/CPU0`) with `type`, `state`, and optional `config_state` fields
- Tagged with `ParserTag.PLATFORM`

## Test plan
- [x] Fixture `001_basic` uses real device output from an ASR 9010 (ntc-templates reference data)
- [x] All 7 parametrized tests pass (parser correctness + JSON convention + placeholder sentinel checks)
- [x] Pre-commit hooks pass (ruff, xenon, pretty-format-json, check-docstring-first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)