### PR TITLE
feat(juniper_junos): add parser for show system uptime

### DIFF
--- a/changes/+juniper-junos-show-system-uptime.parser_added
+++ b/changes/+juniper-junos-show-system-uptime.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show system uptime` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_system_uptime.py
+++ b/src/muninn/parsers/juniper_junos/show_system_uptime.py
@@ -26,6 +26,10 @@ class ShowSystemUptimeResult(TypedDict):
     last_configured_ago: str
     last_configured_by: NotRequired[str]
     uptime: str
+    users: int
+    load_average_1m: float
+    load_average_5m: float
+    load_average_15m: float
 
 
 _TS = r"\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\s+\S+"
@@ -49,7 +53,14 @@ class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
     _LAST_CONFIGURED = re.compile(
         rf"^Last configured:\s+{_TS_AGO}" r"(?:\s+by\s+(?P<user>\S+))?"
     )
-    _UPTIME = re.compile(r"^\s*\d+:\d{2}[AP]M\s+up\s+(?P<uptime>.+?),\s+\d+\s+users?,")
+    _UPTIME = re.compile(
+        r"^\s*\d+:\d{2}[AP]M\s+up\s+(?P<uptime>.+?),"
+        r"\s+(?P<users>\d+)\s+users?,"
+        r"\s+load averages?:\s+"
+        r"(?P<load1>\d+\.\d+),\s+"
+        r"(?P<load5>\d+\.\d+),\s+"
+        r"(?P<load15>\d+\.\d+)"
+    )
 
     _REQUIRED_FIELDS = (
         "current_time",
@@ -60,10 +71,14 @@ class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
         "last_configured_at",
         "last_configured_ago",
         "uptime",
+        "users",
+        "load_average_1m",
+        "load_average_5m",
+        "load_average_15m",
     )
 
     @classmethod
-    def _parse_timestamp_line(cls, line: str, result: dict[str, str]) -> bool:
+    def _parse_timestamp_line(cls, line: str, result: dict[str, object]) -> bool:
         """Try to match a timestamp+ago line and store its fields."""
         patterns = (
             (cls._SYSTEM_BOOTED, "system_booted"),
@@ -82,7 +97,7 @@ class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
         return False
 
     @classmethod
-    def _parse_line(cls, line: str, result: dict[str, str]) -> None:
+    def _parse_line(cls, line: str, result: dict[str, object]) -> None:
         """Parse a single line, updating result in place."""
         if match := cls._CURRENT_TIME.match(line):
             result["current_time"] = match.group("time")
@@ -92,6 +107,10 @@ class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
             pass
         elif match := cls._UPTIME.match(line):
             result["uptime"] = match.group("uptime")
+            result["users"] = int(match.group("users"))
+            result["load_average_1m"] = float(match.group("load1"))
+            result["load_average_5m"] = float(match.group("load5"))
+            result["load_average_15m"] = float(match.group("load15"))
 
     @classmethod
     def parse(cls, output: str) -> ShowSystemUptimeResult:
@@ -106,7 +125,7 @@ class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
         Raises:
             ValueError: If required fields cannot be parsed.
         """
-        result: dict[str, str] = {}
+        result: dict[str, object] = {}
 
         for line in output.splitlines():
             stripped = line.strip()

--- a/src/muninn/parsers/juniper_junos/show_system_uptime.py
+++ b/src/muninn/parsers/juniper_junos/show_system_uptime.py
@@ -1,7 +1,7 @@
 """Parser for 'show system uptime' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -118,4 +118,4 @@ class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
             msg = f"Missing required fields: {', '.join(missing)}"
             raise ValueError(msg)
 
-        return ShowSystemUptimeResult(**result)  # type: ignore[typeddict-item]
+        return cast(ShowSystemUptimeResult, result)

--- a/src/muninn/parsers/juniper_junos/show_system_uptime.py
+++ b/src/muninn/parsers/juniper_junos/show_system_uptime.py
@@ -1,0 +1,121 @@
+"""Parser for 'show system uptime' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowSystemUptimeResult(TypedDict):
+    """Schema for 'show system uptime' parsed output.
+
+    Captures current time, time source, boot time, protocol start time,
+    last configuration change, and uptime string from Juniper Junos devices.
+    """
+
+    current_time: str
+    time_source: NotRequired[str]
+    system_booted_at: str
+    system_booted_ago: str
+    protocols_started_at: str
+    protocols_started_ago: str
+    last_configured_at: str
+    last_configured_ago: str
+    last_configured_by: NotRequired[str]
+    uptime: str
+
+
+_TS = r"\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\s+\S+"
+_TS_AGO = rf"(?P<time>{_TS})\s+\((?P<ago>[^)]+)\)"
+
+
+@register(OS.JUNIPER_JUNOS, "show system uptime")
+class ShowSystemUptimeParser(BaseParser[ShowSystemUptimeResult]):
+    """Parser for 'show system uptime' command on Juniper Junos.
+
+    Parses current time, boot time, protocol start time, last configuration
+    change, and the uptime summary line.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _CURRENT_TIME = re.compile(rf"^Current time:\s+(?P<time>{_TS})")
+    _TIME_SOURCE = re.compile(r"^Time Source:\s+(?P<source>.+?)\s*$")
+    _SYSTEM_BOOTED = re.compile(rf"^System booted:\s+{_TS_AGO}")
+    _PROTOCOLS_STARTED = re.compile(rf"^Protocols started:\s+{_TS_AGO}")
+    _LAST_CONFIGURED = re.compile(
+        rf"^Last configured:\s+{_TS_AGO}" r"(?:\s+by\s+(?P<user>\S+))?"
+    )
+    _UPTIME = re.compile(r"^\s*\d+:\d{2}[AP]M\s+up\s+(?P<uptime>.+?),\s+\d+\s+users?,")
+
+    _REQUIRED_FIELDS = (
+        "current_time",
+        "system_booted_at",
+        "system_booted_ago",
+        "protocols_started_at",
+        "protocols_started_ago",
+        "last_configured_at",
+        "last_configured_ago",
+        "uptime",
+    )
+
+    @classmethod
+    def _parse_timestamp_line(cls, line: str, result: dict[str, str]) -> bool:
+        """Try to match a timestamp+ago line and store its fields."""
+        patterns = (
+            (cls._SYSTEM_BOOTED, "system_booted"),
+            (cls._PROTOCOLS_STARTED, "protocols_started"),
+            (cls._LAST_CONFIGURED, "last_configured"),
+        )
+        for pattern, prefix in patterns:
+            match = pattern.match(line)
+            if not match:
+                continue
+            result[f"{prefix}_at"] = match.group("time")
+            result[f"{prefix}_ago"] = match.group("ago")
+            if "user" in match.groupdict() and match.group("user"):
+                result[f"{prefix}_by"] = match.group("user")
+            return True
+        return False
+
+    @classmethod
+    def _parse_line(cls, line: str, result: dict[str, str]) -> None:
+        """Parse a single line, updating result in place."""
+        if match := cls._CURRENT_TIME.match(line):
+            result["current_time"] = match.group("time")
+        elif match := cls._TIME_SOURCE.match(line):
+            result["time_source"] = match.group("source")
+        elif cls._parse_timestamp_line(line, result):
+            pass
+        elif match := cls._UPTIME.match(line):
+            result["uptime"] = match.group("uptime")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSystemUptimeResult:
+        """Parse 'show system uptime' output on Juniper Junos.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed uptime information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result: dict[str, str] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped:
+                cls._parse_line(stripped, result)
+
+        missing = [f for f in cls._REQUIRED_FIELDS if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return ShowSystemUptimeResult(**result)  # type: ignore[typeddict-item]

--- a/tests/parsers/juniper_junos/show_system_uptime/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_system_uptime/001_basic/expected.json
@@ -1,0 +1,12 @@
+{
+    "current_time": "2021-08-31 08:48:11 MSK",
+    "time_source": "NTP CLOCK",
+    "system_booted_at": "2021-03-29 13:32:05 MSK",
+    "system_booted_ago": "22w0d 19:16 ago",
+    "protocols_started_at": "2021-03-29 13:37:11 MSK",
+    "protocols_started_ago": "22w0d 19:11 ago",
+    "last_configured_at": "2021-07-13 16:35:35 MSK",
+    "last_configured_ago": "6w6d 16:12 ago",
+    "last_configured_by": "admin",
+    "uptime": "154 days, 19:16"
+}

--- a/tests/parsers/juniper_junos/show_system_uptime/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_system_uptime/001_basic/expected.json
@@ -8,5 +8,9 @@
     "last_configured_at": "2021-07-13 16:35:35 MSK",
     "last_configured_ago": "6w6d 16:12 ago",
     "last_configured_by": "admin",
-    "uptime": "154 days, 19:16"
+    "uptime": "154 days, 19:16",
+    "users": 2,
+    "load_average_1m": 0.04,
+    "load_average_5m": 0.04,
+    "load_average_15m": 0.01
 }

--- a/tests/parsers/juniper_junos/show_system_uptime/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_system_uptime/001_basic/input.txt
@@ -1,0 +1,6 @@
+Current time: 2021-08-31 08:48:11 MSK
+Time Source:  NTP CLOCK
+System booted: 2021-03-29 13:32:05 MSK (22w0d 19:16 ago)
+Protocols started: 2021-03-29 13:37:11 MSK (22w0d 19:11 ago)
+Last configured: 2021-07-13 16:35:35 MSK (6w6d 16:12 ago) by admin
+ 8:48AM  up 154 days, 19:16, 2 users, load averages: 0.04, 0.04, 0.01

--- a/tests/parsers/juniper_junos/show_system_uptime/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_system_uptime/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic system uptime output with NTP clock source
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show system uptime` on Juniper Junos (`juniper_junos`)
- Extracts current time, time source, boot time, protocol start time, last configuration change (with user), and uptime string
- Tagged with `ParserTag.SYSTEM`

## Test plan
- [x] Test fixture `001_basic` with real device output from ntc-templates
- [x] All 7 parametrized tests pass (parser correctness, JSON conventions, placeholder sentinels)
- [x] ruff check/format, xenon complexity, bandit security scan all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)