### PR TITLE
feat(paloalto_panos): add parser for show counter global

### DIFF
--- a/changes/+paloalto-panos-show-counter-global.parser_added
+++ b/changes/+paloalto-panos-show-counter-global.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show counter global` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/show_counter_global.py
+++ b/src/muninn/parsers/paloalto_panos/show_counter_global.py
@@ -1,7 +1,7 @@
 """Parser for 'show counter global' command on Palo Alto PAN-OS."""
 
 import re
-from typing import ClassVar, TypedDict
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -20,19 +20,29 @@ class CounterEntry(TypedDict):
     description: str
 
 
-ShowCounterGlobalResult = dict[str, CounterEntry]
+class ShowCounterGlobalResult(TypedDict):
+    """Schema for 'show counter global' parsed output."""
+
+    elapsed_time_seconds: NotRequired[float]
+    counters: dict[str, CounterEntry]
 
 
 @register(OS.PALOALTO_PANOS, "show counter global")
 class ShowCounterGlobalParser(BaseParser[ShowCounterGlobalResult]):
     """Parser for 'show counter global' command on Palo Alto PAN-OS.
 
-    Parses the tabular global counters output into a dict-of-dicts keyed
-    by counter name, with each entry containing value, rate, severity,
-    category, aspect, and description.
+    Parses the tabular global counters output. The result includes the
+    sampling window header (``elapsed_time_seconds``) when present and a
+    ``counters`` dict keyed by counter name, each entry containing value,
+    rate, severity, category, aspect, and description.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    # Header line: "Elapsed time since last sampling: 349.576 seconds"
+    _ELAPSED_TIME_LINE = re.compile(
+        r"^Elapsed time since last sampling:\s+(?P<seconds>[\d.]+)\s+seconds\s*$"
+    )
 
     # Matches counter lines: name, value, rate, severity, category, aspect, description
     _COUNTER_LINE = re.compile(
@@ -53,20 +63,30 @@ class ShowCounterGlobalParser(BaseParser[ShowCounterGlobalResult]):
             output: Raw CLI output from command.
 
         Returns:
-            Dict of counter entries keyed by counter name.
+            Dict containing optional ``elapsed_time_seconds`` and a
+            ``counters`` mapping keyed by counter name.
 
         Raises:
             ValueError: If no counters are found in the output.
         """
-        result: ShowCounterGlobalResult = {}
+        counters: dict[str, CounterEntry] = {}
+        elapsed_time_seconds: float | None = None
 
-        for line in output.splitlines():
-            match = cls._COUNTER_LINE.match(line.strip())
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+
+            if elapsed_time_seconds is None:
+                elapsed_match = cls._ELAPSED_TIME_LINE.match(line)
+                if elapsed_match:
+                    elapsed_time_seconds = float(elapsed_match.group("seconds"))
+                    continue
+
+            match = cls._COUNTER_LINE.match(line)
             if not match:
                 continue
 
             name = match.group("name")
-            result[name] = CounterEntry(
+            counters[name] = CounterEntry(
                 value=int(match.group("value")),
                 rate=int(match.group("rate")),
                 severity=match.group("severity"),
@@ -75,8 +95,11 @@ class ShowCounterGlobalParser(BaseParser[ShowCounterGlobalResult]):
                 description=match.group("description"),
             )
 
-        if not result:
+        if not counters:
             msg = "No counters found in output"
             raise ValueError(msg)
 
+        result: ShowCounterGlobalResult = {"counters": counters}
+        if elapsed_time_seconds is not None:
+            result["elapsed_time_seconds"] = elapsed_time_seconds
         return result

--- a/src/muninn/parsers/paloalto_panos/show_counter_global.py
+++ b/src/muninn/parsers/paloalto_panos/show_counter_global.py
@@ -1,0 +1,82 @@
+"""Parser for 'show counter global' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class CounterEntry(TypedDict):
+    """Schema for a single global counter entry."""
+
+    value: int
+    rate: int
+    severity: str
+    category: str
+    aspect: str
+    description: str
+
+
+ShowCounterGlobalResult = dict[str, CounterEntry]
+
+
+@register(OS.PALOALTO_PANOS, "show counter global")
+class ShowCounterGlobalParser(BaseParser[ShowCounterGlobalResult]):
+    """Parser for 'show counter global' command on Palo Alto PAN-OS.
+
+    Parses the tabular global counters output into a dict-of-dicts keyed
+    by counter name, with each entry containing value, rate, severity,
+    category, aspect, and description.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    # Matches counter lines: name, value, rate, severity, category, aspect, description
+    _COUNTER_LINE = re.compile(
+        r"^(?P<name>\S+)"
+        r"\s+(?P<value>\d+)"
+        r"\s+(?P<rate>\d+)"
+        r"\s+(?P<severity>\S+)"
+        r"\s+(?P<category>\S+)"
+        r"\s+(?P<aspect>\S+)"
+        r"\s+(?P<description>.+?)\s*$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCounterGlobalResult:
+        """Parse 'show counter global' output on PAN-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict of counter entries keyed by counter name.
+
+        Raises:
+            ValueError: If no counters are found in the output.
+        """
+        result: ShowCounterGlobalResult = {}
+
+        for line in output.splitlines():
+            match = cls._COUNTER_LINE.match(line.strip())
+            if not match:
+                continue
+
+            name = match.group("name")
+            result[name] = CounterEntry(
+                value=int(match.group("value")),
+                rate=int(match.group("rate")),
+                severity=match.group("severity"),
+                category=match.group("category"),
+                aspect=match.group("aspect"),
+                description=match.group("description"),
+            )
+
+        if not result:
+            msg = "No counters found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/paloalto_panos/show_counter_global/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_counter_global/001_basic/expected.json
@@ -1,58 +1,61 @@
 {
-    "pkt_recv": {
-        "value": 29,
-        "rate": 0,
-        "severity": "info",
-        "category": "packet",
-        "aspect": "pktproc",
-        "description": "Packets received"
-    },
-    "pkt_sent": {
-        "value": 21,
-        "rate": 0,
-        "severity": "info",
-        "category": "packet",
-        "aspect": "pktproc",
-        "description": "Packets transmitted"
-    },
-    "pkt_sock_recv": {
-        "value": 1,
-        "rate": 0,
-        "severity": "info",
-        "category": "packet",
-        "aspect": "pktproc",
-        "description": "Packets received at socket level - delayed counter"
-    },
-    "pkt_lldp_sent": {
-        "value": 1,
-        "rate": 0,
-        "severity": "info",
-        "category": "packet",
-        "aspect": "pktproc",
-        "description": "LLDP Packets transmitted"
-    },
-    "flow_rcv_dot1q_tag_err": {
-        "value": 1,
-        "rate": 0,
-        "severity": "drop",
-        "category": "flow",
-        "aspect": "parse",
-        "description": "Packets dropped: 802.1q tag not configured"
-    },
-    "flow_no_interface": {
-        "value": 1,
-        "rate": 0,
-        "severity": "drop",
-        "category": "flow",
-        "aspect": "parse",
-        "description": "Packets dropped: invalid interface"
-    },
-    "ssl_hsm_up_down_event_rcv": {
-        "value": 1,
-        "rate": 0,
-        "severity": "info",
-        "category": "ssl",
-        "aspect": "pktproc",
-        "description": "The number of HSM up/down events received"
+    "elapsed_time_seconds": 349.576,
+    "counters": {
+        "pkt_recv": {
+            "value": 29,
+            "rate": 0,
+            "severity": "info",
+            "category": "packet",
+            "aspect": "pktproc",
+            "description": "Packets received"
+        },
+        "pkt_sent": {
+            "value": 21,
+            "rate": 0,
+            "severity": "info",
+            "category": "packet",
+            "aspect": "pktproc",
+            "description": "Packets transmitted"
+        },
+        "pkt_sock_recv": {
+            "value": 1,
+            "rate": 0,
+            "severity": "info",
+            "category": "packet",
+            "aspect": "pktproc",
+            "description": "Packets received at socket level - delayed counter"
+        },
+        "pkt_lldp_sent": {
+            "value": 1,
+            "rate": 0,
+            "severity": "info",
+            "category": "packet",
+            "aspect": "pktproc",
+            "description": "LLDP Packets transmitted"
+        },
+        "flow_rcv_dot1q_tag_err": {
+            "value": 1,
+            "rate": 0,
+            "severity": "drop",
+            "category": "flow",
+            "aspect": "parse",
+            "description": "Packets dropped: 802.1q tag not configured"
+        },
+        "flow_no_interface": {
+            "value": 1,
+            "rate": 0,
+            "severity": "drop",
+            "category": "flow",
+            "aspect": "parse",
+            "description": "Packets dropped: invalid interface"
+        },
+        "ssl_hsm_up_down_event_rcv": {
+            "value": 1,
+            "rate": 0,
+            "severity": "info",
+            "category": "ssl",
+            "aspect": "pktproc",
+            "description": "The number of HSM up/down events received"
+        }
     }
 }

--- a/tests/parsers/paloalto_panos/show_counter_global/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_counter_global/001_basic/expected.json
@@ -1,0 +1,58 @@
+{
+    "pkt_recv": {
+        "value": 29,
+        "rate": 0,
+        "severity": "info",
+        "category": "packet",
+        "aspect": "pktproc",
+        "description": "Packets received"
+    },
+    "pkt_sent": {
+        "value": 21,
+        "rate": 0,
+        "severity": "info",
+        "category": "packet",
+        "aspect": "pktproc",
+        "description": "Packets transmitted"
+    },
+    "pkt_sock_recv": {
+        "value": 1,
+        "rate": 0,
+        "severity": "info",
+        "category": "packet",
+        "aspect": "pktproc",
+        "description": "Packets received at socket level - delayed counter"
+    },
+    "pkt_lldp_sent": {
+        "value": 1,
+        "rate": 0,
+        "severity": "info",
+        "category": "packet",
+        "aspect": "pktproc",
+        "description": "LLDP Packets transmitted"
+    },
+    "flow_rcv_dot1q_tag_err": {
+        "value": 1,
+        "rate": 0,
+        "severity": "drop",
+        "category": "flow",
+        "aspect": "parse",
+        "description": "Packets dropped: 802.1q tag not configured"
+    },
+    "flow_no_interface": {
+        "value": 1,
+        "rate": 0,
+        "severity": "drop",
+        "category": "flow",
+        "aspect": "parse",
+        "description": "Packets dropped: invalid interface"
+    },
+    "ssl_hsm_up_down_event_rcv": {
+        "value": 1,
+        "rate": 0,
+        "severity": "info",
+        "category": "ssl",
+        "aspect": "pktproc",
+        "description": "The number of HSM up/down events received"
+    }
+}

--- a/tests/parsers/paloalto_panos/show_counter_global/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/show_counter_global/001_basic/input.txt
@@ -1,0 +1,15 @@
+Global counters:
+Elapsed time since last sampling: 349.576 seconds
+
+name                                   value     rate severity  category  aspect    description
+--------------------------------------------------------------------------------
+pkt_recv                                  29        0 info      packet    pktproc   Packets received
+pkt_sent                                  21        0 info      packet    pktproc   Packets transmitted
+pkt_sock_recv                              1        0 info      packet    pktproc   Packets received at socket level - delayed counter
+pkt_lldp_sent                              1        0 info      packet    pktproc   LLDP Packets transmitted
+flow_rcv_dot1q_tag_err                     1        0 drop      flow      parse     Packets dropped: 802.1q tag not configured
+flow_no_interface                          1        0 drop      flow      parse     Packets dropped: invalid interface
+ssl_hsm_up_down_event_rcv                  1        0 info      ssl       pktproc   The number of HSM up/down events received
+--------------------------------------------------------------------------------
+Total counters shown: 7
+--------------------------------------------------------------------------------

--- a/tests/parsers/paloalto_panos/show_counter_global/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/show_counter_global/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic global counters with packet, flow, and SSL counters
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show counter global` on Palo Alto PAN-OS
- Parses tabular global counters into a dict-of-dicts keyed by counter name
- Each entry includes value (int), rate (int), severity, category, aspect, and description fields

## Test plan
- [x] Parser test fixture with real device output (001_basic)
- [x] All 7 parametrized tests pass (parser correctness, JSON conventions, placeholder sentinels)
- [x] Pre-commit hooks pass (ruff, xenon, formatting, end-of-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)