### PR TITLE
feat(juniper_junos): add parser for show chassis hardware

### DIFF
--- a/changes/+juniper-junos-show-chassis-hardware.parser_added
+++ b/changes/+juniper-junos-show-chassis-hardware.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show chassis hardware` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_chassis_hardware.py
+++ b/src/muninn/parsers/juniper_junos/show_chassis_hardware.py
@@ -1,0 +1,183 @@
+"""Parser for 'show chassis hardware' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class HardwareItem(TypedDict):
+    """Schema for a single hardware inventory item."""
+
+    version: NotRequired[str]
+    part_number: NotRequired[str]
+    serial_number: NotRequired[str]
+    description: NotRequired[str]
+    children: NotRequired[dict[str, "HardwareItem"]]
+
+
+ShowChassisHardwareResult = dict[str, HardwareItem]
+
+
+@register(OS.JUNIPER_JUNOS, "show chassis hardware")
+class ShowChassisHardwareParser(BaseParser[ShowChassisHardwareResult]):
+    """Parser for 'show chassis hardware' command on Juniper Junos.
+
+    Parses the hierarchical hardware inventory table into a nested
+    dict-of-dicts structure reflecting the chassis component hierarchy.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INVENTORY})
+
+    _HEADER_PATTERN = re.compile(
+        r"^Item\s+Version\s+Part number\s+Serial number\s+Description\s*$"
+    )
+
+    _PREAMBLE_PATTERN = re.compile(r"^Hardware inventory:\s*$")
+
+    # Number of spaces per indentation level in the output
+    _INDENT_SPACES = 2
+
+    # Sentinel values that should be treated as absent
+    _BUILTIN_SENTINEL = "BUILTIN"
+    _NON_JNPR_SENTINEL = "NON-JNPR"
+
+    _SKIP_SENTINELS: ClassVar[frozenset[str]] = frozenset(
+        {_BUILTIN_SENTINEL, _NON_JNPR_SENTINEL}
+    )
+
+    # Column positions (0-indexed) from the standard Junos header layout:
+    # Item             Version  Part number  Serial number     Description
+    _COL_VERSION = 17
+    _COL_PART_NUMBER = 26
+    _COL_SERIAL_NUMBER = 39
+    _COL_DESCRIPTION = 57
+
+    @classmethod
+    def _extract_column(cls, line: str, start: int, end: int) -> str:
+        """Extract and strip a fixed-width column value from a line."""
+        if len(line) <= start:
+            return ""
+        segment = line[start:end] if len(line) >= end else line[start:]
+        return segment.strip()
+
+    @classmethod
+    def _is_skippable(cls, line: str) -> bool:
+        """Return True if the line is not a data row."""
+        stripped = line.strip()
+        if not stripped:
+            return True
+        if cls._HEADER_PATTERN.match(stripped):
+            return True
+        return bool(cls._PREAMBLE_PATTERN.match(stripped))
+
+    @classmethod
+    def _keep_field(cls, value: str) -> str | None:
+        """Return the value if it is meaningful, or None for sentinels/blanks."""
+        if not value or value in cls._SKIP_SENTINELS:
+            return None
+        return value
+
+    @classmethod
+    def _build_item(cls, line: str) -> HardwareItem:
+        """Build a HardwareItem from the column values in a data line."""
+        item: HardwareItem = {}
+
+        if version := cls._keep_field(
+            cls._extract_column(line, cls._COL_VERSION, cls._COL_PART_NUMBER)
+        ):
+            item["version"] = version
+
+        if part_number := cls._keep_field(
+            cls._extract_column(line, cls._COL_PART_NUMBER, cls._COL_SERIAL_NUMBER)
+        ):
+            item["part_number"] = part_number
+
+        if serial_number := cls._keep_field(
+            cls._extract_column(line, cls._COL_SERIAL_NUMBER, cls._COL_DESCRIPTION)
+        ):
+            item["serial_number"] = serial_number
+
+        if description := cls._extract_column(line, cls._COL_DESCRIPTION, len(line)):
+            item["description"] = description
+
+        return item
+
+    @classmethod
+    def _parse_line(cls, line: str) -> tuple[int, str, HardwareItem] | None:
+        """Parse a hardware item line using fixed column positions.
+
+        Returns:
+            Tuple of (indent_level, item_name, item_dict), or None if the
+            line is not a data row (header, preamble, or blank).
+        """
+        if cls._is_skippable(line):
+            return None
+
+        name = line[: cls._COL_VERSION].strip()
+        if not name:
+            return None
+
+        indent_chars = len(line) - len(line.lstrip(" "))
+        indent_level = indent_chars // cls._INDENT_SPACES
+
+        return indent_level, name, cls._build_item(line)
+
+    @classmethod
+    def parse(cls, output: str) -> ShowChassisHardwareResult:
+        """Parse 'show chassis hardware' output into structured data.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Nested dict-of-dicts representing the hardware inventory hierarchy.
+
+        Raises:
+            ValueError: If no hardware items are found in the output.
+        """
+        result: ShowChassisHardwareResult = {}
+
+        # Stack tracks (indent_level, children_dict) for building hierarchy.
+        # Root sentinel at level -1 holds the top-level result dict.
+        stack: list[tuple[int, dict[str, HardwareItem]]] = [(-1, result)]
+
+        for line in output.splitlines():
+            parsed = cls._parse_line(line)
+            if parsed is None:
+                continue
+
+            indent_level, name, item = parsed
+
+            # Pop back to the nearest ancestor at a shallower indent level
+            while len(stack) > 1 and stack[-1][0] >= indent_level:
+                stack.pop()
+
+            parent_dict = stack[-1][1]
+            parent_dict[name] = item
+
+            # Push a lazy children dict so deeper items nest under this one
+            stack.append((indent_level, item.setdefault("children", {})))
+
+        # Remove empty children dicts from leaf nodes
+        cls._prune_empty_children(result)
+
+        if not result:
+            msg = "No hardware items found in output"
+            raise ValueError(msg)
+
+        return result
+
+    @classmethod
+    def _prune_empty_children(cls, items: dict[str, HardwareItem]) -> None:
+        """Recursively remove empty 'children' dicts from leaf items."""
+        for item in items.values():
+            if "children" in item:
+                children = item["children"]
+                if children:
+                    cls._prune_empty_children(children)
+                else:
+                    del item["children"]

--- a/tests/parsers/juniper_junos/show_chassis_hardware/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_chassis_hardware/001_basic/expected.json
@@ -1,0 +1,131 @@
+{
+    "Chassis": {
+        "serial_number": "A1111",
+        "description": "MX10-T"
+    },
+    "Midplane": {
+        "version": "REV 08",
+        "part_number": "711-038213",
+        "serial_number": "XXXX2118",
+        "description": "MX10-T"
+    },
+    "PEM 0": {
+        "version": "Rev 05",
+        "part_number": "740-028288",
+        "serial_number": "AJ00000",
+        "description": "AC Power Entry Module"
+    },
+    "PEM 1": {
+        "version": "Rev 05",
+        "part_number": "740-028288",
+        "serial_number": "AJ00001",
+        "description": "AC Power Entry Module"
+    },
+    "Routing Engine": {
+        "description": "Routing Engine"
+    },
+    "TFEB 0": {
+        "description": "Forwarding Engine Processor",
+        "children": {
+            "QXM 0": {
+                "version": "REV 05",
+                "part_number": "711-028408",
+                "serial_number": "ABCB4000",
+                "description": "MPC QXM"
+            }
+        }
+    },
+    "FPC 0": {
+        "description": "MPC BUILTIN",
+        "children": {
+            "MIC 0": {
+                "description": "4x 10GE XFP",
+                "children": {
+                    "PIC 0": {
+                        "description": "4x 10GE XFP",
+                        "children": {
+                            "Xcvr 0": {
+                                "version": "REV 01",
+                                "part_number": "740-011571",
+                                "serial_number": "USASR24490",
+                                "description": "XFP-10G-SR"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "FPC 1": {
+        "description": "MPC BUILTIN",
+        "children": {
+            "MIC 0": {
+                "version": "REV 30",
+                "part_number": "750-028380",
+                "serial_number": "CALW4921",
+                "description": "3D 2x 10GE XFP",
+                "children": {
+                    "PIC 0": {
+                        "description": "1x 10GE XFP",
+                        "children": {
+                            "Xcvr 0": {
+                                "version": "REV 01",
+                                "part_number": "740-011607",
+                                "serial_number": "A1JACT3",
+                                "description": "XFP-10G-LR"
+                            }
+                        }
+                    },
+                    "PIC 1": {
+                        "description": "1x 10GE XFP",
+                        "children": {
+                            "Xcvr 0": {
+                                "version": "REV 01",
+                                "part_number": "740-011607",
+                                "serial_number": "A1KBPNC",
+                                "description": "XFP-10G-LR"
+                            }
+                        }
+                    }
+                }
+            },
+            "MIC 1": {
+                "version": "REV 20",
+                "part_number": "750-028380",
+                "serial_number": "ABCC2190",
+                "description": "3D 2x 10GE XFP",
+                "children": {
+                    "PIC 2": {
+                        "description": "1x 10GE XFP",
+                        "children": {
+                            "Xcvr 0": {
+                                "serial_number": "CC37BK0PQ",
+                                "description": "XFP-10G-SR"
+                            }
+                        }
+                    },
+                    "PIC 3": {
+                        "description": "1x 10GE XFP",
+                        "children": {
+                            "Xcvr 0": {
+                                "version": "REV 01",
+                                "part_number": "740-014279",
+                                "serial_number": "EOXH27560005",
+                                "description": "XFP-10G-LR"
+                            },
+                            "Xcvr 1": {
+                                "version": "REV 01",
+                                "part_number": "740-014279",
+                                "serial_number": "XXXXXXXXXXXX",
+                                "description": "XFP-10G-LR"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "Fan Tray": {
+        "description": "Fan Tray"
+    }
+}

--- a/tests/parsers/juniper_junos/show_chassis_hardware/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_chassis_hardware/001_basic/input.txt
@@ -1,0 +1,26 @@
+Hardware inventory:
+Item             Version  Part number  Serial number     Description
+Chassis                                A1111             MX10-T
+Midplane         REV 08   711-038213   XXXX2118          MX10-T
+PEM 0            Rev 05   740-028288   AJ00000           AC Power Entry Module
+PEM 1            Rev 05   740-028288   AJ00001           AC Power Entry Module
+Routing Engine            BUILTIN      BUILTIN           Routing Engine
+TFEB 0                    BUILTIN      BUILTIN           Forwarding Engine Processor
+  QXM 0          REV 05   711-028408   ABCB4000          MPC QXM
+FPC 0                     BUILTIN      BUILTIN           MPC BUILTIN
+  MIC 0                   BUILTIN      BUILTIN           4x 10GE XFP
+    PIC 0                 BUILTIN      BUILTIN           4x 10GE XFP
+      Xcvr 0     REV 01   740-011571   USASR24490        XFP-10G-SR
+FPC 1                     BUILTIN      BUILTIN           MPC BUILTIN
+  MIC 0          REV 30   750-028380   CALW4921          3D 2x 10GE XFP
+    PIC 0                 BUILTIN      BUILTIN           1x 10GE XFP
+      Xcvr 0     REV 01   740-011607   A1JACT3           XFP-10G-LR
+    PIC 1                 BUILTIN      BUILTIN           1x 10GE XFP
+      Xcvr 0     REV 01   740-011607   A1KBPNC           XFP-10G-LR
+  MIC 1          REV 20   750-028380   ABCC2190          3D 2x 10GE XFP
+    PIC 2                 BUILTIN      BUILTIN           1x 10GE XFP
+      Xcvr 0              NON-JNPR     CC37BK0PQ         XFP-10G-SR
+    PIC 3                 BUILTIN      BUILTIN           1x 10GE XFP
+      Xcvr 0     REV 01   740-014279   EOXH27560005      XFP-10G-LR
+      Xcvr 1     REV 01   740-014279   XXXXXXXXXXXX      XFP-10G-LR
+Fan Tray                                                 Fan Tray

--- a/tests/parsers/juniper_junos/show_chassis_hardware/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_chassis_hardware/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: MX10-T chassis with multiple FPCs, MICs, PICs, and transceivers
+platform: MX10-T
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show chassis hardware` on Juniper Junos (`juniper_junos`)
- Parses hierarchical hardware inventory into nested dict-of-dicts structure (chassis -> slots -> sub-modules -> transceivers)
- Extracts version, part number, serial number, and description fields using fixed column positions
- Filters out BUILTIN and NON-JNPR sentinel values (omits keys rather than carrying placeholder strings)
- Tagged with `ParserTag.INVENTORY`

## Test plan
- [x] Test fixture `001_basic` with MX10-T chassis output covering FPCs, MICs, PICs, transceivers, PEMs, fan tray
- [x] All placeholder sentinel tests pass (no hyphens, NA, None, or empty strings in expected.json)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity under B threshold
- [x] Bandit security scan clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)