### PR TITLE
feat(arista_eos): add parser for `show clock`

### DIFF
--- a/changes/+arista-eos-show-clock.parser_added
+++ b/changes/+arista-eos-show-clock.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show clock` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_clock.py
+++ b/src/muninn/parsers/arista_eos/show_clock.py
@@ -1,0 +1,91 @@
+"""Parser for 'show clock' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowClockResult(TypedDict):
+    """Schema for 'show clock' parsed output on Arista EOS."""
+
+    time: str
+    timezone: str
+    day_of_week: str
+    month: str
+    day: str
+    year: str
+
+
+@register(OS.ARISTA_EOS, "show clock")
+class ShowClockParser(BaseParser[ShowClockResult]):
+    """Parser for 'show clock' command on Arista EOS.
+
+    Parses the current device time, date components, and timezone.
+
+    Expected CLI output format::
+
+        Mon Jan 14 18:42:49 2013
+        timezone is US/Central
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    # Line 1: day_of_week month day HH:MM:SS year
+    _DATETIME_PATTERN = re.compile(
+        r"^(?P<day_of_week>\w+)\s+"
+        r"(?P<month>\w+)\s+"
+        r"(?P<day>\d+)\s+"
+        r"(?P<time>\d+:\d+:\d+)\s+"
+        r"(?P<year>\d{4})$"
+    )
+
+    # Line 2: timezone is <tz>
+    _TIMEZONE_PATTERN = re.compile(r"^timezone is\s+(?P<timezone>\S+)")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowClockResult:
+        """Parse 'show clock' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed clock information with time, timezone, and date fields.
+
+        Raises:
+            ValueError: If required fields cannot be parsed from the output.
+        """
+        datetime_match = None
+        timezone_value = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._DATETIME_PATTERN.match(stripped):
+                datetime_match = match
+
+            if match := cls._TIMEZONE_PATTERN.match(stripped):
+                timezone_value = match.group("timezone")
+
+        if datetime_match is None:
+            msg = "No date/time line found in output"
+            raise ValueError(msg)
+
+        if timezone_value is None:
+            msg = "No timezone line found in output"
+            raise ValueError(msg)
+
+        return ShowClockResult(
+            time=datetime_match.group("time"),
+            timezone=timezone_value,
+            day_of_week=datetime_match.group("day_of_week"),
+            month=datetime_match.group("month"),
+            day=datetime_match.group("day"),
+            year=datetime_match.group("year"),
+        )

--- a/src/muninn/parsers/arista_eos/show_clock.py
+++ b/src/muninn/parsers/arista_eos/show_clock.py
@@ -16,8 +16,8 @@ class ShowClockResult(TypedDict):
     timezone: str
     day_of_week: str
     month: str
-    day: str
-    year: str
+    day: int
+    year: int
 
 
 @register(OS.ARISTA_EOS, "show clock")
@@ -86,6 +86,6 @@ class ShowClockParser(BaseParser[ShowClockResult]):
             timezone=timezone_value,
             day_of_week=datetime_match.group("day_of_week"),
             month=datetime_match.group("month"),
-            day=datetime_match.group("day"),
-            year=datetime_match.group("year"),
+            day=int(datetime_match.group("day")),
+            year=int(datetime_match.group("year")),
         )

--- a/tests/parsers/arista_eos/show_clock/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_clock/001_basic/expected.json
@@ -1,0 +1,8 @@
+{
+    "time": "18:42:49",
+    "timezone": "US/Central",
+    "day_of_week": "Mon",
+    "month": "Jan",
+    "day": "14",
+    "year": "2013"
+}

--- a/tests/parsers/arista_eos/show_clock/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_clock/001_basic/expected.json
@@ -3,6 +3,6 @@
     "timezone": "US/Central",
     "day_of_week": "Mon",
     "month": "Jan",
-    "day": "14",
-    "year": "2013"
+    "day": 14,
+    "year": 2013
 }

--- a/tests/parsers/arista_eos/show_clock/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_clock/001_basic/input.txt
@@ -1,0 +1,2 @@
+Mon Jan 14 18:42:49 2013
+timezone is US/Central

--- a/tests/parsers/arista_eos/show_clock/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_clock/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic clock output with US/Central timezone
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show clock` on Arista EOS

## Test plan
- [x] Parser tests pass
- [x] Sentinel/placeholder tests pass
- [x] Ruff/bandit/xenon checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)