### PR TITLE
feat(arista_eos): add parser for show reload cause

### DIFF
--- a/changes/+arista-eos-show-reload-cause.parser_added
+++ b/changes/+arista-eos-show-reload-cause.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show reload cause` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_reload_cause.py
+++ b/src/muninn/parsers/arista_eos/show_reload_cause.py
@@ -5,108 +5,161 @@ from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_RE
 from muninn.registry import register
 from muninn.tags import ParserTag
 
 
-class ShowReloadCauseResult(TypedDict):
-    """Schema for 'show reload cause' parsed output on Arista EOS."""
+class ReloadCauseEntry(TypedDict):
+    """One reload cause record from 'show reload cause' on Arista EOS."""
 
-    reload_cause: str
+    cause: str
     reload_time: NotRequired[str]
     recommended_action: NotRequired[str]
     debugging_information: NotRequired[str]
 
 
-# Section header labels mapped to internal section keys.
-_SECTION_HEADERS: dict[str, str] = {
+class ShowReloadCauseResult(TypedDict):
+    """Schema for 'show reload cause' parsed output on Arista EOS."""
+
+    causes: dict[str, ReloadCauseEntry]
+
+
+_RELOAD_CAUSE_HEADER_RE = re.compile(r"^Reload Cause (?P<index>\d+):")
+_RELOAD_TIME_RE = re.compile(r"^Reload occurred at (?P<time>.+)\.$")
+
+# Subsection header labels mapped to internal field keys on ReloadCauseEntry.
+_SUBSECTION_HEADERS: dict[str, str] = {
     "Reload Time:": "reload_time",
     "Recommended Action:": "recommended_action",
     "Debugging Information:": "debugging_information",
 }
 
-# Optional result keys that should be omitted when their value is a sentinel.
-_OPTIONAL_SENTINEL_KEYS = ("recommended_action", "debugging_information")
+# Optional fields whose values are dropped when they match a no-data sentinel.
+_OPTIONAL_SENTINEL_FIELDS = (
+    "recommended_action",
+    "debugging_information",
+)
+
+_NO_VALUE_SENTINELS = frozenset({"none available", "no information available"})
 
 
 @register(OS.ARISTA_EOS, "show reload cause")
 class ShowReloadCauseParser(BaseParser[ShowReloadCauseResult]):
     """Parser for 'show reload cause' command on Arista EOS.
 
-    Parses reload cause, timestamp, recommended action, and debugging
-    information from the command output.
+    Parses one or more reload-cause records.  Each record carries a numeric
+    index from ``Reload Cause N:``, the cause description, and optional
+    ``Reload Time``, ``Recommended Action``, and ``Debugging Information``
+    subsections.  Sentinel values such as ``None available`` are omitted.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
 
-    _RELOAD_CAUSE_HEADER = re.compile(r"^Reload Cause \d+:")
-    _RELOAD_TIME = re.compile(r"^Reload occurred at (?P<time>.+)\.$")
-    _SEPARATOR = re.compile(r"^-{2,}$")
+    @staticmethod
+    def _is_meaningful(value: str) -> bool:
+        """Return True when *value* is not a no-data sentinel."""
+        return value.lower().rstrip(".") not in _NO_VALUE_SENTINELS
 
-    # Values that indicate "no data" and should be omitted from output.
-    _NO_VALUE_SENTINELS = frozenset({"none available", "no information available"})
-
-    @classmethod
-    def _detect_section(cls, line: str) -> str | None:
-        """Return the section key if *line* is a section header, else None."""
-        if cls._RELOAD_CAUSE_HEADER.match(line):
-            return "reload_cause"
-        for header, key in _SECTION_HEADERS.items():
+    @staticmethod
+    def _detect_subsection(line: str) -> str | None:
+        """Return the subsection field key for *line*, or None."""
+        for header, key in _SUBSECTION_HEADERS.items():
             if line.startswith(header):
                 return key
         return None
 
     @classmethod
-    def _is_meaningful(cls, value: str) -> bool:
-        """Return True when *value* is not a no-data sentinel."""
-        return value.lower().rstrip(".") not in cls._NO_VALUE_SENTINELS
-
-    @classmethod
-    def _extract_sections(cls, output: str) -> dict[str, str]:
-        """Walk the output and return a mapping of section key to content."""
-        current_section: str | None = None
-        sections: dict[str, str] = {}
-
-        for line in output.splitlines():
-            stripped = line.strip()
-
-            if not stripped or cls._SEPARATOR.match(stripped):
-                continue
-
-            detected = cls._detect_section(stripped)
-            if detected is not None:
-                current_section = detected
-                continue
-
-            if current_section is not None and current_section not in sections:
-                cls._store_section_value(current_section, stripped, sections)
-
-        return sections
-
-    @classmethod
-    def _store_section_value(
-        cls, section: str, line: str, sections: dict[str, str]
+    def _finalize_subsection(
+        cls, entry: dict[str, str], field: str, lines: list[str]
     ) -> None:
-        """Extract and store the value for the given *section*."""
-        if section == "reload_time":
-            if match := cls._RELOAD_TIME.match(line):
-                sections[section] = match.group("time")
-        else:
-            sections[section] = line
+        """Store *lines* into *entry* under *field*, normalizing per-field."""
+        if not lines:
+            return
+        value = "\n".join(lines).strip()
+        if not value:
+            return
+        if field == "reload_time":
+            if match := _RELOAD_TIME_RE.match(value):
+                entry[field] = match.group("time")
+            return
+        if field in _OPTIONAL_SENTINEL_FIELDS and not cls._is_meaningful(value):
+            return
+        entry[field] = value
 
     @classmethod
-    def _build_result(cls, sections: dict[str, str]) -> ShowReloadCauseResult:
-        """Build the typed result dict from extracted sections."""
-        result = ShowReloadCauseResult(reload_cause=sections["reload_cause"])
+    def _flush_record(
+        cls,
+        causes: dict[str, ReloadCauseEntry],
+        index: str | None,
+        cause_lines: list[str],
+        current_field: str | None,
+        current_lines: list[str],
+        subsections: dict[str, str],
+    ) -> None:
+        """Finalize the in-progress record and append it to *causes*."""
+        if index is None:
+            return
+        if current_field is not None:
+            scratch: dict[str, str] = {}
+            cls._finalize_subsection(scratch, current_field, current_lines)
+            subsections.update(scratch)
+        cause_text = "\n".join(cause_lines).strip()
+        if not cause_text:
+            return
+        entry: ReloadCauseEntry = {"cause": cause_text}
+        for field in ("reload_time", "recommended_action", "debugging_information"):
+            if field in subsections:
+                entry[field] = subsections[field]  # type: ignore[literal-required]
+        causes[index] = entry
 
-        if "reload_time" in sections:
-            result["reload_time"] = sections["reload_time"]
+    @classmethod
+    def _parse_records(cls, output: str) -> dict[str, ReloadCauseEntry]:
+        """Walk *output* and return a mapping of cause index to entry."""
+        causes: dict[str, ReloadCauseEntry] = {}
+        index: str | None = None
+        cause_lines: list[str] = []
+        subsections: dict[str, str] = {}
+        current_field: str | None = None
+        current_lines: list[str] = []
 
-        for key in _OPTIONAL_SENTINEL_KEYS:
-            if key in sections and cls._is_meaningful(sections[key]):
-                result[key] = sections[key]  # type: ignore[literal-required]
+        for raw_line in output.splitlines():
+            stripped = raw_line.strip()
+            if not stripped or SEPARATOR_DASH_RE.match(stripped):
+                continue
 
-        return result
+            if cause_match := _RELOAD_CAUSE_HEADER_RE.match(stripped):
+                cls._flush_record(
+                    causes,
+                    index,
+                    cause_lines,
+                    current_field,
+                    current_lines,
+                    subsections,
+                )
+                index = cause_match.group("index")
+                cause_lines = []
+                subsections = {}
+                current_field = None
+                current_lines = []
+                continue
+
+            if (subsection := cls._detect_subsection(stripped)) is not None:
+                if current_field is not None:
+                    cls._finalize_subsection(subsections, current_field, current_lines)
+                current_field = subsection
+                current_lines = []
+                continue
+
+            if current_field is None:
+                cause_lines.append(stripped)
+            else:
+                current_lines.append(stripped)
+
+        cls._flush_record(
+            causes, index, cause_lines, current_field, current_lines, subsections
+        )
+        return causes
 
     @classmethod
     def parse(cls, output: str) -> ShowReloadCauseResult:
@@ -116,15 +169,13 @@ class ShowReloadCauseParser(BaseParser[ShowReloadCauseResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Parsed reload cause information.
+            Parsed reload-cause records keyed by cause index.
 
         Raises:
             ValueError: If no reload cause can be found in the output.
         """
-        sections = cls._extract_sections(output)
-
-        if "reload_cause" not in sections:
+        causes = cls._parse_records(output)
+        if not causes:
             msg = "No reload cause found in output"
             raise ValueError(msg)
-
-        return cls._build_result(sections)
+        return {"causes": causes}

--- a/src/muninn/parsers/arista_eos/show_reload_cause.py
+++ b/src/muninn/parsers/arista_eos/show_reload_cause.py
@@ -1,0 +1,130 @@
+"""Parser for 'show reload cause' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowReloadCauseResult(TypedDict):
+    """Schema for 'show reload cause' parsed output on Arista EOS."""
+
+    reload_cause: str
+    reload_time: NotRequired[str]
+    recommended_action: NotRequired[str]
+    debugging_information: NotRequired[str]
+
+
+# Section header labels mapped to internal section keys.
+_SECTION_HEADERS: dict[str, str] = {
+    "Reload Time:": "reload_time",
+    "Recommended Action:": "recommended_action",
+    "Debugging Information:": "debugging_information",
+}
+
+# Optional result keys that should be omitted when their value is a sentinel.
+_OPTIONAL_SENTINEL_KEYS = ("recommended_action", "debugging_information")
+
+
+@register(OS.ARISTA_EOS, "show reload cause")
+class ShowReloadCauseParser(BaseParser[ShowReloadCauseResult]):
+    """Parser for 'show reload cause' command on Arista EOS.
+
+    Parses reload cause, timestamp, recommended action, and debugging
+    information from the command output.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _RELOAD_CAUSE_HEADER = re.compile(r"^Reload Cause \d+:")
+    _RELOAD_TIME = re.compile(r"^Reload occurred at (?P<time>.+)\.$")
+    _SEPARATOR = re.compile(r"^-{2,}$")
+
+    # Values that indicate "no data" and should be omitted from output.
+    _NO_VALUE_SENTINELS = frozenset({"none available", "no information available"})
+
+    @classmethod
+    def _detect_section(cls, line: str) -> str | None:
+        """Return the section key if *line* is a section header, else None."""
+        if cls._RELOAD_CAUSE_HEADER.match(line):
+            return "reload_cause"
+        for header, key in _SECTION_HEADERS.items():
+            if line.startswith(header):
+                return key
+        return None
+
+    @classmethod
+    def _is_meaningful(cls, value: str) -> bool:
+        """Return True when *value* is not a no-data sentinel."""
+        return value.lower().rstrip(".") not in cls._NO_VALUE_SENTINELS
+
+    @classmethod
+    def _extract_sections(cls, output: str) -> dict[str, str]:
+        """Walk the output and return a mapping of section key to content."""
+        current_section: str | None = None
+        sections: dict[str, str] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            if not stripped or cls._SEPARATOR.match(stripped):
+                continue
+
+            detected = cls._detect_section(stripped)
+            if detected is not None:
+                current_section = detected
+                continue
+
+            if current_section is not None and current_section not in sections:
+                cls._store_section_value(current_section, stripped, sections)
+
+        return sections
+
+    @classmethod
+    def _store_section_value(
+        cls, section: str, line: str, sections: dict[str, str]
+    ) -> None:
+        """Extract and store the value for the given *section*."""
+        if section == "reload_time":
+            if match := cls._RELOAD_TIME.match(line):
+                sections[section] = match.group("time")
+        else:
+            sections[section] = line
+
+    @classmethod
+    def _build_result(cls, sections: dict[str, str]) -> ShowReloadCauseResult:
+        """Build the typed result dict from extracted sections."""
+        result = ShowReloadCauseResult(reload_cause=sections["reload_cause"])
+
+        if "reload_time" in sections:
+            result["reload_time"] = sections["reload_time"]
+
+        for key in _OPTIONAL_SENTINEL_KEYS:
+            if key in sections and cls._is_meaningful(sections[key]):
+                result[key] = sections[key]  # type: ignore[literal-required]
+
+        return result
+
+    @classmethod
+    def parse(cls, output: str) -> ShowReloadCauseResult:
+        """Parse 'show reload cause' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed reload cause information.
+
+        Raises:
+            ValueError: If no reload cause can be found in the output.
+        """
+        sections = cls._extract_sections(output)
+
+        if "reload_cause" not in sections:
+            msg = "No reload cause found in output"
+            raise ValueError(msg)
+
+        return cls._build_result(sections)

--- a/tests/parsers/arista_eos/show_reload_cause/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_reload_cause/001_basic/expected.json
@@ -1,5 +1,9 @@
 {
-    "reload_cause": "The system rebooted due to a Power Loss",
-    "reload_time": "Fri Feb 23 14:18:49 2018 UTC",
-    "recommended_action": "No action necessary."
+    "causes": {
+        "1": {
+            "cause": "The system rebooted due to a Power Loss",
+            "reload_time": "Fri Feb 23 14:18:49 2018 UTC",
+            "recommended_action": "No action necessary."
+        }
+    }
 }

--- a/tests/parsers/arista_eos/show_reload_cause/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_reload_cause/001_basic/expected.json
@@ -1,0 +1,5 @@
+{
+    "reload_cause": "The system rebooted due to a Power Loss",
+    "reload_time": "Fri Feb 23 14:18:49 2018 UTC",
+    "recommended_action": "No action necessary."
+}

--- a/tests/parsers/arista_eos/show_reload_cause/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_reload_cause/001_basic/input.txt
@@ -1,0 +1,15 @@
+Reload Cause 1:
+-------------------
+The system rebooted due to a Power Loss
+
+Reload Time:
+------------
+Reload occurred at Fri Feb 23 14:18:49 2018 UTC.
+
+Recommended Action:
+-------------------
+No action necessary.
+
+Debugging Information:
+----------------------
+None available.

--- a/tests/parsers/arista_eos/show_reload_cause/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_reload_cause/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic reload cause with power loss
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show reload cause` on Arista EOS
- Extracts reload cause, reload time, recommended action, and debugging information
- Omits sentinel values like "None available" from structured output rather than carrying them as string placeholders

## Test plan
- [x] Parser test fixture with real device output (`001_basic`)
- [x] All placeholder sentinel tests pass (no banned values in `expected.json`)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)
- [x] Pre-commit hooks pass (ruff, xenon, formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)