### PR TITLE
feat(cisco_iosxr): add parser for `show ipv4 interface`

### DIFF
--- a/changes/+cisco-iosxr-show-ipv4-interface.parser_added
+++ b/changes/+cisco-iosxr-show-ipv4-interface.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ipv4 interface` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_ipv4_interface.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ipv4_interface.py
@@ -1,0 +1,335 @@
+"""Parser for 'show ipv4 interface' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class IPv4InterfaceEntry(TypedDict, total=False):
+    """Schema for a single interface entry in 'show ipv4 interface' output.
+
+    All fields except interface_status and protocol_status are optional
+    because shutdown interfaces may only show VRF and
+    "Internet protocol processing disabled".
+    """
+
+    interface_status: str
+    protocol_status: str
+    vrf: str
+    vrf_id: str
+    ip_address: str
+    prefix_length: int
+    mtu: int
+    ip_mtu: int
+    proxy_arp: bool
+    icmp_redirects: str
+    icmp_unreachables: str
+    icmp_mask_replies: str
+    directed_broadcast: bool
+    table_id: str
+    multicast_groups: list[str]
+    outgoing_access_list: str
+    inbound_access_list: str
+    helper_address: str
+
+
+class ShowIPv4InterfaceResult(TypedDict):
+    """Schema for 'show ipv4 interface' parsed output.
+
+    Dict-of-dicts keyed by canonical interface name.
+    """
+
+    interfaces: dict[str, IPv4InterfaceEntry]
+
+
+@register(OS.CISCO_IOSXR, "show ipv4 interface")
+class ShowIPv4InterfaceParser(BaseParser[ShowIPv4InterfaceResult]):
+    """Parser for 'show ipv4 interface' command on Cisco IOS-XR.
+
+    Parses per-interface IPv4 configuration and status information into
+    a dict-of-dicts keyed by canonical interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+        }
+    )
+
+    # Header line: "GigabitEthernet0/0/0/0 is Up, ipv4 protocol is Up"
+    _INTF_HEADER = re.compile(
+        r"^(?P<name>\S+)\s+is\s+(?P<status>\S+),\s+"
+        r"ipv4\s+protocol\s+is\s+(?P<proto>\S+)\s*$",
+        re.IGNORECASE,
+    )
+
+    _VRF = re.compile(
+        r"^\s+Vrf\s+is\s+(?P<vrf>\S+)\s+\(vrfid\s+(?P<vrfid>\S+)\)",
+        re.IGNORECASE,
+    )
+
+    _ADDRESS = re.compile(
+        r"^\s+Internet\s+address\s+is\s+(?P<ip>\S+)/(?P<prefix>\d+)",
+        re.IGNORECASE,
+    )
+
+    _MTU = re.compile(
+        r"^\s+MTU\s+is\s+(?P<mtu>\d+)\s+\((?P<ip_mtu>\d+)\s+is\s+available",
+        re.IGNORECASE,
+    )
+
+    _HELPER = re.compile(
+        r"^\s+Helper\s+address\s+is\s+(?P<helper>.+)$",
+        re.IGNORECASE,
+    )
+
+    _MULTICAST = re.compile(
+        r"^\s+Multicast\s+reserved\s+groups\s+joined:\s*(?P<groups>.+)$",
+        re.IGNORECASE,
+    )
+
+    _MULTICAST_CONT = re.compile(
+        r"^\s{6,}(?P<groups>[\d.]+(?:\s+[\d.]+)*)$",
+    )
+
+    _DIRECTED_BROADCAST = re.compile(
+        r"^\s+Directed\s+broadcast\s+forwarding\s+is\s+(?P<state>\S+)",
+        re.IGNORECASE,
+    )
+
+    _OUT_ACL = re.compile(
+        r"^\s+Outgoing\s+access\s+list\s+is\s+(?P<acl>.+)$",
+        re.IGNORECASE,
+    )
+
+    _IN_ACL = re.compile(
+        r"^\s+Inbound\s+(?:common\s+)?access\s+list\s+is\s+(?P<common>.+?),"
+        r"\s+access\s+list\s+is\s+(?P<acl>.+)$",
+        re.IGNORECASE,
+    )
+
+    _IN_ACL_SIMPLE = re.compile(
+        r"^\s+Inbound\s+access\s+list\s+is\s+(?P<acl>.+)$",
+        re.IGNORECASE,
+    )
+
+    _PROXY_ARP = re.compile(
+        r"^\s+Proxy\s+ARP\s+is\s+(?P<state>\S+)",
+        re.IGNORECASE,
+    )
+
+    _ICMP_REDIRECTS = re.compile(
+        r"^\s+ICMP\s+redirects\s+are\s+(?P<state>.+)$",
+        re.IGNORECASE,
+    )
+
+    _ICMP_UNREACHABLES = re.compile(
+        r"^\s+ICMP\s+unreachables\s+are\s+(?P<state>.+)$",
+        re.IGNORECASE,
+    )
+
+    _ICMP_MASK = re.compile(
+        r"^\s+ICMP\s+mask\s+replies\s+are\s+(?P<state>.+)$",
+        re.IGNORECASE,
+    )
+
+    _TABLE_ID = re.compile(
+        r"^\s+Table\s+Id\s+is\s+(?P<id>\S+)",
+        re.IGNORECASE,
+    )
+
+    _NOT_SET = "not set"
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIPv4InterfaceResult:
+        """Parse 'show ipv4 interface' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IPv4 interface information keyed by interface name.
+
+        Raises:
+            ValueError: If no interface entries can be parsed from the output.
+        """
+        interfaces: dict[str, IPv4InterfaceEntry] = {}
+        current: IPv4InterfaceEntry | None = None
+        current_name: str | None = None
+        collecting_multicast = False
+
+        for line in output.splitlines():
+            # Check for interface header line
+            header = cls._INTF_HEADER.match(line)
+            if header:
+                current = IPv4InterfaceEntry(
+                    interface_status=header.group("status"),
+                    protocol_status=header.group("proto"),
+                )
+                current_name = canonical_interface_name(
+                    header.group("name"), os=OS.CISCO_IOSXR
+                )
+                interfaces[current_name] = current
+                collecting_multicast = False
+                continue
+
+            if current is None:
+                continue
+
+            # Multicast continuation lines (indented IP addresses)
+            if collecting_multicast:
+                mc_cont = cls._MULTICAST_CONT.match(line)
+                if mc_cont:
+                    current.setdefault("multicast_groups", []).extend(
+                        mc_cont.group("groups").split()
+                    )
+                    continue
+                collecting_multicast = False
+
+            cls._parse_detail_line(line, current)
+
+            # Check if this line started multicast collection
+            mc = cls._MULTICAST.match(line)
+            if mc:
+                collecting_multicast = True
+
+        if not interfaces:
+            msg = "No interface entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIPv4InterfaceResult, {"interfaces": interfaces})
+
+    @classmethod
+    def _parse_detail_line(cls, line: str, entry: IPv4InterfaceEntry) -> None:
+        """Parse a single detail line within an interface block."""
+        parsers = (
+            cls._try_parse_vrf,
+            cls._try_parse_address,
+            cls._try_parse_mtu,
+            cls._try_parse_helper,
+            cls._try_parse_multicast,
+            cls._try_parse_forwarding,
+            cls._try_parse_acl,
+            cls._try_parse_icmp,
+            cls._try_parse_table_id,
+        )
+        for parser_fn in parsers:
+            if parser_fn(line, entry):
+                return
+
+    @classmethod
+    def _try_parse_vrf(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse VRF line. Returns True if matched."""
+        m = cls._VRF.match(line)
+        if not m:
+            return False
+        entry["vrf"] = m.group("vrf")
+        entry["vrf_id"] = m.group("vrfid")
+        return True
+
+    @classmethod
+    def _try_parse_address(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse IP address line. Returns True if matched."""
+        m = cls._ADDRESS.match(line)
+        if not m:
+            return False
+        entry["ip_address"] = m.group("ip")
+        entry["prefix_length"] = int(m.group("prefix"))
+        return True
+
+    @classmethod
+    def _try_parse_mtu(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse MTU line. Returns True if matched."""
+        m = cls._MTU.match(line)
+        if not m:
+            return False
+        entry["mtu"] = int(m.group("mtu"))
+        entry["ip_mtu"] = int(m.group("ip_mtu"))
+        return True
+
+    @classmethod
+    def _try_parse_helper(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse helper address line. Returns True if matched."""
+        m = cls._HELPER.match(line)
+        if not m:
+            return False
+        value = m.group("helper").strip()
+        if value.lower() != cls._NOT_SET:
+            entry["helper_address"] = value
+        return True
+
+    @classmethod
+    def _try_parse_multicast(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse multicast groups line. Returns True if matched."""
+        m = cls._MULTICAST.match(line)
+        if not m:
+            return False
+        entry["multicast_groups"] = m.group("groups").split()
+        return True
+
+    @classmethod
+    def _try_parse_forwarding(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse directed broadcast and proxy ARP. Returns True if matched."""
+        m = cls._DIRECTED_BROADCAST.match(line)
+        if m:
+            entry["directed_broadcast"] = m.group("state").lower() == "enabled"
+            return True
+        m = cls._PROXY_ARP.match(line)
+        if m:
+            entry["proxy_arp"] = m.group("state").lower() == "enabled"
+            return True
+        return False
+
+    @classmethod
+    def _try_parse_acl(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse ACL lines. Returns True if matched."""
+        m = cls._OUT_ACL.match(line)
+        if m:
+            value = m.group("acl").strip()
+            if value.lower() != cls._NOT_SET:
+                entry["outgoing_access_list"] = value
+            return True
+        m = cls._IN_ACL.match(line)
+        if m:
+            acl_value = m.group("acl").strip()
+            if acl_value.lower() != cls._NOT_SET:
+                entry["inbound_access_list"] = acl_value
+            return True
+        m = cls._IN_ACL_SIMPLE.match(line)
+        if m:
+            acl_value = m.group("acl").strip()
+            if acl_value.lower() != cls._NOT_SET:
+                entry["inbound_access_list"] = acl_value
+            return True
+        return False
+
+    @classmethod
+    def _try_parse_icmp(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse ICMP settings lines. Returns True if matched."""
+        m = cls._ICMP_REDIRECTS.match(line)
+        if m:
+            entry["icmp_redirects"] = m.group("state").strip()
+            return True
+        m = cls._ICMP_UNREACHABLES.match(line)
+        if m:
+            entry["icmp_unreachables"] = m.group("state").strip()
+            return True
+        m = cls._ICMP_MASK.match(line)
+        if m:
+            entry["icmp_mask_replies"] = m.group("state").strip()
+            return True
+        return False
+
+    @classmethod
+    def _try_parse_table_id(cls, line: str, entry: IPv4InterfaceEntry) -> bool:
+        """Try to parse table ID line. Returns True if matched."""
+        m = cls._TABLE_ID.match(line)
+        if not m:
+            return False
+        entry["table_id"] = m.group("id")
+        return True

--- a/src/muninn/parsers/cisco_iosxr/show_ipv4_interface.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ipv4_interface.py
@@ -35,6 +35,7 @@ class IPv4InterfaceEntry(TypedDict, total=False):
     multicast_groups: list[str]
     outgoing_access_list: str
     inbound_access_list: str
+    inbound_common_access_list: str
     helper_address: str
 
 
@@ -108,7 +109,7 @@ class ShowIPv4InterfaceParser(BaseParser[ShowIPv4InterfaceResult]):
     )
 
     _IN_ACL = re.compile(
-        r"^\s+Inbound\s+(?:common\s+)?access\s+list\s+is\s+(?P<common>.+?),"
+        r"^\s+Inbound\s+common\s+access\s+list\s+is\s+(?P<common>.+?),"
         r"\s+access\s+list\s+is\s+(?P<acl>.+)$",
         re.IGNORECASE,
     )
@@ -296,6 +297,9 @@ class ShowIPv4InterfaceParser(BaseParser[ShowIPv4InterfaceResult]):
             return True
         m = cls._IN_ACL.match(line)
         if m:
+            common_value = m.group("common").strip()
+            if common_value.lower() != cls._NOT_SET:
+                entry["inbound_common_access_list"] = common_value
             acl_value = m.group("acl").strip()
             if acl_value.lower() != cls._NOT_SET:
                 entry["inbound_access_list"] = acl_value

--- a/tests/parsers/cisco_iosxr/show_ipv4_interface/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_ipv4_interface/001_basic/expected.json
@@ -1,0 +1,48 @@
+{
+    "interfaces": {
+        "GigabitEthernet0/0/0/0": {
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf": "default",
+            "vrf_id": "0x60000000",
+            "ip_address": "10.2.0.2",
+            "prefix_length": 30,
+            "mtu": 1514,
+            "ip_mtu": 1500,
+            "multicast_groups": [
+                "224.0.0.2",
+                "224.0.0.1",
+                "224.0.0.9",
+                "224.0.0.10"
+            ],
+            "directed_broadcast": false,
+            "proxy_arp": false,
+            "icmp_redirects": "never sent",
+            "icmp_unreachables": "always sent",
+            "icmp_mask_replies": "never sent",
+            "table_id": "0xe0000000"
+        },
+        "GigabitEthernet0/0/0/1": {
+            "interface_status": "Up",
+            "protocol_status": "Up",
+            "vrf": "default",
+            "vrf_id": "0x60000000",
+            "ip_address": "10.0.7.1",
+            "prefix_length": 30,
+            "mtu": 1514,
+            "ip_mtu": 1500,
+            "multicast_groups": [
+                "224.0.0.2",
+                "224.0.0.1",
+                "224.0.0.5",
+                "224.0.0.6"
+            ],
+            "directed_broadcast": false,
+            "proxy_arp": false,
+            "icmp_redirects": "never sent",
+            "icmp_unreachables": "always sent",
+            "icmp_mask_replies": "never sent",
+            "table_id": "0xe0000000"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_ipv4_interface/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_ipv4_interface/001_basic/input.txt
@@ -1,0 +1,31 @@
+Sun Jun 19 08:45:14.652 UTC
+GigabitEthernet0/0/0/0 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.2.0.2/30
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.2 224.0.0.1 224.0.0.9
+      224.0.0.10
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  common access list is not set, access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000
+GigabitEthernet0/0/0/1 is Up, ipv4 protocol is Up
+  Vrf is default (vrfid 0x60000000)
+  Internet address is 10.0.7.1/30
+  MTU is 1514 (1500 is available to IP)
+  Helper address is not set
+  Multicast reserved groups joined: 224.0.0.2 224.0.0.1 224.0.0.5
+      224.0.0.6
+  Directed broadcast forwarding is disabled
+  Outgoing access list is not set
+  Inbound  common access list is not set, access list is not set
+  Proxy ARP is disabled
+  ICMP redirects are never sent
+  ICMP unreachables are always sent
+  ICMP mask replies are never sent
+  Table Id is 0xe0000000

--- a/tests/parsers/cisco_iosxr/show_ipv4_interface/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_ipv4_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Multiple GigabitEthernet interfaces with IPv4 addresses and multicast groups"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show ipv4 interface` on Cisco IOS-XR
- Parses per-interface IPv4 configuration: IP address, prefix length, VRF, MTU, proxy ARP, ICMP settings, ACLs, multicast groups, directed broadcast, and table ID
- Dict-of-dicts output keyed by canonical interface name; shutdown interfaces with no IP config included with minimal fields
- Tagged with `ParserTag.INTERFACES`

## Test plan
- [x] Parser test fixture with real device output (ntc-templates source) passes
- [x] All placeholder sentinel checks pass (no banned values)
- [x] JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity under B threshold
- [x] Bandit security scan clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)