### PR TITLE
feat(juniper_junos): add parser for show isis adjacency

### DIFF
--- a/changes/+juniper-junos-show-isis-adjacency.parser_added
+++ b/changes/+juniper-junos-show-isis-adjacency.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show isis adjacency` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_isis_adjacency.py
+++ b/src/muninn/parsers/juniper_junos/show_isis_adjacency.py
@@ -1,7 +1,7 @@
 """Parser for 'show isis adjacency' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -9,24 +9,19 @@ from muninn.registry import register
 from muninn.tags import ParserTag
 
 
-class IsisAdjacencyEntry(TypedDict, total=False):
+class IsisAdjacencyEntry(TypedDict):
     """Schema for a single IS-IS adjacency entry.
 
     Attributes:
-        interface: Local interface name (e.g., ``ge-0/0/2.0``).
-        system: IS-IS system name or ID of the neighbor.
-        level: IS-IS level (e.g., ``1``, ``2``, ``3``).
         state: Adjacency state (e.g., ``Up``, ``Down``, ``Init``).
         hold_time: Hold timer countdown in seconds.
         snpa: Subnetwork Point of Attachment (MAC address of the neighbor).
+            Omitted on link types that do not expose a SNPA value.
     """
 
-    interface: str
-    system: str
-    level: int
     state: str
     hold_time: int
-    snpa: str
+    snpa: NotRequired[str]
 
 
 class ShowIsisAdjacencyResult(TypedDict):
@@ -99,15 +94,12 @@ class ShowIsisAdjacencyParser(BaseParser[ShowIsisAdjacencyResult]):
 
             interface = match.group("interface")
             system = match.group("system")
-            level = str(match.group("level"))
+            level = match.group("level")
 
-            entry = IsisAdjacencyEntry(
-                interface=interface,
-                system=system,
-                level=int(match.group("level")),
-                state=match.group("state"),
-                hold_time=int(match.group("hold_time")),
-            )
+            entry: IsisAdjacencyEntry = {
+                "state": match.group("state"),
+                "hold_time": int(match.group("hold_time")),
+            }
 
             snpa = match.group("snpa")
             if snpa is not None:
@@ -119,4 +111,4 @@ class ShowIsisAdjacencyParser(BaseParser[ShowIsisAdjacencyResult]):
             msg = "No IS-IS adjacencies found in output"
             raise ValueError(msg)
 
-        return cast(ShowIsisAdjacencyResult, {"adjacencies": adjacencies})
+        return ShowIsisAdjacencyResult(adjacencies=adjacencies)

--- a/src/muninn/parsers/juniper_junos/show_isis_adjacency.py
+++ b/src/muninn/parsers/juniper_junos/show_isis_adjacency.py
@@ -1,0 +1,122 @@
+"""Parser for 'show isis adjacency' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class IsisAdjacencyEntry(TypedDict, total=False):
+    """Schema for a single IS-IS adjacency entry.
+
+    Attributes:
+        interface: Local interface name (e.g., ``ge-0/0/2.0``).
+        system: IS-IS system name or ID of the neighbor.
+        level: IS-IS level (e.g., ``1``, ``2``, ``3``).
+        state: Adjacency state (e.g., ``Up``, ``Down``, ``Init``).
+        hold_time: Hold timer countdown in seconds.
+        snpa: Subnetwork Point of Attachment (MAC address of the neighbor).
+    """
+
+    interface: str
+    system: str
+    level: int
+    state: str
+    hold_time: int
+    snpa: str
+
+
+class ShowIsisAdjacencyResult(TypedDict):
+    """Schema for 'show isis adjacency' parsed output.
+
+    Top-level dict-of-dicts keyed by interface, then system, then level.
+    """
+
+    adjacencies: dict[str, dict[str, dict[str, IsisAdjacencyEntry]]]
+
+
+# Junos 'show isis adjacency' output format:
+# Interface             System         L State        Hold (secs) SNPA
+# ge-0/0/2.0            CSR2           1  Up                   22  50:0:0:2:0:1
+# ge-0/0/3.0            XRv3           3  Up                   25
+_ADJACENCY_PATTERN = re.compile(
+    r"^(?P<interface>\S+)\s+"
+    r"(?P<system>\S+)\s+"
+    r"(?P<level>\d+)\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<hold_time>\d+)"
+    r"(?:\s+(?P<snpa>\S+))?\s*$"
+)
+
+# Junos prompt lines like "{master:0}" or "{primary:node0}"
+_PROMPT_PATTERN = re.compile(r"^\{.+\}\s*$")
+
+
+@register(OS.JUNIPER_JUNOS, "show isis adjacency")
+class ShowIsisAdjacencyParser(BaseParser[ShowIsisAdjacencyResult]):
+    """Parser for 'show isis adjacency' command on Juniper Junos.
+
+    Parses IS-IS adjacency information from the adjacency table.
+    Adjacencies are keyed by interface, then system, then level.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.ISIS,
+            ParserTag.ROUTING,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIsisAdjacencyResult:
+        """Parse 'show isis adjacency' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed adjacency data keyed by interface, system, and level.
+
+        Raises:
+            ValueError: If no adjacencies found in output.
+        """
+        adjacencies: dict[str, dict[str, dict[str, IsisAdjacencyEntry]]] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if _PROMPT_PATTERN.match(stripped):
+                continue
+
+            match = _ADJACENCY_PATTERN.match(stripped)
+            if match is None:
+                continue
+
+            interface = match.group("interface")
+            system = match.group("system")
+            level = str(match.group("level"))
+
+            entry = IsisAdjacencyEntry(
+                interface=interface,
+                system=system,
+                level=int(match.group("level")),
+                state=match.group("state"),
+                hold_time=int(match.group("hold_time")),
+            )
+
+            snpa = match.group("snpa")
+            if snpa is not None:
+                entry["snpa"] = snpa
+
+            adjacencies.setdefault(interface, {}).setdefault(system, {})[level] = entry
+
+        if not adjacencies:
+            msg = "No IS-IS adjacencies found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIsisAdjacencyResult, {"adjacencies": adjacencies})

--- a/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/expected.json
@@ -1,0 +1,53 @@
+{
+    "adjacencies": {
+        "ge-0/0/2.0": {
+            "CSR2": {
+                "1": {
+                    "interface": "ge-0/0/2.0",
+                    "system": "CSR2",
+                    "level": 1,
+                    "state": "Up",
+                    "hold_time": 22,
+                    "snpa": "50:0:0:2:0:1"
+                },
+                "2": {
+                    "interface": "ge-0/0/2.0",
+                    "system": "CSR2",
+                    "level": 2,
+                    "state": "Up",
+                    "hold_time": 25,
+                    "snpa": "50:0:0:2:0:1"
+                }
+            },
+            "XRv3": {
+                "1": {
+                    "interface": "ge-0/0/2.0",
+                    "system": "XRv3",
+                    "level": 1,
+                    "state": "Up",
+                    "hold_time": 8,
+                    "snpa": "50:0:0:3:0:2"
+                },
+                "2": {
+                    "interface": "ge-0/0/2.0",
+                    "system": "XRv3",
+                    "level": 2,
+                    "state": "Up",
+                    "hold_time": 8,
+                    "snpa": "50:0:0:3:0:2"
+                }
+            }
+        },
+        "ge-0/0/3.0": {
+            "XRv3": {
+                "3": {
+                    "interface": "ge-0/0/3.0",
+                    "system": "XRv3",
+                    "level": 3,
+                    "state": "Up",
+                    "hold_time": 25
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/expected.json
@@ -3,17 +3,11 @@
         "ge-0/0/2.0": {
             "CSR2": {
                 "1": {
-                    "interface": "ge-0/0/2.0",
-                    "system": "CSR2",
-                    "level": 1,
                     "state": "Up",
                     "hold_time": 22,
                     "snpa": "50:0:0:2:0:1"
                 },
                 "2": {
-                    "interface": "ge-0/0/2.0",
-                    "system": "CSR2",
-                    "level": 2,
                     "state": "Up",
                     "hold_time": 25,
                     "snpa": "50:0:0:2:0:1"
@@ -21,17 +15,11 @@
             },
             "XRv3": {
                 "1": {
-                    "interface": "ge-0/0/2.0",
-                    "system": "XRv3",
-                    "level": 1,
                     "state": "Up",
                     "hold_time": 8,
                     "snpa": "50:0:0:3:0:2"
                 },
                 "2": {
-                    "interface": "ge-0/0/2.0",
-                    "system": "XRv3",
-                    "level": 2,
                     "state": "Up",
                     "hold_time": 8,
                     "snpa": "50:0:0:3:0:2"
@@ -41,9 +29,6 @@
         "ge-0/0/3.0": {
             "XRv3": {
                 "3": {
-                    "interface": "ge-0/0/3.0",
-                    "system": "XRv3",
-                    "level": 3,
                     "state": "Up",
                     "hold_time": 25
                 }

--- a/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/input.txt
@@ -1,0 +1,8 @@
+Interface             System         L State        Hold (secs) SNPA
+ge-0/0/2.0            CSR2           1  Up                   22  50:0:0:2:0:1
+ge-0/0/2.0            CSR2           2  Up                   25  50:0:0:2:0:1
+ge-0/0/2.0            XRv3           1  Up                    8  50:0:0:3:0:2
+ge-0/0/2.0            XRv3           2  Up                    8  50:0:0:3:0:2
+ge-0/0/3.0            XRv3           3  Up                   25
+
+{master:0}

--- a/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_isis_adjacency/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple IS-IS adjacencies across two interfaces with mixed levels
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show isis adjacency` on Juniper Junos
- Outputs dict-of-dicts keyed by interface, system name, and IS-IS level
- Handles optional SNPA field (absent on some adjacencies) and Junos prompt lines
- Tagged with `ParserTag.ISIS` and `ParserTag.ROUTING`

## Test plan
- [x] Test fixture `001_basic` with 5 adjacencies across 2 interfaces, 2 systems, and 3 levels
- [x] Covers optional SNPA field (present on 4 entries, absent on 1)
- [x] All pre-commit hooks pass (ruff, xenon, bandit, json formatting)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)