### PR TITLE
feat(arista_eos): add parser for show ip bgp summary

### DIFF
--- a/changes/+arista-eos-show-ip-bgp-summary.parser_added
+++ b/changes/+arista-eos-show-ip-bgp-summary.parser_added
@@ -1,0 +1,1 @@
+Added `show ip bgp summary` parser for Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ip_bgp_summary.py
+++ b/src/muninn/parsers/arista_eos/show_ip_bgp_summary.py
@@ -1,15 +1,25 @@
 """Parser for 'show ip bgp summary' command on Arista EOS.
 
-Arista EOS ``show ip bgp summary`` displays the BGP router identifier,
-local AS number, VRF name, and a neighbor table with per-peer statistics
-including messages received/sent, state or prefix count, and uptime.
+Arista EOS emits two related layouts for ``show ip bgp summary``:
+
+* **Legacy** — a single ``BGP router identifier X, local AS number Y`` line
+  followed by a neighbor table whose final column is the combined
+  ``State/PfxRcd`` (numeric when the session is established, a state name
+  like ``Idle`` / ``Active`` otherwise).
+* **Modern** — one or more ``BGP summary information for VRF <name>``
+  banners, each followed by ``Router identifier X, local AS number Y`` and
+  a neighbor table whose state and prefix-received / prefix-accepted
+  columns are separate.
+
+Both layouts are parsed into the same VRF-keyed structure.
 """
 
 import re
-from typing import ClassVar, NotRequired, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 
@@ -24,29 +34,53 @@ class NeighborEntry(TypedDict):
     in_queue: int
     out_queue: int
     up_down: str
-    state_pfxrcd: str
+    state: str
+    prefixes_received: NotRequired[int]
+    prefixes_accepted: NotRequired[int]
 
 
-class ShowIpBgpSummaryResult(TypedDict):
-    """Schema for 'show ip bgp summary' parsed output on Arista EOS."""
+class VrfEntry(TypedDict):
+    """Schema for a single VRF's BGP summary block."""
 
     router_id: str
     local_as: int
-    vrf: NotRequired[str]
     neighbors: dict[str, NeighborEntry]
 
 
-_ROUTER_ID_RE = re.compile(
-    r"^BGP router identifier (?P<router_id>\S+),\s*"
-    r"local AS number (?P<local_as>\d+)"
+class ShowIpBgpSummaryResult(TypedDict):
+    """Schema for 'show ip bgp summary' parsed output on Arista EOS.
+
+    The top-level value is keyed by VRF name.  Captures from the legacy
+    single-VRF output (which does not name the VRF) are recorded under
+    ``"default"``.
+    """
+
+    vrfs: dict[str, VrfEntry]
+
+
+_VRF_BANNER_RE = re.compile(
+    r"^BGP summary information for VRF\s+(?P<vrf>\S+)",
+    re.I,
 )
 
-_VRF_RE = re.compile(r"^VRF name:\s*(?P<vrf>\S+)", re.I)
+# Matches both layouts:
+#   "BGP router identifier 10.0.0.1, local AS number 65000"   (legacy)
+#   "Router identifier 10.0.0.1, local AS number 65000"       (modern)
+_ROUTER_ID_RE = re.compile(
+    rf"(?:BGP\s+)?Router identifier\s+(?P<router_id>{IPV4_ADDRESS}),\s*"
+    r"local AS number\s+(?P<local_as>\d+)",
+    re.I,
+)
 
 _NEIGHBOR_HEADER_RE = re.compile(r"^Neighbor\s+V\s+AS\s+MsgRcvd")
 
-_NEIGHBOR_LINE_RE = re.compile(
-    r"^(?P<neighbor>\S+)\s+"
+# Single regex covering both the legacy combined ``State/PfxRcd`` column and
+# the modern split ``State PfxRcd PfxAcc`` columns.  When the session is
+# established, the legacy format emits just the prefix count as a digit
+# string in the state slot; the modern format emits ``Estab`` followed by
+# the counts.
+_NEIGHBOR_RE = re.compile(
+    rf"^(?P<neighbor>{IPV4_ADDRESS})\s+"
     r"(?P<version>\d+)\s+"
     r"(?P<remote_as>\d+)\s+"
     r"(?P<msg_rcvd>\d+)\s+"
@@ -54,71 +88,92 @@ _NEIGHBOR_LINE_RE = re.compile(
     r"(?P<in_q>\d+)\s+"
     r"(?P<out_q>\d+)\s+"
     r"(?P<up_down>\S+)\s+"
-    r"(?P<state_pfxrcd>\S+.*?)\s*$"
+    r"(?P<state_token>\S+)"
+    r"(?:\s+(?P<pfx_rcvd>\d+)(?:\s+(?P<pfx_acc>\d+))?)?\s*$"
 )
 
 
-def _parse_neighbor_line(m: re.Match[str]) -> NeighborEntry:
+def _build_neighbor(m: re.Match[str]) -> NeighborEntry:
     """Build a NeighborEntry from a regex match on a neighbor table line."""
-    return NeighborEntry(
-        bgp_version=int(m.group("version")),
-        remote_as=int(m.group("remote_as")),
-        msg_rcvd=int(m.group("msg_rcvd")),
-        msg_sent=int(m.group("msg_sent")),
-        in_queue=int(m.group("in_q")),
-        out_queue=int(m.group("out_q")),
-        up_down=m.group("up_down"),
-        state_pfxrcd=m.group("state_pfxrcd").strip(),
-    )
+    state_token = m.group("state_token")
+    pfx_rcvd_grp = m.group("pfx_rcvd")
+    pfx_acc_grp = m.group("pfx_acc")
+
+    entry: NeighborEntry = {
+        "bgp_version": int(m.group("version")),
+        "remote_as": int(m.group("remote_as")),
+        "msg_rcvd": int(m.group("msg_rcvd")),
+        "msg_sent": int(m.group("msg_sent")),
+        "in_queue": int(m.group("in_q")),
+        "out_queue": int(m.group("out_q")),
+        "up_down": m.group("up_down"),
+        "state": _normalize_state(state_token),
+    }
+    if state_token.isdigit():
+        entry["prefixes_received"] = int(state_token)
+    if pfx_rcvd_grp is not None:
+        entry["prefixes_received"] = int(pfx_rcvd_grp)
+    if pfx_acc_grp is not None:
+        entry["prefixes_accepted"] = int(pfx_acc_grp)
+    return entry
 
 
-def _parse_neighbors(lines: list[str]) -> dict[str, NeighborEntry]:
-    """Parse neighbor entries from lines following the neighbor table header."""
-    neighbors: dict[str, NeighborEntry] = {}
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if m := _NEIGHBOR_LINE_RE.match(stripped):
-            neighbors[m.group("neighbor")] = _parse_neighbor_line(m)
-    return neighbors
+def _normalize_state(token: str) -> str:
+    """Translate a state column token into a canonical state name."""
+    if token.isdigit() or token.lower().startswith("estab"):
+        return "Established"
+    return token
 
 
-class _HeaderFields:
-    """Container for fields extracted from the BGP summary header."""
+class _ParseState:
+    """Mutable state threaded through line-by-line parsing."""
 
-    __slots__ = ("local_as", "neighbor_start", "router_id", "vrf")
+    __slots__ = ("current_entry", "current_vrf", "in_neighbor_table", "vrfs")
 
     def __init__(self) -> None:
-        self.router_id: str | None = None
-        self.local_as: int | None = None
-        self.vrf: str | None = None
-        self.neighbor_start: int | None = None
+        self.vrfs: dict[str, VrfEntry] = {}
+        self.current_vrf: str = "default"
+        self.current_entry: VrfEntry | None = None
+        self.in_neighbor_table: bool = False
+
+    def start_vrf(self, vrf: str) -> None:
+        self.current_vrf = vrf
+        self.current_entry = None
+        self.in_neighbor_table = False
+
+    def start_block(self, router_id: str, local_as: int) -> None:
+        entry: VrfEntry = {
+            "router_id": router_id,
+            "local_as": local_as,
+            "neighbors": {},
+        }
+        self.vrfs[self.current_vrf] = entry
+        self.current_entry = entry
+        self.in_neighbor_table = False
 
 
-def _extract_header(lines: list[str]) -> _HeaderFields:
-    """Scan output lines for router-id, local-AS, VRF, and neighbor offset."""
-    fields = _HeaderFields()
-    for idx, line in enumerate(lines):
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if m := _ROUTER_ID_RE.match(stripped):
-            fields.router_id = m.group("router_id")
-            fields.local_as = int(m.group("local_as"))
-        elif m := _VRF_RE.match(stripped):
-            fields.vrf = m.group("vrf")
-        elif _NEIGHBOR_HEADER_RE.match(stripped):
-            fields.neighbor_start = idx + 1
-    return fields
+def _consume_line(state: _ParseState, line: str) -> None:
+    """Update parser state from a single non-blank input line."""
+    if m := _VRF_BANNER_RE.match(line):
+        state.start_vrf(m.group("vrf"))
+        return
+    if m := _ROUTER_ID_RE.match(line):
+        state.start_block(m.group("router_id"), int(m.group("local_as")))
+        return
+    if _NEIGHBOR_HEADER_RE.match(line):
+        state.in_neighbor_table = True
+        return
+    if state.in_neighbor_table and state.current_entry is not None:
+        if m := _NEIGHBOR_RE.match(line):
+            state.current_entry["neighbors"][m.group("neighbor")] = _build_neighbor(m)
 
 
 @register(OS.ARISTA_EOS, "show ip bgp summary")
 class ShowIpBgpSummaryParser(BaseParser["ShowIpBgpSummaryResult"]):
     """Parser for 'show ip bgp summary' on Arista EOS.
 
-    Parses BGP process header information and the neighbor summary table.
-    Output is keyed by neighbor IP address in a dict-of-dicts structure.
+    Parses one or more VRF blocks into a ``vrfs`` mapping; each VRF entry
+    contains its router-id, local AS, and a neighbor dict keyed by IP.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
@@ -131,30 +186,19 @@ class ShowIpBgpSummaryParser(BaseParser["ShowIpBgpSummaryResult"]):
             output: Raw CLI output from the command.
 
         Returns:
-            Parsed BGP summary information.
+            Parsed BGP summary information nested by VRF.
 
         Raises:
-            ValueError: If required fields cannot be parsed from the output.
+            ValueError: If no BGP router identifier / local-AS line is found.
         """
-        all_lines = output.splitlines()
-        hdr = _extract_header(all_lines)
+        state = _ParseState()
+        for line in output.splitlines():
+            stripped = line.strip()
+            if stripped:
+                _consume_line(state, stripped)
 
-        if hdr.router_id is None or hdr.local_as is None:
+        if not state.vrfs:
             msg = "Missing BGP router identifier or local AS number"
             raise ValueError(msg)
 
-        if hdr.neighbor_start is not None:
-            neighbor_lines = all_lines[hdr.neighbor_start :]
-        else:
-            neighbor_lines = []
-
-        result: dict[str, object] = {
-            "router_id": hdr.router_id,
-            "local_as": hdr.local_as,
-            "neighbors": _parse_neighbors(neighbor_lines),
-        }
-
-        if hdr.vrf is not None:
-            result["vrf"] = hdr.vrf
-
-        return cast(ShowIpBgpSummaryResult, result)
+        return {"vrfs": state.vrfs}

--- a/src/muninn/parsers/arista_eos/show_ip_bgp_summary.py
+++ b/src/muninn/parsers/arista_eos/show_ip_bgp_summary.py
@@ -1,0 +1,160 @@
+"""Parser for 'show ip bgp summary' command on Arista EOS.
+
+Arista EOS ``show ip bgp summary`` displays the BGP router identifier,
+local AS number, VRF name, and a neighbor table with per-peer statistics
+including messages received/sent, state or prefix count, and uptime.
+"""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NeighborEntry(TypedDict):
+    """Schema for a single BGP neighbor in the summary table."""
+
+    bgp_version: int
+    remote_as: int
+    msg_rcvd: int
+    msg_sent: int
+    in_queue: int
+    out_queue: int
+    up_down: str
+    state_pfxrcd: str
+
+
+class ShowIpBgpSummaryResult(TypedDict):
+    """Schema for 'show ip bgp summary' parsed output on Arista EOS."""
+
+    router_id: str
+    local_as: int
+    vrf: NotRequired[str]
+    neighbors: dict[str, NeighborEntry]
+
+
+_ROUTER_ID_RE = re.compile(
+    r"^BGP router identifier (?P<router_id>\S+),\s*"
+    r"local AS number (?P<local_as>\d+)"
+)
+
+_VRF_RE = re.compile(r"^VRF name:\s*(?P<vrf>\S+)", re.I)
+
+_NEIGHBOR_HEADER_RE = re.compile(r"^Neighbor\s+V\s+AS\s+MsgRcvd")
+
+_NEIGHBOR_LINE_RE = re.compile(
+    r"^(?P<neighbor>\S+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<remote_as>\d+)\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<in_q>\d+)\s+"
+    r"(?P<out_q>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfxrcd>\S+.*?)\s*$"
+)
+
+
+def _parse_neighbor_line(m: re.Match[str]) -> NeighborEntry:
+    """Build a NeighborEntry from a regex match on a neighbor table line."""
+    return NeighborEntry(
+        bgp_version=int(m.group("version")),
+        remote_as=int(m.group("remote_as")),
+        msg_rcvd=int(m.group("msg_rcvd")),
+        msg_sent=int(m.group("msg_sent")),
+        in_queue=int(m.group("in_q")),
+        out_queue=int(m.group("out_q")),
+        up_down=m.group("up_down"),
+        state_pfxrcd=m.group("state_pfxrcd").strip(),
+    )
+
+
+def _parse_neighbors(lines: list[str]) -> dict[str, NeighborEntry]:
+    """Parse neighbor entries from lines following the neighbor table header."""
+    neighbors: dict[str, NeighborEntry] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if m := _NEIGHBOR_LINE_RE.match(stripped):
+            neighbors[m.group("neighbor")] = _parse_neighbor_line(m)
+    return neighbors
+
+
+class _HeaderFields:
+    """Container for fields extracted from the BGP summary header."""
+
+    __slots__ = ("local_as", "neighbor_start", "router_id", "vrf")
+
+    def __init__(self) -> None:
+        self.router_id: str | None = None
+        self.local_as: int | None = None
+        self.vrf: str | None = None
+        self.neighbor_start: int | None = None
+
+
+def _extract_header(lines: list[str]) -> _HeaderFields:
+    """Scan output lines for router-id, local-AS, VRF, and neighbor offset."""
+    fields = _HeaderFields()
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if m := _ROUTER_ID_RE.match(stripped):
+            fields.router_id = m.group("router_id")
+            fields.local_as = int(m.group("local_as"))
+        elif m := _VRF_RE.match(stripped):
+            fields.vrf = m.group("vrf")
+        elif _NEIGHBOR_HEADER_RE.match(stripped):
+            fields.neighbor_start = idx + 1
+    return fields
+
+
+@register(OS.ARISTA_EOS, "show ip bgp summary")
+class ShowIpBgpSummaryParser(BaseParser["ShowIpBgpSummaryResult"]):
+    """Parser for 'show ip bgp summary' on Arista EOS.
+
+    Parses BGP process header information and the neighbor summary table.
+    Output is keyed by neighbor IP address in a dict-of-dicts structure.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpBgpSummaryResult:
+        """Parse 'show ip bgp summary' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed BGP summary information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed from the output.
+        """
+        all_lines = output.splitlines()
+        hdr = _extract_header(all_lines)
+
+        if hdr.router_id is None or hdr.local_as is None:
+            msg = "Missing BGP router identifier or local AS number"
+            raise ValueError(msg)
+
+        if hdr.neighbor_start is not None:
+            neighbor_lines = all_lines[hdr.neighbor_start :]
+        else:
+            neighbor_lines = []
+
+        result: dict[str, object] = {
+            "router_id": hdr.router_id,
+            "local_as": hdr.local_as,
+            "neighbors": _parse_neighbors(neighbor_lines),
+        }
+
+        if hdr.vrf is not None:
+            result["vrf"] = hdr.vrf
+
+        return cast(ShowIpBgpSummaryResult, result)

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/expected.json
@@ -1,26 +1,32 @@
 {
-    "router_id": "10.26.0.22",
-    "local_as": 65533,
-    "neighbors": {
-        "10.17.254.78": {
-            "bgp_version": 4,
-            "remote_as": 65534,
-            "msg_rcvd": 187,
-            "msg_sent": 191,
-            "in_queue": 0,
-            "out_queue": 0,
-            "up_down": "02:49:40",
-            "state_pfxrcd": "7"
-        },
-        "10.17.254.2": {
-            "bgp_version": 4,
-            "remote_as": 65533,
-            "msg_rcvd": 184,
-            "msg_sent": 191,
-            "in_queue": 0,
-            "out_queue": 0,
-            "up_down": "02:59:41",
-            "state_pfxrcd": "7"
+    "vrfs": {
+        "default": {
+            "router_id": "10.26.0.22",
+            "local_as": 65533,
+            "neighbors": {
+                "10.17.254.78": {
+                    "bgp_version": 4,
+                    "remote_as": 65534,
+                    "msg_rcvd": 187,
+                    "msg_sent": 191,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "02:49:40",
+                    "state": "Established",
+                    "prefixes_received": 7
+                },
+                "10.17.254.2": {
+                    "bgp_version": 4,
+                    "remote_as": 65533,
+                    "msg_rcvd": 184,
+                    "msg_sent": 191,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "02:59:41",
+                    "state": "Established",
+                    "prefixes_received": 7
+                }
+            }
         }
     }
 }

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "router_id": "10.26.0.22",
+    "local_as": 65533,
+    "neighbors": {
+        "10.17.254.78": {
+            "bgp_version": 4,
+            "remote_as": 65534,
+            "msg_rcvd": 187,
+            "msg_sent": 191,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "02:49:40",
+            "state_pfxrcd": "7"
+        },
+        "10.17.254.2": {
+            "bgp_version": 4,
+            "remote_as": 65533,
+            "msg_rcvd": 184,
+            "msg_sent": 191,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "02:59:41",
+            "state_pfxrcd": "7"
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/input.txt
@@ -1,0 +1,4 @@
+BGP router identifier 10.26.0.22, local AS number 65533
+Neighbor         V  AS      MsgRcvd   MsgSent  InQ OutQ  Up/Down State/PfxRcd
+10.17.254.78    4  65534       187       191    0    0 02:49:40 7
+10.17.254.2     4  65533       184       191    0    0 02:59:41 7

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic BGP summary with two neighbors in established state
+platform: Unknown
+software_version: EOS

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/002_multi_vrf/expected.json
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/002_multi_vrf/expected.json
@@ -1,0 +1,70 @@
+{
+    "vrfs": {
+        "RED": {
+            "router_id": "192.168.1.1",
+            "local_as": 645001,
+            "neighbors": {
+                "192.168.1.2": {
+                    "bgp_version": 4,
+                    "remote_as": 65002,
+                    "msg_rcvd": 1753556,
+                    "msg_sent": 1761743,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "40d23h",
+                    "state": "Established",
+                    "prefixes_received": 7,
+                    "prefixes_accepted": 4
+                }
+            }
+        },
+        "WHITE": {
+            "router_id": "192.168.2.1",
+            "local_as": 65011,
+            "neighbors": {
+                "192.168.2.2": {
+                    "bgp_version": 4,
+                    "remote_as": 65012,
+                    "msg_rcvd": 7405942,
+                    "msg_sent": 7406081,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "270d13h",
+                    "state": "Established",
+                    "prefixes_received": 7,
+                    "prefixes_accepted": 5
+                }
+            }
+        },
+        "BLUE": {
+            "router_id": "192.168.3.1",
+            "local_as": 65021,
+            "neighbors": {
+                "192.168.3.2": {
+                    "bgp_version": 4,
+                    "remote_as": 65022,
+                    "msg_rcvd": 1171721,
+                    "msg_sent": 1171752,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "67d19h",
+                    "state": "Established",
+                    "prefixes_received": 25,
+                    "prefixes_accepted": 25
+                },
+                "192.168.3.3": {
+                    "bgp_version": 4,
+                    "remote_as": 65023,
+                    "msg_rcvd": 97651,
+                    "msg_sent": 97643,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "40d23h",
+                    "state": "Established",
+                    "prefixes_received": 18,
+                    "prefixes_accepted": 18
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/002_multi_vrf/input.txt
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/002_multi_vrf/input.txt
@@ -1,0 +1,16 @@
+BGP summary information for VRF RED
+Router identifier 192.168.1.1, local AS number 645001
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  192.168.1.2      4  65002        1753556   1761743    0    0   40d23h Estab  7      4
+BGP summary information for VRF WHITE
+Router identifier 192.168.2.1, local AS number 65011
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  192.168.2.2      4  65012        7405942   7406081    0    0  270d13h Estab  7      5
+BGP summary information for VRF BLUE
+Router identifier 192.168.3.1, local AS number 65021
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  192.168.3.2      4  65022        1171721   1171752    0    0   67d19h Estab  25     25
+  192.168.3.3      4  65023          97651     97643    0    0   40d23h Estab  18     18

--- a/tests/parsers/arista_eos/show_ip_bgp_summary/002_multi_vrf/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_bgp_summary/002_multi_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multi-VRF BGP summary using the modern "BGP summary information for VRF X" header layout with separate State / PfxRcd / PfxAcc columns
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add `show ip bgp summary` parser for Arista EOS
- Parses router ID, local AS, optional VRF, and neighbor table into dict-of-dicts keyed by neighbor IP
- Tagged with `BGP` and `ROUTING`
- Test fixture sourced from ntc-templates real device output

## Test plan
- [x] Parser test passes: `test_parser[arista_eos/show_ip_bgp_summary/001_basic]`
- [x] All fixture convention tests pass (no placeholder sentinels, no list-of-dicts, no pipe keys)
- [x] `ruff check` and `ruff format` clean
- [x] `xenon` complexity under B threshold
- [x] `bandit` security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)