### PR TITLE
feat(arista_eos): add parser for `show hostname`

### DIFF
--- a/changes/+arista-eos-show-hostname.parser_added
+++ b/changes/+arista-eos-show-hostname.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show hostname` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_hostname.py
+++ b/src/muninn/parsers/arista_eos/show_hostname.py
@@ -1,0 +1,71 @@
+"""Parser for 'show hostname' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowHostnameResult(TypedDict):
+    """Schema for 'show hostname' parsed output on Arista EOS."""
+
+    hostname: str
+    fqdn: NotRequired[str]
+
+
+@register(OS.ARISTA_EOS, "show hostname")
+class ShowHostnameParser(BaseParser[ShowHostnameResult]):
+    """Parser for 'show hostname' command on Arista EOS.
+
+    Parses the device hostname and optional FQDN.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _HOSTNAME_PATTERN = re.compile(r"^Hostname:\s+(?P<hostname>\S+)")
+    _FQDN_PATTERN = re.compile(r"^FQDN:\s+(?P<fqdn>\S+)")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowHostnameResult:
+        """Parse 'show hostname' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed hostname information.
+
+        Raises:
+            ValueError: If hostname cannot be parsed from output.
+        """
+        hostname: str | None = None
+        fqdn: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._HOSTNAME_PATTERN.match(stripped):
+                hostname = match.group("hostname")
+                continue
+
+            if match := cls._FQDN_PATTERN.match(stripped):
+                fqdn = match.group("fqdn")
+                continue
+
+        if hostname is None:
+            msg = "No hostname found in output"
+            raise ValueError(msg)
+
+        result = ShowHostnameResult(hostname=hostname)
+
+        # Only include FQDN if it differs from hostname
+        # (i.e., it actually contains a domain)
+        if fqdn is not None and fqdn != hostname:
+            result["fqdn"] = fqdn
+
+        return result

--- a/tests/parsers/arista_eos/show_hostname/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_hostname/001_basic/expected.json
@@ -1,0 +1,4 @@
+{
+    "hostname": "spine1",
+    "fqdn": "spine1.company.com"
+}

--- a/tests/parsers/arista_eos/show_hostname/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_hostname/001_basic/input.txt
@@ -1,0 +1,3 @@
+eos-spine1#show hostname
+Hostname: spine1
+FQDN:     spine1.company.com

--- a/tests/parsers/arista_eos/show_hostname/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_hostname/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show hostname with FQDN configured
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show hostname` on Arista EOS

## Test plan
- [x] Parser tests pass
- [x] Sentinel/placeholder tests pass
- [x] Ruff/bandit/xenon checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)