### PR TITLE
feat(arista_eos): add parser for show ip interface brief

### DIFF
--- a/changes/+arista-eos-show-ip-interface-brief.parser_added
+++ b/changes/+arista-eos-show-ip-interface-brief.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ip interface brief` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ip_interface_brief.py
+++ b/src/muninn/parsers/arista_eos/show_ip_interface_brief.py
@@ -1,0 +1,102 @@
+"""Parser for 'show ip interface brief' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class IpInterfaceBriefEntry(TypedDict):
+    """Schema for a single interface entry from 'show ip interface brief'."""
+
+    ip_address: NotRequired[str]
+    status: str
+    protocol: str
+    mtu: int
+
+
+class ShowIpInterfaceBriefResult(TypedDict):
+    """Schema for 'show ip interface brief' parsed output on Arista EOS."""
+
+    interfaces: dict[str, IpInterfaceBriefEntry]
+
+
+@register(OS.ARISTA_EOS, "show ip interface brief")
+class ShowIpInterfaceBriefParser(BaseParser[ShowIpInterfaceBriefResult]):
+    """Parser for 'show ip interface brief' command on Arista EOS.
+
+    Parses interface name, IP address, status, protocol, and MTU.
+    Output is keyed by interface name using a dict-of-dicts pattern.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    _HEADER_PATTERN = re.compile(
+        r"^\s*Interface\s+IP Address\s+Status\s+Protocol\s+MTU"
+    )
+
+    # Example lines:
+    # Loopback0              1.1.1.1/32         up         up             65535
+    # Management1            unassigned         down       down            1500
+    _INTERFACE_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+"
+        r"(?P<ip_address>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<protocol>\S+)\s+"
+        r"(?P<mtu>\d+)\s*$"
+    )
+
+    _UNASSIGNED = "unassigned"
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpInterfaceBriefResult:
+        """Parse 'show ip interface brief' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed interface data keyed by interface name.
+
+        Raises:
+            ValueError: If no interfaces found in output.
+        """
+        interfaces: dict[str, IpInterfaceBriefEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped or cls._HEADER_PATTERN.match(stripped):
+                continue
+
+            match = cls._INTERFACE_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.ARISTA_EOS
+            )
+            ip_address = match.group("ip_address")
+            status = match.group("status")
+            protocol = match.group("protocol")
+            mtu = int(match.group("mtu"))
+
+            entry: IpInterfaceBriefEntry = {
+                "status": status,
+                "protocol": protocol,
+                "mtu": mtu,
+            }
+
+            if ip_address.lower() != cls._UNASSIGNED:
+                entry["ip_address"] = ip_address
+
+            interfaces[interface] = entry
+
+        if not interfaces:
+            msg = "No interfaces found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpInterfaceBriefResult, {"interfaces": interfaces})

--- a/tests/parsers/arista_eos/show_ip_interface_brief/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_interface_brief/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "interfaces": {
+        "Loopback0": {
+            "ip_address": "1.1.1.1/32",
+            "status": "up",
+            "protocol": "up",
+            "mtu": 65535
+        },
+        "Management1": {
+            "status": "down",
+            "protocol": "down",
+            "mtu": 1500
+        },
+        "Vlan10": {
+            "status": "down",
+            "protocol": "lowerlayerdown",
+            "mtu": 1500
+        },
+        "Ethernet5": {
+            "ip_address": "10.0.0.1/24",
+            "status": "up",
+            "protocol": "up",
+            "mtu": 1500
+        },
+        "Port-channel1": {
+            "ip_address": "11.11.11.11/24",
+            "status": "down",
+            "protocol": "lowerlayerdown",
+            "mtu": 1500
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_interface_brief/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ip_interface_brief/001_basic/input.txt
@@ -1,0 +1,6 @@
+Interface              IP Address         Status     Protocol         MTU
+Loopback0              1.1.1.1/32         up         up             65535
+Management1            unassigned         down       down            1500
+Vlan10                 unassigned         down       lowerlayerdown  1500
+Ethernet5              10.0.0.1/24        up         up              1500
+Port-Channel1          11.11.11.11/24     down       lowerlayerdown  1500

--- a/tests/parsers/arista_eos/show_ip_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_interface_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic IP interface brief with loopback, management, VLAN, ethernet, and port-channel
+platform: vEOS
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add parser for `show ip interface brief` on Arista EOS
- Returns dict-of-dicts keyed by canonical interface name with IP address, status, protocol, and MTU
- Unassigned IPs omit the `ip_address` key rather than carrying a placeholder string

## Test plan
- [x] Test fixture `001_basic` with real device output covering Loopback, Management, Vlan, Ethernet, and Port-channel interfaces
- [x] All 6848 tests pass including placeholder sentinel checks, JSON convention checks, and canonical interface name normalization
- [x] Pre-commit hooks (ruff, xenon, formatting) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)