### PR TITLE
feat(paloalto_panos): add parser for show interface logical

### DIFF
--- a/changes/+paloalto-panos-show-interface-logical.parser_added
+++ b/changes/+paloalto-panos-show-interface-logical.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interface logical` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/show_interface_logical.py
+++ b/src/muninn/parsers/paloalto_panos/show_interface_logical.py
@@ -1,0 +1,151 @@
+"""Parser for 'show interface logical' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypeAlias, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_NA_SENTINEL = "N/A"
+
+# Forwarding values recognised by PAN-OS (vr:<name> or "ha").
+_FORWARDING_PREFIXES = ("vr:",)
+_FORWARDING_LITERALS = frozenset({"ha"})
+
+
+def _is_forwarding_value(token: str) -> bool:
+    """Return True if *token* is a known forwarding-context value."""
+    return token in _FORWARDING_LITERALS or any(
+        token.startswith(p) for p in _FORWARDING_PREFIXES
+    )
+
+
+class InterfaceLogicalEntry(TypedDict):
+    """Schema for a single logical interface entry."""
+
+    id: int
+    vsys: int
+    tag: int
+    zone: NotRequired[str]
+    forwarding: NotRequired[str]
+    address: NotRequired[str]
+
+
+ShowInterfaceLogicalResult: TypeAlias = dict[str, InterfaceLogicalEntry]
+
+
+# Lines to skip during parsing.
+_SKIP_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^-{10,}"),
+    re.compile(r"^name\s+id\s+vsys", re.IGNORECASE),
+    re.compile(r"^total\s+configured\s+logical\s+interfaces", re.IGNORECASE),
+)
+
+# Matches the fixed fields: name, id, vsys, and captures the rest.
+_INTERFACE_LINE = re.compile(
+    r"^(?P<name>\S+)\s+(?P<id>\d+)\s+(?P<vsys>\d+)\s+(?P<rest>.*)$"
+)
+
+
+def _should_skip(line: str) -> bool:
+    """Return True if *line* is a header, separator, or summary."""
+    return any(p.match(line) for p in _SKIP_PATTERNS)
+
+
+def _set_optional(entry: InterfaceLogicalEntry, key: str, value: str) -> None:
+    """Set *key* on *entry* unless *value* is the N/A sentinel."""
+    if value != _NA_SENTINEL:
+        entry[key] = value  # type: ignore[literal-required]
+
+
+def _extract_zone_and_forwarding(
+    tokens: list[str], entry: InterfaceLogicalEntry
+) -> None:
+    """Populate zone and forwarding from the tokens between vsys and tag."""
+    if not tokens:
+        return
+
+    last = tokens[-1]
+    if _is_forwarding_value(last):
+        entry["forwarding"] = last
+        zone_tokens = tokens[:-1]
+    elif last == _NA_SENTINEL:
+        zone_tokens = tokens[:-1]
+    else:
+        zone_tokens = tokens
+
+    if zone_tokens:
+        _set_optional(entry, "zone", " ".join(zone_tokens))
+
+
+def _parse_trailing_fields(tokens: list[str], entry: InterfaceLogicalEntry) -> bool:
+    """Parse tag, address, zone, and forwarding from *tokens*.
+
+    Returns True on success, False if the tokens cannot be parsed.
+    """
+    if len(tokens) < 2:
+        return False
+
+    tag_raw = tokens[-2]
+    if not tag_raw.isdigit():
+        return False
+
+    entry["tag"] = int(tag_raw)
+    _set_optional(entry, "address", tokens[-1])
+    _extract_zone_and_forwarding(tokens[:-2], entry)
+    return True
+
+
+@register(OS.PALOALTO_PANOS, "show interface logical")
+class ShowInterfaceLogicalParser(BaseParser[ShowInterfaceLogicalResult]):
+    """Parser for 'show interface logical' command on Palo Alto PAN-OS.
+
+    Parses the tabular output listing logical interfaces with their ID,
+    vsys, zone, forwarding context, VLAN tag, and IP address.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfaceLogicalResult:
+        """Parse 'show interface logical' output on PAN-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed interface data keyed by interface name.
+
+        Raises:
+            ValueError: If no interfaces are found in output.
+        """
+        result: dict[str, InterfaceLogicalEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped or _should_skip(stripped):
+                continue
+
+            match = _INTERFACE_LINE.match(stripped)
+            if not match:
+                continue
+
+            entry: InterfaceLogicalEntry = {
+                "id": int(match.group("id")),
+                "vsys": int(match.group("vsys")),
+                "tag": 0,
+            }
+
+            tokens = match.group("rest").split()
+            if not _parse_trailing_fields(tokens, entry):
+                continue
+
+            result[match.group("name")] = entry
+
+        if not result:
+            msg = "No interfaces found in output"
+            raise ValueError(msg)
+
+        return cast(ShowInterfaceLogicalResult, result)

--- a/src/muninn/parsers/paloalto_panos/show_interface_logical.py
+++ b/src/muninn/parsers/paloalto_panos/show_interface_logical.py
@@ -1,7 +1,7 @@
 """Parser for 'show interface logical' command on Palo Alto PAN-OS."""
 
 import re
-from typing import ClassVar, NotRequired, TypeAlias, TypedDict, cast
+from typing import ClassVar, Literal, NotRequired, TypeAlias, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -54,10 +54,14 @@ def _should_skip(line: str) -> bool:
     return any(p.match(line) for p in _SKIP_PATTERNS)
 
 
-def _set_optional(entry: InterfaceLogicalEntry, key: str, value: str) -> None:
+def _set_optional(
+    entry: InterfaceLogicalEntry,
+    key: Literal["zone", "forwarding", "address"],
+    value: str,
+) -> None:
     """Set *key* on *entry* unless *value* is the N/A sentinel."""
     if value != _NA_SENTINEL:
-        entry[key] = value  # type: ignore[literal-required]
+        entry[key] = value
 
 
 def _extract_zone_and_forwarding(

--- a/tests/parsers/paloalto_panos/show_interface_logical/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_interface_logical/001_basic/expected.json
@@ -1,0 +1,115 @@
+{
+    "ethernet1/1": {
+        "id": 16,
+        "vsys": 1,
+        "tag": 0
+    },
+    "ethernet1/2": {
+        "id": 17,
+        "vsys": 1,
+        "tag": 0
+    },
+    "ethernet1/2.100": {
+        "id": 275,
+        "vsys": 1,
+        "tag": 100,
+        "zone": "ISP1",
+        "forwarding": "vr:default",
+        "address": "65.5.44.46/30"
+    },
+    "ethernet1/3": {
+        "id": 18,
+        "vsys": 1,
+        "tag": 0
+    },
+    "ethernet1/3.101": {
+        "id": 278,
+        "vsys": 1,
+        "tag": 101,
+        "zone": "ISP2",
+        "forwarding": "vr:default",
+        "address": "65.5.26.46/30"
+    },
+    "ethernet1/4": {
+        "id": 19,
+        "vsys": 1,
+        "tag": 0
+    },
+    "ethernet1/4.102": {
+        "id": 256,
+        "vsys": 1,
+        "tag": 102,
+        "zone": "WAN",
+        "forwarding": "vr:default",
+        "address": "10.10.134.1/24"
+    },
+    "ethernet1/5": {
+        "id": 20,
+        "vsys": 1,
+        "tag": 0
+    },
+    "ethernet1/5.103": {
+        "id": 261,
+        "vsys": 1,
+        "tag": 101,
+        "zone": "Voice",
+        "forwarding": "vr:default",
+        "address": "10.10.248.49/24"
+    },
+    "ethernet1/6": {
+        "id": 21,
+        "vsys": 1,
+        "tag": 0
+    },
+    "ethernet1/6.104": {
+        "id": 265,
+        "vsys": 1,
+        "tag": 901,
+        "zone": "Video",
+        "forwarding": "vr:default",
+        "address": "10.10.10.1/24"
+    },
+    "ethernet1/7": {
+        "id": 22,
+        "vsys": 1,
+        "tag": 0,
+        "zone": "Guest1"
+    },
+    "ethernet1/7.700": {
+        "id": 267,
+        "vsys": 1,
+        "tag": 700,
+        "zone": "Guest1",
+        "forwarding": "vr:default",
+        "address": "10.10.100.1/23"
+    },
+    "dedicated-ha1": {
+        "id": 5,
+        "vsys": 1,
+        "tag": 0,
+        "forwarding": "ha",
+        "address": "10.1.1.1/30"
+    },
+    "dedicated-ha2": {
+        "id": 6,
+        "vsys": 1,
+        "tag": 0,
+        "forwarding": "ha",
+        "address": "10.2.2.1/30"
+    },
+    "vlan": {
+        "id": 1,
+        "vsys": 1,
+        "tag": 0
+    },
+    "loopback": {
+        "id": 3,
+        "vsys": 1,
+        "tag": 0
+    },
+    "tunnel": {
+        "id": 4,
+        "vsys": 1,
+        "tag": 0
+    }
+}

--- a/tests/parsers/paloalto_panos/show_interface_logical/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/show_interface_logical/001_basic/input.txt
@@ -1,0 +1,22 @@
+total configured logical interfaces: 38
+​
+name                id    vsys zone             forwarding               tag    address
+------------------- ----- ---- ---------------- ------------------------ ------ ------------------
+ethernet1/1         16    1                     N/A                      0      N/A
+ethernet1/2         17    1                     N/A                      0      N/A
+ethernet1/2.100     275   1    ISP1         vr:default               100    65.5.44.46/30
+ethernet1/3         18    1                     N/A                      0      N/A
+ethernet1/3.101     278   1    ISP2         vr:default               101    65.5.26.46/30
+ethernet1/4         19    1                     N/A                      0      N/A
+ethernet1/4.102     256   1    WAN     vr:default               102    10.10.134.1/24
+ethernet1/5         20    1                     N/A                      0      N/A
+ethernet1/5.103     261   1    Voice            vr:default               101    10.10.248.49/24
+ethernet1/6         21    1                     N/A                      0      N/A
+ethernet1/6.104     265   1    Video            vr:default               901    10.10.10.1/24
+ethernet1/7         22    1    Guest1   N/A                      0      N/A
+ethernet1/7.700     267   1    Guest1   vr:default               700    10.10.100.1/23
+dedicated-ha1       5     1                     ha                       0      10.1.1.1/30
+dedicated-ha2       6     1                     ha                       0      10.2.2.1/30
+vlan                1     1                     N/A                      0      N/A
+loopback            3     1                     N/A                      0      N/A
+tunnel              4     1                     N/A                      0      N/A

--- a/tests/parsers/paloalto_panos/show_interface_logical/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/show_interface_logical/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Mixed physical, subinterface, HA, and virtual logical interfaces
+platform: PA-5050
+software_version: unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show interface logical` on Palo Alto PAN-OS
- Returns dict-of-dicts keyed by interface name with id, vsys, tag, and optional zone, forwarding, and address fields
- N/A sentinel values from CLI output are omitted rather than stored as placeholder strings

## Test plan
- [x] Parser test with real device output covering physical, subinterface, HA, and virtual interfaces
- [x] All 6710 existing tests pass
- [x] All sentinel/placeholder checks pass (no N/A, empty string, or hyphen values in expected.json)
- [x] Ruff lint and format clean
- [x] Xenon complexity within limits (average A, max absolute B)
- [x] Bandit security scan clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)