### PR TITLE
feat(cisco_iosxr): add parser for `show install active`

### DIFF
--- a/changes/+cisco-iosxr-show-install-active.parser_added
+++ b/changes/+cisco-iosxr-show-install-active.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show install active` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_install_active.py
+++ b/src/muninn/parsers/cisco_iosxr/show_install_active.py
@@ -1,0 +1,122 @@
+"""Parser for 'show install active' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NodeInfo(TypedDict):
+    """Schema for a single node's install information."""
+
+    node_type: str
+    boot_partition: str
+    active_packages: list[str]
+
+
+class ShowInstallActiveResult(TypedDict):
+    """Schema for 'show install active' parsed output on IOS-XR.
+
+    Top-level keys:
+        label: The software label (e.g. "7.3.2").
+        nodes: Dict keyed by node location (e.g. "0/RP0/CPU0") mapping to
+            node details including type, boot partition, and active packages.
+    """
+
+    label: NotRequired[str]
+    nodes: dict[str, NodeInfo]
+
+
+@register(OS.CISCO_IOSXR, "show install active")
+class ShowInstallActiveParser(BaseParser[ShowInstallActiveResult]):
+    """Parser for 'show install active' command on Cisco IOS-XR.
+
+    Parses the active installed packages per node/location, including
+    the software label, boot partition, and package list for each node.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _LABEL = re.compile(r"^Label\s*:\s*(?P<label>\S+)")
+    _NODE = re.compile(r"^Node\s+(?P<location>\S+)\s+\[(?P<node_type>[^\]]+)\]")
+    _BOOT_PARTITION = re.compile(r"^\s+Boot Partition:\s+(?P<partition>\S+)")
+    _ACTIVE_PACKAGES_COUNT = re.compile(r"^\s+Active Packages:\s+\d+")
+    _PACKAGE = re.compile(r"^\s{8}(?P<package>.+\S)")
+
+    @classmethod
+    def _parse_node_line(
+        cls,
+        line: str,
+        current_node: str | None,
+        nodes: dict[str, NodeInfo],
+        in_packages: bool,
+    ) -> tuple[str | None, bool]:
+        """Parse a line within a node block, updating node state.
+
+        Returns:
+            Tuple of (current_node, in_packages) after processing the line.
+        """
+        if match := cls._BOOT_PARTITION.match(line):
+            if current_node is not None:
+                nodes[current_node]["boot_partition"] = match.group("partition")
+            return current_node, in_packages
+
+        if cls._ACTIVE_PACKAGES_COUNT.match(line):
+            return current_node, True
+
+        if in_packages and current_node is not None:
+            if match := cls._PACKAGE.match(line):
+                nodes[current_node]["active_packages"].append(match.group("package"))
+
+        return current_node, in_packages
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInstallActiveResult:
+        """Parse 'show install active' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed install information with nodes and their active packages.
+
+        Raises:
+            ValueError: If no node information can be parsed.
+        """
+        result: dict[str, object] = {}
+        nodes: dict[str, NodeInfo] = {}
+        current_node: str | None = None
+        in_packages = False
+
+        for line in output.splitlines():
+            if not line.strip():
+                in_packages = False
+                continue
+
+            if match := cls._LABEL.match(line):
+                result["label"] = match.group("label")
+                continue
+
+            if match := cls._NODE.match(line):
+                current_node = match.group("location")
+                nodes[current_node] = NodeInfo(
+                    node_type=match.group("node_type"),
+                    boot_partition="",
+                    active_packages=[],
+                )
+                in_packages = False
+                continue
+
+            current_node, in_packages = cls._parse_node_line(
+                line, current_node, nodes, in_packages
+            )
+
+        if not nodes:
+            msg = "No node information found in output"
+            raise ValueError(msg)
+
+        result["nodes"] = nodes
+        return ShowInstallActiveResult(**result)  # type: ignore[arg-type]

--- a/src/muninn/parsers/cisco_iosxr/show_install_active.py
+++ b/src/muninn/parsers/cisco_iosxr/show_install_active.py
@@ -13,7 +13,7 @@ class NodeInfo(TypedDict):
     """Schema for a single node's install information."""
 
     node_type: str
-    boot_partition: str
+    boot_partition: NotRequired[str]
     active_packages: list[str]
 
 
@@ -104,7 +104,6 @@ class ShowInstallActiveParser(BaseParser[ShowInstallActiveResult]):
                 current_node = match.group("location")
                 nodes[current_node] = NodeInfo(
                     node_type=match.group("node_type"),
-                    boot_partition="",
                     active_packages=[],
                 )
                 in_packages = False

--- a/src/muninn/parsers/cisco_iosxr/show_install_active.py
+++ b/src/muninn/parsers/cisco_iosxr/show_install_active.py
@@ -86,7 +86,7 @@ class ShowInstallActiveParser(BaseParser[ShowInstallActiveResult]):
         Raises:
             ValueError: If no node information can be parsed.
         """
-        result: dict[str, object] = {}
+        label: str | None = None
         nodes: dict[str, NodeInfo] = {}
         current_node: str | None = None
         in_packages = False
@@ -97,7 +97,7 @@ class ShowInstallActiveParser(BaseParser[ShowInstallActiveResult]):
                 continue
 
             if match := cls._LABEL.match(line):
-                result["label"] = match.group("label")
+                label = match.group("label")
                 continue
 
             if match := cls._NODE.match(line):
@@ -118,5 +118,7 @@ class ShowInstallActiveParser(BaseParser[ShowInstallActiveResult]):
             msg = "No node information found in output"
             raise ValueError(msg)
 
-        result["nodes"] = nodes
-        return ShowInstallActiveResult(**result)  # type: ignore[arg-type]
+        result = ShowInstallActiveResult(nodes=nodes)
+        if label is not None:
+            result["label"] = label
+        return result

--- a/tests/parsers/cisco_iosxr/show_install_active/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_install_active/001_basic/expected.json
@@ -1,0 +1,101 @@
+{
+    "label": "7.3.2",
+    "nodes": {
+        "0/RP0/CPU0": {
+            "node_type": "RP",
+            "boot_partition": "xr_lv38",
+            "active_packages": [
+                "ncs5500-xr-7.3.2 version=7.3.2 [Boot image]",
+                "ncs5500-mcast-3.0.0.0-r732",
+                "ncs5500-dpa-3.0.0.1-r732.CSCwa07903",
+                "ncs5500-mpls-2.1.0.0-r732",
+                "ncs5500-os-6.0.0.1-r732.CSCvq20498",
+                "ncs5500-k9sec-3.2.0.0-r732",
+                "ncs5500-os-support-4.0.0.2-r732.CSCvz72160",
+                "ncs5500-eigrp-1.0.0.0-r732",
+                "ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439",
+                "ncs5500-li-1.0.0.0-r732",
+                "ncs5500-parser-3.0.0.1-r732.CSCwa44780",
+                "ncs5500-dpa-fwding-4.1.0.3-r732.CSCwa01375",
+                "ncs5500-mgbl-3.0.0.0-r732",
+                "ncs5500-isis-2.1.0.0-r732",
+                "ncs5500-bgp-2.0.0.1-r732.CSCvz94897",
+                "ncs5500-mpls-te-rsvp-3.1.0.0-r732",
+                "ncs5500-infra-5.0.0.5-r732.CSCvu13993",
+                "ncs5500-ospf-3.0.0.0-r732"
+            ]
+        },
+        "0/RP1/CPU0": {
+            "node_type": "RP",
+            "boot_partition": "xr_lv38",
+            "active_packages": [
+                "ncs5500-xr-7.3.2 version=7.3.2 [Boot image]",
+                "ncs5500-mcast-3.0.0.0-r732",
+                "ncs5500-dpa-3.0.0.3-r732.CSCvz54050",
+                "ncs5500-mpls-2.1.0.0-r732",
+                "ncs5500-os-6.0.0.1-r732.CSCvq20498",
+                "ncs5500-k9sec-3.2.0.0-r732",
+                "ncs5500-eigrp-1.0.0.0-r732",
+                "ncs5500-os-support-4.0.0.5-r732.CSCwa01498",
+                "ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439",
+                "ncs5500-li-1.0.0.0-r732",
+                "ncs5500-parser-3.0.0.1-r732.CSCwa44780",
+                "ncs5500-dpa-fwding-4.1.0.3-r732.CSCwa01375",
+                "ncs5500-mgbl-3.0.0.0-r732",
+                "ncs5500-isis-2.1.0.0-r732",
+                "ncs5500-bgp-2.0.0.1-r732.CSCvz94897",
+                "ncs5500-mpls-te-rsvp-3.1.0.0-r732",
+                "ncs5500-infra-5.0.0.5-r732.CSCvu13993",
+                "ncs5500-ospf-3.0.0.0-r732"
+            ]
+        },
+        "0/0/CPU0": {
+            "node_type": "LC",
+            "boot_partition": "xr_lv0",
+            "active_packages": [
+                "ncs5500-xr-7.3.2 version=7.3.2 [Boot image]",
+                "ncs5500-eigrp-1.0.0.0-r732",
+                "ncs5500-k9sec-3.2.0.0-r732",
+                "ncs5500-mpls-2.1.0.0-r732",
+                "ncs5500-li-1.0.0.0-r732",
+                "ncs5500-mgbl-3.0.0.0-r732",
+                "ncs5500-mpls-te-rsvp-3.1.0.0-r732",
+                "ncs5500-isis-2.1.0.0-r732",
+                "ncs5500-ospf-3.0.0.0-r732",
+                "ncs5500-mcast-3.0.0.0-r732",
+                "ncs5500-bgp-2.0.0.1-r732.CSCvz94897",
+                "ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439",
+                "ncs5500-os-6.0.0.1-r732.CSCvq20498",
+                "ncs5500-os-support-4.0.0.5-r732.CSCwa01498",
+                "ncs5500-dpa-3.0.0.5-r732.CSCwa05129",
+                "ncs5500-parser-3.0.0.1-r732.CSCwa44780",
+                "ncs5500-infra-5.0.0.5-r732.CSCvu13993",
+                "ncs5500-dpa-fwding-4.1.0.3-r732.CSCwa01375"
+            ]
+        },
+        "0/1/CPU0": {
+            "node_type": "LC",
+            "boot_partition": "xr_lv38",
+            "active_packages": [
+                "ncs5500-xr-7.3.2 version=7.3.2 [Boot image]",
+                "ncs5500-dpa-3.0.0.5-r732.CSCwa05129",
+                "ncs5500-mcast-3.0.0.0-r732",
+                "ncs5500-mpls-2.1.0.0-r732",
+                "ncs5500-os-6.0.0.1-r732.CSCvq20498",
+                "ncs5500-k9sec-3.2.0.0-r732",
+                "ncs5500-eigrp-1.0.0.0-r732",
+                "ncs5500-os-support-4.0.0.5-r732.CSCwa01498",
+                "ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439",
+                "ncs5500-dpa-fwding-4.1.0.1-r732.CSCwa03269",
+                "ncs5500-li-1.0.0.0-r732",
+                "ncs5500-parser-3.0.0.1-r732.CSCwa44780",
+                "ncs5500-mgbl-3.0.0.0-r732",
+                "ncs5500-isis-2.1.0.0-r732",
+                "ncs5500-bgp-2.0.0.1-r732.CSCvz94897",
+                "ncs5500-mpls-te-rsvp-3.1.0.0-r732",
+                "ncs5500-infra-5.0.0.5-r732.CSCvu13993",
+                "ncs5500-ospf-3.0.0.0-r732"
+            ]
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_install_active/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_install_active/001_basic/input.txt
@@ -1,0 +1,90 @@
+Mon Feb 28 23:36:31.563 CET
+Label : 7.3.2
+
+Node 0/RP0/CPU0 [RP]
+  Boot Partition: xr_lv38
+  Active Packages: 18
+        ncs5500-xr-7.3.2 version=7.3.2 [Boot image]
+        ncs5500-mcast-3.0.0.0-r732
+        ncs5500-dpa-3.0.0.1-r732.CSCwa07903
+        ncs5500-mpls-2.1.0.0-r732
+        ncs5500-os-6.0.0.1-r732.CSCvq20498
+        ncs5500-k9sec-3.2.0.0-r732
+        ncs5500-os-support-4.0.0.2-r732.CSCvz72160
+        ncs5500-eigrp-1.0.0.0-r732
+        ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439
+        ncs5500-li-1.0.0.0-r732
+        ncs5500-parser-3.0.0.1-r732.CSCwa44780
+        ncs5500-dpa-fwding-4.1.0.3-r732.CSCwa01375
+        ncs5500-mgbl-3.0.0.0-r732
+        ncs5500-isis-2.1.0.0-r732
+        ncs5500-bgp-2.0.0.1-r732.CSCvz94897
+        ncs5500-mpls-te-rsvp-3.1.0.0-r732
+        ncs5500-infra-5.0.0.5-r732.CSCvu13993
+        ncs5500-ospf-3.0.0.0-r732
+
+Node 0/RP1/CPU0 [RP]
+  Boot Partition: xr_lv38
+  Active Packages: 18
+        ncs5500-xr-7.3.2 version=7.3.2 [Boot image]
+        ncs5500-mcast-3.0.0.0-r732
+        ncs5500-dpa-3.0.0.3-r732.CSCvz54050
+        ncs5500-mpls-2.1.0.0-r732
+        ncs5500-os-6.0.0.1-r732.CSCvq20498
+        ncs5500-k9sec-3.2.0.0-r732
+        ncs5500-eigrp-1.0.0.0-r732
+        ncs5500-os-support-4.0.0.5-r732.CSCwa01498
+        ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439
+        ncs5500-li-1.0.0.0-r732
+        ncs5500-parser-3.0.0.1-r732.CSCwa44780
+        ncs5500-dpa-fwding-4.1.0.3-r732.CSCwa01375
+        ncs5500-mgbl-3.0.0.0-r732
+        ncs5500-isis-2.1.0.0-r732
+        ncs5500-bgp-2.0.0.1-r732.CSCvz94897
+        ncs5500-mpls-te-rsvp-3.1.0.0-r732
+        ncs5500-infra-5.0.0.5-r732.CSCvu13993
+        ncs5500-ospf-3.0.0.0-r732
+
+Node 0/0/CPU0 [LC]
+  Boot Partition: xr_lv0
+  Active Packages: 18
+        ncs5500-xr-7.3.2 version=7.3.2 [Boot image]
+        ncs5500-eigrp-1.0.0.0-r732
+        ncs5500-k9sec-3.2.0.0-r732
+        ncs5500-mpls-2.1.0.0-r732
+        ncs5500-li-1.0.0.0-r732
+        ncs5500-mgbl-3.0.0.0-r732
+        ncs5500-mpls-te-rsvp-3.1.0.0-r732
+        ncs5500-isis-2.1.0.0-r732
+        ncs5500-ospf-3.0.0.0-r732
+        ncs5500-mcast-3.0.0.0-r732
+        ncs5500-bgp-2.0.0.1-r732.CSCvz94897
+        ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439
+        ncs5500-os-6.0.0.1-r732.CSCvq20498
+        ncs5500-os-support-4.0.0.5-r732.CSCwa01498
+        ncs5500-dpa-3.0.0.5-r732.CSCwa05129
+        ncs5500-parser-3.0.0.1-r732.CSCwa44780
+        ncs5500-infra-5.0.0.5-r732.CSCvu13993
+        ncs5500-dpa-fwding-4.1.0.3-r732.CSCwa01375
+
+Node 0/1/CPU0 [LC]
+  Boot Partition: xr_lv38
+  Active Packages: 18
+        ncs5500-xr-7.3.2 version=7.3.2 [Boot image]
+        ncs5500-dpa-3.0.0.5-r732.CSCwa05129
+        ncs5500-mcast-3.0.0.0-r732
+        ncs5500-mpls-2.1.0.0-r732
+        ncs5500-os-6.0.0.1-r732.CSCvq20498
+        ncs5500-k9sec-3.2.0.0-r732
+        ncs5500-eigrp-1.0.0.0-r732
+        ncs5500-os-support-4.0.0.5-r732.CSCwa01498
+        ncs5500-iosxr-fwding-4.1.0.1-r732.CSCwa34439
+        ncs5500-dpa-fwding-4.1.0.1-r732.CSCwa03269
+        ncs5500-li-1.0.0.0-r732
+        ncs5500-parser-3.0.0.1-r732.CSCwa44780
+        ncs5500-mgbl-3.0.0.0-r732
+        ncs5500-isis-2.1.0.0-r732
+        ncs5500-bgp-2.0.0.1-r732.CSCvz94897
+        ncs5500-mpls-te-rsvp-3.1.0.0-r732
+        ncs5500-infra-5.0.0.5-r732.CSCvu13993
+        ncs5500-ospf-3.0.0.0-r732

--- a/tests/parsers/cisco_iosxr/show_install_active/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_install_active/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "NCS 5500 with multiple RP and LC nodes running IOS-XR 7.3.2"
+platform: "NCS 5500"
+software_version: "IOS-XR 7.3.2"


### PR DESCRIPTION
## Summary
- Add new parser for `show install active` on Cisco IOS-XR
- Parses per-node active package information including software label, node type (RP/LC), boot partition, and package lists
- Uses dict-of-dicts keyed by node location (e.g. `0/RP0/CPU0`)

## Test plan
- [x] Test fixture with real NCS 5500 output (4 nodes: 2 RP, 2 LC, 18 packages each)
- [x] All fixture convention tests pass (no placeholder sentinels, no list-of-dicts, no pipe keys)
- [x] Pre-commit hooks pass (ruff, xenon, JSON formatting)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)