### PR TITLE
feat(cisco_iosxr): add parser for `show logging`

### DIFF
--- a/changes/+cisco-iosxr-show-logging.parser_added
+++ b/changes/+cisco-iosxr-show-logging.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show logging` on Cisco IOS-XR. Parses syslog configuration (console, monitor, trap, buffer levels and counts) and log buffer entries.

--- a/src/muninn/parsers/cisco_iosxr/show_logging.py
+++ b/src/muninn/parsers/cisco_iosxr/show_logging.py
@@ -1,0 +1,201 @@
+"""Parser for 'show logging' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class LogEntry(TypedDict):
+    """Schema for a single syslog message entry."""
+
+    node: str
+    timestamp: str
+    process: str
+    pid: int
+    message: str
+
+
+class ShowLoggingResult(TypedDict):
+    """Schema for 'show logging' parsed output on IOS-XR."""
+
+    # Global syslog state
+    syslog_logging_enabled: bool
+    messages_dropped: int
+    flushes: int
+    overruns: int
+
+    # Console logging
+    console_logging_enabled: bool
+    console_logging_level: NotRequired[str]
+    console_logging_messages_logged: NotRequired[int]
+
+    # Monitor logging
+    monitor_logging_level: str
+    monitor_logging_messages_logged: int
+
+    # Trap logging
+    trap_logging_level: str
+    trap_logging_messages_logged: int
+
+    # Buffer logging
+    buffer_logging_level: str
+    buffer_logging_messages_logged: int
+    buffer_size_bytes: int
+
+    # Log entries from the buffer
+    log_entries: list[LogEntry]
+
+
+@register(OS.CISCO_IOSXR, "show logging")
+class ShowLoggingParser(BaseParser[ShowLoggingResult]):
+    """Parser for 'show logging' command on Cisco IOS-XR.
+
+    Parses logging configuration (console, monitor, trap, buffer levels)
+    and syslog message entries from the log buffer.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.LOGGING})
+
+    # Syslog logging: enabled (0 messages dropped, 0 flushes, 0 overruns)
+    _SYSLOG_STATUS = re.compile(
+        r"Syslog logging:\s+(?P<state>\S+)\s+"
+        r"\((?P<dropped>\d+)\s+messages?\s+dropped,\s+"
+        r"(?P<flushes>\d+)\s+flushes?,\s+"
+        r"(?P<overruns>\d+)\s+overruns?\)",
+    )
+
+    # Console logging: Disabled
+    # Console logging: level warnings, 42 messages logged
+    _CONSOLE_LOGGING = re.compile(
+        r"Console logging:\s+"
+        r"(?:(?P<disabled>Disabled)|level\s+(?P<level>\S+),\s+"
+        r"(?P<count>\d+)\s+messages?\s+logged)",
+        re.I,
+    )
+
+    # Monitor logging: level debugging, 0 messages logged
+    _MONITOR_LOGGING = re.compile(
+        r"Monitor logging:\s+level\s+(?P<level>\S+),\s+"
+        r"(?P<count>\d+)\s+messages?\s+logged",
+        re.I,
+    )
+
+    # Trap logging: level informational, 0 messages logged
+    _TRAP_LOGGING = re.compile(
+        r"Trap logging:\s+level\s+(?P<level>\S+),\s+"
+        r"(?P<count>\d+)\s+messages?\s+logged",
+        re.I,
+    )
+
+    # Buffer logging: level debugging, 114 messages logged
+    _BUFFER_LOGGING = re.compile(
+        r"Buffer logging:\s+level\s+(?P<level>\S+),\s+"
+        r"(?P<count>\d+)\s+messages?\s+logged",
+        re.I,
+    )
+
+    # Log Buffer (2097152 bytes):
+    _BUFFER_SIZE = re.compile(
+        r"Log Buffer\s+\((?P<size>\d+)\s+bytes\)",
+    )
+
+    # Log entry: RP/0/RP0/CPU0:Sep 25 23:24:28.852 UTC: spp[113]: message text
+    # Also handles admin node format: 0/RP0/ADMIN0:Sep 25 ...
+    _LOG_ENTRY = re.compile(
+        r"^(?P<node>\S+?):(?P<timestamp>\w+\s+\d+\s+[\d:.]+\s+\S+):\s+"
+        r"(?P<process>[^\[]+)\[(?P<pid>\d+)\]:\s+(?P<message>.+)$",
+    )
+
+    @classmethod
+    def _parse_config_line(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse logging config lines (syslog, console, monitor, trap, buffer)."""
+        if match := cls._SYSLOG_STATUS.search(line):
+            result["syslog_logging_enabled"] = match.group("state").lower() == "enabled"
+            result["messages_dropped"] = int(match.group("dropped"))
+            result["flushes"] = int(match.group("flushes"))
+            result["overruns"] = int(match.group("overruns"))
+            return True
+
+        if match := cls._CONSOLE_LOGGING.search(line):
+            if match.group("disabled"):
+                result["console_logging_enabled"] = False
+            else:
+                result["console_logging_enabled"] = True
+                result["console_logging_level"] = match.group("level")
+                result["console_logging_messages_logged"] = int(match.group("count"))
+            return True
+
+        if match := cls._MONITOR_LOGGING.search(line):
+            result["monitor_logging_level"] = match.group("level")
+            result["monitor_logging_messages_logged"] = int(match.group("count"))
+            return True
+
+        if match := cls._TRAP_LOGGING.search(line):
+            result["trap_logging_level"] = match.group("level")
+            result["trap_logging_messages_logged"] = int(match.group("count"))
+            return True
+
+        if match := cls._BUFFER_LOGGING.search(line):
+            result["buffer_logging_level"] = match.group("level")
+            result["buffer_logging_messages_logged"] = int(match.group("count"))
+            return True
+
+        if match := cls._BUFFER_SIZE.search(line):
+            result["buffer_size_bytes"] = int(match.group("size"))
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_log_entry(cls, line: str) -> LogEntry | None:
+        """Parse a single syslog buffer entry line, returning None if not matched."""
+        if match := cls._LOG_ENTRY.match(line):
+            return LogEntry(
+                node=match.group("node"),
+                timestamp=match.group("timestamp"),
+                process=match.group("process"),
+                pid=int(match.group("pid")),
+                message=match.group("message"),
+            )
+        return None
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLoggingResult:
+        """Parse 'show logging' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed logging configuration and log entries.
+
+        Raises:
+            ValueError: If required syslog status line cannot be parsed.
+        """
+        result: dict[str, object] = {}
+        log_entries: list[LogEntry] = []
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if cls._parse_config_line(stripped, result):
+                continue
+
+            entry = cls._parse_log_entry(stripped)
+            if entry is not None:
+                log_entries.append(entry)
+
+        # Validate required fields
+        if "syslog_logging_enabled" not in result:
+            msg = "Could not parse syslog logging status from output"
+            raise ValueError(msg)
+
+        result["log_entries"] = log_entries
+
+        return result  # type: ignore[return-value]

--- a/src/muninn/parsers/cisco_iosxr/show_logging.py
+++ b/src/muninn/parsers/cisco_iosxr/show_logging.py
@@ -1,7 +1,7 @@
 """Parser for 'show logging' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -198,4 +198,4 @@ class ShowLoggingParser(BaseParser[ShowLoggingResult]):
 
         result["log_entries"] = log_entries
 
-        return result  # type: ignore[return-value]
+        return cast(ShowLoggingResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_logging.py
+++ b/src/muninn/parsers/cisco_iosxr/show_logging.py
@@ -34,17 +34,17 @@ class ShowLoggingResult(TypedDict):
     console_logging_messages_logged: NotRequired[int]
 
     # Monitor logging
-    monitor_logging_level: str
-    monitor_logging_messages_logged: int
+    monitor_logging_level: NotRequired[str]
+    monitor_logging_messages_logged: NotRequired[int]
 
     # Trap logging
-    trap_logging_level: str
-    trap_logging_messages_logged: int
+    trap_logging_level: NotRequired[str]
+    trap_logging_messages_logged: NotRequired[int]
 
     # Buffer logging
-    buffer_logging_level: str
-    buffer_logging_messages_logged: int
-    buffer_size_bytes: int
+    buffer_logging_level: NotRequired[str]
+    buffer_logging_messages_logged: NotRequired[int]
+    buffer_size_bytes: NotRequired[int]
 
     # Log entries from the buffer
     log_entries: list[LogEntry]

--- a/tests/parsers/cisco_iosxr/show_logging/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_logging/001_basic/expected.json
@@ -1,0 +1,814 @@
+{
+    "syslog_logging_enabled": true,
+    "messages_dropped": 0,
+    "flushes": 0,
+    "overruns": 0,
+    "console_logging_enabled": false,
+    "monitor_logging_level": "debugging",
+    "monitor_logging_messages_logged": 0,
+    "trap_logging_level": "informational",
+    "trap_logging_messages_logged": 0,
+    "buffer_logging_level": "debugging",
+    "buffer_logging_messages_logged": 114,
+    "buffer_size_bytes": 2097152,
+    "log_entries": [
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.852 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Initialized socket RX node"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.852 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Initialized socket TX node"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.852 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Registered socket plugin"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.929 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Initialized punt classification node"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.929 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Initialized client inject node"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.930 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Registered XRv9k SPP plugin"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.932 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Opened UDP socket at 172.16.4.1:9920 (Punt/Inject crucial)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.932 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Opened UDP socket at 172.16.4.1:9921 (Punt/Inject high)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.932 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Opened UDP socket at 172.16.4.1:9922 (Punt/Inject medium)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.932 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Opened UDP socket at 172.16.4.1:9923 (Punt/Inject low)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.939 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Opened raw socket on eth0 (Management)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:28.939 UTC",
+            "process": "spp",
+            "pid": 113,
+            "message": "Successfully initialized socket devices"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:29.114 UTC",
+            "process": "syslogd",
+            "pid": 342,
+            "message": "%SECURITY-XR_SSL-6-INFO : XR SSL info: Setting fips register"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Pakman memory region 0x10000000 .. 0x18000000, size 128Mb (32 scale)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 64000 particle of size 256"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 32000 particle of size 512"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 16000 particle of size 768"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 8000 particle of size 1648"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 3200 particle of size 2560"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 3200 particle of size 4608"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 960 particle of size 6240"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:31.124 UTC",
+            "process": "platform_packet_partner",
+            "pid": 173,
+            "message": "Creating 1600 particle of size 512"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:48.161 UTC",
+            "process": "netio",
+            "pid": 202,
+            "message": "FINT (IFH 00000010) interface specification received"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:48.161 UTC",
+            "process": "netio",
+            "pid": 202,
+            "message": "Attached to IFH 00000010 IDB (FINT0_RP0_CPU0)"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:51.562 UTC",
+            "process": "fib_mgr",
+            "pid": 364,
+            "message": "RC for sysdb_bind wrt \"/cfg/gl/pdcef/lba/hash/fields/mpls/\" is 0x0"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:51.564 UTC",
+            "process": "fib_mgr",
+            "pid": 364,
+            "message": "RC for sysdb_register_notification wrt \"mpls_entropy-label\" is 0x0"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:51.566 UTC",
+            "process": "fib_mgr",
+            "pid": 364,
+            "message": "RC for sysdb_register_verification wrt \"mpls_entropy-label\" is 0x0"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:51.572 UTC",
+            "process": "fib_mgr",
+            "pid": 364,
+            "message": "ss_fib_plat_cfg_hash_fields_ipv6_flow_label_register - sysdb_bind for /cfg/gl/pdcef/lba/hash/fields/ipv6/ succeeded. rc: 0x0"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:54.958 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "debug_register per_flow successful"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:55.044 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:55.044 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:57.134 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:24:57.625 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:02.828 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:04.832 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:09.253 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:09.253 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:10.057 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:10.057 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:11.091 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "debug_register per_flow successful"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:18.815 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "debug_register per_flow successful"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:19.020 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:19.020 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:20.470 UTC",
+            "process": "cepki",
+            "pid": 363,
+            "message": "%SECURITY-PKI-6-LOG_INFO_DETAIL : FIPS POST Successful for  cepki"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:22.669 UTC",
+            "process": "PPP-MA",
+            "pid": 406,
+            "message": "debug_register per_flow successful"
+        },
+        {
+            "node": "0/RP0/ADMIN0",
+            "timestamp": "Sep 25 23:25:25.856 UTC",
+            "process": "wd_diskmon",
+            "pid": 3204,
+            "message": "%INFRA-WD_DISKMON_SYSADMIN-4-DISK_WARN : Sysadmin: Device: /var/log Usage %: 84 , State: MINOR, MINOR Threshold %: 80"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:28.866 UTC",
+            "process": "ipsec_mp",
+            "pid": 385,
+            "message": "%SECURITY-IMP-6-PROC_READY : Process ipsec_mp is ready"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:29.370 UTC",
+            "process": "pim6",
+            "pid": 1254,
+            "message": "%ROUTING-IPV4_PIM-5-HA_NOTICE : NSR not ready"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:30.045 UTC",
+            "process": "cepki",
+            "pid": 363,
+            "message": "%SECURITY-CEPKI-6-KEY_INFO : One or more host keypairs exist. Not auto-generating keypairs."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:31.533 UTC",
+            "process": "kim",
+            "pid": 213,
+            "message": "%INFRA-KIM-6-LOG_INFO : XR statistics will be pushed into the Linux kernel at 1 second intervals"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:32.821 UTC",
+            "process": "smartlicserver",
+            "pid": 186,
+            "message": "SMART_LIC-6-EXPORT_CONTROLLED:Usage of export controlled features is not allowed"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:34.886 UTC",
+            "process": "smartlicserver",
+            "pid": 186,
+            "message": "SMART_LIC-6-AGENT_READY:Smart Agent for Licensing is initialized"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:34.886 UTC",
+            "process": "smartlicserver",
+            "pid": 186,
+            "message": "SMART_LIC-6-AGENT_ENABLED:Smart Agent for Licensing is enabled"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:34.995 UTC",
+            "process": "smartlicserver",
+            "pid": 186,
+            "message": "SMART_LIC-6-EXPORT_CONTROLLED:Usage of export controlled features is not allowed"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:35.161 UTC",
+            "process": "plat_sl_client",
+            "pid": 344,
+            "message": "%LICENSE-PLAT_CLIENT-6-STATE_CHANGE : Licensing platform state changing from UNKNOWN to UNREGISTERED"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:43.320 UTC",
+            "process": "pim",
+            "pid": 1253,
+            "message": "%ROUTING-IPV4_PIM-5-HA_NOTICE : NSR not ready"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:25:48.725 UTC",
+            "process": "syslog_dev",
+            "pid": 119,
+            "message": "attestation_agent[1273] PID-4484: attestation_agent: no process found"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:02.458 UTC",
+            "process": "ospfv3",
+            "pid": 1046,
+            "message": "%ROUTING-OSPFv3-5-HA_NOTICE_START : Starting OSPFv3"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:03.920 UTC",
+            "process": "ospfv3",
+            "pid": 1046,
+            "message": "%ROUTING-OSPFv3-5-HA_NOTICE : Process 1: OSPFv3 process initialization complete"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:04.009 UTC",
+            "process": "ospfv3",
+            "pid": 1046,
+            "message": "%ROUTING-OSPFv3-5-HA_NOTICE : Process 1: Signaled PROC_AVAILABLE"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:04.166 UTC",
+            "process": "ospf",
+            "pid": 1027,
+            "message": "%ROUTING-OSPF-5-HA_NOTICE_START : Starting OSPF"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:04.614 UTC",
+            "process": "isis",
+            "pid": 1012,
+            "message": "%ROUTING-ISIS-5-NSR_PM_ROLE_CHG : ISIS NSR PM role change, reg-type 0, HA-role: , 1"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:04.809 UTC",
+            "process": "isis",
+            "pid": 1011,
+            "message": "%ROUTING-ISIS-5-NSR_PM_ROLE_CHG : ISIS NSR PM role change, reg-type 0, HA-role: , 1"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:06.241 UTC",
+            "process": "isis",
+            "pid": 1012,
+            "message": "%ROUTING-ISIS-6-INFO_STARTUP_START : Cold controlled start beginning"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:06.246 UTC",
+            "process": "ospf",
+            "pid": 1027,
+            "message": "%ROUTING-OSPF-6-HA_INFO : Process 1: OSPF process initialization complete"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:06.443 UTC",
+            "process": "ospf",
+            "pid": 1027,
+            "message": "%ROUTING-OSPF-5-HA_NOTICE : Process 1: Signaled PROC_AVAILABLE"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:06.543 UTC",
+            "process": "isis",
+            "pid": 1011,
+            "message": "%ROUTING-ISIS-6-INFO_STARTUP_START : Cold controlled start beginning"
+        },
+        {
+            "node": "0/RP0/ADMIN0",
+            "timestamp": "Sep 25 23:26:10.603 UTC",
+            "process": "aaad",
+            "pid": 3149,
+            "message": "%MGBL-AAAD-7-DEBUG :  Not allowing to sync from XR VM to Admin VM after first user creation."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:14.008 UTC",
+            "process": "emsd",
+            "pid": 1114,
+            "message": "%MGBL-EMS-6-EMSD_SERVICE_START : emsd service start"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:14.008 UTC",
+            "process": "emsd",
+            "pid": 1114,
+            "message": "gRPC is secure with TLS"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:15.539 UTC",
+            "process": "bpm",
+            "pid": 1093,
+            "message": "%ROUTING-BGP-5-ASYNC_IPC_STATUS : bpm-active:(bgp-bpm-active)inst-id 0, Service Published"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:15.803 UTC",
+            "process": "exec",
+            "pid": 67271,
+            "message": "%MGBL-exec-3-LOGIN_AUTHEN : Login Authentication failed. Exiting..."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.761 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.761 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.761 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.761 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.762 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.762 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.764 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.764 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:17.764 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:18.198 UTC",
+            "process": "ifmgr",
+            "pid": 189,
+            "message": "%PKT_INFRA-LINK-3-UPDOWN : Interface MgmtEth0/RP0/CPU0/0, changed state to Down"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:18.198 UTC",
+            "process": "ifmgr",
+            "pid": 189,
+            "message": "%PKT_INFRA-LINEPROTO-5-UPDOWN : Line protocol on Interface MgmtEth0/RP0/CPU0/0, changed state to Down"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:18.202 UTC",
+            "process": "cfgmgr-rp",
+            "pid": 247,
+            "message": "%MGBL-CONFIG-6-OIR_RESTORE : Configuration for node '0/RP0/CPU0' has been restored."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:18.276 UTC",
+            "process": "ifmgr",
+            "pid": 189,
+            "message": "%PKT_INFRA-LINK-3-UPDOWN : Interface MgmtEth0/RP0/CPU0/0, changed state to Up"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:18.278 UTC",
+            "process": "ifmgr",
+            "pid": 189,
+            "message": "%PKT_INFRA-LINEPROTO-5-UPDOWN : Line protocol on Interface MgmtEth0/RP0/CPU0/0, changed state to Up"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:18.594 UTC",
+            "process": "smartlicserver",
+            "pid": 186,
+            "message": "SMART_LIC-6-EXPORT_CONTROLLED:Usage of export controlled features is not allowed"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:19.268 UTC",
+            "process": "bpm",
+            "pid": 1093,
+            "message": "%ROUTING-BGP-5-ASYNC_IPC_STATUS : bpm-default:(A)inst-id 0, Connection Open"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:19.674 UTC",
+            "process": "bgp",
+            "pid": 1078,
+            "message": "%ROUTING-BGP-5-ASYNC_IPC_STATUS : default, process instance 1:(A)inst-id 0, Connection Establised"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:19.822 UTC",
+            "process": "pppoe_ma",
+            "pid": 217,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:19.822 UTC",
+            "process": "ipsub_ma",
+            "pid": 169,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:19.822 UTC",
+            "process": "iedged",
+            "pid": 409,
+            "message": "%SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available]."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:20.264 UTC",
+            "process": "bgp",
+            "pid": 1078,
+            "message": "%ROUTING-BGP-5-ASYNC_IPC_STATUS : default:(A)inst-id 0, Initial Config Done"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:22.016 UTC",
+            "process": "isis",
+            "pid": 1011,
+            "message": "%ROUTING-ISIS-6-INFO_STARTUP_FINISH : Cold controlled start completed"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:23.522 UTC",
+            "process": "isis",
+            "pid": 1012,
+            "message": "%ROUTING-ISIS-6-INFO_STARTUP_FINISH : Cold controlled start completed"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:46.668 UTC",
+            "process": "syslog_dev",
+            "pid": 119,
+            "message": "ztp[133] PID-4191: ZTP will now run in the background."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:46.668 UTC",
+            "process": "syslog_dev",
+            "pid": 119,
+            "message": "ztp[133] PID-4191: ZTP might bring up the interfaces if they are in shutdown state."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:46.668 UTC",
+            "process": "syslog_dev",
+            "pid": 119,
+            "message": "ztp[133] PID-4191: Please use \"show logging\" or look at /var/log/ztp.log to check progress."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:26:46.790 UTC",
+            "process": "ZTP",
+            "pid": 67506,
+            "message": "%OS-SYSLOG-6-LOG_INFO : ZTP running in background"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:27:17.623 UTC",
+            "process": "exec",
+            "pid": 67679,
+            "message": "%SECURITY-LOGIN-6-AUTHEN_SUCCESS : Successfully authenticated user 'admin' from 'console' on 'con0_RP0_CPU0'"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:27:22.691 UTC",
+            "process": "config",
+            "pid": 67726,
+            "message": "%MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000024' to view the changes."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:27:22.997 UTC",
+            "process": "config",
+            "pid": 67726,
+            "message": "%MGBL-SYS-5-CONFIG_I : Configured from console by admin"
+        },
+        {
+            "node": "0/RP0/ADMIN0",
+            "timestamp": "Sep 25 23:27:53.784 UTC",
+            "process": "dumper",
+            "pid": 3156,
+            "message": "%INFRA-CALVADOS_DUMPER-6-HOST_COPY_SUCCESS : Copied host file /misc/scratch/core/default-sdr--1.20200925-232222.core.RP.lxcdump.tar.lz4 to 0/RP0:/misc/disk1"
+        },
+        {
+            "node": "0/RP0/ADMIN0",
+            "timestamp": "Sep 25 23:27:53.892 UTC",
+            "process": "dumper",
+            "pid": 3156,
+            "message": "%INFRA-CALVADOS_DUMPER-6-HOST_REMV_SUCCESS : Deleted HostOS file /misc/scratch/core/default-sdr--1.20200925-232222.core.RP.lxcdump.tar.lz4"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:28:57.463 UTC",
+            "process": "config",
+            "pid": 68848,
+            "message": "%MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000025' to view the changes."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:28:57.781 UTC",
+            "process": "config",
+            "pid": 68848,
+            "message": "%MGBL-SYS-5-CONFIG_I : Configured from console by admin"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:30:54.216 UTC",
+            "process": "config",
+            "pid": 69226,
+            "message": "%MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000026' to view the changes."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:30:54.587 UTC",
+            "process": "config",
+            "pid": 69226,
+            "message": "%MGBL-SYS-5-CONFIG_I : Configured from console by admin"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:31:34.897 UTC",
+            "process": "config",
+            "pid": 69352,
+            "message": "%MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000027' to view the changes."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:31:35.276 UTC",
+            "process": "config",
+            "pid": 69352,
+            "message": "%MGBL-SYS-5-CONFIG_I : Configured from console by admin"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:32:59.081 UTC",
+            "process": "config",
+            "pid": 69570,
+            "message": "%MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000028' to view the changes."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:32:59.395 UTC",
+            "process": "config",
+            "pid": 69570,
+            "message": "%MGBL-SYS-5-CONFIG_I : Configured from console by admin"
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:34:19.268 UTC",
+            "process": "config",
+            "pid": 65700,
+            "message": "%MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000029' to view the changes."
+        },
+        {
+            "node": "RP/0/RP0/CPU0",
+            "timestamp": "Sep 25 23:34:19.600 UTC",
+            "process": "config",
+            "pid": 65700,
+            "message": "%MGBL-SYS-5-CONFIG_I : Configured from console by admin"
+        }
+    ]
+}

--- a/tests/parsers/cisco_iosxr/show_logging/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_logging/001_basic/input.txt
@@ -1,0 +1,125 @@
+
+Fri Sep 25 23:34:26.169 UTC
+Syslog logging: enabled (0 messages dropped, 0 flushes, 0 overruns)
+    Console logging: Disabled
+    Monitor logging: level debugging, 0 messages logged
+    Trap logging: level informational, 0 messages logged
+    Buffer logging: level debugging, 114 messages logged
+
+Log Buffer (2097152 bytes):
+
+RP/0/RP0/CPU0:Sep 25 23:24:28.852 UTC: spp[113]: Initialized socket RX node
+RP/0/RP0/CPU0:Sep 25 23:24:28.852 UTC: spp[113]: Initialized socket TX node
+RP/0/RP0/CPU0:Sep 25 23:24:28.852 UTC: spp[113]: Registered socket plugin
+RP/0/RP0/CPU0:Sep 25 23:24:28.929 UTC: spp[113]: Initialized punt classification node
+RP/0/RP0/CPU0:Sep 25 23:24:28.929 UTC: spp[113]: Initialized client inject node
+RP/0/RP0/CPU0:Sep 25 23:24:28.930 UTC: spp[113]: Registered XRv9k SPP plugin
+RP/0/RP0/CPU0:Sep 25 23:24:28.932 UTC: spp[113]: Opened UDP socket at 172.16.4.1:9920 (Punt/Inject crucial)
+RP/0/RP0/CPU0:Sep 25 23:24:28.932 UTC: spp[113]: Opened UDP socket at 172.16.4.1:9921 (Punt/Inject high)
+RP/0/RP0/CPU0:Sep 25 23:24:28.932 UTC: spp[113]: Opened UDP socket at 172.16.4.1:9922 (Punt/Inject medium)
+RP/0/RP0/CPU0:Sep 25 23:24:28.932 UTC: spp[113]: Opened UDP socket at 172.16.4.1:9923 (Punt/Inject low)
+RP/0/RP0/CPU0:Sep 25 23:24:28.939 UTC: spp[113]: Opened raw socket on eth0 (Management)
+RP/0/RP0/CPU0:Sep 25 23:24:28.939 UTC: spp[113]: Successfully initialized socket devices
+RP/0/RP0/CPU0:Sep 25 23:24:29.114 UTC: syslogd[342]: %SECURITY-XR_SSL-6-INFO : XR SSL info: Setting fips register
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Pakman memory region 0x10000000 .. 0x18000000, size 128Mb (32 scale)
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 64000 particle of size 256
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 32000 particle of size 512
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 16000 particle of size 768
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 8000 particle of size 1648
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 3200 particle of size 2560
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 3200 particle of size 4608
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 960 particle of size 6240
+RP/0/RP0/CPU0:Sep 25 23:24:31.124 UTC: platform_packet_partner[173]: Creating 1600 particle of size 512
+RP/0/RP0/CPU0:Sep 25 23:24:48.161 UTC: netio[202]: FINT (IFH 00000010) interface specification received
+RP/0/RP0/CPU0:Sep 25 23:24:48.161 UTC: netio[202]: Attached to IFH 00000010 IDB (FINT0_RP0_CPU0)
+RP/0/RP0/CPU0:Sep 25 23:24:51.562 UTC: fib_mgr[364]: RC for sysdb_bind wrt "/cfg/gl/pdcef/lba/hash/fields/mpls/" is 0x0
+RP/0/RP0/CPU0:Sep 25 23:24:51.564 UTC: fib_mgr[364]: RC for sysdb_register_notification wrt "mpls_entropy-label" is 0x0
+RP/0/RP0/CPU0:Sep 25 23:24:51.566 UTC: fib_mgr[364]: RC for sysdb_register_verification wrt "mpls_entropy-label" is 0x0
+RP/0/RP0/CPU0:Sep 25 23:24:51.572 UTC: fib_mgr[364]: ss_fib_plat_cfg_hash_fields_ipv6_flow_label_register - sysdb_bind for /cfg/gl/pdcef/lba/hash/fields/ipv6/ succeeded. rc: 0x0
+RP/0/RP0/CPU0:Sep 25 23:24:54.958 UTC: iedged[409]: debug_register per_flow successful
+RP/0/RP0/CPU0:Sep 25 23:24:55.044 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:24:55.044 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:24:57.134 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:24:57.625 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:25:02.828 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:04.832 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:25:09.253 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:09.253 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:10.057 UTC: ipsub_ma[169]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:10.057 UTC: ipsub_ma[169]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:11.091 UTC: ipsub_ma[169]: debug_register per_flow successful
+RP/0/RP0/CPU0:Sep 25 23:25:18.815 UTC: pppoe_ma[217]: debug_register per_flow successful
+RP/0/RP0/CPU0:Sep 25 23:25:19.020 UTC: pppoe_ma[217]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V4 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:19.020 UTC: pppoe_ma[217]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:25:20.470 UTC: cepki[363]: %SECURITY-PKI-6-LOG_INFO_DETAIL : FIPS POST Successful for  cepki
+RP/0/RP0/CPU0:Sep 25 23:25:22.669 UTC: PPP-MA[406]: debug_register per_flow successful
+0/RP0/ADMIN0:Sep 25 23:25:25.856 UTC: wd_diskmon[3204]: %INFRA-WD_DISKMON_SYSADMIN-4-DISK_WARN : Sysadmin: Device: /var/log Usage %: 84 , State: MINOR, MINOR Threshold %: 80
+RP/0/RP0/CPU0:Sep 25 23:25:28.866 UTC: ipsec_mp[385]: %SECURITY-IMP-6-PROC_READY : Process ipsec_mp is ready
+RP/0/RP0/CPU0:Sep 25 23:25:29.370 UTC: pim6[1254]: %ROUTING-IPV4_PIM-5-HA_NOTICE : NSR not ready
+RP/0/RP0/CPU0:Sep 25 23:25:30.045 UTC: cepki[363]: %SECURITY-CEPKI-6-KEY_INFO : One or more host keypairs exist. Not auto-generating keypairs.
+RP/0/RP0/CPU0:Sep 25 23:25:31.533 UTC: kim[213]: %INFRA-KIM-6-LOG_INFO : XR statistics will be pushed into the Linux kernel at 1 second intervals
+RP/0/RP0/CPU0:Sep 25 23:25:32.821 UTC: smartlicserver[186]: SMART_LIC-6-EXPORT_CONTROLLED:Usage of export controlled features is not allowed
+RP/0/RP0/CPU0:Sep 25 23:25:34.886 UTC: smartlicserver[186]: SMART_LIC-6-AGENT_READY:Smart Agent for Licensing is initialized
+RP/0/RP0/CPU0:Sep 25 23:25:34.886 UTC: smartlicserver[186]: SMART_LIC-6-AGENT_ENABLED:Smart Agent for Licensing is enabled
+RP/0/RP0/CPU0:Sep 25 23:25:34.995 UTC: smartlicserver[186]: SMART_LIC-6-EXPORT_CONTROLLED:Usage of export controlled features is not allowed
+RP/0/RP0/CPU0:Sep 25 23:25:35.161 UTC: plat_sl_client[344]: %LICENSE-PLAT_CLIENT-6-STATE_CHANGE : Licensing platform state changing from UNKNOWN to UNREGISTERED
+RP/0/RP0/CPU0:Sep 25 23:25:43.320 UTC: pim[1253]: %ROUTING-IPV4_PIM-5-HA_NOTICE : NSR not ready
+RP/0/RP0/CPU0:Sep 25 23:25:48.725 UTC: syslog_dev[119]: attestation_agent[1273] PID-4484: attestation_agent: no process found
+RP/0/RP0/CPU0:Sep 25 23:26:02.458 UTC: ospfv3[1046]: %ROUTING-OSPFv3-5-HA_NOTICE_START : Starting OSPFv3
+RP/0/RP0/CPU0:Sep 25 23:26:03.920 UTC: ospfv3[1046]: %ROUTING-OSPFv3-5-HA_NOTICE : Process 1: OSPFv3 process initialization complete
+RP/0/RP0/CPU0:Sep 25 23:26:04.009 UTC: ospfv3[1046]: %ROUTING-OSPFv3-5-HA_NOTICE : Process 1: Signaled PROC_AVAILABLE
+RP/0/RP0/CPU0:Sep 25 23:26:04.166 UTC: ospf[1027]: %ROUTING-OSPF-5-HA_NOTICE_START : Starting OSPF
+RP/0/RP0/CPU0:Sep 25 23:26:04.614 UTC: isis[1012]: %ROUTING-ISIS-5-NSR_PM_ROLE_CHG : ISIS NSR PM role change, reg-type 0, HA-role: , 1
+RP/0/RP0/CPU0:Sep 25 23:26:04.809 UTC: isis[1011]: %ROUTING-ISIS-5-NSR_PM_ROLE_CHG : ISIS NSR PM role change, reg-type 0, HA-role: , 1
+RP/0/RP0/CPU0:Sep 25 23:26:06.241 UTC: isis[1012]: %ROUTING-ISIS-6-INFO_STARTUP_START : Cold controlled start beginning
+RP/0/RP0/CPU0:Sep 25 23:26:06.246 UTC: ospf[1027]: %ROUTING-OSPF-6-HA_INFO : Process 1: OSPF process initialization complete
+RP/0/RP0/CPU0:Sep 25 23:26:06.443 UTC: ospf[1027]: %ROUTING-OSPF-5-HA_NOTICE : Process 1: Signaled PROC_AVAILABLE
+RP/0/RP0/CPU0:Sep 25 23:26:06.543 UTC: isis[1011]: %ROUTING-ISIS-6-INFO_STARTUP_START : Cold controlled start beginning
+0/RP0/ADMIN0:Sep 25 23:26:10.603 UTC: aaad[3149]: %MGBL-AAAD-7-DEBUG :  Not allowing to sync from XR VM to Admin VM after first user creation.
+RP/0/RP0/CPU0:Sep 25 23:26:14.008 UTC: emsd[1114]: %MGBL-EMS-6-EMSD_SERVICE_START : emsd service start
+RP/0/RP0/CPU0:Sep 25 23:26:14.008 UTC: emsd[1114]: gRPC is secure with TLS
+RP/0/RP0/CPU0:Sep 25 23:26:15.539 UTC: bpm[1093]: %ROUTING-BGP-5-ASYNC_IPC_STATUS : bpm-active:(bgp-bpm-active)inst-id 0, Service Published
+RP/0/RP0/CPU0:Sep 25 23:26:15.803 UTC: exec[67271]: %MGBL-exec-3-LOGIN_AUTHEN : Login Authentication failed. Exiting...
+RP/0/RP0/CPU0:Sep 25 23:26:17.761 UTC: pppoe_ma[217]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:17.761 UTC: pppoe_ma[217]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:17.761 UTC: ipsub_ma[169]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:17.761 UTC: ipsub_ma[169]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:17.762 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V4 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:17.762 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:17.764 UTC: ipsub_ma[169]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:26:17.764 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:26:17.764 UTC: pppoe_ma[217]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is not ready. Reason: [V6 Subscriber infra process(es) is unavailable].
+RP/0/RP0/CPU0:Sep 25 23:26:18.198 UTC: ifmgr[189]: %PKT_INFRA-LINK-3-UPDOWN : Interface MgmtEth0/RP0/CPU0/0, changed state to Down
+RP/0/RP0/CPU0:Sep 25 23:26:18.198 UTC: ifmgr[189]: %PKT_INFRA-LINEPROTO-5-UPDOWN : Line protocol on Interface MgmtEth0/RP0/CPU0/0, changed state to Down
+RP/0/RP0/CPU0:Sep 25 23:26:18.202 UTC: cfgmgr-rp[247]: %MGBL-CONFIG-6-OIR_RESTORE : Configuration for node '0/RP0/CPU0' has been restored.
+RP/0/RP0/CPU0:Sep 25 23:26:18.276 UTC: ifmgr[189]: %PKT_INFRA-LINK-3-UPDOWN : Interface MgmtEth0/RP0/CPU0/0, changed state to Up
+RP/0/RP0/CPU0:Sep 25 23:26:18.278 UTC: ifmgr[189]: %PKT_INFRA-LINEPROTO-5-UPDOWN : Line protocol on Interface MgmtEth0/RP0/CPU0/0, changed state to Up
+RP/0/RP0/CPU0:Sep 25 23:26:18.594 UTC: smartlicserver[186]: SMART_LIC-6-EXPORT_CONTROLLED:Usage of export controlled features is not allowed
+RP/0/RP0/CPU0:Sep 25 23:26:19.268 UTC: bpm[1093]: %ROUTING-BGP-5-ASYNC_IPC_STATUS : bpm-default:(A)inst-id 0, Connection Open
+RP/0/RP0/CPU0:Sep 25 23:26:19.674 UTC: bgp[1078]: %ROUTING-BGP-5-ASYNC_IPC_STATUS : default, process instance 1:(A)inst-id 0, Connection Establised
+RP/0/RP0/CPU0:Sep 25 23:26:19.822 UTC: pppoe_ma[217]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:19.822 UTC: ipsub_ma[169]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:19.822 UTC: iedged[409]: %SUBSCRIBER-SUB_UTIL-5-SESSION_THROTTLE : Subscriber Infra is ready. Reason: [V6 Subscriber infra process(es) is available].
+RP/0/RP0/CPU0:Sep 25 23:26:20.264 UTC: bgp[1078]: %ROUTING-BGP-5-ASYNC_IPC_STATUS : default:(A)inst-id 0, Initial Config Done
+RP/0/RP0/CPU0:Sep 25 23:26:22.016 UTC: isis[1011]: %ROUTING-ISIS-6-INFO_STARTUP_FINISH : Cold controlled start completed
+RP/0/RP0/CPU0:Sep 25 23:26:23.522 UTC: isis[1012]: %ROUTING-ISIS-6-INFO_STARTUP_FINISH : Cold controlled start completed
+RP/0/RP0/CPU0:Sep 25 23:26:46.668 UTC: syslog_dev[119]: ztp[133] PID-4191: ZTP will now run in the background.
+RP/0/RP0/CPU0:Sep 25 23:26:46.668 UTC: syslog_dev[119]: ztp[133] PID-4191: ZTP might bring up the interfaces if they are in shutdown state.
+RP/0/RP0/CPU0:Sep 25 23:26:46.668 UTC: syslog_dev[119]: ztp[133] PID-4191: Please use "show logging" or look at /var/log/ztp.log to check progress.
+RP/0/RP0/CPU0:Sep 25 23:26:46.790 UTC: ZTP[67506]: %OS-SYSLOG-6-LOG_INFO : ZTP running in background
+RP/0/RP0/CPU0:Sep 25 23:27:17.623 UTC: exec[67679]: %SECURITY-LOGIN-6-AUTHEN_SUCCESS : Successfully authenticated user 'admin' from 'console' on 'con0_RP0_CPU0'
+RP/0/RP0/CPU0:Sep 25 23:27:22.691 UTC: config[67726]: %MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000024' to view the changes.
+RP/0/RP0/CPU0:Sep 25 23:27:22.997 UTC: config[67726]: %MGBL-SYS-5-CONFIG_I : Configured from console by admin
+0/RP0/ADMIN0:Sep 25 23:27:53.784 UTC: dumper[3156]: %INFRA-CALVADOS_DUMPER-6-HOST_COPY_SUCCESS : Copied host file /misc/scratch/core/default-sdr--1.20200925-232222.core.RP.lxcdump.tar.lz4 to 0/RP0:/misc/disk1
+0/RP0/ADMIN0:Sep 25 23:27:53.892 UTC: dumper[3156]: %INFRA-CALVADOS_DUMPER-6-HOST_REMV_SUCCESS : Deleted HostOS file /misc/scratch/core/default-sdr--1.20200925-232222.core.RP.lxcdump.tar.lz4
+RP/0/RP0/CPU0:Sep 25 23:28:57.463 UTC: config[68848]: %MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000025' to view the changes.
+RP/0/RP0/CPU0:Sep 25 23:28:57.781 UTC: config[68848]: %MGBL-SYS-5-CONFIG_I : Configured from console by admin
+RP/0/RP0/CPU0:Sep 25 23:30:54.216 UTC: config[69226]: %MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000026' to view the changes.
+RP/0/RP0/CPU0:Sep 25 23:30:54.587 UTC: config[69226]: %MGBL-SYS-5-CONFIG_I : Configured from console by admin
+RP/0/RP0/CPU0:Sep 25 23:31:34.897 UTC: config[69352]: %MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000027' to view the changes.
+RP/0/RP0/CPU0:Sep 25 23:31:35.276 UTC: config[69352]: %MGBL-SYS-5-CONFIG_I : Configured from console by admin
+RP/0/RP0/CPU0:Sep 25 23:32:59.081 UTC: config[69570]: %MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000028' to view the changes.
+RP/0/RP0/CPU0:Sep 25 23:32:59.395 UTC: config[69570]: %MGBL-SYS-5-CONFIG_I : Configured from console by admin
+RP/0/RP0/CPU0:Sep 25 23:34:19.268 UTC: config[65700]: %MGBL-CONFIG-6-DB_COMMIT : Configuration committed by user 'admin'. Use 'show configuration commit changes 1000000029' to view the changes.
+RP/0/RP0/CPU0:Sep 25 23:34:19.600 UTC: config[65700]: %MGBL-SYS-5-CONFIG_I : Configured from console by admin
+RP/0/RP0/CPU0:R2_xr#

--- a/tests/parsers/cisco_iosxr/show_logging/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_logging/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Standard show logging output with disabled console, buffer entries"
+platform: "XRv9000"
+software_version: "IOS-XR 6.6.3"

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -152,6 +152,8 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         # --- Cisco IOS-XR ---
         "cisco_iosxr/show_ip_route/001_ospf_ecmp_connected/expected.json",
         "cisco_iosxr/show_ip_route/002_mixed_protocols_ecmp/expected.json",
+        # log_entries uses list-of-dicts; no natural unique key for syslog messages.
+        "cisco_iosxr/show_logging/001_basic/expected.json",
         # --- NX-OS ---
         "nxos/show_bgp_all_dampening_flap-statistics/001_basic/expected.json",
         "nxos/show_bgp_vrf_all_all/001_basic/expected.json",


### PR DESCRIPTION
## Summary
- Add new parser for `show logging` on Cisco IOS-XR (`cisco_iosxr`)
- Parses syslog configuration: console/monitor/trap/buffer logging levels, message counts, buffer size, and enabled/disabled state
- Parses log buffer entries extracting node, timestamp, process name, PID, and message text
- Handles both standard RP nodes (`RP/0/RP0/CPU0`) and admin nodes (`0/RP0/ADMIN0`)

## Test plan
- [x] Test fixture `001_basic` uses real XRv9000 device output from genieparser golden samples
- [x] Parser test passes (`test_parser[cisco_iosxr/show_logging/001_basic]`)
- [x] Placeholder sentinel checks pass (no banned values in expected.json)
- [x] Pre-commit hooks pass (ruff, format, xenon complexity, json formatting)
- [x] Full test suite passes (6848 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)