### PR TITLE
feat(cisco_iosxr): add parser for `show interfaces summary`

### DIFF
--- a/changes/+cisco-iosxr-show-interfaces-summary.parser_added
+++ b/changes/+cisco-iosxr-show-interfaces-summary.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interfaces summary` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_interfaces_summary.py
+++ b/src/muninn/parsers/cisco_iosxr/show_interfaces_summary.py
@@ -1,0 +1,113 @@
+"""Parser for 'show interfaces summary' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class InterfaceTypeSummaryEntry(TypedDict):
+    """Schema for a single interface type row in 'show interfaces summary' output."""
+
+    total: int
+    up: int
+    down: int
+    admin_down: int
+
+
+class ShowInterfacesSummaryResult(TypedDict):
+    """Schema for 'show interfaces summary' parsed output.
+
+    Contains an ``all_types`` totals entry and a ``by_type`` dict-of-dicts
+    keyed by the IOS-XR interface type identifier (e.g. ``IFT_ETHERBUNDLE``).
+    """
+
+    all_types: InterfaceTypeSummaryEntry
+    by_type: dict[str, InterfaceTypeSummaryEntry]
+
+
+@register(OS.CISCO_IOSXR, "show interfaces summary")
+class ShowInterfacesSummaryParser(BaseParser[ShowInterfacesSummaryResult]):
+    """Parser for 'show interfaces summary' command on Cisco IOS-XR.
+
+    Parses the tabular interface type summary into structured counts
+    with an overall total and per-type breakdown.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+        }
+    )
+
+    # Matches the "ALL TYPES" aggregate row.
+    _ALL_TYPES_PATTERN = re.compile(
+        r"^\s*ALL\s+TYPES"
+        r"\s+(?P<total>\d+)"
+        r"\s+(?P<up>\d+)"
+        r"\s+(?P<down>\d+)"
+        r"\s+(?P<admin_down>\d+)"
+        r"\s*$",
+        re.IGNORECASE,
+    )
+
+    # Matches individual IFT_* rows (e.g. IFT_ETHERBUNDLE, IFT_TENGETHERNET).
+    _IFT_PATTERN = re.compile(
+        r"^\s*(?P<ift_name>IFT_\S+)"
+        r"\s+(?P<total>\d+)"
+        r"\s+(?P<up>\d+)"
+        r"\s+(?P<down>\d+)"
+        r"\s+(?P<admin_down>\d+)"
+        r"\s*$",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesSummaryResult:
+        """Parse 'show interfaces summary' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed interface summary with overall totals and per-type breakdown.
+
+        Raises:
+            ValueError: If the ALL TYPES aggregate row cannot be found.
+        """
+        all_types: InterfaceTypeSummaryEntry | None = None
+        by_type: dict[str, InterfaceTypeSummaryEntry] = {}
+
+        for line in output.splitlines():
+            all_match = cls._ALL_TYPES_PATTERN.match(line)
+            if all_match:
+                all_types = InterfaceTypeSummaryEntry(
+                    total=int(all_match.group("total")),
+                    up=int(all_match.group("up")),
+                    down=int(all_match.group("down")),
+                    admin_down=int(all_match.group("admin_down")),
+                )
+                continue
+
+            ift_match = cls._IFT_PATTERN.match(line)
+            if ift_match:
+                name = ift_match.group("ift_name")
+                entry = InterfaceTypeSummaryEntry(
+                    total=int(ift_match.group("total")),
+                    up=int(ift_match.group("up")),
+                    down=int(ift_match.group("down")),
+                    admin_down=int(ift_match.group("admin_down")),
+                )
+                by_type[name] = entry
+
+        if all_types is None:
+            msg = "No ALL TYPES summary row found in output"
+            raise ValueError(msg)
+
+        return ShowInterfacesSummaryResult(
+            all_types=all_types,
+            by_type=by_type,
+        )

--- a/tests/parsers/cisco_iosxr/show_interfaces_summary/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_interfaces_summary/001_basic/expected.json
@@ -1,0 +1,46 @@
+{
+    "all_types": {
+        "total": 81,
+        "up": 51,
+        "down": 0,
+        "admin_down": 30
+    },
+    "by_type": {
+        "IFT_ETHERBUNDLE": {
+            "total": 11,
+            "up": 11,
+            "down": 0,
+            "admin_down": 0
+        },
+        "IFT_HUNDREDGE": {
+            "total": 26,
+            "up": 2,
+            "down": 0,
+            "admin_down": 24
+        },
+        "IFT_LOOPBACK": {
+            "total": 1,
+            "up": 1,
+            "down": 0,
+            "admin_down": 0
+        },
+        "IFT_ETHERNET": {
+            "total": 2,
+            "up": 0,
+            "down": 0,
+            "admin_down": 2
+        },
+        "IFT_NULL": {
+            "total": 1,
+            "up": 1,
+            "down": 0,
+            "admin_down": 0
+        },
+        "IFT_TENGETHERNET": {
+            "total": 40,
+            "up": 36,
+            "down": 0,
+            "admin_down": 4
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_interfaces_summary/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_interfaces_summary/001_basic/input.txt
@@ -1,0 +1,10 @@
+Interface Type          Total    UP       Down     Admin Down
+--------------          -----    --       ----     ----------
+ALL TYPES               81       51       0        30
+--------------
+IFT_ETHERBUNDLE         11       11       0        0
+IFT_HUNDREDGE           26       2        0        24
+IFT_LOOPBACK            1        1        0        0
+IFT_ETHERNET            2        0        0        2
+IFT_NULL                1        1        0        0
+IFT_TENGETHERNET        40       36       0        4

--- a/tests/parsers/cisco_iosxr/show_interfaces_summary/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_interfaces_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Interface type summary with Bundle-Ether, HundredGigE, Loopback, Ethernet, Null, and TenGigE types"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add parser for `show interfaces summary` on Cisco IOS-XR
- Parses interface type summary table into structured counts: overall ALL TYPES totals and per-type (IFT_*) breakdown with total/up/down/admin_down counters
- Includes test fixture from real device output

## Test plan
- [x] Parser test passes: `uv run pytest tests/parsers/test_parsers.py -k "show_interfaces_summary" -v`
- [x] Placeholder sentinel tests pass: `uv run pytest tests/parsers/test_fixture_placeholder_sentinels.py -k "show_interfaces_summary" -v`
- [x] Ruff lint and format clean
- [x] Xenon complexity check passes (max-absolute B, max-modules B, max-average A)
- [x] Bandit security scan clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)