### PR TITLE
feat(paloalto_panos): add parser for show jobs all

### DIFF
--- a/changes/+paloalto-panos-show-jobs-all.parser_added
+++ b/changes/+paloalto-panos-show-jobs-all.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show jobs all` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/show_jobs_all.py
+++ b/src/muninn/parsers/paloalto_panos/show_jobs_all.py
@@ -1,0 +1,85 @@
+"""Parser for 'show jobs all' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowJobsAllEntry(TypedDict):
+    """Schema for a single job entry."""
+
+    enqueued: str
+    job_type: str
+    status: str
+    result: str
+    completed: NotRequired[str]
+
+
+ShowJobsAllResult = dict[str, ShowJobsAllEntry]
+
+
+@register(OS.PALOALTO_PANOS, "show jobs all")
+class ShowJobsAllParser(BaseParser[ShowJobsAllResult]):
+    """Parser for 'show jobs all' command on Palo Alto PAN-OS.
+
+    Parses the tabular job listing into a dict-of-dicts keyed by job ID.
+    Each entry contains the enqueued timestamp, job type, status, result,
+    and completed time.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    # Match lines like:
+    # 2016/04/28 03:05:24        2341      FqdnRefresh       FIN     OK 03:05:41
+    _JOB_LINE = re.compile(
+        r"^(?P<enqueued>\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2})"
+        r"\s+(?P<id>\d+)"
+        r"\s+(?P<type>\S+)"
+        r"\s+(?P<status>\S+)"
+        r"\s+(?P<result>\S+)"
+        r"(?:\s+(?P<completed>\S+))?"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowJobsAllResult:
+        """Parse 'show jobs all' output on PAN-OS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict of job entries keyed by job ID string.
+
+        Raises:
+            ValueError: If no job entries are found in the output.
+        """
+        result: ShowJobsAllResult = {}
+
+        for line in output.splitlines():
+            match = cls._JOB_LINE.match(line.strip())
+            if not match:
+                continue
+
+            job_id = match.group("id")
+            entry = ShowJobsAllEntry(
+                enqueued=match.group("enqueued"),
+                job_type=match.group("type"),
+                status=match.group("status"),
+                result=match.group("result"),
+            )
+
+            completed = match.group("completed")
+            if completed:
+                entry["completed"] = completed
+
+            result[job_id] = entry
+
+        if not result:
+            msg = "No job entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/paloalto_panos/show_jobs_all/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_jobs_all/001_basic/expected.json
@@ -1,0 +1,58 @@
+{
+    "2341": {
+        "enqueued": "2016/04/28 03:05:24",
+        "job_type": "FqdnRefresh",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "03:05:41"
+    },
+    "2340": {
+        "enqueued": "2016/04/28 02:35:05",
+        "job_type": "FqdnRefresh",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "02:35:22"
+    },
+    "2339": {
+        "enqueued": "2016/04/28 02:05:03",
+        "job_type": "FqdnRefresh",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "02:05:21"
+    },
+    "2338": {
+        "enqueued": "2016/04/28 01:35:01",
+        "job_type": "FqdnRefresh",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "01:35:01"
+    },
+    "2337": {
+        "enqueued": "2016/04/28 01:04:43",
+        "job_type": "FqdnRefresh",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "01:05:00"
+    },
+    "2336": {
+        "enqueued": "2016/04/28 01:01:43",
+        "job_type": "Antivirus",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "01:02:26"
+    },
+    "2335": {
+        "enqueued": "2016/04/28 01:00:09",
+        "job_type": "Install",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "01:01:43"
+    },
+    "2334": {
+        "enqueued": "2016/04/28 01:00:06",
+        "job_type": "Downld",
+        "status": "FIN",
+        "result": "OK",
+        "completed": "01:00:08"
+    }
+}

--- a/tests/parsers/paloalto_panos/show_jobs_all/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/show_jobs_all/001_basic/input.txt
@@ -1,0 +1,10 @@
+Enqueued                     ID             Type    Status Result Completed
+--------------------------------------------------------------------------
+2016/04/28 03:05:24        2341      FqdnRefresh       FIN     OK 03:05:41
+2016/04/28 02:35:05        2340      FqdnRefresh       FIN     OK 02:35:22
+2016/04/28 02:05:03        2339      FqdnRefresh       FIN     OK 02:05:21
+2016/04/28 01:35:01        2338      FqdnRefresh       FIN     OK 01:35:01
+2016/04/28 01:04:43        2337      FqdnRefresh       FIN     OK 01:05:00
+2016/04/28 01:01:43        2336        Antivirus       FIN     OK 01:02:26
+2016/04/28 01:00:09        2335          Install       FIN     OK 01:01:43
+2016/04/28 01:00:06        2334           Downld       FIN     OK 01:00:08

--- a/tests/parsers/paloalto_panos/show_jobs_all/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/show_jobs_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic job listing with multiple completed jobs
+platform: PA-VM
+software_version: "7.0.1"


### PR DESCRIPTION
## Summary
- Add parser for `show jobs all` on Palo Alto PAN-OS
- Returns dict-of-dicts keyed by job ID (string), with enqueued time, job type, status, result, and completed time
- Includes test fixture from real PA-VM 7.0.1 device output

## Test plan
- [x] Parser test passes against real device fixture (`001_basic`)
- [x] All placeholder sentinel guardrails pass (no banned values)
- [x] JSON convention checks pass (no lists-of-dicts, no pipe keys)
- [x] ruff check and format clean
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)