### PR TITLE
feat(paloalto_panos): add parser for test security-policy-match

### DIFF
--- a/changes/+paloalto-panos-test-security-policy-match.parser_added
+++ b/changes/+paloalto-panos-test-security-policy-match.parser_added
@@ -1,0 +1,1 @@
+Added parser for `test security-policy-match` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/test_security_policy_match.py
+++ b/src/muninn/parsers/paloalto_panos/test_security_policy_match.py
@@ -1,0 +1,173 @@
+"""Parser for 'test security-policy-match' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class SecurityPolicyMatchEntry(TypedDict):
+    """Schema for a single matched security policy rule."""
+
+    index: int
+    from_zone: str
+    source: list[str]
+    to_zone: str
+    destination: list[str]
+    user: str
+    source_device: str
+    destination_device: str
+    category: str
+    application_service: list[str]
+    action: str
+    icmp_unreachable: bool
+    terminal: bool
+
+    source_region: NotRequired[str]
+    destination_region: NotRequired[str]
+
+
+SecurityPolicyMatchResult = dict[str, SecurityPolicyMatchEntry]
+
+
+# Maps PAN-OS field names to TypedDict keys
+_FIELD_MAP: dict[str, str] = {
+    "from": "from_zone",
+    "source": "source",
+    "source-region": "source_region",
+    "to": "to_zone",
+    "destination": "destination",
+    "destination-region": "destination_region",
+    "user": "user",
+    "source-device": "source_device",
+    "destinataion-device": "destination_device",  # PAN-OS typo preserved
+    "category": "category",
+    "application/service": "application_service",
+    "action": "action",
+    "icmp-unreachable": "icmp_unreachable",
+    "terminal": "terminal",
+}
+
+# Fields where "none" means absent (omit from output)
+_NONE_OMIT_FIELDS: frozenset[str] = frozenset({"source_region", "destination_region"})
+
+# Fields that hold boolean yes/no values
+_BOOL_FIELDS: frozenset[str] = frozenset({"icmp_unreachable", "terminal"})
+
+# Fields that always hold list values (even when a single item)
+_LIST_FIELDS: frozenset[str] = frozenset(
+    {"source", "destination", "application_service"}
+)
+
+
+@register(OS.PALOALTO_PANOS, "test security-policy-match")
+class TestSecurityPolicyMatchParser(
+    BaseParser[SecurityPolicyMatchResult],
+):
+    """Parser for 'test security-policy-match' on Palo Alto PAN-OS.
+
+    Parses matched security policy rules into a dictionary keyed by
+    rule name, with each value containing the rule's match criteria
+    and action.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    _HEADER_PATTERN = re.compile(
+        r'^"(?P<name>.+?);\s*index:\s*(?P<index>\d+)"\s*\{',
+    )
+    _KV_PATTERN = re.compile(
+        r"^\s+(?P<key>[a-zA-Z/_-]+):?\s+(?P<value>.+)$",
+    )
+    _LIST_PATTERN = re.compile(r"\[([^\]]*)\]")
+
+    @classmethod
+    def _parse_list_value(cls, raw_value: str) -> list[str]:
+        """Parse a value that may be a bracketed list or a single item."""
+        list_match = cls._LIST_PATTERN.search(raw_value)
+        if list_match:
+            return list_match.group(1).strip().split()
+        return [raw_value.strip()]
+
+    @classmethod
+    def _parse_value(
+        cls,
+        field_name: str,
+        raw_value: str,
+    ) -> str | bool | list[str]:
+        """Convert a raw string value to the appropriate Python type."""
+        raw_value = raw_value.rstrip(";")
+
+        if field_name in _BOOL_FIELDS:
+            return raw_value.strip().lower() == "yes"
+
+        if field_name in _LIST_FIELDS:
+            return cls._parse_list_value(raw_value)
+
+        return raw_value.strip()
+
+    @classmethod
+    def _parse_kv_line(
+        cls,
+        line: str,
+        entry: dict[str, object],
+    ) -> None:
+        """Parse a single key-value line into *entry*, ignoring unknown keys."""
+        kv_match = cls._KV_PATTERN.match(line)
+        if not kv_match:
+            return
+
+        raw_key = kv_match.group("key").rstrip(":")
+        field_name = _FIELD_MAP.get(raw_key)
+        if field_name is None:
+            return
+
+        parsed = cls._parse_value(field_name, kv_match.group("value"))
+
+        # Omit "none" sentinel for optional region fields
+        if field_name in _NONE_OMIT_FIELDS and parsed == "none":
+            return
+
+        entry[field_name] = parsed
+
+    @classmethod
+    def parse(cls, output: str) -> SecurityPolicyMatchResult:
+        """Parse 'test security-policy-match' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dictionary keyed by rule name with match details.
+
+        Raises:
+            ValueError: If no policy rules are found in output.
+        """
+        result: SecurityPolicyMatchResult = {}
+        current_name: str | None = None
+        current_entry: dict[str, object] = {}
+
+        for line in output.splitlines():
+            header_match = cls._HEADER_PATTERN.match(line)
+            if header_match:
+                current_name = header_match.group("name")
+                current_entry = {"index": int(header_match.group("index"))}
+                continue
+
+            if line.strip() == "}" and current_name is not None:
+                result[current_name] = current_entry  # type: ignore[assignment]
+                current_name = None
+                current_entry = {}
+                continue
+
+            if current_name is not None:
+                cls._parse_kv_line(line, current_entry)
+
+        if not result:
+            msg = "No security policy match rules found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/paloalto_panos/test_security_policy_match.py
+++ b/src/muninn/parsers/paloalto_panos/test_security_policy_match.py
@@ -1,7 +1,7 @@
 """Parser for 'test security-policy-match' command on Palo Alto PAN-OS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -63,11 +63,22 @@ _LIST_FIELDS: frozenset[str] = frozenset(
 )
 
 
-@register(OS.PALOALTO_PANOS, "test security-policy-match")
+@register(
+    OS.PALOALTO_PANOS,
+    r"test security-policy-match (?P<arguments>.+)",
+)
 class TestSecurityPolicyMatchParser(
     BaseParser[SecurityPolicyMatchResult],
 ):
     """Parser for 'test security-policy-match' on Palo Alto PAN-OS.
+
+    The PAN-OS ``test security-policy-match`` command requires variable
+    arguments such as ``from``, ``to``, ``source``, ``destination``,
+    and ``protocol`` to evaluate against the policy. The registered
+    pattern captures everything after the verb so any concrete
+    invocation routes to this parser; the arguments themselves are
+    not consumed because all match details come from the device
+    output.
 
     Parses matched security policy rules into a dictionary keyed by
     rule name, with each value containing the rule's match criteria
@@ -158,7 +169,7 @@ class TestSecurityPolicyMatchParser(
                 continue
 
             if line.strip() == "}" and current_name is not None:
-                result[current_name] = current_entry  # type: ignore[assignment]
+                result[current_name] = cast("SecurityPolicyMatchEntry", current_entry)
                 current_name = None
                 current_entry = {}
                 continue

--- a/tests/parsers/paloalto_panos/test_security_policy_match/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/test_security_policy_match/001_basic/expected.json
@@ -1,0 +1,67 @@
+{
+    "Allow 10.125.100.58-To-Google DNS": {
+        "index": 1,
+        "from_zone": "Internal",
+        "source": [
+            "10.125.100.58"
+        ],
+        "to_zone": "External",
+        "destination": [
+            "8.8.8.8"
+        ],
+        "user": "any",
+        "source_device": "any",
+        "destination_device": "any",
+        "category": "any",
+        "application_service": [
+            "0:any/tcp/any/59"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    },
+    "Allow 10.125.100.58-To-1.1.1.1": {
+        "index": 2,
+        "from_zone": "Internal",
+        "source": [
+            "10.125.100.58"
+        ],
+        "to_zone": "External",
+        "destination": [
+            "1.1.1.1"
+        ],
+        "user": "any",
+        "source_device": "any",
+        "destination_device": "any",
+        "category": "any",
+        "application_service": [
+            "0:any/tcp/any/53"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    },
+    "Allow DNS_Objects-To-192.0.2.10": {
+        "index": 4,
+        "from_zone": "Internal",
+        "source": [
+            "1.1.1.1",
+            "8.8.8.8"
+        ],
+        "to_zone": "External",
+        "destination": [
+            "192.0.2.10"
+        ],
+        "user": "any",
+        "source_device": "any",
+        "destination_device": "any",
+        "category": "any",
+        "application_service": [
+            "0:any/tcp/any/53",
+            "1:any/tcp/any/54"
+        ],
+        "action": "allow",
+        "icmp_unreachable": false,
+        "terminal": true
+    }
+}

--- a/tests/parsers/paloalto_panos/test_security_policy_match/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/test_security_policy_match/001_basic/input.txt
@@ -1,0 +1,50 @@
+"Allow 10.125.100.58-To-Google DNS; index: 1" {
+        from Internal;
+        source 10.125.100.58;
+        source-region none;
+        to External;
+        destination 8.8.8.8;
+        destination-region none;
+        user any;
+        source-device any;
+        destinataion-device any;
+        category any;
+        application/service 0:any/tcp/any/59;
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}
+
+"Allow 10.125.100.58-To-1.1.1.1; index: 2" {
+        from Internal;
+        source 10.125.100.58;
+        source-region none;
+        to External;
+        destination 1.1.1.1;
+        destination-region none;
+        user any;
+        source-device any;
+        destinataion-device any;
+        category any;
+        application/service 0:any/tcp/any/53;
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}
+
+"Allow DNS_Objects-To-192.0.2.10; index: 4" {
+        from Internal;
+        source [ 1.1.1.1 8.8.8.8 ];
+        source-region none;
+        to External;
+        destination 192.0.2.10;
+        destination-region none;
+        user any;
+        source-device any;
+        destinataion-device any;
+        category any;
+        application/service [0:any/tcp/any/53 1:any/tcp/any/54 ];
+        action allow;
+        icmp-unreachable: no
+        terminal yes;
+}

--- a/tests/parsers/paloalto_panos/test_security_policy_match/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/test_security_policy_match/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple matched security policy rules with single and list source/destination values
+platform: PA-VM
+software_version: "Unknown"

--- a/tests/parsers/paloalto_panos/test_security_policy_match/command.txt
+++ b/tests/parsers/paloalto_panos/test_security_policy_match/command.txt
@@ -1,0 +1,1 @@
+test security-policy-match

--- a/tests/parsers/paloalto_panos/test_security_policy_match/command.txt
+++ b/tests/parsers/paloalto_panos/test_security_policy_match/command.txt
@@ -1,1 +1,1 @@
-test security-policy-match
+test security-policy-match from Internal to External source 10.125.100.58 destination 8.8.8.8 protocol 6 destination-port 53


### PR DESCRIPTION
## Summary
- Added new parser for `test security-policy-match` on Palo Alto PAN-OS
- Returns dict-of-dicts keyed by rule name, with index, zones, source/destination, action, application/service, and boolean flags
- Handles both single-value and bracketed-list fields; omits "none" region sentinels per project conventions
- Includes test fixture with 3 matched rules (single values and list values)

## Test plan
- [x] Parser test passes (`test_parser[paloalto_panos/test_security-policy-match/001_basic]`)
- [x] All fixture sentinel/convention checks pass (no banned placeholder values)
- [x] Empty output raises `ValueError`
- [x] `ruff check` and `ruff format` clean
- [x] `bandit` security scan clean
- [x] `xenon` complexity under threshold (max-absolute B, max-average A)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)