### PR TITLE
feat(paloalto_panos): add parser for show mac all

### DIFF
--- a/changes/+paloalto-panos-show-mac-all.parser_added
+++ b/changes/+paloalto-panos-show-mac-all.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show mac all` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/show_mac_all.py
+++ b/src/muninn/parsers/paloalto_panos/show_mac_all.py
@@ -1,0 +1,134 @@
+"""Parser for 'show mac all' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import MAC_ADDRESS_COLON
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class MacEntry(TypedDict):
+    """Schema for a single MAC table entry."""
+
+    vlan: str
+    mac_address: str
+    interface: str
+    status: str
+    ttl: int
+    status_description: NotRequired[str]
+
+
+class ShowMacAllResult(TypedDict):
+    """Schema for 'show mac all' parsed output."""
+
+    max_entries: int
+    default_timeout: int
+    total_entries: int
+    total_entries_shown: int
+    entries: dict[str, MacEntry]
+
+
+# Map single-character status codes to human-readable descriptions
+_STATUS_MAP: dict[str, str] = {
+    "s": "static",
+    "c": "complete",
+    "i": "incomplete",
+}
+
+
+@register(OS.PALOALTO_PANOS, "show mac all")
+class ShowMacAllParser(BaseParser[ShowMacAllResult]):
+    """Parser for 'show mac all' command on Palo Alto PAN-OS.
+
+    Parses the tabular MAC address output into a dictionary keyed by
+    MAC address, with each value containing VLAN, interface, status, and TTL.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.MAC,
+        }
+    )
+
+    _MAC_LINE = re.compile(
+        r"^(?P<vlan>\S+)\s+"
+        rf"(?P<mac>{MAC_ADDRESS_COLON})\s+"
+        r"(?P<interface>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<ttl>\d+)\s*$"
+    )
+
+    _HEADER_PATTERNS: ClassVar[dict[str, re.Pattern[str]]] = {
+        "max_entries": re.compile(
+            r"maximum of entries supported\s*:\s*(\d+)", re.IGNORECASE
+        ),
+        "default_timeout": re.compile(r"default timeout\s*:\s*(\d+)", re.IGNORECASE),
+        "total_entries": re.compile(
+            r"total MAC entries in table\s*:\s*(\d+)", re.IGNORECASE
+        ),
+        "total_entries_shown": re.compile(
+            r"total MAC entries shown\s*:\s*(\d+)", re.IGNORECASE
+        ),
+    }
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMacAllResult:
+        """Parse 'show mac all' output on PAN-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dictionary with header metadata and entries keyed by MAC address.
+
+        Raises:
+            ValueError: If no valid MAC entries are found in the output.
+        """
+        entries: dict[str, MacEntry] = {}
+        header: dict[str, int] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            # Try header patterns
+            for key, pattern in cls._HEADER_PATTERNS.items():
+                header_match = pattern.search(stripped)
+                if header_match:
+                    header[key] = int(header_match.group(1))
+                    break
+
+            match = cls._MAC_LINE.match(stripped)
+            if not match:
+                continue
+
+            mac_address = match.group("mac")
+            status_code = match.group("status")
+
+            entry: MacEntry = {
+                "vlan": match.group("vlan"),
+                "mac_address": mac_address,
+                "interface": match.group("interface"),
+                "status": status_code,
+                "ttl": int(match.group("ttl")),
+            }
+
+            description = _STATUS_MAP.get(status_code)
+            if description is not None:
+                entry["status_description"] = description
+
+            entries[mac_address] = entry
+
+        if not entries:
+            msg = "No valid MAC entries found in output"
+            raise ValueError(msg)
+
+        return ShowMacAllResult(
+            max_entries=header.get("max_entries", 0),
+            default_timeout=header.get("default_timeout", 0),
+            total_entries=header.get("total_entries", 0),
+            total_entries_shown=header.get("total_entries_shown", 0),
+            entries=entries,
+        )

--- a/tests/parsers/paloalto_panos/show_mac_all/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_mac_all/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "max_entries": 1500,
+    "default_timeout": 1800,
+    "total_entries": 3,
+    "total_entries_shown": 3,
+    "entries": {
+        "00:50:00:00:07:00": {
+            "vlan": "Test",
+            "mac_address": "00:50:00:00:07:00",
+            "interface": "ethernet1/2.110",
+            "status": "c",
+            "ttl": 1778,
+            "status_description": "complete"
+        },
+        "00:50:00:00:08:00": {
+            "vlan": "Test",
+            "mac_address": "00:50:00:00:08:00",
+            "interface": "ethernet1/2.111",
+            "status": "c",
+            "ttl": 1796,
+            "status_description": "complete"
+        },
+        "50:00:00:02:00:01": {
+            "vlan": "Test",
+            "mac_address": "50:00:00:02:00:01",
+            "interface": "ethernet1/2.110",
+            "status": "c",
+            "ttl": 704,
+            "status_description": "complete"
+        }
+    }
+}

--- a/tests/parsers/paloalto_panos/show_mac_all/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/show_mac_all/001_basic/input.txt
@@ -1,0 +1,12 @@
+
+maximum of entries supported :      1500
+default timeout :                   1800 seconds
+total MAC entries in table :        3
+total MAC entries shown :           3
+status: s - static, c - complete, i - incomplete
+
+vlan                hw address        interface         status   ttl
+--------------------------------------------------------------------------------
+Test                00:50:00:00:07:00 ethernet1/2.110     c      1778
+Test                00:50:00:00:08:00 ethernet1/2.111     c      1796
+Test                50:00:00:02:00:01 ethernet1/2.110     c      704

--- a/tests/parsers/paloalto_panos/show_mac_all/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/show_mac_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic MAC address table with three complete entries
+platform: PA-VM
+software_version: "10.1.0"


### PR DESCRIPTION
## Summary
- Add new parser for `show mac all` on Palo Alto PAN-OS
- Parses MAC address table into dict-of-dicts keyed by MAC address, with VLAN, interface, status, TTL, and status description fields
- Follows the same structure as the existing `show arp all` PAN-OS parser

## Test plan
- [x] Parser test fixture with real device output passes (`001_basic`)
- [x] Fixture passes all placeholder sentinel checks (no banned values)
- [x] Fixture passes JSON convention checks (no list-of-dicts, no pipe keys)
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)