### PR TITLE
feat(juniper_junos): add parser for `show route summary`

### DIFF
--- a/changes/+juniper-junos-show-route-summary.parser_added
+++ b/changes/+juniper-junos-show-route-summary.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show route summary` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_route_summary.py
+++ b/src/muninn/parsers/juniper_junos/show_route_summary.py
@@ -1,0 +1,179 @@
+"""Parser for 'show route summary' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ProtocolEntry(TypedDict):
+    """Schema for a protocol's route counts within a routing table."""
+
+    routes: int
+    active: int
+
+
+class RoutingTableEntry(TypedDict):
+    """Schema for a single routing table summary."""
+
+    destinations: int
+    total_routes: int
+    active: int
+    holddown: int
+    hidden: int
+    protocols: dict[str, ProtocolEntry]
+
+
+class HighwaterMark(TypedDict):
+    """Schema for highwater mark statistics."""
+
+    rib_unique_destination_routes: int
+    rib_routes: int
+    fib_routes: int
+    vrf_type_routing_instances: NotRequired[int]
+
+
+class ShowRouteSummaryResult(TypedDict):
+    """Schema for 'show route summary' parsed output on Juniper Junos.
+
+    Captures AS number, router ID, highwater marks, and per-table
+    route summaries with protocol breakdowns.
+    """
+
+    autonomous_system: int
+    router_id: str
+    highwater_mark: HighwaterMark
+    tables: dict[str, RoutingTableEntry]
+
+
+# --- Header patterns ---
+_AS_RE = re.compile(r"^Autonomous system number:\s+(?P<as>\d+)\s*$")
+_ROUTER_ID_RE = re.compile(r"^Router ID:\s+(?P<id>\S+)\s*$")
+
+# --- Highwater mark patterns ---
+_HW_RIB_DEST_RE = re.compile(
+    r"^\s*RIB unique destination routes:\s+(?P<val>\d+)\s+at\s+"
+)
+_HW_RIB_ROUTES_RE = re.compile(r"^\s*RIB routes\s*:\s+(?P<val>\d+)\s+at\s+")
+_HW_FIB_ROUTES_RE = re.compile(r"^\s*FIB routes\s*:\s+(?P<val>\d+)\s+at\s+")
+_HW_VRF_RE = re.compile(r"^\s*VRF type routing instances\s*:\s+(?P<val>\d+)\s+at\s+")
+
+# --- Routing table header ---
+# e.g. "inet.0: 993427 destinations, 8574425 routes (992253 active, ...)"
+_TABLE_RE = re.compile(
+    r"^(?P<name>\S+):\s+(?P<dest>\d+)\s+destinations?,\s+(?P<routes>\d+)\s+routes?\s+"
+    r"\((?P<active>\d+)\s+active,\s+(?P<holddown>\d+)\s+holddown,\s+"
+    r"(?P<hidden>\d+)\s+hidden\)\s*$"
+)
+
+# --- Protocol line within a table ---
+# e.g. "              Direct:      8 routes,      7 active"
+_PROTO_RE = re.compile(
+    r"^\s+(?P<proto>\S+):\s+(?P<routes>\d+)\s+routes?,\s+(?P<active>\d+)\s+active\s*$"
+)
+
+
+def _parse_highwater(lines: list[str]) -> HighwaterMark:
+    """Parse the highwater mark section from output lines."""
+    hw: dict[str, int] = {}
+
+    for line in lines:
+        if m := _HW_RIB_DEST_RE.match(line):
+            hw["rib_unique_destination_routes"] = int(m.group("val"))
+        elif m := _HW_RIB_ROUTES_RE.match(line):
+            hw["rib_routes"] = int(m.group("val"))
+        elif m := _HW_FIB_ROUTES_RE.match(line):
+            hw["fib_routes"] = int(m.group("val"))
+        elif m := _HW_VRF_RE.match(line):
+            hw["vrf_type_routing_instances"] = int(m.group("val"))
+
+    return cast(HighwaterMark, hw)
+
+
+def _parse_tables(lines: list[str]) -> dict[str, RoutingTableEntry]:
+    """Parse all routing table summaries from output lines."""
+    tables: dict[str, RoutingTableEntry] = {}
+    current_table: str | None = None
+
+    for line in lines:
+        if m := _TABLE_RE.match(line):
+            current_table = m.group("name")
+            tables[current_table] = RoutingTableEntry(
+                destinations=int(m.group("dest")),
+                total_routes=int(m.group("routes")),
+                active=int(m.group("active")),
+                holddown=int(m.group("holddown")),
+                hidden=int(m.group("hidden")),
+                protocols={},
+            )
+            continue
+
+        if current_table is not None:
+            if m := _PROTO_RE.match(line):
+                tables[current_table]["protocols"][m.group("proto")] = ProtocolEntry(
+                    routes=int(m.group("routes")),
+                    active=int(m.group("active")),
+                )
+
+    return tables
+
+
+@register(OS.JUNIPER_JUNOS, "show route summary")
+class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
+    """Parser for 'show route summary' command on Juniper Junos.
+
+    Parses AS number, router ID, highwater marks, and per-routing-table
+    summaries including protocol-level route breakdowns.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteSummaryResult:
+        """Parse 'show route summary' output on Juniper Junos.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed route summary information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        lines = output.splitlines()
+
+        autonomous_system: int | None = None
+        router_id: str | None = None
+
+        for line in lines:
+            stripped = line.strip()
+
+            if m := _AS_RE.match(stripped):
+                autonomous_system = int(m.group("as"))
+                continue
+
+            if m := _ROUTER_ID_RE.match(stripped):
+                router_id = m.group("id")
+                continue
+
+        if autonomous_system is None:
+            msg = "Missing required field: autonomous system number"
+            raise ValueError(msg)
+
+        if router_id is None:
+            msg = "Missing required field: router ID"
+            raise ValueError(msg)
+
+        highwater = _parse_highwater(lines)
+        tables = _parse_tables(lines)
+
+        return ShowRouteSummaryResult(
+            autonomous_system=autonomous_system,
+            router_id=router_id,
+            highwater_mark=highwater,
+            tables=tables,
+        )

--- a/src/muninn/parsers/juniper_junos/show_route_summary.py
+++ b/src/muninn/parsers/juniper_junos/show_route_summary.py
@@ -27,13 +27,30 @@ class RoutingTableEntry(TypedDict):
     protocols: dict[str, ProtocolEntry]
 
 
-class HighwaterMark(TypedDict):
-    """Schema for highwater mark statistics."""
+class HighwaterEntry(TypedDict):
+    """Schema for a single highwater mark statistic.
 
-    rib_unique_destination_routes: int
-    rib_routes: int
-    fib_routes: int
-    vrf_type_routing_instances: NotRequired[int]
+    Captures the all-time peak value, the timestamp at which it was
+    observed, and (when present) the time-averaged watermark.
+    """
+
+    value: int
+    at: str
+    time_averaged: NotRequired[int]
+
+
+class HighwaterMark(TypedDict):
+    """Schema for highwater mark statistics.
+
+    Each field is ``NotRequired`` because Junos may omit individual
+    rows depending on platform / release, and the parser writes each
+    key only when its line is present in the device output.
+    """
+
+    rib_unique_destination_routes: NotRequired[HighwaterEntry]
+    rib_routes: NotRequired[HighwaterEntry]
+    fib_routes: NotRequired[HighwaterEntry]
+    vrf_type_routing_instances: NotRequired[HighwaterEntry]
 
 
 class ShowRouteSummaryResult(TypedDict):
@@ -43,23 +60,30 @@ class ShowRouteSummaryResult(TypedDict):
     route summaries with protocol breakdowns.
     """
 
-    autonomous_system: int
+    autonomous_system: int | str
     router_id: str
     highwater_mark: HighwaterMark
     tables: dict[str, RoutingTableEntry]
 
 
 # --- Header patterns ---
-_AS_RE = re.compile(r"^Autonomous system number:\s+(?P<as>\d+)\s*$")
+# AS may appear as plain integer or asdot notation (e.g. ``65000.100``).
+_AS_RE = re.compile(r"^Autonomous system number:\s+(?P<as>\S+)\s*$")
 _ROUTER_ID_RE = re.compile(r"^Router ID:\s+(?P<id>\S+)\s*$")
 
 # --- Highwater mark patterns ---
-_HW_RIB_DEST_RE = re.compile(
-    r"^\s*RIB unique destination routes:\s+(?P<val>\d+)\s+at\s+"
+# Each line has the form:
+#   "<label>: <value> at <YYYY-MM-DD HH:MM:SS>[ / <averaged>]"
+# The averaged watermark is present on most rows but absent on rows
+# such as ``VRF type routing instances`` in some releases.
+_HW_TAIL = (
+    r"(?P<val>\d+)\s+at\s+(?P<at>\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})"
+    r"(?:\s+/\s+(?P<avg>\d+))?\s*$"
 )
-_HW_RIB_ROUTES_RE = re.compile(r"^\s*RIB routes\s*:\s+(?P<val>\d+)\s+at\s+")
-_HW_FIB_ROUTES_RE = re.compile(r"^\s*FIB routes\s*:\s+(?P<val>\d+)\s+at\s+")
-_HW_VRF_RE = re.compile(r"^\s*VRF type routing instances\s*:\s+(?P<val>\d+)\s+at\s+")
+_HW_RIB_DEST_RE = re.compile(r"^\s*RIB unique destination routes:\s+" + _HW_TAIL)
+_HW_RIB_ROUTES_RE = re.compile(r"^\s*RIB routes\s*:\s+" + _HW_TAIL)
+_HW_FIB_ROUTES_RE = re.compile(r"^\s*FIB routes\s*:\s+" + _HW_TAIL)
+_HW_VRF_RE = re.compile(r"^\s*VRF type routing instances\s*:\s+" + _HW_TAIL)
 
 # --- Routing table header ---
 # e.g. "inet.0: 993427 destinations, 8574425 routes (992253 active, ...)"
@@ -76,19 +100,31 @@ _PROTO_RE = re.compile(
 )
 
 
+def _build_hw_entry(m: re.Match[str]) -> HighwaterEntry:
+    """Build a HighwaterEntry from a matched highwater line."""
+    entry: HighwaterEntry = {
+        "value": int(m.group("val")),
+        "at": m.group("at"),
+    }
+    avg = m.groupdict().get("avg")
+    if avg is not None:
+        entry["time_averaged"] = int(avg)
+    return entry
+
+
 def _parse_highwater(lines: list[str]) -> HighwaterMark:
     """Parse the highwater mark section from output lines."""
-    hw: dict[str, int] = {}
+    hw: dict[str, HighwaterEntry] = {}
 
     for line in lines:
         if m := _HW_RIB_DEST_RE.match(line):
-            hw["rib_unique_destination_routes"] = int(m.group("val"))
+            hw["rib_unique_destination_routes"] = _build_hw_entry(m)
         elif m := _HW_RIB_ROUTES_RE.match(line):
-            hw["rib_routes"] = int(m.group("val"))
+            hw["rib_routes"] = _build_hw_entry(m)
         elif m := _HW_FIB_ROUTES_RE.match(line):
-            hw["fib_routes"] = int(m.group("val"))
+            hw["fib_routes"] = _build_hw_entry(m)
         elif m := _HW_VRF_RE.match(line):
-            hw["vrf_type_routing_instances"] = int(m.group("val"))
+            hw["vrf_type_routing_instances"] = _build_hw_entry(m)
 
     return cast(HighwaterMark, hw)
 
@@ -146,14 +182,16 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
         """
         lines = output.splitlines()
 
-        autonomous_system: int | None = None
+        autonomous_system: int | str | None = None
         router_id: str | None = None
 
         for line in lines:
             stripped = line.strip()
 
             if m := _AS_RE.match(stripped):
-                autonomous_system = int(m.group("as"))
+                raw_as = m.group("as")
+                # Preserve asdot notation as a string; otherwise emit int.
+                autonomous_system = int(raw_as) if raw_as.isdigit() else raw_as
                 continue
 
             if m := _ROUTER_ID_RE.match(stripped):

--- a/tests/parsers/juniper_junos/show_route_summary/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_route_summary/001_basic/expected.json
@@ -2,10 +2,25 @@
     "autonomous_system": 65000,
     "router_id": "129.250.0.2",
     "highwater_mark": {
-        "rib_unique_destination_routes": 1221502,
-        "rib_routes": 11101463,
-        "fib_routes": 1207937,
-        "vrf_type_routing_instances": 1
+        "rib_unique_destination_routes": {
+            "value": 1221502,
+            "at": "2000-01-01 00:00:00",
+            "time_averaged": 1217389
+        },
+        "rib_routes": {
+            "value": 11101463,
+            "at": "2000-01-01 00:00:00",
+            "time_averaged": 10394871
+        },
+        "fib_routes": {
+            "value": 1207937,
+            "at": "2000-01-01 00:00:00",
+            "time_averaged": 1203820
+        },
+        "vrf_type_routing_instances": {
+            "value": 1,
+            "at": "2000-01-01 00:00:00"
+        }
     },
     "tables": {
         "inet.0": {

--- a/tests/parsers/juniper_junos/show_route_summary/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_route_summary/001_basic/expected.json
@@ -1,0 +1,125 @@
+{
+    "autonomous_system": 65000,
+    "router_id": "129.250.0.2",
+    "highwater_mark": {
+        "rib_unique_destination_routes": 1221502,
+        "rib_routes": 11101463,
+        "fib_routes": 1207937,
+        "vrf_type_routing_instances": 1
+    },
+    "tables": {
+        "inet.0": {
+            "destinations": 993427,
+            "total_routes": 8574425,
+            "active": 992253,
+            "holddown": 13182,
+            "hidden": 1328663,
+            "protocols": {
+                "Direct": {
+                    "routes": 8,
+                    "active": 7
+                },
+                "Local": {
+                    "routes": 7,
+                    "active": 7
+                },
+                "BGP": {
+                    "routes": 8568064,
+                    "active": 985893
+                },
+                "Static": {
+                    "routes": 2,
+                    "active": 2
+                },
+                "IS-IS": {
+                    "routes": 6343,
+                    "active": 6343
+                },
+                "LDP": {
+                    "routes": 1,
+                    "active": 1
+                }
+            }
+        },
+        "iso.0": {
+            "destinations": 1,
+            "total_routes": 1,
+            "active": 1,
+            "holddown": 0,
+            "hidden": 0,
+            "protocols": {
+                "Direct": {
+                    "routes": 1,
+                    "active": 1
+                }
+            }
+        },
+        "mpls.0": {
+            "destinations": 284,
+            "total_routes": 284,
+            "active": 284,
+            "holddown": 0,
+            "hidden": 0,
+            "protocols": {
+                "MPLS": {
+                    "routes": 6,
+                    "active": 6
+                },
+                "RSVP": {
+                    "routes": 4,
+                    "active": 4
+                },
+                "LDP": {
+                    "routes": 274,
+                    "active": 274
+                }
+            }
+        },
+        "inet6.0": {
+            "destinations": 214385,
+            "total_routes": 1781556,
+            "active": 214292,
+            "holddown": 2700,
+            "hidden": 257364,
+            "protocols": {
+                "Direct": {
+                    "routes": 4,
+                    "active": 4
+                },
+                "Local": {
+                    "routes": 4,
+                    "active": 4
+                },
+                "BGP": {
+                    "routes": 1775906,
+                    "active": 208642
+                },
+                "Static": {
+                    "routes": 2,
+                    "active": 2
+                },
+                "IS-IS": {
+                    "routes": 5639,
+                    "active": 5639
+                },
+                "INET6": {
+                    "routes": 1,
+                    "active": 1
+                }
+            }
+        },
+        "l2circuit.0": {
+            "destinations": 1,
+            "total_routes": 1,
+            "active": 1,
+            "holddown": 0,
+            "hidden": 0,
+            "protocols": {
+                "LDP": {
+                    "routes": 1,
+                    "active": 1
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_route_summary/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_route_summary/001_basic/input.txt
@@ -1,0 +1,35 @@
+Autonomous system number: 65000
+Router ID: 129.250.0.2
+
+Highwater Mark (All time / Time averaged watermark)
+    RIB unique destination routes: 1221502 at 2000-01-01 00:00:00 / 1217389
+    RIB routes                   : 11101463 at 2000-01-01 00:00:00 / 10394871
+    FIB routes                   : 1207937 at 2000-01-01 00:00:00 / 1203820
+    VRF type routing instances   : 1 at 2000-01-01 00:00:00
+
+inet.0: 993427 destinations, 8574425 routes (992253 active, 13182 holddown, 1328663 hidden)
+              Direct:      8 routes,      7 active
+               Local:      7 routes,      7 active
+                 BGP: 8568064 routes, 985893 active
+              Static:      2 routes,      2 active
+               IS-IS:   6343 routes,   6343 active
+                 LDP:      1 routes,      1 active
+
+iso.0: 1 destinations, 1 routes (1 active, 0 holddown, 0 hidden)
+              Direct:      1 routes,      1 active
+
+mpls.0: 284 destinations, 284 routes (284 active, 0 holddown, 0 hidden)
+                MPLS:      6 routes,      6 active
+                RSVP:      4 routes,      4 active
+                 LDP:    274 routes,    274 active
+
+inet6.0: 214385 destinations, 1781556 routes (214292 active, 2700 holddown, 257364 hidden)
+              Direct:      4 routes,      4 active
+               Local:      4 routes,      4 active
+                 BGP: 1775906 routes, 208642 active
+              Static:      2 routes,      2 active
+               IS-IS:   5639 routes,   5639 active
+               INET6:      1 routes,      1 active
+
+l2circuit.0: 1 destinations, 1 routes (1 active, 0 holddown, 0 hidden)
+                 LDP:      1 routes,      1 active

--- a/tests/parsers/juniper_junos/show_route_summary/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_route_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple routing tables with protocol breakdowns and highwater marks
+platform: MX Series
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show route summary` on Juniper Junos (`juniper_junos`)
- Parses AS number, router ID, highwater marks, and per-routing-table summaries with protocol-level route breakdowns (destinations, active/holddown/hidden counts)
- Includes test fixture from real MX Series device output covering 5 routing tables (inet.0, iso.0, mpls.0, inet6.0, l2circuit.0)

## Test plan
- [x] Parser test passes against real device fixture (`001_basic`)
- [x] All fixture sentinel checks pass (no placeholder values)
- [x] JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] Ruff lint and format clean
- [x] Xenon complexity under B threshold
- [x] Bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)