### PR TITLE
feat(juniper_junos): add parser for show ipv6 neighbors

### DIFF
--- a/changes/+juniper-junos-show-ipv6-neighbors.parser_added
+++ b/changes/+juniper-junos-show-ipv6-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ipv6 neighbors` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/juniper_junos/show_ipv6_neighbors.py
@@ -1,0 +1,95 @@
+"""Parser for 'show ipv6 neighbors' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import MAC_ADDRESS_COLON
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class Ipv6NeighborEntry(TypedDict):
+    """Schema for a single IPv6 neighbor entry."""
+
+    mac_address: str
+    state: str
+    expire_seconds: int
+    is_router: bool
+    is_secure: bool
+    interface: str
+    flags: NotRequired[str]
+
+
+class ShowIpv6NeighborsResult(TypedDict):
+    """Schema for 'show ipv6 neighbors' parsed output.
+
+    Neighbor entries are keyed by IPv6 address.
+    """
+
+    ipv6_neighbors: dict[str, Ipv6NeighborEntry]
+
+
+@register(OS.JUNIPER_JUNOS, "show ipv6 neighbors")
+class ShowIpv6NeighborsParser(BaseParser[ShowIpv6NeighborsResult]):
+    """Parser for 'show ipv6 neighbors' command on Juniper Junos.
+
+    Parses IPv6 neighbor discovery table entries containing IPv6 address,
+    MAC address, state, expiry, router flag, secure flag, and interface.
+
+    Example output::
+
+        IPv6 Address         Linklayer Address  State
+        2001:db8::1          00:50:56:ff:00:4b  reachable
+        fe80::250:56ff:fe04  00:50:56:ff:e0:4e  delay
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ARP})
+
+    _NEIGHBOR_ENTRY = re.compile(
+        r"^\s*(?P<ipv6>\S+)\s+"
+        rf"(?P<mac>{MAC_ADDRESS_COLON})\s+"
+        r"(?P<state>\S+)\s+"
+        r"(?P<expire>\d+)\s+"
+        r"(?P<router>yes|no)\s+"
+        r"(?P<secure>yes|no)\s+"
+        r"(?P<interface>\S+)\s*$",
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpv6NeighborsResult:
+        """Parse 'show ipv6 neighbors' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed IPv6 neighbor entries keyed by IPv6 address.
+
+        Raises:
+            ValueError: If no neighbor entries are found in the output.
+        """
+        neighbors: dict[str, Ipv6NeighborEntry] = {}
+
+        for line in output.splitlines():
+            match = cls._NEIGHBOR_ENTRY.match(line)
+            if not match:
+                continue
+
+            ipv6_address = match.group("ipv6")
+            entry = Ipv6NeighborEntry(
+                mac_address=match.group("mac").lower(),
+                state=match.group("state"),
+                expire_seconds=int(match.group("expire")),
+                is_router=match.group("router") == "yes",
+                is_secure=match.group("secure") == "yes",
+                interface=match.group("interface"),
+            )
+            neighbors[ipv6_address] = entry
+
+        if not neighbors:
+            msg = "No IPv6 neighbor entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpv6NeighborsResult, {"ipv6_neighbors": neighbors})

--- a/src/muninn/parsers/juniper_junos/show_ipv6_neighbors.py
+++ b/src/muninn/parsers/juniper_junos/show_ipv6_neighbors.py
@@ -19,7 +19,6 @@ class Ipv6NeighborEntry(TypedDict):
     is_router: bool
     is_secure: bool
     interface: str
-    flags: NotRequired[str]
 
 
 class ShowIpv6NeighborsResult(TypedDict):
@@ -29,6 +28,7 @@ class ShowIpv6NeighborsResult(TypedDict):
     """
 
     ipv6_neighbors: dict[str, Ipv6NeighborEntry]
+    total_entries: NotRequired[int]
 
 
 @register(OS.JUNIPER_JUNOS, "show ipv6 neighbors")
@@ -56,6 +56,7 @@ class ShowIpv6NeighborsParser(BaseParser[ShowIpv6NeighborsResult]):
         r"(?P<secure>yes|no)\s+"
         r"(?P<interface>\S+)\s*$",
     )
+    _TOTAL_ENTRIES = re.compile(r"^\s*Total entries:\s*(?P<count>\d+)\s*$")
 
     @classmethod
     def parse(cls, output: str) -> ShowIpv6NeighborsResult:
@@ -71,25 +72,34 @@ class ShowIpv6NeighborsParser(BaseParser[ShowIpv6NeighborsResult]):
             ValueError: If no neighbor entries are found in the output.
         """
         neighbors: dict[str, Ipv6NeighborEntry] = {}
+        total_entries: int | None = None
 
         for line in output.splitlines():
             match = cls._NEIGHBOR_ENTRY.match(line)
-            if not match:
+            if match:
+                ipv6_address = match.group("ipv6")
+                entry = Ipv6NeighborEntry(
+                    mac_address=match.group("mac").lower(),
+                    state=match.group("state"),
+                    expire_seconds=int(match.group("expire")),
+                    is_router=match.group("router") == "yes",
+                    is_secure=match.group("secure") == "yes",
+                    interface=match.group("interface"),
+                )
+                neighbors[ipv6_address] = entry
                 continue
 
-            ipv6_address = match.group("ipv6")
-            entry = Ipv6NeighborEntry(
-                mac_address=match.group("mac").lower(),
-                state=match.group("state"),
-                expire_seconds=int(match.group("expire")),
-                is_router=match.group("router") == "yes",
-                is_secure=match.group("secure") == "yes",
-                interface=match.group("interface"),
-            )
-            neighbors[ipv6_address] = entry
+            total_match = cls._TOTAL_ENTRIES.match(line)
+            if total_match:
+                total_entries = int(total_match.group("count"))
 
         if not neighbors:
             msg = "No IPv6 neighbor entries found in output"
             raise ValueError(msg)
 
-        return cast(ShowIpv6NeighborsResult, {"ipv6_neighbors": neighbors})
+        result: ShowIpv6NeighborsResult = cast(
+            ShowIpv6NeighborsResult, {"ipv6_neighbors": neighbors}
+        )
+        if total_entries is not None:
+            result["total_entries"] = total_entries
+        return result

--- a/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/expected.json
@@ -1,0 +1,28 @@
+{
+    "ipv6_neighbors": {
+        "2001:db8:eb18:6337::1": {
+            "mac_address": "00:50:56:ff:00:4b",
+            "state": "reachable",
+            "expire_seconds": 28,
+            "is_router": true,
+            "is_secure": false,
+            "interface": "ge-0/0/1.0"
+        },
+        "fe80::250:56ff:feff:e04e": {
+            "mac_address": "00:50:56:ff:e0:4e",
+            "state": "delay",
+            "expire_seconds": 4,
+            "is_router": true,
+            "is_secure": false,
+            "interface": "ge-0/0/0.0"
+        },
+        "fe80::250:56ff:feff:4b": {
+            "mac_address": "00:50:56:ff:00:4b",
+            "state": "reachable",
+            "expire_seconds": 43,
+            "is_router": true,
+            "is_secure": false,
+            "interface": "ge-0/0/1.0"
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/expected.json
@@ -24,5 +24,6 @@
             "is_secure": false,
             "interface": "ge-0/0/1.0"
         }
-    }
+    },
+    "total_entries": 3
 }

--- a/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/input.txt
@@ -1,0 +1,7 @@
+
+        show ipv6 neighbors
+        IPv6 Address                  Linklayer Address  State       Exp   Rtr  Secure  Interface
+        2001:db8:eb18:6337::1           00:50:56:ff:00:4b  reachable   28    yes  no      ge-0/0/1.0
+        fe80::250:56ff:feff:e04e      00:50:56:ff:e0:4e  delay       4     yes  no      ge-0/0/0.0
+        fe80::250:56ff:feff:4b      00:50:56:ff:00:4b  reachable   43    yes  no      ge-0/0/1.0
+        Total entries: 3

--- a/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_ipv6_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic IPv6 neighbor table with multiple entries across interfaces
+platform: vmx
+software_version: "18.2R1.9"


### PR DESCRIPTION
## Summary
- Add new parser for `show ipv6 neighbors` on Juniper Junos
- Parses IPv6 neighbor discovery table into dict-of-dicts keyed by IPv6 address
- Extracts MAC address, state, expiry seconds, router/secure flags, and interface per entry
- Tagged with `ParserTag.ARP`

## Test plan
- [x] Parser test fixture with real device output (genieparser golden output, vmx 18.2R1.9)
- [x] All 6848 tests pass
- [x] Pre-commit hooks pass (ruff, format, xenon complexity)
- [x] No placeholder sentinel violations in expected.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)