### PR TITLE
feat(cisco_iosxr): add parser for `show isis neighbors`

### DIFF
--- a/changes/+cisco-iosxr-show-isis-neighbors.parser_added
+++ b/changes/+cisco-iosxr-show-isis-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show isis neighbors` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_isis_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_isis_neighbors.py
@@ -1,0 +1,137 @@
+"""Parser for 'show isis neighbors' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class IsisNeighborEntry(TypedDict):
+    """Schema for a single IS-IS neighbor entry."""
+
+    snpa: str
+    state: str
+    holdtime: int
+    neighbor_type: str
+    ietf_nsf: NotRequired[str]
+
+
+class ShowIsisNeighborsResult(TypedDict):
+    """Schema for 'show isis neighbors' parsed output.
+
+    Top-level keys are IS-IS instance IDs. Each instance maps system IDs
+    to a dict of interfaces, each containing the neighbor entry.
+    """
+
+    instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]]
+
+
+# Instance header: "IS-IS <tag> neighbors:"
+_INSTANCE_PATTERN = re.compile(r"^IS-IS\s+(?P<instance>\S+)\s+neighbors:\s*$")
+
+# Neighbor table row:
+# System Id      Interface        SNPA           State Holdtime Type IETF-NSF
+# CSR2           Gi0/0/0/1        5000.0002.0001 Up    23       L1L2 Capable
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<system_id>\S+)\s+"
+    r"(?P<interface>\S+(?:\s+\d\S*)?)\s+"
+    r"(?P<snpa>\S+)\s+"
+    r"(?P<state>\w+)\s+"
+    r"(?P<holdtime>\d+)\s+"
+    r"(?P<type>L1L2|L1|L2)\s*"
+    r"(?P<ietf_nsf>\S+)?\s*$"
+)
+
+# Default instance ID when no header is found (single-instance output).
+_DEFAULT_INSTANCE = "default"
+
+
+@register(OS.CISCO_IOSXR, "show isis neighbors")
+class ShowIsisNeighborsParser(BaseParser["ShowIsisNeighborsResult"]):
+    """Parser for 'show isis neighbors' command on IOS-XR.
+
+    Parses IS-IS neighbor adjacency information. Neighbors are grouped
+    by IS-IS instance, then keyed by system ID and canonical interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.ISIS,
+            ParserTag.ROUTING,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowIsisNeighborsResult":
+        """Parse 'show isis neighbors' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed neighbor data grouped by IS-IS instance, then keyed
+            by system ID and interface.
+
+        Raises:
+            ValueError: If no neighbors found in output.
+        """
+        instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]] = {}
+        current_instance: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            instance_match = _INSTANCE_PATTERN.match(stripped)
+            if instance_match:
+                current_instance = instance_match.group("instance")
+                if current_instance not in instances:
+                    instances[current_instance] = {}
+                continue
+
+            neighbor_match = _NEIGHBOR_PATTERN.match(stripped)
+            if neighbor_match:
+                if current_instance is None:
+                    current_instance = _DEFAULT_INSTANCE
+                    instances[current_instance] = {}
+
+                cls._add_neighbor(instances, current_instance, neighbor_match)
+
+        if not instances:
+            msg = "No IS-IS neighbors found in output"
+            raise ValueError(msg)
+
+        return {"instances": instances}
+
+    @staticmethod
+    def _add_neighbor(
+        instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]],
+        instance_id: str,
+        match: re.Match[str],
+    ) -> None:
+        """Add a parsed neighbor entry to the instances dict."""
+        system_id = match.group("system_id")
+        interface_raw = match.group("interface").strip()
+        interface = canonical_interface_name(interface_raw, os=OS.CISCO_IOSXR)
+
+        neighbors = instances[instance_id]
+        if system_id not in neighbors:
+            neighbors[system_id] = {}
+
+        entry: IsisNeighborEntry = {
+            "snpa": match.group("snpa"),
+            "state": match.group("state"),
+            "holdtime": int(match.group("holdtime")),
+            "neighbor_type": match.group("type"),
+        }
+
+        ietf_nsf = match.group("ietf_nsf")
+        if ietf_nsf:
+            entry["ietf_nsf"] = ietf_nsf
+
+        neighbors[system_id][interface] = entry

--- a/src/muninn/parsers/cisco_iosxr/show_isis_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_isis_neighbors.py
@@ -28,10 +28,14 @@ class ShowIsisNeighborsResult(TypedDict):
     """
 
     instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]]
+    total_neighbor_count: NotRequired[int]
 
 
 # Instance header: "IS-IS <tag> neighbors:"
 _INSTANCE_PATTERN = re.compile(r"^IS-IS\s+(?P<instance>\S+)\s+neighbors:\s*$")
+
+# Summary footer: "Total neighbor count: N"
+_TOTAL_PATTERN = re.compile(r"^Total\s+neighbor\s+count:\s+(?P<count>\d+)\s*$")
 
 # Neighbor table row:
 # System Id      Interface        SNPA           State Holdtime Type IETF-NSF
@@ -81,6 +85,7 @@ class ShowIsisNeighborsParser(BaseParser["ShowIsisNeighborsResult"]):
         """
         instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]] = {}
         current_instance: str | None = None
+        total_neighbor_count: int | None = None
 
         for line in output.splitlines():
             stripped = line.strip()
@@ -92,6 +97,11 @@ class ShowIsisNeighborsParser(BaseParser["ShowIsisNeighborsResult"]):
                 current_instance = instance_match.group("instance")
                 if current_instance not in instances:
                     instances[current_instance] = {}
+                continue
+
+            total_match = _TOTAL_PATTERN.match(stripped)
+            if total_match:
+                total_neighbor_count = int(total_match.group("count"))
                 continue
 
             neighbor_match = _NEIGHBOR_PATTERN.match(stripped)
@@ -106,7 +116,10 @@ class ShowIsisNeighborsParser(BaseParser["ShowIsisNeighborsResult"]):
             msg = "No IS-IS neighbors found in output"
             raise ValueError(msg)
 
-        return {"instances": instances}
+        result: ShowIsisNeighborsResult = {"instances": instances}
+        if total_neighbor_count is not None:
+            result["total_neighbor_count"] = total_neighbor_count
+        return result
 
     @staticmethod
     def _add_neighbor(

--- a/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/expected.json
@@ -1,0 +1,40 @@
+{
+    "instances": {
+        "1": {
+            "CSR2": {
+                "GigabitEthernet0/0/0/1": {
+                    "snpa": "5000.0002.0001",
+                    "state": "Up",
+                    "holdtime": 23,
+                    "neighbor_type": "L1L2",
+                    "ietf_nsf": "Capable"
+                }
+            },
+            "vMX1": {
+                "GigabitEthernet0/0/0/1": {
+                    "snpa": "0005.8671.9202",
+                    "state": "Up",
+                    "holdtime": 18,
+                    "neighbor_type": "L1L2",
+                    "ietf_nsf": "Capable"
+                },
+                "GigabitEthernet0/0/0/3": {
+                    "snpa": "*PtoP*",
+                    "state": "Up",
+                    "holdtime": 25,
+                    "neighbor_type": "L1L2",
+                    "ietf_nsf": "Capable"
+                }
+            },
+            "vEOS4": {
+                "GigabitEthernet0/0/0/2": {
+                    "snpa": "5000.0003.3766",
+                    "state": "Up",
+                    "holdtime": 8,
+                    "neighbor_type": "L2",
+                    "ietf_nsf": "Unable"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/expected.json
@@ -36,5 +36,6 @@
                 }
             }
         }
-    }
+    },
+    "total_neighbor_count": 4
 }

--- a/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/input.txt
@@ -1,0 +1,10 @@
+Tue Jan  3 14:57:35.234 UTC
+
+IS-IS 1 neighbors:
+System Id      Interface        SNPA           State Holdtime Type IETF-NSF
+CSR2           Gi0/0/0/1        5000.0002.0001 Up    23       L1L2 Capable
+vMX1           Gi0/0/0/1        0005.8671.9202 Up    18       L1L2 Capable
+vMX1           Gi0/0/0/3        *PtoP*         Up    25       L1L2 Capable
+vEOS4          Gi0/0/0/2        5000.0003.3766 Up    8        L2   Unable
+
+Total neighbor count: 4

--- a/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_isis_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple IS-IS neighbors with mixed types and IETF-NSF capabilities
+platform: XRv 9000
+software_version: IOS-XR 7.x


### PR DESCRIPTION
## Summary
- Add parser for `show isis neighbors` on Cisco IOS-XR
- Parses IS-IS neighbor adjacency table into dict-of-dicts keyed by instance, system ID, and canonical interface name
- Fields: SNPA, state, holdtime, neighbor type, IETF-NSF capability

## Test plan
- [x] Test fixture from real device output (ntc-templates corpus)
- [x] All parser tests pass (`uv run pytest tests/parsers/ -k show_isis_neighbors`)
- [x] Ruff lint/format clean
- [x] Xenon complexity under B threshold
- [x] Bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)