### PR TITLE
feat(paloalto_panos): add parser for show running security-policy

### DIFF
--- a/changes/+paloalto-panos-show-running-security-policy.parser_added
+++ b/changes/+paloalto-panos-show-running-security-policy.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show running security-policy` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/show_running_security_policy.py
+++ b/src/muninn/parsers/paloalto_panos/show_running_security_policy.py
@@ -1,7 +1,7 @@
 """Parser for 'show running security-policy' command on Palo Alto PAN-OS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -136,7 +136,7 @@ class ShowRunningSecurityPolicyParser(
                 continue
 
             if line.strip() == "}" and current_rule is not None:
-                result[current_rule] = current_data  # type: ignore[assignment]
+                result[current_rule] = cast(SecurityPolicyRuleResult, current_data)
                 current_rule = None
                 continue
 

--- a/src/muninn/parsers/paloalto_panos/show_running_security_policy.py
+++ b/src/muninn/parsers/paloalto_panos/show_running_security_policy.py
@@ -1,0 +1,156 @@
+"""Parser for 'show running security-policy' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class SecurityPolicyRuleResult(TypedDict):
+    """Schema for a single security policy rule."""
+
+    from_zone: list[str]
+    to_zone: list[str]
+    source: list[str]
+    destination: list[str]
+    application_service: list[str]
+    action: str
+    icmp_unreachable: bool
+    terminal: bool
+    user: NotRequired[list[str]]
+    category: NotRequired[list[str]]
+    source_region: NotRequired[list[str]]
+    destination_region: NotRequired[list[str]]
+    rule_type: NotRequired[str]
+
+
+ShowRunningSecurityPolicyResult = dict[str, SecurityPolicyRuleResult]
+
+# Matches a rule header: quoted or unquoted name followed by '{'
+_RULE_HEADER = re.compile(r'^"?(?P<name>[^"{}]+?)"?\s*\{')
+
+# Matches a key-value line inside a rule block
+_KV_LINE = re.compile(r"^\s+(?P<key>[a-z/_-]+):?\s+(?P<value>.+)$")
+
+# Sentinel values treated as "no value" and omitted from output
+_NONE_SENTINELS = frozenset({"none"})
+
+# Maps PAN-OS field names to TypedDict key
+_LIST_FIELDS: dict[str, str] = {
+    "from": "from_zone",
+    "to": "to_zone",
+    "source": "source",
+    "destination": "destination",
+    "source-region": "source_region",
+    "destination-region": "destination_region",
+    "user": "user",
+    "category": "category",
+    "application/service": "application_service",
+}
+
+_BOOL_FIELDS: dict[str, str] = {
+    "icmp-unreachable": "icmp_unreachable",
+    "terminal": "terminal",
+}
+
+_STR_FIELDS: dict[str, str] = {
+    "action": "action",
+    "type": "rule_type",
+}
+
+# List fields where "none" sentinel values should be omitted
+_SKIP_NONE_FIELDS = frozenset({"source_region", "destination_region"})
+
+
+def _parse_value_list(raw: str) -> list[str]:
+    """Parse a value that may be a bracketed list or a single token."""
+    raw = raw.strip().rstrip(";")
+    if raw.startswith("[") and raw.endswith("]"):
+        return raw[1:-1].split()
+    return [raw]
+
+
+def _clean_str(raw: str) -> str:
+    """Strip whitespace and trailing semicolons from a raw value."""
+    return raw.strip().rstrip(";")
+
+
+def _process_list_field(field_name: str, value: str, data: dict[str, object]) -> None:
+    """Parse and store a list-type field, skipping none sentinels where needed."""
+    parsed = _parse_value_list(value)
+    if field_name in _SKIP_NONE_FIELDS:
+        filtered = [v for v in parsed if v.lower() not in _NONE_SENTINELS]
+        if not filtered:
+            return
+        parsed = filtered
+    data[field_name] = parsed
+
+
+def _process_line(key: str, value: str, data: dict[str, object]) -> None:
+    """Route a key-value pair to the appropriate field handler."""
+    if key in _LIST_FIELDS:
+        _process_list_field(_LIST_FIELDS[key], value, data)
+    elif key in _BOOL_FIELDS:
+        data[_BOOL_FIELDS[key]] = _clean_str(value) == "yes"
+    elif key in _STR_FIELDS:
+        data[_STR_FIELDS[key]] = _clean_str(value)
+
+
+@register(OS.PALOALTO_PANOS, "show running security-policy")
+class ShowRunningSecurityPolicyParser(
+    BaseParser[ShowRunningSecurityPolicyResult],
+):
+    """Parser for 'show running security-policy' on Palo Alto PAN-OS.
+
+    Parses security policy rules into a dict-of-dicts keyed by rule name.
+    Each rule contains zone, address, application, and action information.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRunningSecurityPolicyResult:
+        """Parse 'show running security-policy' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict of security policy rules keyed by rule name.
+
+        Raises:
+            ValueError: If no security policy rules are found.
+        """
+        result: ShowRunningSecurityPolicyResult = {}
+        current_rule: str | None = None
+        current_data: dict[str, object] = {}
+
+        for line in output.splitlines():
+            header_match = _RULE_HEADER.match(line)
+            if header_match:
+                current_rule = header_match.group("name")
+                current_data = {}
+                continue
+
+            if line.strip() == "}" and current_rule is not None:
+                result[current_rule] = current_data  # type: ignore[assignment]
+                current_rule = None
+                continue
+
+            if current_rule is None:
+                continue
+
+            kv_match = _KV_LINE.match(line)
+            if kv_match:
+                _process_line(
+                    kv_match.group("key"), kv_match.group("value"), current_data
+                )
+
+        if not result:
+            msg = "No security policy rules found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/paloalto_panos/show_running_security_policy/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_running_security_policy/001_basic/expected.json
@@ -1,0 +1,186 @@
+{
+    "Outside Web Server": {
+        "from_zone": [
+            "Trust"
+        ],
+        "source": [
+            "10.1.1.0/24"
+        ],
+        "to_zone": [
+            "Untrust"
+        ],
+        "destination": [
+            "200.10.10.10"
+        ],
+        "user": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "any/tcp/any/8000",
+            "any/tcp/any/80",
+            "any/tcp/any/8080"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    },
+    "ICMP Any": {
+        "from_zone": [
+            "Trust"
+        ],
+        "source": [
+            "any"
+        ],
+        "to_zone": [
+            "Untrust"
+        ],
+        "destination": [
+            "any"
+        ],
+        "user": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "icmp/icmp/any/any",
+            "ping/icmp/any/any"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    },
+    "DNS Outbound": {
+        "from_zone": [
+            "Trust"
+        ],
+        "source": [
+            "10.1.1.0/24"
+        ],
+        "to_zone": [
+            "Untrust"
+        ],
+        "destination": [
+            "8.8.8.8",
+            "8.8.4.4"
+        ],
+        "user": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "dns/udp/any/53"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    },
+    "Inbound to DMZ Web": {
+        "from_zone": [
+            "Untrust"
+        ],
+        "source": [
+            "any"
+        ],
+        "to_zone": [
+            "DMZ"
+        ],
+        "destination": [
+            "200.10.10.100"
+        ],
+        "user": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "any/tcp/any/8000",
+            "any/tcp/any/80",
+            "any/tcp/any/8080"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    },
+    "Inbound to DMZ Deny": {
+        "from_zone": [
+            "Untrust"
+        ],
+        "source": [
+            "any"
+        ],
+        "to_zone": [
+            "DMZ"
+        ],
+        "destination": [
+            "any"
+        ],
+        "user": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "any/any/any/any"
+        ],
+        "action": "deny",
+        "icmp_unreachable": false,
+        "terminal": false
+    },
+    "intrazone-default": {
+        "from_zone": [
+            "any"
+        ],
+        "source": [
+            "any"
+        ],
+        "to_zone": [
+            "any"
+        ],
+        "destination": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "any/any/any/any"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true,
+        "rule_type": "intrazone"
+    },
+    "interzone-default": {
+        "from_zone": [
+            "any"
+        ],
+        "source": [
+            "any"
+        ],
+        "to_zone": [
+            "any"
+        ],
+        "destination": [
+            "any"
+        ],
+        "category": [
+            "any"
+        ],
+        "application_service": [
+            "any/any/any/any"
+        ],
+        "action": "deny",
+        "icmp_unreachable": false,
+        "terminal": true,
+        "rule_type": "interzone"
+    }
+}

--- a/tests/parsers/paloalto_panos/show_running_security_policy/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/show_running_security_policy/001_basic/input.txt
@@ -1,0 +1,107 @@
+"Outside Web Server" {
+        from Trust;
+        source 10.1.1.0/24;
+        source-region none;
+        to Untrust;
+        destination 200.10.10.10;
+        destination-region none;
+        user any;
+        category any;
+        application/service [ any/tcp/any/8000 any/tcp/any/80 any/tcp/any/8080 ];
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}
+
+"ICMP Any" {
+        from Trust;
+        source any;
+        source-region none;
+        to Untrust;
+        destination any;
+        destination-region none;
+        user any;
+        category any;
+        application/service [ icmp/icmp/any/any ping/icmp/any/any ];
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}
+
+"DNS Outbound" {
+        from Trust;
+        source 10.1.1.0/24;
+        source-region none;
+        to Untrust;
+        destination [ 8.8.8.8 8.8.4.4 ];
+        destination-region none;
+        user any;
+        category any;
+        application/service  dns/udp/any/53;
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}
+
+"Inbound to DMZ Web" {
+        from Untrust;
+        source any;
+        source-region none;
+        to DMZ;
+        destination 200.10.10.100;
+        destination-region none;
+        user any;
+        category any;
+        application/service [ any/tcp/any/8000 any/tcp/any/80 any/tcp/any/8080 ];
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}
+
+"Inbound to DMZ Deny" {
+        from Untrust;
+        source any;
+        source-region none;
+        to DMZ;
+        destination any;
+        destination-region none;
+        user any;
+        category any;
+        application/service  any/any/any/any;
+        action deny;
+        icmp-unreachable: no
+        terminal no;
+}
+
+intrazone-default {
+        from any;
+        source any;
+        source-region none;
+        to any;
+        destination any;
+        destination-region none;
+        category any;
+        application/service  any/any/any/any;
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+        type intrazone;
+}
+
+interzone-default {
+        from any;
+        source any;
+        source-region none;
+        to any;
+        destination any;
+        destination-region none;
+        category any;
+        application/service  any/any/any/any;
+        action deny;
+        icmp-unreachable: no
+        terminal yes;
+        type interzone;
+}
+
+dynamic url: no
+pol objs matched

--- a/tests/parsers/paloalto_panos/show_running_security_policy/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/show_running_security_policy/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple security policy rules with allow/deny actions, zones, and default rules
+platform: PA-VM
+software_version: "7.0.1"

--- a/tests/parsers/paloalto_panos/show_running_security_policy/command.txt
+++ b/tests/parsers/paloalto_panos/show_running_security_policy/command.txt
@@ -1,0 +1,1 @@
+show running security-policy


### PR DESCRIPTION
## Summary
- Add parser for `show running security-policy` on Palo Alto PAN-OS
- Returns dict-of-dicts keyed by rule name with zones, source/destination addresses, application/service entries, action (allow/deny), and optional rule type (intrazone/interzone)
- Omits `source-region` and `destination-region` fields when their value is the "none" sentinel

## Test plan
- [x] Parser test passes with real device output fixture (7 rules including default intrazone/interzone)
- [x] All placeholder sentinel tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)
- [x] Empty output raises ValueError
- [x] Ruff lint and format checks pass
- [x] Xenon complexity within limits (max-absolute B, max-average A)
- [x] Bandit security scan clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)