### PR TITLE
feat(arista_eos): add parser for show mac address-table

### DIFF
--- a/changes/+arista-eos-show-mac-address-table.parser_added
+++ b/changes/+arista-eos-show-mac-address-table.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show mac address-table` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_mac_address_table.py
+++ b/src/muninn/parsers/arista_eos/show_mac_address_table.py
@@ -1,40 +1,42 @@
 """Parser for 'show mac address-table' command on Arista EOS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, Literal, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import MAC_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
 
 
-class MacEntry(TypedDict):
-    """Schema for a single MAC address table entry."""
+class MacTableRow(TypedDict):
+    """One row under ``mac_table[vlan_key][mac_key]``.
 
-    entry_type: str
-    interface: str
+    ``kind`` discriminates unicast vs multicast; ``ports`` is always a list
+    (single-element for unicast). ``moves`` and ``last_move`` only appear on
+    dynamic unicast entries.
+    """
+
+    kind: Literal["unicast", "multicast"]
+    type: str
+    ports: list[str]
     moves: NotRequired[int]
     last_move: NotRequired[str]
-
-
-class MulticastMacEntry(TypedDict):
-    """Schema for a single multicast MAC address table entry."""
-
-    entry_type: str
-    interfaces: list[str]
 
 
 class ShowMacAddressTableResult(TypedDict):
     """Schema for 'show mac address-table' parsed output on Arista EOS.
 
-    Unicast entries are keyed by VLAN ID (str), then by MAC address.
-    Multicast entries follow the same structure but use a list of interfaces.
+    Entries are keyed by VLAN ID (str) then MAC address. Unicast and
+    multicast entries share the same shape and live in the same map, with
+    ``kind`` distinguishing them — matching the IOS / IOS-XE sibling parser.
     """
 
-    unicast: dict[str, dict[str, MacEntry]]
-    multicast: dict[str, dict[str, MulticastMacEntry]]
+    mac_table: dict[str, dict[str, MacTableRow]]
+    total_unicast_mac_addresses: NotRequired[int]
+    total_multicast_mac_addresses: NotRequired[int]
 
 
 @register(OS.ARISTA_EOS, "show mac address-table")
@@ -58,7 +60,7 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
     # Unicast entry: Vlan  MAC  Type  Port  [Moves  Last Move]
     _UNICAST_ENTRY = re.compile(
         r"^\s*(?P<vlan>\d+)\s+"
-        r"(?P<mac>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})\s+"
+        rf"(?P<mac>{MAC_ADDRESS})\s+"
         r"(?P<type>\S+)\s+"
         r"(?P<port>\S+)"
         r"(?:\s+(?P<moves>\d+)\s+(?P<last_move>.+\s+ago))?\s*$"
@@ -77,7 +79,9 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
     # Lines to skip
     _SEPARATOR_LINE = re.compile(r"^-+$")
     _HEADER_LINE = re.compile(r"^\s*Vlan\s+mac\s+Address", re.I)
-    _TOTAL_LINE = re.compile(r"^Total\s+mac\s+Addresses", re.I)
+    _TOTAL_LINE = re.compile(
+        r"^Total\s+mac\s+Addresses[^:]*:\s*(?P<count>\d+)\s*$", re.I
+    )
 
     @classmethod
     def _is_skip_line(cls, line: str) -> bool:
@@ -87,49 +91,47 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
             not stripped
             or cls._SEPARATOR_LINE.match(stripped) is not None
             or cls._HEADER_LINE.match(stripped) is not None
-            or cls._TOTAL_LINE.match(stripped) is not None
             or cls._UNICAST_HEADER.search(stripped) is not None
             or cls._MULTICAST_HEADER.search(stripped) is not None
         )
 
     @classmethod
     def _parse_unicast_line(
-        cls, line: str, table: dict[str, dict[str, MacEntry]]
+        cls, line: str, table: dict[str, dict[str, MacTableRow]]
     ) -> None:
         """Parse a single unicast MAC address table line."""
         match = cls._UNICAST_ENTRY.match(line)
         if not match:
             return
-        entry: MacEntry = {
-            "entry_type": match.group("type").upper(),
-            "interface": canonical_interface_name(
-                match.group("port"), os=OS.ARISTA_EOS
-            ),
+        row: MacTableRow = {
+            "kind": "unicast",
+            "type": match.group("type").lower(),
+            "ports": [canonical_interface_name(match.group("port"), os=OS.ARISTA_EOS)],
         }
         if match.group("moves") is not None:
-            entry["moves"] = int(match.group("moves"))
+            row["moves"] = int(match.group("moves"))
         if match.group("last_move") is not None:
-            entry["last_move"] = match.group("last_move").strip()
-        table.setdefault(match.group("vlan"), {})[match.group("mac")] = entry
+            row["last_move"] = match.group("last_move").strip()
+        table.setdefault(match.group("vlan"), {})[match.group("mac").lower()] = row
 
     @classmethod
     def _parse_multicast_line(
-        cls, line: str, table: dict[str, dict[str, MulticastMacEntry]]
+        cls, line: str, table: dict[str, dict[str, MacTableRow]]
     ) -> None:
         """Parse a single multicast MAC address table line."""
         match = cls._MULTICAST_ENTRY.match(line)
         if not match:
             return
-        interfaces = [
+        ports = [
             canonical_interface_name(p, os=OS.ARISTA_EOS)
             for p in match.group("ports").strip().split()
         ]
-        table.setdefault(match.group("vlan"), {})[match.group("mac")] = (
-            MulticastMacEntry(
-                entry_type=match.group("type").upper(),
-                interfaces=interfaces,
-            )
-        )
+        row: MacTableRow = {
+            "kind": "multicast",
+            "type": match.group("type").lower(),
+            "ports": ports,
+        }
+        table.setdefault(match.group("vlan"), {})[match.group("mac").lower()] = row
 
     @classmethod
     def parse(cls, output: str) -> ShowMacAddressTableResult:
@@ -139,24 +141,40 @@ class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed MAC address table with unicast and multicast sections.
+            Parsed MAC address table with unicast and multicast entries
+            merged under ``mac_table`` keyed by VLAN then MAC, plus
+            optional per-section totals from the footer summaries.
         """
-        unicast: dict[str, dict[str, MacEntry]] = {}
-        multicast: dict[str, dict[str, MulticastMacEntry]] = {}
-        section = "unicast"
+        mac_table: dict[str, dict[str, MacTableRow]] = {}
+        section: Literal["unicast", "multicast"] = "unicast"
+        total_unicast: int | None = None
+        total_multicast: int | None = None
 
         for line in output.splitlines():
             if cls._MULTICAST_HEADER.search(line):
                 section = "multicast"
                 continue
+
+            total_match = cls._TOTAL_LINE.match(line.strip())
+            if total_match:
+                count = int(total_match.group("count"))
+                if section == "unicast":
+                    total_unicast = count
+                else:
+                    total_multicast = count
+                continue
+
             if cls._is_skip_line(line):
                 continue
-            if section == "unicast":
-                cls._parse_unicast_line(line, unicast)
-            else:
-                cls._parse_multicast_line(line, multicast)
 
-        return ShowMacAddressTableResult(
-            unicast=unicast,
-            multicast=multicast,
-        )
+            if section == "unicast":
+                cls._parse_unicast_line(line, mac_table)
+            else:
+                cls._parse_multicast_line(line, mac_table)
+
+        result: ShowMacAddressTableResult = {"mac_table": mac_table}
+        if total_unicast is not None:
+            result["total_unicast_mac_addresses"] = total_unicast
+        if total_multicast is not None:
+            result["total_multicast_mac_addresses"] = total_multicast
+        return result

--- a/src/muninn/parsers/arista_eos/show_mac_address_table.py
+++ b/src/muninn/parsers/arista_eos/show_mac_address_table.py
@@ -1,0 +1,162 @@
+"""Parser for 'show mac address-table' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class MacEntry(TypedDict):
+    """Schema for a single MAC address table entry."""
+
+    entry_type: str
+    interface: str
+    moves: NotRequired[int]
+    last_move: NotRequired[str]
+
+
+class MulticastMacEntry(TypedDict):
+    """Schema for a single multicast MAC address table entry."""
+
+    entry_type: str
+    interfaces: list[str]
+
+
+class ShowMacAddressTableResult(TypedDict):
+    """Schema for 'show mac address-table' parsed output on Arista EOS.
+
+    Unicast entries are keyed by VLAN ID (str), then by MAC address.
+    Multicast entries follow the same structure but use a list of interfaces.
+    """
+
+    unicast: dict[str, dict[str, MacEntry]]
+    multicast: dict[str, dict[str, MulticastMacEntry]]
+
+
+@register(OS.ARISTA_EOS, "show mac address-table")
+class ShowMacAddressTableParser(BaseParser[ShowMacAddressTableResult]):
+    """Parser for 'show mac address-table' command on Arista EOS.
+
+    Parses both unicast and multicast MAC address table sections.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.MAC,
+            ParserTag.SWITCHING,
+        }
+    )
+
+    # Section headers
+    _UNICAST_HEADER = re.compile(r"mac\s+Address\s+Table", re.I)
+    _MULTICAST_HEADER = re.compile(r"Multicast\s+mac\s+Address\s+Table", re.I)
+
+    # Unicast entry: Vlan  MAC  Type  Port  [Moves  Last Move]
+    _UNICAST_ENTRY = re.compile(
+        r"^\s*(?P<vlan>\d+)\s+"
+        r"(?P<mac>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<port>\S+)"
+        r"(?:\s+(?P<moves>\d+)\s+(?P<last_move>.+\s+ago))?\s*$"
+    )
+
+    # Multicast entry: Vlan  MAC  Type  Ports (space-separated list)
+    # MAC pattern is permissive to handle sanitized output where octets
+    # may contain non-hex characters.
+    _MULTICAST_ENTRY = re.compile(
+        r"^\s*(?P<vlan>\d+)\s+"
+        r"(?P<mac>\S{4}\.\S{4}\.\S{4})\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<ports>.+?)\s*$"
+    )
+
+    # Lines to skip
+    _SEPARATOR_LINE = re.compile(r"^-+$")
+    _HEADER_LINE = re.compile(r"^\s*Vlan\s+mac\s+Address", re.I)
+    _TOTAL_LINE = re.compile(r"^Total\s+mac\s+Addresses", re.I)
+
+    @classmethod
+    def _is_skip_line(cls, line: str) -> bool:
+        """Return True if the line should be skipped."""
+        stripped = line.strip()
+        return (
+            not stripped
+            or cls._SEPARATOR_LINE.match(stripped) is not None
+            or cls._HEADER_LINE.match(stripped) is not None
+            or cls._TOTAL_LINE.match(stripped) is not None
+            or cls._UNICAST_HEADER.search(stripped) is not None
+            or cls._MULTICAST_HEADER.search(stripped) is not None
+        )
+
+    @classmethod
+    def _parse_unicast_line(
+        cls, line: str, table: dict[str, dict[str, MacEntry]]
+    ) -> None:
+        """Parse a single unicast MAC address table line."""
+        match = cls._UNICAST_ENTRY.match(line)
+        if not match:
+            return
+        entry: MacEntry = {
+            "entry_type": match.group("type").upper(),
+            "interface": canonical_interface_name(
+                match.group("port"), os=OS.ARISTA_EOS
+            ),
+        }
+        if match.group("moves") is not None:
+            entry["moves"] = int(match.group("moves"))
+        if match.group("last_move") is not None:
+            entry["last_move"] = match.group("last_move").strip()
+        table.setdefault(match.group("vlan"), {})[match.group("mac")] = entry
+
+    @classmethod
+    def _parse_multicast_line(
+        cls, line: str, table: dict[str, dict[str, MulticastMacEntry]]
+    ) -> None:
+        """Parse a single multicast MAC address table line."""
+        match = cls._MULTICAST_ENTRY.match(line)
+        if not match:
+            return
+        interfaces = [
+            canonical_interface_name(p, os=OS.ARISTA_EOS)
+            for p in match.group("ports").strip().split()
+        ]
+        table.setdefault(match.group("vlan"), {})[match.group("mac")] = (
+            MulticastMacEntry(
+                entry_type=match.group("type").upper(),
+                interfaces=interfaces,
+            )
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMacAddressTableResult:
+        """Parse 'show mac address-table' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed MAC address table with unicast and multicast sections.
+        """
+        unicast: dict[str, dict[str, MacEntry]] = {}
+        multicast: dict[str, dict[str, MulticastMacEntry]] = {}
+        section = "unicast"
+
+        for line in output.splitlines():
+            if cls._MULTICAST_HEADER.search(line):
+                section = "multicast"
+                continue
+            if cls._is_skip_line(line):
+                continue
+            if section == "unicast":
+                cls._parse_unicast_line(line, unicast)
+            else:
+                cls._parse_multicast_line(line, multicast)
+
+        return ShowMacAddressTableResult(
+            unicast=unicast,
+            multicast=multicast,
+        )

--- a/tests/parsers/arista_eos/show_mac_address_table/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mac_address_table/001_basic/expected.json
@@ -1,133 +1,189 @@
 {
-    "unicast": {
+    "mac_table": {
         "3": {
             "0012.3694.03ec": {
-                "entry_type": "STATIC",
-                "interface": "Ethernet7"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Ethernet7"
+                ]
             }
         },
         "55": {
             "001c.7313.a3de": {
-                "entry_type": "DYNAMIC",
-                "interface": "Ethernet32",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Ethernet32"
+                ],
                 "moves": 1,
                 "last_move": "0:08:16 ago"
             }
         },
         "101": {
             "001c.8224.36d7": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel2",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel2"
+                ],
                 "moves": 1,
                 "last_move": "9 days, 15:57:28 ago"
             }
         },
         "102": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "001c.8229.a0f3": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel1",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel1"
+                ],
                 "moves": 1,
                 "last_move": "0:05:05 ago"
             }
         },
         "661": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "001c.822f.6b22": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel7",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel7"
+                ],
                 "moves": 1,
                 "last_move": "0:20:10 ago"
             }
         },
         "3000": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "0050.56a8.0016": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel1",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel1"
+                ],
                 "moves": 1,
                 "last_move": "0:07:38 ago"
             }
         },
         "3909": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "001c.822f.6a80": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel1",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel1"
+                ],
                 "moves": 1,
                 "last_move": "0:07:08 ago"
             }
         },
         "3911": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "001c.8220.40fa": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel8",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel8"
+                ],
                 "moves": 1,
                 "last_move": "1:19:58 ago"
             }
         },
         "3912": {
             "001c.822b.033e": {
-                "entry_type": "DYNAMIC",
-                "interface": "Ethernet11",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Ethernet11"
+                ],
                 "moves": 1,
                 "last_move": "9 days, 15:57:23 ago"
             }
         },
         "3913": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "001c.822b.033e": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel1",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel1"
+                ],
                 "moves": 1,
                 "last_move": "0:04:35 ago"
             }
         },
         "3984": {
             "001c.8220.178f": {
-                "entry_type": "DYNAMIC",
-                "interface": "Ethernet8",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Ethernet8"
+                ],
                 "moves": 1,
                 "last_move": "4 days, 15:07:29 ago"
             }
         },
         "3992": {
             "001c.8220.1319": {
-                "entry_type": "STATIC",
-                "interface": "Port-channel1"
+                "kind": "unicast",
+                "type": "static",
+                "ports": [
+                    "Port-channel1"
+                ]
             },
             "001c.8221.07b9": {
-                "entry_type": "DYNAMIC",
-                "interface": "Port-channel6",
+                "kind": "unicast",
+                "type": "dynamic",
+                "ports": [
+                    "Port-channel6"
+                ],
                 "moves": 1,
                 "last_move": "4 days, 15:13:15 ago"
             }
-        }
-    },
-    "multicast": {
+        },
         "4": {
             "c867.3057.8423": {
-                "entry_type": "STATIC",
-                "interfaces": [
+                "kind": "multicast",
+                "type": "static",
+                "ports": [
                     "Port-channel10",
                     "Port-channel123"
                 ]
@@ -135,8 +191,9 @@
         },
         "42": {
             "5309.3057.8423": {
-                "entry_type": "STATIC",
-                "interfaces": [
+                "kind": "multicast",
+                "type": "static",
+                "ports": [
                     "Port-channel135",
                     "Port-channel12",
                     "Port-channel5"
@@ -145,16 +202,18 @@
         },
         "200": {
             "jenn.3057.8423": {
-                "entry_type": "STATIC",
-                "interfaces": [
+                "kind": "multicast",
+                "type": "static",
+                "ports": [
                     "Port-channel66"
                 ]
             }
         },
         "47": {
             "4242.3057.8423": {
-                "entry_type": "STATIC",
-                "interfaces": [
+                "kind": "multicast",
+                "type": "static",
+                "ports": [
                     "Port-channel135",
                     "Port-channel12",
                     "Port-channel5",
@@ -162,5 +221,7 @@
                 ]
             }
         }
-    }
+    },
+    "total_unicast_mac_addresses": 24,
+    "total_multicast_mac_addresses": 1
 }

--- a/tests/parsers/arista_eos/show_mac_address_table/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mac_address_table/001_basic/expected.json
@@ -1,0 +1,166 @@
+{
+    "unicast": {
+        "3": {
+            "0012.3694.03ec": {
+                "entry_type": "STATIC",
+                "interface": "Ethernet7"
+            }
+        },
+        "55": {
+            "001c.7313.a3de": {
+                "entry_type": "DYNAMIC",
+                "interface": "Ethernet32",
+                "moves": 1,
+                "last_move": "0:08:16 ago"
+            }
+        },
+        "101": {
+            "001c.8224.36d7": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel2",
+                "moves": 1,
+                "last_move": "9 days, 15:57:28 ago"
+            }
+        },
+        "102": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "001c.8229.a0f3": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel1",
+                "moves": 1,
+                "last_move": "0:05:05 ago"
+            }
+        },
+        "661": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "001c.822f.6b22": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel7",
+                "moves": 1,
+                "last_move": "0:20:10 ago"
+            }
+        },
+        "3000": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "0050.56a8.0016": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel1",
+                "moves": 1,
+                "last_move": "0:07:38 ago"
+            }
+        },
+        "3909": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "001c.822f.6a80": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel1",
+                "moves": 1,
+                "last_move": "0:07:08 ago"
+            }
+        },
+        "3911": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "001c.8220.40fa": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel8",
+                "moves": 1,
+                "last_move": "1:19:58 ago"
+            }
+        },
+        "3912": {
+            "001c.822b.033e": {
+                "entry_type": "DYNAMIC",
+                "interface": "Ethernet11",
+                "moves": 1,
+                "last_move": "9 days, 15:57:23 ago"
+            }
+        },
+        "3913": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "001c.822b.033e": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel1",
+                "moves": 1,
+                "last_move": "0:04:35 ago"
+            }
+        },
+        "3984": {
+            "001c.8220.178f": {
+                "entry_type": "DYNAMIC",
+                "interface": "Ethernet8",
+                "moves": 1,
+                "last_move": "4 days, 15:07:29 ago"
+            }
+        },
+        "3992": {
+            "001c.8220.1319": {
+                "entry_type": "STATIC",
+                "interface": "Port-channel1"
+            },
+            "001c.8221.07b9": {
+                "entry_type": "DYNAMIC",
+                "interface": "Port-channel6",
+                "moves": 1,
+                "last_move": "4 days, 15:13:15 ago"
+            }
+        }
+    },
+    "multicast": {
+        "4": {
+            "c867.3057.8423": {
+                "entry_type": "STATIC",
+                "interfaces": [
+                    "Port-channel10",
+                    "Port-channel123"
+                ]
+            }
+        },
+        "42": {
+            "5309.3057.8423": {
+                "entry_type": "STATIC",
+                "interfaces": [
+                    "Port-channel135",
+                    "Port-channel12",
+                    "Port-channel5"
+                ]
+            }
+        },
+        "200": {
+            "jenn.3057.8423": {
+                "entry_type": "STATIC",
+                "interfaces": [
+                    "Port-channel66"
+                ]
+            }
+        },
+        "47": {
+            "4242.3057.8423": {
+                "entry_type": "STATIC",
+                "interfaces": [
+                    "Port-channel135",
+                    "Port-channel12",
+                    "Port-channel5",
+                    "Ethernet1/1"
+                ]
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_mac_address_table/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_mac_address_table/001_basic/input.txt
@@ -1,0 +1,36 @@
+          mac Address Table
+------------------------------------------------------------------
+
+Vlan    mac Address       Type        Ports      Moves   Last Move
+----    -----------       ----        -----      -----   ---------
+   3    0012.3694.03ec    STATIC      Et7
+  55        001c.7313.a3de      DYNAMIC        Et32        1    0:08:16 ago
+101    001c.8224.36d7    DYNAMIC     Po2        1       9 days, 15:57:28 ago
+102    001c.8220.1319    STATIC      Po1
+102    001c.8229.a0f3    DYNAMIC     Po1        1       0:05:05 ago
+661    001c.8220.1319    STATIC      Po1
+661    001c.822f.6b22    DYNAMIC     Po7        1       0:20:10 ago
+3000    001c.8220.1319    STATIC      Po1
+3000    0050.56a8.0016    DYNAMIC     Po1        1       0:07:38 ago
+3909    001c.8220.1319    STATIC      Po1
+3909    001c.822f.6a80    DYNAMIC     Po1        1       0:07:08 ago
+3911    001c.8220.1319    STATIC      Po1
+3911    001c.8220.40fa    DYNAMIC     Po8        1       1:19:58 ago
+3912    001c.822b.033e    DYNAMIC     Et11       1       9 days, 15:57:23 ago
+3913    001c.8220.1319    STATIC      Po1
+3913    001c.822b.033e    DYNAMIC     Po1        1       0:04:35 ago
+3984    001c.8220.178f    DYNAMIC     Et8        1       4 days, 15:07:29 ago
+3992    001c.8220.1319    STATIC      Po1
+3992    001c.8221.07b9    DYNAMIC     Po6        1       4 days, 15:13:15 ago
+Total mac Addresses for this criterion: 24
+
+          Multicast mac Address Table
+------------------------------------------------------------------
+
+Vlan    mac Address       Type        Ports
+----    -----------       ----        -----
+   4    c867.3057.8423    STATIC      Po10 Po123
+  42    5309.3057.8423    STATIC      Po135 Po12 po5
+ 200    jenn.3057.8423    STATIC      Po66
+  47    4242.3057.8423    STATIC      Po135 Po12 po5 eth1/1
+Total mac Addresses for this criterion: 1

--- a/tests/parsers/arista_eos/show_mac_address_table/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_mac_address_table/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed unicast and multicast MAC entries across multiple VLANs
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/arista_eos/show_mac_address_table/command.txt
+++ b/tests/parsers/arista_eos/show_mac_address_table/command.txt
@@ -1,0 +1,1 @@
+show mac address-table


### PR DESCRIPTION
## Summary

- Add parser for `show mac address-table` on Arista EOS
- Parses both unicast and multicast MAC address table sections into dict-of-dicts keyed by VLAN ID then MAC address
- Interface names are normalized to canonical form (e.g., `Et7` -> `Ethernet7`, `Po1` -> `Port-channel1`)

## Test plan

- [x] Parser test fixture with mixed unicast/multicast entries across multiple VLANs
- [x] All 6848 existing tests pass
- [x] Pre-commit hooks pass (ruff, xenon, JSON formatting, etc.)
- [x] Fixture passes placeholder sentinel checks (no banned values)
- [x] Fixture passes canonical interface normalization check

🤖 Generated with [Claude Code](https://claude.com/claude-code)