### PR TITLE
feat(juniper_junos): add parser for show system processes summary

### DIFF
--- a/changes/+juniper-junos-show-system-processes-summary.parser_added
+++ b/changes/+juniper-junos-show-system-processes-summary.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show system processes summary` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_system_processes_summary.py
+++ b/src/muninn/parsers/juniper_junos/show_system_processes_summary.py
@@ -58,6 +58,7 @@ class ShowSystemProcessesSummaryResult(TypedDict):
     load_average_5min: float
     load_average_15min: float
     uptime: str
+    current_time: str
     processes: ProcessCounts
     cpu: CpuUsage
     memory: MemoryUsage
@@ -104,7 +105,8 @@ class ShowSystemProcessesSummaryParser(
         r"last pid:\s*(?P<last_pid>\d+);\s*"
         r"load averages:\s*(?P<load1>[\d.]+),\s*"
         r"(?P<load5>[\d.]+),\s*(?P<load15>[\d.]+)\s+"
-        r"up\s+(?P<uptime>\S+)",
+        r"up\s+(?P<uptime>\S+)\s+"
+        r"(?P<current_time>\d{2}:\d{2}:\d{2})",
     )
 
     _THREADS_PATTERN = re.compile(
@@ -196,6 +198,7 @@ class ShowSystemProcessesSummaryParser(
             load_average_5min=float(header.group("load5")),
             load_average_15min=float(header.group("load15")),
             uptime=header.group("uptime"),
+            current_time=header.group("current_time"),
             processes=ProcessCounts(
                 total=int(threads.group("total")),
                 running=int(threads.group("running")),

--- a/src/muninn/parsers/juniper_junos/show_system_processes_summary.py
+++ b/src/muninn/parsers/juniper_junos/show_system_processes_summary.py
@@ -1,0 +1,218 @@
+"""Parser for 'show system processes summary' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ProcessCounts(TypedDict):
+    """Schema for thread/process state counts."""
+
+    total: int
+    running: int
+    sleeping: int
+    zombie: int
+    waiting: int
+
+
+class CpuUsage(TypedDict):
+    """Schema for CPU usage percentages."""
+
+    user: float
+    nice: float
+    system: float
+    interrupt: float
+    idle: float
+
+
+class MemoryUsage(TypedDict):
+    """Schema for memory usage."""
+
+    active_mb: int
+    inactive_mb: int
+    wired_mb: int
+    buffer_mb: int
+    free_mb: int
+
+
+class SwapUsage(TypedDict):
+    """Schema for swap usage."""
+
+    total_mb: int
+    free_mb: int
+
+
+class ShowSystemProcessesSummaryResult(TypedDict):
+    """Schema for 'show system processes summary' parsed output.
+
+    Captures CPU load averages, memory/swap usage, and process state
+    counts from Juniper Junos devices.
+    """
+
+    last_pid: int
+    load_average_1min: float
+    load_average_5min: float
+    load_average_15min: float
+    uptime: str
+    processes: ProcessCounts
+    cpu: CpuUsage
+    memory: MemoryUsage
+    swap: SwapUsage
+
+
+_MEM_UNIT_MULTIPLIERS: dict[str, int] = {
+    "K": 1,
+    "M": 1,
+    "G": 1024,
+    "T": 1024 * 1024,
+}
+
+
+def _parse_mem_value_mb(value_str: str) -> int:
+    """Convert a memory string like '3977M', '14G', '504K' to megabytes.
+
+    Values in KB are rounded down to 0 MB for sub-megabyte quantities.
+    """
+    unit = value_str[-1].upper()
+    numeric = int(value_str[:-1])
+    multiplier = _MEM_UNIT_MULTIPLIERS.get(unit)
+    if multiplier is None:
+        msg = f"Unknown memory unit: {unit!r}"
+        raise ValueError(msg)
+    if unit == "K":
+        return numeric // 1024
+    return numeric * multiplier
+
+
+@register(OS.JUNIPER_JUNOS, "show system processes summary")
+class ShowSystemProcessesSummaryParser(
+    BaseParser[ShowSystemProcessesSummaryResult],
+):
+    """Parser for 'show system processes summary' command on Juniper Junos.
+
+    Parses the summary header (load averages, CPU, memory, swap, and
+    process state counts). Individual process lines are not included.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _HEADER_PATTERN = re.compile(
+        r"last pid:\s*(?P<last_pid>\d+);\s*"
+        r"load averages:\s*(?P<load1>[\d.]+),\s*"
+        r"(?P<load5>[\d.]+),\s*(?P<load15>[\d.]+)\s+"
+        r"up\s+(?P<uptime>\S+)",
+    )
+
+    _THREADS_PATTERN = re.compile(
+        r"(?P<total>\d+)\s+threads:\s+"
+        r"(?P<running>\d+)\s+running,\s+"
+        r"(?P<sleeping>\d+)\s+sleeping,\s+"
+        r"(?P<zombie>\d+)\s+zombie,\s+"
+        r"(?P<waiting>\d+)\s+waiting",
+    )
+
+    _CPU_PATTERN = re.compile(
+        r"CPU:\s+"
+        r"(?P<user>[\d.]+)%\s+user,\s+"
+        r"(?P<nice>[\d.]+)%\s+nice,\s+"
+        r"(?P<system>[\d.]+)%\s+system,\s+"
+        r"(?P<interrupt>[\d.]+)%\s+interrupt,\s+"
+        r"(?P<idle>[\d.]+)%\s+idle",
+    )
+
+    _MEM_PATTERN = re.compile(
+        r"Mem:\s+"
+        r"(?P<active>\d+[KMGT])\s+Active,\s+"
+        r"(?P<inactive>\d+[KMGT])\s+Inact,\s+"
+        r"(?P<wired>\d+[KMGT])\s+Wired,\s+"
+        r"(?P<buffer>\d+[KMGT])\s+Buf,\s+"
+        r"(?P<free>\d+[KMGT])\s+Free",
+    )
+
+    _SWAP_PATTERN = re.compile(
+        r"Swap:\s+"
+        r"(?P<total>\d+[KMGT])\s+Total,\s+"
+        r"(?P<free>\d+[KMGT])\s+Free",
+    )
+
+    _MatchStr = re.Match[str]
+
+    @classmethod
+    def _match_all_sections(
+        cls, output: str
+    ) -> tuple[_MatchStr, _MatchStr, _MatchStr, _MatchStr, _MatchStr]:
+        """Match all required sections, raising ValueError if any are missing."""
+        patterns: dict[str, re.Pattern[str]] = {
+            "header (load averages)": cls._HEADER_PATTERN,
+            "thread counts": cls._THREADS_PATTERN,
+            "CPU usage": cls._CPU_PATTERN,
+            "memory usage": cls._MEM_PATTERN,
+            "swap usage": cls._SWAP_PATTERN,
+        }
+        matches: dict[str, re.Match[str] | None] = {
+            name: pat.search(output) for name, pat in patterns.items()
+        }
+        missing = [name for name, m in matches.items() if m is None]
+        if missing:
+            msg = f"Could not parse: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        # All values are guaranteed non-None after the missing check
+        vals = [m for m in matches.values() if m is not None]
+        return (vals[0], vals[1], vals[2], vals[3], vals[4])
+
+    @staticmethod
+    def _build_memory(m: re.Match[str]) -> MemoryUsage:
+        return MemoryUsage(
+            active_mb=_parse_mem_value_mb(m.group("active")),
+            inactive_mb=_parse_mem_value_mb(m.group("inactive")),
+            wired_mb=_parse_mem_value_mb(m.group("wired")),
+            buffer_mb=_parse_mem_value_mb(m.group("buffer")),
+            free_mb=_parse_mem_value_mb(m.group("free")),
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSystemProcessesSummaryResult:
+        """Parse 'show system processes summary' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed process summary information.
+
+        Raises:
+            ValueError: If required sections cannot be parsed.
+        """
+        header, threads, cpu, mem, swap = cls._match_all_sections(output)
+
+        return ShowSystemProcessesSummaryResult(
+            last_pid=int(header.group("last_pid")),
+            load_average_1min=float(header.group("load1")),
+            load_average_5min=float(header.group("load5")),
+            load_average_15min=float(header.group("load15")),
+            uptime=header.group("uptime"),
+            processes=ProcessCounts(
+                total=int(threads.group("total")),
+                running=int(threads.group("running")),
+                sleeping=int(threads.group("sleeping")),
+                zombie=int(threads.group("zombie")),
+                waiting=int(threads.group("waiting")),
+            ),
+            cpu=CpuUsage(
+                user=float(cpu.group("user")),
+                nice=float(cpu.group("nice")),
+                system=float(cpu.group("system")),
+                interrupt=float(cpu.group("interrupt")),
+                idle=float(cpu.group("idle")),
+            ),
+            memory=cls._build_memory(mem),
+            swap=SwapUsage(
+                total_mb=_parse_mem_value_mb(swap.group("total")),
+                free_mb=_parse_mem_value_mb(swap.group("free")),
+            ),
+        )

--- a/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "last_pid": 24931,
+    "load_average_1min": 0.89,
+    "load_average_5min": 0.94,
+    "load_average_15min": 0.81,
+    "uptime": "41+06:26:24",
+    "processes": {
+        "total": 545,
+        "running": 9,
+        "sleeping": 481,
+        "zombie": 1,
+        "waiting": 54
+    },
+    "cpu": {
+        "user": 14.7,
+        "nice": 0.0,
+        "system": 4.1,
+        "interrupt": 0.2,
+        "idle": 81.0
+    },
+    "memory": {
+        "active_mb": 3977,
+        "inactive_mb": 14336,
+        "wired_mb": 1815,
+        "buffer_mb": 504,
+        "free_mb": 75776
+    },
+    "swap": {
+        "total_mb": 12288,
+        "free_mb": 12288
+    }
+}

--- a/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/expected.json
@@ -4,6 +4,7 @@
     "load_average_5min": 0.94,
     "load_average_15min": 0.81,
     "uptime": "41+06:26:24",
+    "current_time": "00:51:55",
     "processes": {
         "total": 545,
         "running": 9,

--- a/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/input.txt
@@ -1,0 +1,39 @@
+last pid: 24931;  load averages:  0.89,  0.94,  0.81  up 41+06:26:24    00:51:55
+545 threads:   9 running, 481 sleeping, 1 zombie, 54 waiting
+CPU: 14.7% user,  0.0% nice,  4.1% system,  0.2% interrupt, 81.0% idle
+Mem: 3977M Active, 14G Inact, 1815M Wired, 504M Buf, 74G Free
+Swap: 12G Total, 12G Free
+
+  PID USERNAME    PRI NICE   SIZE    RES STATE    C   TIME    WCPU COMMAND
+   11 root        155 ki31     0B   128K CPU7     7 787.8H  98.58% idle{idle: cpu7}
+   11 root        155 ki31     0B   128K CPU0     0 931.9H  98.39% idle{idle: cpu0}
+   11 root        155 ki31     0B   128K CPU2     2 783.0H  96.88% idle{idle: cpu2}
+   11 root        155 ki31     0B   128K RUN      5 787.6H  96.78% idle{idle: cpu5}
+   11 root        155 ki31     0B   128K CPU4     4 786.1H  96.68% idle{idle: cpu4}
+   11 root        155 ki31     0B   128K CPU6     6 787.6H  93.26% idle{idle: cpu6}
+   11 root        155 ki31     0B   128K CPU1     1 785.5H  91.70% idle{idle: cpu1}
+   11 root        155 ki31     0B   128K CPU3     3 785.6H  90.67% idle{idle: cpu3}
+19880 root         25    0   801M    74M select   2 132.6H  15.09% cosd
+19926 root         24    0   735M    27M select   7 113.5H  11.87% snmpd
+19929 root         22    0   805M    86M select   3  81.9H   9.28% mib2d
+19876 root         21    0    14G    13G kqread   3 938.4H   2.69% rpd{rpd}
+19876 root         21    0    14G    13G kqread   3  20.3H   2.69% rpd{junos-bgpshard3}
+19876 root         21    0    14G    13G kqread   4  20.3H   1.76% rpd{junos-bgpshard0}
+19876 root         20    0    14G    13G kqread   0  24.6H   1.46% rpd{junos-bgpshard2}
+19914 root         21    0   839M   118M select   5  18.4H   1.37% jinsightd{jinsightd}
+19876 root         20    0    14G    13G kqread   1  22.2H   1.27% rpd{junos-bgpshard1}
+   12 root        -60    -     0B   864K WAIT     0  69:18   1.17% intr{swi4: clock (0)}
+19315 root         21    0   880M    78M select   6 898:25   0.98% chassisd{chassisd}
+19921 root         20    0   131M    49M select   2 596:38   0.59% na-grpcd{na-grpcd}
+19876 root         20    0    14G    13G kqread   6 489:58   0.59% rpd{bgp-updio-3}
+24926 remote       20    0    95M    25M select   1   0:00   0.59% cli
+   12 root        -92    -     0B   864K WAIT     0 162:55   0.49% intr{irq271: ixlv0:que 0}
+24923 root         22    0   756M    13M select   7   0:00   0.29% sshd
+   12 root        -72    -     0B   864K WAIT     1 417:28   0.20% intr{swi1: netisr 2}
+19352 root         20    0   724M  8544K select   2 106:54   0.20% timingd{ptp_stack}
+24925 remote       20    0   756M    13M select   6   0:00   0.20% sshd
+19858 root        -16    -     0B    16K select   1 184:43   0.10% ppt_11_80000010
+19743 root        -16    -     0B    16K select   7 172:15   0.10% ppt_11_80000013
+21670 root        -16    -     0B    16K select   0 166:12   0.10% ppt_11_80000015
+    2 root        -16    -     0B    16K jfe_jo   2 138:19   0.10% jfe_job_0_0
+24931 root         20    0    14M  3636K CPU5     5   0:00   0.00% top

--- a/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_system_processes_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic process summary output from a Juniper device
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show system processes summary` on Juniper Junos
- Extracts CPU load averages (1/5/15 min), memory usage, swap usage, process state counts, uptime, and last PID
- Memory values are normalized to megabytes regardless of input unit (K/M/G/T)

## Test plan
- [x] Parser test with real device output fixture passes
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (no list-of-dicts, no pipe in keys)
- [x] ruff check and format pass
- [x] bandit security scan clean
- [x] xenon complexity under B threshold
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)