### PR TITLE
feat(linux): add parser for ifconfig

### DIFF
--- a/changes/+linux-ifconfig.parser_added
+++ b/changes/+linux-ifconfig.parser_added
@@ -1,0 +1,1 @@
+Added parser for `ifconfig` on Linux.

--- a/src/muninn/parsers/linux/ifconfig.py
+++ b/src/muninn/parsers/linux/ifconfig.py
@@ -1,0 +1,316 @@
+"""Parser for 'ifconfig' command on Linux."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class IPv4Entry(TypedDict):
+    """Schema for an IPv4 address entry."""
+
+    address: str
+    netmask: str
+    broadcast: NotRequired[str]
+
+
+class IPv6Entry(TypedDict):
+    """Schema for an IPv6 address entry."""
+
+    address: str
+    prefix_length: int
+    scope_id: str
+
+
+class Counters(TypedDict):
+    """Schema for interface RX/TX counters."""
+
+    rx_packets: int
+    rx_bytes: int
+    rx_errors: int
+    rx_dropped: int
+    rx_overruns: int
+    rx_frame: int
+    tx_packets: int
+    tx_bytes: int
+    tx_errors: int
+    tx_dropped: int
+    tx_overruns: int
+    tx_carrier: int
+    tx_collisions: int
+
+
+class InterfaceEntry(TypedDict):
+    """Schema for a single interface from ifconfig output."""
+
+    flags: str
+    mtu: int
+    mac_address: NotRequired[str]
+    link_encap: str
+    tx_queue_length: int
+    ipv4: NotRequired[dict[str, IPv4Entry]]
+    ipv6: NotRequired[dict[str, IPv6Entry]]
+    counters: Counters
+    device_interrupt: NotRequired[int]
+    device_memory: NotRequired[str]
+
+
+IfconfigResult = dict[str, InterfaceEntry]
+
+# Modern ifconfig format (iproute2-style):
+# eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+_IFACE_HEADER_RE = re.compile(
+    r"^(?P<name>\S+?):\s+flags=\d+<(?P<flags>[^>]*)>\s+mtu\s+(?P<mtu>\d+)"
+)
+
+# inet 192.168.1.1  netmask 255.255.255.0  broadcast 192.168.1.255
+_INET_RE = re.compile(
+    r"^\s+inet\s+(?P<addr>\S+)"
+    r"\s+netmask\s+(?P<netmask>\S+)"
+    r"(?:\s+broadcast\s+(?P<broadcast>\S+))?"
+)
+
+# inet6 fe80::1  prefixlen 64  scopeid 0x20<link>
+_INET6_RE = re.compile(
+    r"^\s+inet6\s+(?P<addr>\S+)"
+    r"\s+prefixlen\s+(?P<prefixlen>\d+)"
+    r"\s+scopeid\s+(?P<scopeid>\S+)"
+)
+
+# ether 02:42:04:ff:68:9b  txqueuelen 0  (Ethernet)
+# loop  txqueuelen 1000  (Local Loopback)
+_LINK_RE = re.compile(
+    r"^\s+(?P<type>ether|loop)\s+"
+    r"(?:(?P<mac>[0-9a-f:]+)\s+)?"
+    r"txqueuelen\s+(?P<txq>\d+)"
+    r"\s+\((?P<encap>[^)]+)\)"
+)
+
+# RX packets 2567079  bytes 636136982 (606.6 MiB)
+_RX_PACKETS_RE = re.compile(
+    r"^\s+RX\s+packets\s+(?P<packets>\d+)\s+bytes\s+(?P<bytes>\d+)"
+)
+
+# RX errors 0  dropped 0  overruns 0  frame 0
+_RX_ERRORS_RE = re.compile(
+    r"^\s+RX\s+errors\s+(?P<errors>\d+)"
+    r"\s+dropped\s+(?P<dropped>\d+)"
+    r"\s+overruns\s+(?P<overruns>\d+)"
+    r"\s+frame\s+(?P<frame>\d+)"
+)
+
+# TX packets 3057807  bytes 628781252 (599.6 MiB)
+_TX_PACKETS_RE = re.compile(
+    r"^\s+TX\s+packets\s+(?P<packets>\d+)\s+bytes\s+(?P<bytes>\d+)"
+)
+
+# TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+_TX_ERRORS_RE = re.compile(
+    r"^\s+TX\s+errors\s+(?P<errors>\d+)"
+    r"\s+dropped\s+(?P<dropped>\d+)"
+    r"\s+overruns\s+(?P<overruns>\d+)"
+    r"\s+carrier\s+(?P<carrier>\d+)"
+    r"\s+collisions\s+(?P<collisions>\d+)"
+)
+
+# device interrupt 16  memory 0xe9200000-e9220000
+_DEVICE_RE = re.compile(
+    r"^\s+device\s+interrupt\s+(?P<irq>\d+)"
+    r"(?:\s+memory\s+(?P<memory>\S+))?"
+)
+
+
+def _new_counters() -> Counters:
+    """Return a zero-initialized Counters dict."""
+    return Counters(
+        rx_packets=0,
+        rx_bytes=0,
+        rx_errors=0,
+        rx_dropped=0,
+        rx_overruns=0,
+        rx_frame=0,
+        tx_packets=0,
+        tx_bytes=0,
+        tx_errors=0,
+        tx_dropped=0,
+        tx_overruns=0,
+        tx_carrier=0,
+        tx_collisions=0,
+    )
+
+
+def _parse_interface_block(lines: list[str]) -> tuple[str, InterfaceEntry] | None:
+    """Parse a single interface block into a (name, InterfaceEntry) tuple."""
+    if not lines:
+        return None
+
+    header_match = _IFACE_HEADER_RE.match(lines[0])
+    if not header_match:
+        return None
+
+    name = header_match.group("name")
+    counters = _new_counters()
+
+    entry: InterfaceEntry = {
+        "flags": header_match.group("flags"),
+        "mtu": int(header_match.group("mtu")),
+        "link_encap": "unknown",
+        "tx_queue_length": 0,
+        "counters": counters,
+    }
+
+    for line in lines[1:]:
+        _parse_detail_line(line, entry, counters)
+
+    return name, entry
+
+
+def _parse_inet(line: str, entry: InterfaceEntry) -> bool:
+    """Parse an IPv4 address line. Returns True if matched."""
+    match = _INET_RE.match(line)
+    if not match:
+        return False
+    addr = match.group("addr")
+    ipv4_entry = IPv4Entry(address=addr, netmask=match.group("netmask"))
+    if match.group("broadcast"):
+        ipv4_entry["broadcast"] = match.group("broadcast")
+    entry.setdefault("ipv4", {})[addr] = ipv4_entry
+    return True
+
+
+def _parse_inet6(line: str, entry: InterfaceEntry) -> bool:
+    """Parse an IPv6 address line. Returns True if matched."""
+    match = _INET6_RE.match(line)
+    if not match:
+        return False
+    addr = match.group("addr")
+    entry.setdefault("ipv6", {})[addr] = IPv6Entry(
+        address=addr,
+        prefix_length=int(match.group("prefixlen")),
+        scope_id=match.group("scopeid"),
+    )
+    return True
+
+
+def _parse_link(line: str, entry: InterfaceEntry) -> bool:
+    """Parse a link/encap line. Returns True if matched."""
+    match = _LINK_RE.match(line)
+    if not match:
+        return False
+    entry["link_encap"] = match.group("encap")
+    entry["tx_queue_length"] = int(match.group("txq"))
+    if match.group("mac"):
+        entry["mac_address"] = match.group("mac")
+    return True
+
+
+def _parse_rx_counters(line: str, counters: Counters) -> bool:
+    """Parse RX packets/bytes and RX errors lines. Returns True if matched."""
+    match = _RX_PACKETS_RE.match(line)
+    if match:
+        counters["rx_packets"] = int(match.group("packets"))
+        counters["rx_bytes"] = int(match.group("bytes"))
+        return True
+    match = _RX_ERRORS_RE.match(line)
+    if match:
+        counters["rx_errors"] = int(match.group("errors"))
+        counters["rx_dropped"] = int(match.group("dropped"))
+        counters["rx_overruns"] = int(match.group("overruns"))
+        counters["rx_frame"] = int(match.group("frame"))
+        return True
+    return False
+
+
+def _parse_tx_counters(line: str, counters: Counters) -> bool:
+    """Parse TX packets/bytes and TX errors lines. Returns True if matched."""
+    match = _TX_PACKETS_RE.match(line)
+    if match:
+        counters["tx_packets"] = int(match.group("packets"))
+        counters["tx_bytes"] = int(match.group("bytes"))
+        return True
+    match = _TX_ERRORS_RE.match(line)
+    if match:
+        counters["tx_errors"] = int(match.group("errors"))
+        counters["tx_dropped"] = int(match.group("dropped"))
+        counters["tx_overruns"] = int(match.group("overruns"))
+        counters["tx_carrier"] = int(match.group("carrier"))
+        counters["tx_collisions"] = int(match.group("collisions"))
+        return True
+    return False
+
+
+def _parse_device_info(line: str, entry: InterfaceEntry) -> bool:
+    """Parse device interrupt/memory line. Returns True if matched."""
+    match = _DEVICE_RE.match(line)
+    if not match:
+        return False
+    entry["device_interrupt"] = int(match.group("irq"))
+    if match.group("memory"):
+        entry["device_memory"] = match.group("memory")
+    return True
+
+
+def _parse_detail_line(line: str, entry: InterfaceEntry, counters: Counters) -> None:
+    """Dispatch a single detail line to the appropriate sub-parser."""
+    if _parse_inet(line, entry):
+        return
+    if _parse_inet6(line, entry):
+        return
+    if _parse_link(line, entry):
+        return
+    if _parse_rx_counters(line, counters):
+        return
+    if _parse_tx_counters(line, counters):
+        return
+    _parse_device_info(line, entry)
+
+
+@register(OS.LINUX, "ifconfig")
+class IfconfigParser(BaseParser[IfconfigResult]):
+    """Parser for 'ifconfig' command on Linux.
+
+    Parses interface information including flags, MTU, MAC addresses,
+    IPv4/IPv6 addresses, and TX/RX counters.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> IfconfigResult:
+        """Parse 'ifconfig' output on Linux.
+
+        Args:
+            output: Raw CLI output from the ifconfig command.
+
+        Returns:
+            Dict of interface entries keyed by interface name.
+
+        Raises:
+            ValueError: If no interfaces can be parsed.
+        """
+        result: IfconfigResult = {}
+        current_block: list[str] = []
+
+        for line in output.splitlines():
+            # An interface header starts at column 0 (no leading whitespace)
+            if line and not line[0].isspace():
+                parsed = _parse_interface_block(current_block)
+                if parsed:
+                    result[parsed[0]] = parsed[1]
+                current_block = [line]
+            elif line.strip():
+                current_block.append(line)
+
+        # Process the last block
+        parsed = _parse_interface_block(current_block)
+        if parsed:
+            result[parsed[0]] = parsed[1]
+
+        if not result:
+            msg = "No interfaces found in ifconfig output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/linux/ifconfig/001_basic/expected.json
+++ b/tests/parsers/linux/ifconfig/001_basic/expected.json
@@ -1,0 +1,240 @@
+{
+    "br-225e1b78e114": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "mac_address": "02:42:04:ff:68:9b",
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "ipv4": {
+            "192.168.66.1": {
+                "address": "192.168.66.1",
+                "netmask": "255.255.255.0",
+                "broadcast": "192.168.66.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:4ff:feff:689b": {
+                "address": "fe80::42:4ff:feff:689b",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "counters": {
+            "rx_packets": 2567079,
+            "rx_bytes": 636136982,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3057807,
+            "tx_bytes": 628781252,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        }
+    },
+    "docker0": {
+        "flags": "UP,BROADCAST,MULTICAST",
+        "mtu": 1500,
+        "mac_address": "02:42:b0:ff:60:2f",
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "ipv4": {
+            "172.17.0.1": {
+                "address": "172.17.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.17.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:b0ff:feff:602f": {
+                "address": "fe80::42:b0ff:feff:602f",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "counters": {
+            "rx_packets": 201975,
+            "rx_bytes": 13092415,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 464814,
+            "tx_bytes": 610816249,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        }
+    },
+    "enp0s20f0u1": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "mac_address": "10:6f:3f:ff:f0:ba",
+        "link_encap": "Ethernet",
+        "tx_queue_length": 1000,
+        "ipv4": {
+            "10.71.131.250": {
+                "address": "10.71.131.250",
+                "netmask": "255.255.248.0",
+                "broadcast": "10.71.135.255"
+            }
+        },
+        "ipv6": {
+            "fe80::8cd5:9a1e:621f:6328": {
+                "address": "fe80::8cd5:9a1e:621f:6328",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "counters": {
+            "rx_packets": 33613574,
+            "rx_bytes": 5840995377,
+            "rx_errors": 0,
+            "rx_dropped": 146055,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 1774425,
+            "tx_bytes": 310494465,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        }
+    },
+    "enp0s31f6": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "mac_address": "48:2a:e3:ff:58:55",
+        "link_encap": "Ethernet",
+        "tx_queue_length": 1000,
+        "ipv4": {
+            "192.168.100.51": {
+                "address": "192.168.100.51",
+                "netmask": "255.255.255.0",
+                "broadcast": "192.168.100.255"
+            }
+        },
+        "ipv6": {
+            "fe80::39:1a5c:726d:b23e": {
+                "address": "fe80::39:1a5c:726d:b23e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "counters": {
+            "rx_packets": 66766,
+            "rx_bytes": 4274334,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 365916,
+            "tx_bytes": 67689136,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "device_interrupt": 16,
+        "device_memory": "0xe9200000-e9220000"
+    },
+    "lo": {
+        "flags": "UP,LOOPBACK,RUNNING",
+        "mtu": 65536,
+        "link_encap": "Local Loopback",
+        "tx_queue_length": 1000,
+        "ipv4": {
+            "127.0.0.1": {
+                "address": "127.0.0.1",
+                "netmask": "255.0.0.0"
+            }
+        },
+        "ipv6": {
+            "::1": {
+                "address": "::1",
+                "prefix_length": 128,
+                "scope_id": "0x10<host>"
+            }
+        },
+        "counters": {
+            "rx_packets": 100389,
+            "rx_bytes": 16793726,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 100389,
+            "tx_bytes": 16793726,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        }
+    },
+    "veth9882519": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "mac_address": "4a:e2:88:ff:28:12",
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "ipv6": {
+            "fe80::48e2:88ff:feff:2812": {
+                "address": "fe80::48e2:88ff:feff:2812",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "counters": {
+            "rx_packets": 18100,
+            "rx_bytes": 1952201,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 41811,
+            "tx_bytes": 6932145,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        }
+    },
+    "veth00b6d52": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "mac_address": "62:e7:71:ff:cd:c2",
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "ipv6": {
+            "fe80::60e7:71ff:feff:cdc2": {
+                "address": "fe80::60e7:71ff:feff:cdc2",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "counters": {
+            "rx_packets": 16974,
+            "rx_bytes": 2234130,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 39152,
+            "tx_bytes": 3745874,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        }
+    }
+}

--- a/tests/parsers/linux/ifconfig/001_basic/input.txt
+++ b/tests/parsers/linux/ifconfig/001_basic/input.txt
@@ -1,0 +1,61 @@
+br-225e1b78e114: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 192.168.66.1  netmask 255.255.255.0  broadcast 192.168.66.255
+        inet6 fe80::42:4ff:feff:689b  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:04:ff:68:9b  txqueuelen 0  (Ethernet)
+        RX packets 2567079  bytes 636136982 (606.6 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3057807  bytes 628781252 (599.6 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+docker0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.17.0.1  netmask 255.255.0.0  broadcast 172.17.255.255
+        inet6 fe80::42:b0ff:feff:602f  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:b0:ff:60:2f  txqueuelen 0  (Ethernet)
+        RX packets 201975  bytes 13092415 (12.4 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 464814  bytes 610816249 (582.5 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+enp0s20f0u1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 10.71.131.250  netmask 255.255.248.0  broadcast 10.71.135.255
+        inet6 fe80::8cd5:9a1e:621f:6328  prefixlen 64  scopeid 0x20<link>
+        ether 10:6f:3f:ff:f0:ba  txqueuelen 1000  (Ethernet)
+        RX packets 33613574  bytes 5840995377 (5.4 GiB)
+        RX errors 0  dropped 146055  overruns 0  frame 0
+        TX packets 1774425  bytes 310494465 (296.1 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+enp0s31f6: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 192.168.100.51  netmask 255.255.255.0  broadcast 192.168.100.255
+        inet6 fe80::39:1a5c:726d:b23e  prefixlen 64  scopeid 0x20<link>
+        ether 48:2a:e3:ff:58:55  txqueuelen 1000  (Ethernet)
+        RX packets 66766  bytes 4274334 (4.0 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 365916  bytes 67689136 (64.5 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+        device interrupt 16  memory 0xe9200000-e9220000
+
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+        inet 127.0.0.1  netmask 255.0.0.0
+        inet6 ::1  prefixlen 128  scopeid 0x10<host>
+        loop  txqueuelen 1000  (Local Loopback)
+        RX packets 100389  bytes 16793726 (16.0 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 100389  bytes 16793726 (16.0 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth9882519: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::48e2:88ff:feff:2812  prefixlen 64  scopeid 0x20<link>
+        ether 4a:e2:88:ff:28:12  txqueuelen 0  (Ethernet)
+        RX packets 18100  bytes 1952201 (1.8 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 41811  bytes 6932145 (6.6 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth00b6d52: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::60e7:71ff:feff:cdc2  prefixlen 64  scopeid 0x20<link>
+        ether 62:e7:71:ff:cd:c2  txqueuelen 0  (Ethernet)
+        RX packets 16974  bytes 2234130 (2.1 MiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 39152  bytes 3745874 (3.5 MiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

--- a/tests/parsers/linux/ifconfig/001_basic/metadata.yaml
+++ b/tests/parsers/linux/ifconfig/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces including bridge, docker, physical, loopback, and veth
+platform: linux
+software_version: unknown

--- a/tests/parsers/linux/ifconfig/002_playground_host/expected.json
+++ b/tests/parsers/linux/ifconfig/002_playground_host/expected.json
@@ -1,0 +1,1025 @@
+{
+    "br-5028ba90e534": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 0,
+            "tx_bytes": 0,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.28.0.1": {
+                "address": "172.28.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.28.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:c2ff:fe6b:90a2": {
+                "address": "fe80::42:c2ff:fe6b:90a2",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:c2:6b:90:a2"
+    },
+    "br-6ab220ad63c4": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 0,
+            "tx_bytes": 0,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.29.0.1": {
+                "address": "172.29.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.29.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:efff:fe59:79e1": {
+                "address": "fe80::42:efff:fe59:79e1",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:ef:59:79:e1"
+    },
+    "br-9e73dba82b15": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 0,
+            "tx_bytes": 0,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.18.0.1": {
+                "address": "172.18.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.18.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:61ff:fe44:fecb": {
+                "address": "fe80::42:61ff:fe44:fecb",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:61:44:fe:cb"
+    },
+    "br-b1aea78a85ac": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 0,
+            "tx_bytes": 0,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.27.0.1": {
+                "address": "172.27.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.27.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:35ff:fe59:5dee": {
+                "address": "fe80::42:35ff:fe59:5dee",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:35:59:5d:ee"
+    },
+    "br-ce2012183c45": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 0,
+            "tx_bytes": 0,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.23.0.1": {
+                "address": "172.23.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.23.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:8eff:fee4:529e": {
+                "address": "fe80::42:8eff:fee4:529e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:8e:e4:52:9e"
+    },
+    "br-f42520551f76": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 0,
+            "tx_bytes": 0,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.19.0.1": {
+                "address": "172.19.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.19.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:b8ff:fe54:9465": {
+                "address": "fe80::42:b8ff:fe54:9465",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:b8:54:94:65"
+    },
+    "docker0": {
+        "flags": "UP,BROADCAST,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 30045,
+            "rx_bytes": 1895498,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 49944,
+            "tx_bytes": 584574501,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "172.17.0.1": {
+                "address": "172.17.0.1",
+                "netmask": "255.255.0.0",
+                "broadcast": "172.17.255.255"
+            }
+        },
+        "ipv6": {
+            "fe80::42:a5ff:fee8:5a87": {
+                "address": "fe80::42:a5ff:fee8:5a87",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "02:42:a5:e8:5a:87"
+    },
+    "ens18": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 1000,
+        "counters": {
+            "rx_packets": 90962575,
+            "rx_bytes": 51990037677,
+            "rx_errors": 0,
+            "rx_dropped": 10008,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 47356727,
+            "tx_bytes": 26816561060,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "192.168.1.27": {
+                "address": "192.168.1.27",
+                "netmask": "255.255.255.0",
+                "broadcast": "192.168.1.255"
+            }
+        },
+        "ipv6": {
+            "2001:db8:1::e44d:93ff:fef7:b849": {
+                "address": "2001:db8:1::e44d:93ff:fef7:b849",
+                "prefix_length": 64,
+                "scope_id": "0x0<global>"
+            },
+            "fe80::e44d:93ff:fef7:b849": {
+                "address": "fe80::e44d:93ff:fef7:b849",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "e6:4d:93:f7:b8:49"
+    },
+    "lo": {
+        "flags": "UP,LOOPBACK,RUNNING",
+        "mtu": 65536,
+        "link_encap": "Local Loopback",
+        "tx_queue_length": 1000,
+        "counters": {
+            "rx_packets": 39144710,
+            "rx_bytes": 9329319148,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 39144710,
+            "tx_bytes": 9329319148,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv4": {
+            "127.0.0.1": {
+                "address": "127.0.0.1",
+                "netmask": "255.0.0.0"
+            }
+        },
+        "ipv6": {
+            "::1": {
+                "address": "::1",
+                "prefix_length": 128,
+                "scope_id": "0x10<host>"
+            }
+        }
+    },
+    "veth09fe7c1": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 5860755,
+            "rx_bytes": 536447802,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3101317,
+            "tx_bytes": 356630190,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::48af:5ff:fee8:f0cb": {
+                "address": "fe80::48af:5ff:fee8:f0cb",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "4a:af:05:e8:f0:cb"
+    },
+    "veth16ba3e2": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 7752,
+            "rx_bytes": 2392935,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 11072,
+            "tx_bytes": 2986568,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::3405:caff:fed9:2a62": {
+                "address": "fe80::3405:caff:fed9:2a62",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "36:05:ca:d9:2a:62"
+    },
+    "veth1e38cb5": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 14838305,
+            "rx_bytes": 3525551835,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 17011671,
+            "tx_bytes": 3338288777,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::d0e7:2bff:fe1f:b60e": {
+                "address": "fe80::d0e7:2bff:fe1f:b60e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "d2:e7:2b:1f:b6:0e"
+    },
+    "veth2689c48": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 4163,
+            "rx_bytes": 3760593,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 6090,
+            "tx_bytes": 1531326,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::c4a2:44ff:fe75:b7d5": {
+                "address": "fe80::c4a2:44ff:fe75:b7d5",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "c6:a2:44:75:b7:d5"
+    },
+    "veth3c44d68": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 107663333,
+            "rx_bytes": 10754339613,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 55068784,
+            "tx_bytes": 15094746110,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::4017:35ff:fe32:8ac5": {
+                "address": "fe80::4017:35ff:fe32:8ac5",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "42:17:35:32:8a:c5"
+    },
+    "veth506ca58": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 103,
+            "rx_bytes": 11957,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3958,
+            "tx_bytes": 1025025,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::8035:cdff:feb5:743": {
+                "address": "fe80::8035:cdff:feb5:743",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "82:35:cd:b5:07:43"
+    },
+    "veth58eda36": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 1481,
+            "tx_bytes": 103846,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::8863:89ff:fe3b:5a4e": {
+                "address": "fe80::8863:89ff:fe3b:5a4e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "8a:63:89:3b:5a:4e"
+    },
+    "veth59f5140": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 1478,
+            "tx_bytes": 103636,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::28c6:9ff:fe87:18b4": {
+                "address": "fe80::28c6:9ff:fe87:18b4",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "2a:c6:09:87:18:b4"
+    },
+    "veth60dfa64": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 17008102,
+            "rx_bytes": 3337427503,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 14841872,
+            "tx_bytes": 3526413049,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::1c17:a0ff:fe4b:df6c": {
+                "address": "fe80::1c17:a0ff:fe4b:df6c",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "1e:17:a0:4b:df:6c"
+    },
+    "veth683798b": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3950,
+            "tx_bytes": 901709,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::a4a2:6cff:fe92:2a1e": {
+                "address": "fe80::a4a2:6cff:fe92:2a1e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "a6:a2:6c:92:2a:1e"
+    },
+    "veth746c084": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 23540,
+            "rx_bytes": 2670558,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 24445,
+            "tx_bytes": 9620869,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::e02f:36ff:fe00:5d3e": {
+                "address": "fe80::e02f:36ff:fe00:5d3e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "e2:2f:36:00:5d:3e"
+    },
+    "veth81628b7": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 6159,
+            "rx_bytes": 415805,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 9075,
+            "tx_bytes": 1192929,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::300f:9ff:fe2e:e014": {
+                "address": "fe80::300f:9ff:fe2e:e014",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "32:0f:09:2e:e0:14"
+    },
+    "veth8ce08c1": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 3501,
+            "rx_bytes": 240418,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 6793,
+            "tx_bytes": 1311128,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::24f0:66ff:fe79:38e0": {
+                "address": "fe80::24f0:66ff:fe79:38e0",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "26:f0:66:79:38:e0"
+    },
+    "veth8f52935": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3877,
+            "tx_bytes": 1012061,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::9cb3:bfff:fe5e:3536": {
+                "address": "fe80::9cb3:bfff:fe5e:3536",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "9e:b3:bf:5e:35:36"
+    },
+    "veth93e8f6e": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 460,
+            "rx_bytes": 59460,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 4445,
+            "tx_bytes": 1254054,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::b47c:cff:fe2f:6f69": {
+                "address": "fe80::b47c:cff:fe2f:6f69",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "b6:7c:0c:2f:6f:69"
+    },
+    "veth9812b72": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 500424,
+            "rx_bytes": 567163237,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 681278,
+            "tx_bytes": 1881511069,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::50d1:56ff:fe55:775b": {
+                "address": "fe80::50d1:56ff:fe55:775b",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "52:d1:56:55:77:5b"
+    },
+    "vetha968406": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 204753,
+            "rx_bytes": 33702723,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 165402,
+            "tx_bytes": 23389686,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::9ce9:4fff:fe39:592a": {
+                "address": "fe80::9ce9:4fff:fe39:592a",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "9e:e9:4f:39:59:2a"
+    },
+    "vethae29dc7": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3873,
+            "tx_bytes": 1011741,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::20ec:59ff:fe7c:9125": {
+                "address": "fe80::20ec:59ff:fe7c:9125",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "22:ec:59:7c:91:25"
+    },
+    "vethb6af214": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 1485,
+            "tx_bytes": 104222,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::408e:4aff:fe38:353d": {
+                "address": "fe80::408e:4aff:fe38:353d",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "42:8e:4a:38:35:3d"
+    },
+    "vethbf8e533": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 6295,
+            "rx_bytes": 2718131,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 8850,
+            "tx_bytes": 1763767,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::e0f0:31ff:fe9b:97": {
+                "address": "fe80::e0f0:31ff:fe9b:97",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "e2:f0:31:9b:00:97"
+    },
+    "vethcc4062e": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 54862942,
+            "rx_bytes": 15059625487,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 107507682,
+            "tx_bytes": 10733087076,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::746b:75ff:fe4a:a0b0": {
+                "address": "fe80::746b:75ff:fe4a:a0b0",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "76:6b:75:4a:a0:b0"
+    },
+    "vethd417d97": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 0,
+            "rx_bytes": 0,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 3876,
+            "tx_bytes": 1012011,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::dcdd:93ff:fe15:19dd": {
+                "address": "fe80::dcdd:93ff:fe15:19dd",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "de:dd:93:15:19:dd"
+    },
+    "vethdb87f13": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 5460,
+            "rx_bytes": 841533,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 8468,
+            "tx_bytes": 1806481,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::f02d:3ff:fec6:cc8e": {
+                "address": "fe80::f02d:3ff:fec6:cc8e",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "f2:2d:03:c6:cc:8e"
+    },
+    "vethf05a4e5": {
+        "flags": "UP,BROADCAST,RUNNING,MULTICAST",
+        "mtu": 1500,
+        "link_encap": "Ethernet",
+        "tx_queue_length": 0,
+        "counters": {
+            "rx_packets": 543,
+            "rx_bytes": 113765,
+            "rx_errors": 0,
+            "rx_dropped": 0,
+            "rx_overruns": 0,
+            "rx_frame": 0,
+            "tx_packets": 2457,
+            "tx_bytes": 852153,
+            "tx_errors": 0,
+            "tx_dropped": 0,
+            "tx_overruns": 0,
+            "tx_carrier": 0,
+            "tx_collisions": 0
+        },
+        "ipv6": {
+            "fe80::c40f:c4ff:fea6:65c1": {
+                "address": "fe80::c40f:c4ff:fea6:65c1",
+                "prefix_length": 64,
+                "scope_id": "0x20<link>"
+            }
+        },
+        "mac_address": "c6:0f:c4:a6:65:c1"
+    }
+}

--- a/tests/parsers/linux/ifconfig/002_playground_host/input.txt
+++ b/tests/parsers/linux/ifconfig/002_playground_host/input.txt
@@ -1,0 +1,273 @@
+br-5028ba90e534: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 172.28.0.1  netmask 255.255.0.0  broadcast 172.28.255.255
+        inet6 fe80::42:c2ff:fe6b:90a2  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:c2:6b:90:a2  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-6ab220ad63c4: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 172.29.0.1  netmask 255.255.0.0  broadcast 172.29.255.255
+        inet6 fe80::42:efff:fe59:79e1  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:ef:59:79:e1  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-9e73dba82b15: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 172.18.0.1  netmask 255.255.0.0  broadcast 172.18.255.255
+        inet6 fe80::42:61ff:fe44:fecb  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:61:44:fe:cb  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-b1aea78a85ac: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 172.27.0.1  netmask 255.255.0.0  broadcast 172.27.255.255
+        inet6 fe80::42:35ff:fe59:5dee  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:35:59:5d:ee  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-ce2012183c45: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 172.23.0.1  netmask 255.255.0.0  broadcast 172.23.255.255
+        inet6 fe80::42:8eff:fee4:529e  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:8e:e4:52:9e  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-f42520551f76: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 172.19.0.1  netmask 255.255.0.0  broadcast 172.19.255.255
+        inet6 fe80::42:b8ff:fe54:9465  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:b8:54:94:65  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+docker0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.17.0.1  netmask 255.255.0.0  broadcast 172.17.255.255
+        inet6 fe80::42:a5ff:fee8:5a87  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:a5:e8:5a:87  txqueuelen 0  (Ethernet)
+        RX packets 30045  bytes 1895498 (1.8 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 49944  bytes 584574501 (584.5 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+ens18: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 192.168.1.27  netmask 255.255.255.0  broadcast 192.168.1.255
+        inet6 2001:db8:1::e44d:93ff:fef7:b849  prefixlen 64  scopeid 0x0<global>
+        inet6 fe80::e44d:93ff:fef7:b849  prefixlen 64  scopeid 0x20<link>
+        ether e6:4d:93:f7:b8:49  txqueuelen 1000  (Ethernet)
+        RX packets 90962575  bytes 51990037677 (51.9 GB)
+        RX errors 0  dropped 10008  overruns 0  frame 0
+        TX packets 47356727  bytes 26816561060 (26.8 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+        inet 127.0.0.1  netmask 255.0.0.0
+        inet6 ::1  prefixlen 128  scopeid 0x10<host>
+        loop  txqueuelen 1000  (Local Loopback)
+        RX packets 39144710  bytes 9329319148 (9.3 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 39144710  bytes 9329319148 (9.3 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth09fe7c1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::48af:5ff:fee8:f0cb  prefixlen 64  scopeid 0x20<link>
+        ether 4a:af:05:e8:f0:cb  txqueuelen 0  (Ethernet)
+        RX packets 5860755  bytes 536447802 (536.4 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3101317  bytes 356630190 (356.6 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth16ba3e2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::3405:caff:fed9:2a62  prefixlen 64  scopeid 0x20<link>
+        ether 36:05:ca:d9:2a:62  txqueuelen 0  (Ethernet)
+        RX packets 7752  bytes 2392935 (2.3 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 11072  bytes 2986568 (2.9 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth1e38cb5: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::d0e7:2bff:fe1f:b60e  prefixlen 64  scopeid 0x20<link>
+        ether d2:e7:2b:1f:b6:0e  txqueuelen 0  (Ethernet)
+        RX packets 14838305  bytes 3525551835 (3.5 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 17011671  bytes 3338288777 (3.3 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth2689c48: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::c4a2:44ff:fe75:b7d5  prefixlen 64  scopeid 0x20<link>
+        ether c6:a2:44:75:b7:d5  txqueuelen 0  (Ethernet)
+        RX packets 4163  bytes 3760593 (3.7 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 6090  bytes 1531326 (1.5 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth3c44d68: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::4017:35ff:fe32:8ac5  prefixlen 64  scopeid 0x20<link>
+        ether 42:17:35:32:8a:c5  txqueuelen 0  (Ethernet)
+        RX packets 107663333  bytes 10754339613 (10.7 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 55068784  bytes 15094746110 (15.0 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth506ca58: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::8035:cdff:feb5:743  prefixlen 64  scopeid 0x20<link>
+        ether 82:35:cd:b5:07:43  txqueuelen 0  (Ethernet)
+        RX packets 103  bytes 11957 (11.9 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3958  bytes 1025025 (1.0 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth58eda36: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::8863:89ff:fe3b:5a4e  prefixlen 64  scopeid 0x20<link>
+        ether 8a:63:89:3b:5a:4e  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 1481  bytes 103846 (103.8 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth59f5140: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::28c6:9ff:fe87:18b4  prefixlen 64  scopeid 0x20<link>
+        ether 2a:c6:09:87:18:b4  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 1478  bytes 103636 (103.6 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth60dfa64: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::1c17:a0ff:fe4b:df6c  prefixlen 64  scopeid 0x20<link>
+        ether 1e:17:a0:4b:df:6c  txqueuelen 0  (Ethernet)
+        RX packets 17008102  bytes 3337427503 (3.3 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 14841872  bytes 3526413049 (3.5 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth683798b: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::a4a2:6cff:fe92:2a1e  prefixlen 64  scopeid 0x20<link>
+        ether a6:a2:6c:92:2a:1e  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3950  bytes 901709 (901.7 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth746c084: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::e02f:36ff:fe00:5d3e  prefixlen 64  scopeid 0x20<link>
+        ether e2:2f:36:00:5d:3e  txqueuelen 0  (Ethernet)
+        RX packets 23540  bytes 2670558 (2.6 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 24445  bytes 9620869 (9.6 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth81628b7: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::300f:9ff:fe2e:e014  prefixlen 64  scopeid 0x20<link>
+        ether 32:0f:09:2e:e0:14  txqueuelen 0  (Ethernet)
+        RX packets 6159  bytes 415805 (415.8 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 9075  bytes 1192929 (1.1 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth8ce08c1: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::24f0:66ff:fe79:38e0  prefixlen 64  scopeid 0x20<link>
+        ether 26:f0:66:79:38:e0  txqueuelen 0  (Ethernet)
+        RX packets 3501  bytes 240418 (240.4 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 6793  bytes 1311128 (1.3 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth8f52935: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::9cb3:bfff:fe5e:3536  prefixlen 64  scopeid 0x20<link>
+        ether 9e:b3:bf:5e:35:36  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3877  bytes 1012061 (1.0 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth93e8f6e: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::b47c:cff:fe2f:6f69  prefixlen 64  scopeid 0x20<link>
+        ether b6:7c:0c:2f:6f:69  txqueuelen 0  (Ethernet)
+        RX packets 460  bytes 59460 (59.4 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 4445  bytes 1254054 (1.2 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+veth9812b72: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::50d1:56ff:fe55:775b  prefixlen 64  scopeid 0x20<link>
+        ether 52:d1:56:55:77:5b  txqueuelen 0  (Ethernet)
+        RX packets 500424  bytes 567163237 (567.1 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 681278  bytes 1881511069 (1.8 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vetha968406: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::9ce9:4fff:fe39:592a  prefixlen 64  scopeid 0x20<link>
+        ether 9e:e9:4f:39:59:2a  txqueuelen 0  (Ethernet)
+        RX packets 204753  bytes 33702723 (33.7 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 165402  bytes 23389686 (23.3 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethae29dc7: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::20ec:59ff:fe7c:9125  prefixlen 64  scopeid 0x20<link>
+        ether 22:ec:59:7c:91:25  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3873  bytes 1011741 (1.0 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethb6af214: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::408e:4aff:fe38:353d  prefixlen 64  scopeid 0x20<link>
+        ether 42:8e:4a:38:35:3d  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 1485  bytes 104222 (104.2 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethbf8e533: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::e0f0:31ff:fe9b:97  prefixlen 64  scopeid 0x20<link>
+        ether e2:f0:31:9b:00:97  txqueuelen 0  (Ethernet)
+        RX packets 6295  bytes 2718131 (2.7 MB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 8850  bytes 1763767 (1.7 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethcc4062e: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::746b:75ff:fe4a:a0b0  prefixlen 64  scopeid 0x20<link>
+        ether 76:6b:75:4a:a0:b0  txqueuelen 0  (Ethernet)
+        RX packets 54862942  bytes 15059625487 (15.0 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 107507682  bytes 10733087076 (10.7 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethd417d97: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::dcdd:93ff:fe15:19dd  prefixlen 64  scopeid 0x20<link>
+        ether de:dd:93:15:19:dd  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 3876  bytes 1012011 (1.0 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethdb87f13: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::f02d:3ff:fec6:cc8e  prefixlen 64  scopeid 0x20<link>
+        ether f2:2d:03:c6:cc:8e  txqueuelen 0  (Ethernet)
+        RX packets 5460  bytes 841533 (841.5 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 8468  bytes 1806481 (1.8 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+vethf05a4e5: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet6 fe80::c40f:c4ff:fea6:65c1  prefixlen 64  scopeid 0x20<link>
+        ether c6:0f:c4:a6:65:c1  txqueuelen 0  (Ethernet)
+        RX packets 543  bytes 113765 (113.7 KB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 2457  bytes 852153 (852.1 KB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

--- a/tests/parsers/linux/ifconfig/002_playground_host/metadata.yaml
+++ b/tests/parsers/linux/ifconfig/002_playground_host/metadata.yaml
@@ -1,0 +1,3 @@
+description: ifconfig output from a Linux host running Docker with many bridge and veth interfaces
+platform: linux
+software_version: net-tools 2.10


### PR DESCRIPTION
## Summary
- Add new parser for the `ifconfig` command on Linux (`OS.LINUX`)
- Parses modern ifconfig output format: interface flags, MTU, MAC addresses, IPv4/IPv6 addresses, TX/RX counters, and device interrupt/memory info
- Dict-of-dicts output keyed by interface name with `TypedDict` schema
- Test fixture uses real device output with 7 interfaces (bridge, docker, physical, loopback, veth)

## Test plan
- [x] Parser test passes against real golden output (`001_basic`)
- [x] Empty output raises `ValueError`
- [x] All fixture convention tests pass (no placeholder sentinels, no list-of-dicts, no pipe keys)
- [x] `ruff check` and `ruff format` clean
- [x] `xenon` complexity under B threshold
- [x] `bandit` security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)