### PR TITLE
feat(juniper_junos): add parser for show rsvp interface

### DIFF
--- a/changes/+juniper-junos-show-rsvp-interface.parser_added
+++ b/changes/+juniper-junos-show-rsvp-interface.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show rsvp interface` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_rsvp_interface.py
+++ b/src/muninn/parsers/juniper_junos/show_rsvp_interface.py
@@ -1,0 +1,148 @@
+"""Parser for 'show rsvp interface' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class RsvpInterfaceEntry(TypedDict):
+    """Schema for a single RSVP interface entry.
+
+    Attributes:
+        interface: Interface name (e.g., ``ae0.0``).
+        state: Interface state (e.g., ``Up``, ``Down``).
+        active_reservations: Number of active RSVP reservations.
+        subscription_percent: Subscription percentage.
+        static_bandwidth_bps: Static bandwidth in bits per second.
+        available_bandwidth_bps: Available bandwidth in bits per second.
+        reserved_bandwidth_bps: Reserved bandwidth in bits per second.
+        highwater_mark_bps: Highwater mark in bits per second.
+    """
+
+    interface: str
+    state: str
+    active_reservations: int
+    subscription_percent: int
+    static_bandwidth_bps: float
+    available_bandwidth_bps: float
+    reserved_bandwidth_bps: float
+    highwater_mark_bps: float
+
+
+class ShowRsvpInterfaceResult(TypedDict):
+    """Schema for 'show rsvp interface' parsed output.
+
+    Top-level dict-of-dicts keyed by interface name.
+    """
+
+    interfaces: dict[str, RsvpInterfaceEntry]
+
+
+_BW_MULTIPLIERS: dict[str, float] = {
+    "bps": 1.0,
+    "kbps": 1e3,
+    "mbps": 1e6,
+    "gbps": 1e9,
+    "tbps": 1e12,
+}
+
+# Pattern for bandwidth values like "400Gbps", "1.49104Mbps", "0bps"
+_BW_PATTERN = re.compile(r"^(?P<value>[\d.]+)(?P<unit>[A-Za-z]+)$")
+
+# Junos 'show rsvp interface' data line format:
+# ae0.0                  Up      10    95%  400Gbps     380Gbps     200kbps     251kbps
+_INTERFACE_PATTERN = re.compile(
+    r"^(?P<interface>\S+)\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<active_resv>\d+)\s+"
+    r"(?P<subscription>\d+)%\s+"
+    r"(?P<static_bw>\S+)\s+"
+    r"(?P<avail_bw>\S+)\s+"
+    r"(?P<reserved_bw>\S+)\s+"
+    r"(?P<highwater>\S+)\s*$"
+)
+
+
+def _parse_bandwidth(value: str) -> float:
+    """Convert a Junos bandwidth string to bits per second.
+
+    Args:
+        value: Bandwidth string (e.g., ``400Gbps``, ``1.49104Mbps``, ``0bps``).
+
+    Returns:
+        Bandwidth in bits per second.
+
+    Raises:
+        ValueError: If the bandwidth string cannot be parsed.
+    """
+    match = _BW_PATTERN.match(value)
+    if match is None:
+        msg = f"Cannot parse bandwidth value: {value!r}"
+        raise ValueError(msg)
+
+    numeric = float(match.group("value"))
+    unit = match.group("unit").lower()
+
+    if unit not in _BW_MULTIPLIERS:
+        msg = f"Unknown bandwidth unit: {match.group('unit')!r}"
+        raise ValueError(msg)
+
+    return numeric * _BW_MULTIPLIERS[unit]
+
+
+@register(OS.JUNIPER_JUNOS, "show rsvp interface")
+class ShowRsvpInterfaceParser(BaseParser[ShowRsvpInterfaceResult]):
+    """Parser for 'show rsvp interface' command on Juniper Junos.
+
+    Parses RSVP interface information including bandwidth allocation,
+    reservation counts, and subscription levels. Interfaces are keyed
+    by their name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MPLS})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRsvpInterfaceResult:
+        """Parse 'show rsvp interface' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed interface data keyed by interface name.
+
+        Raises:
+            ValueError: If no RSVP interfaces found in output.
+        """
+        interfaces: dict[str, RsvpInterfaceEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = _INTERFACE_PATTERN.match(stripped)
+            if match is None:
+                continue
+
+            interface = match.group("interface")
+            interfaces[interface] = RsvpInterfaceEntry(
+                interface=interface,
+                state=match.group("state"),
+                active_reservations=int(match.group("active_resv")),
+                subscription_percent=int(match.group("subscription")),
+                static_bandwidth_bps=_parse_bandwidth(match.group("static_bw")),
+                available_bandwidth_bps=_parse_bandwidth(match.group("avail_bw")),
+                reserved_bandwidth_bps=_parse_bandwidth(match.group("reserved_bw")),
+                highwater_mark_bps=_parse_bandwidth(match.group("highwater")),
+            )
+
+        if not interfaces:
+            msg = "No RSVP interfaces found in output"
+            raise ValueError(msg)
+
+        return cast(ShowRsvpInterfaceResult, {"interfaces": interfaces})

--- a/tests/parsers/juniper_junos/show_rsvp_interface/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_rsvp_interface/001_basic/expected.json
@@ -1,0 +1,54 @@
+{
+    "interfaces": {
+        "ae0.0": {
+            "interface": "ae0.0",
+            "state": "Up",
+            "active_reservations": 10,
+            "subscription_percent": 95,
+            "static_bandwidth_bps": 400000000000.0,
+            "available_bandwidth_bps": 380000000000.0,
+            "reserved_bandwidth_bps": 200000.0,
+            "highwater_mark_bps": 251000.0
+        },
+        "ae2.0": {
+            "interface": "ae2.0",
+            "state": "Up",
+            "active_reservations": 86,
+            "subscription_percent": 95,
+            "static_bandwidth_bps": 200000000000.0,
+            "available_bandwidth_bps": 189999000000.0,
+            "reserved_bandwidth_bps": 1491040.0,
+            "highwater_mark_bps": 6915270.0
+        },
+        "ae3.0": {
+            "interface": "ae3.0",
+            "state": "Up",
+            "active_reservations": 73,
+            "subscription_percent": 95,
+            "static_bandwidth_bps": 100000000000.0,
+            "available_bandwidth_bps": 94999400000.0,
+            "reserved_bandwidth_bps": 572791.0,
+            "highwater_mark_bps": 1783750.0
+        },
+        "ae4.0": {
+            "interface": "ae4.0",
+            "state": "Up",
+            "active_reservations": 0,
+            "subscription_percent": 95,
+            "static_bandwidth_bps": 100000000000.0,
+            "available_bandwidth_bps": 95000000000.0,
+            "reserved_bandwidth_bps": 0.0,
+            "highwater_mark_bps": 0.0
+        },
+        "ae5.0": {
+            "interface": "ae5.0",
+            "state": "Up",
+            "active_reservations": 54,
+            "subscription_percent": 95,
+            "static_bandwidth_bps": 400000000000.0,
+            "available_bandwidth_bps": 380000000000.0,
+            "reserved_bandwidth_bps": 8164.0,
+            "highwater_mark_bps": 22649.0
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_rsvp_interface/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_rsvp_interface/001_basic/input.txt
@@ -1,0 +1,10 @@
+Warning: License key missing; requires 'rsvp' license
+
+RSVP interface: 5 active
+                          Active  Subscr- Static      Available   Reserved    Highwater
+Interface          State  resv    iption  BW          BW          BW          mark
+ae0.0                  Up      10    95%  400Gbps     380Gbps     200kbps     251kbps
+ae2.0                  Up      86    95%  200Gbps     189.999Gbps 1.49104Mbps 6.91527Mbps
+ae3.0                  Up      73    95%  100Gbps     94.9994Gbps 572.791kbps 1.78375Mbps
+ae4.0                  Up       0    95%  100Gbps     95Gbps      0bps        0bps
+ae5.0                  Up      54    95%  400Gbps     380Gbps     8.164kbps   22.649kbps

--- a/tests/parsers/juniper_junos/show_rsvp_interface/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_rsvp_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic RSVP interface output with five active interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show rsvp interface` on Juniper Junos, tagged with `MPLS`
- Parses interface state, active reservations, subscription percentage, and bandwidth values (static, available, reserved, highwater mark) converted from Junos notation to bits per second
- Includes test fixture with real device output covering five active interfaces with varied bandwidth scales (Gbps, Mbps, kbps, bps)

## Test plan
- [x] Parser test passes (`test_parser[juniper_junos/show_rsvp_interface/001_basic]`)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity under threshold B
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)