### PR TITLE
feat(linux): add parser for dmidecode -t memory

### DIFF
--- a/changes/+linux-dmidecode-t-memory.parser_added
+++ b/changes/+linux-dmidecode-t-memory.parser_added
@@ -1,0 +1,1 @@
+Added parser for `dmidecode -t memory` on Linux.

--- a/src/muninn/parsers/linux/dmidecode_t_memory.py
+++ b/src/muninn/parsers/linux/dmidecode_t_memory.py
@@ -16,6 +16,7 @@ _OMIT_VALUES = frozenset(
         "Unknown",
         "No Module Installed",
         "Reserved",
+        "None",
     }
 )
 

--- a/src/muninn/parsers/linux/dmidecode_t_memory.py
+++ b/src/muninn/parsers/linux/dmidecode_t_memory.py
@@ -1,0 +1,236 @@
+"""Parser for 'dmidecode -t memory' command on Linux."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Sentinel values that should be omitted from output rather than carried through.
+_OMIT_VALUES = frozenset(
+    {
+        "Not Specified",
+        "Not Provided",
+        "Unknown",
+        "No Module Installed",
+        "Reserved",
+    }
+)
+
+# Pattern matching the Handle header line preceding each section
+_SECTION_HEADER_RE = re.compile(r"^Handle\s+\S+,\s+DMI\s+type\s+\d+,\s+\d+\s+bytes$")
+
+# Pattern matching a key-value pair line with leading tab
+_KV_RE = re.compile(r"^\t(?P<key>[^:]+):\s+(?P<value>.+)$")
+
+# Pattern to extract numeric value and unit (e.g. "1111 MB", "1111 MHz")
+_NUMERIC_UNIT_RE = re.compile(r"^(?P<number>\d+)\s+\S+$")
+
+# Pattern for width fields (e.g. "10 bits")
+_WIDTH_RE = re.compile(r"^(?P<width>\d+)\s+bits$")
+
+# Simple string fields to copy directly from dmidecode key to output key
+_DEVICE_STRING_FIELDS: tuple[tuple[str, str], ...] = (
+    ("Array Handle", "array_handle"),
+    ("Error Information Handle", "error_information_handle"),
+    ("Form Factor", "form_factor"),
+    ("Set", "set"),
+    ("Bank Locator", "bank_locator"),
+    ("Type", "type"),
+    ("Type Detail", "type_detail"),
+    ("Manufacturer", "manufacturer"),
+    ("Serial Number", "serial_number"),
+    ("Asset Tag", "asset_tag"),
+    ("Part Number", "part_number"),
+)
+
+
+class PhysicalMemoryArray(TypedDict):
+    """Schema for a Physical Memory Array section."""
+
+    location: str
+    use: str
+    error_correction_type: NotRequired[str]
+    maximum_capacity: str
+    number_of_devices: int
+
+
+class MemoryDevice(TypedDict):
+    """Schema for a Memory Device section."""
+
+    array_handle: NotRequired[str]
+    error_information_handle: NotRequired[str]
+    total_width_bits: NotRequired[int]
+    data_width_bits: NotRequired[int]
+    size_mb: NotRequired[int]
+    form_factor: NotRequired[str]
+    set: NotRequired[str]
+    locator: str
+    bank_locator: NotRequired[str]
+    type: NotRequired[str]
+    type_detail: NotRequired[str]
+    speed_mhz: NotRequired[int]
+    manufacturer: NotRequired[str]
+    serial_number: NotRequired[str]
+    asset_tag: NotRequired[str]
+    part_number: NotRequired[str]
+    rank: NotRequired[int]
+
+
+class DmidecodeMemoryResult(TypedDict):
+    """Schema for 'dmidecode -t memory' parsed output."""
+
+    physical_memory_arrays: dict[str, PhysicalMemoryArray]
+    memory_devices: dict[str, MemoryDevice]
+
+
+def _parse_kv_pairs(lines: list[str]) -> dict[str, str]:
+    """Parse indented key-value lines into a dict, omitting sentinels."""
+    result: dict[str, str] = {}
+    for line in lines:
+        match = _KV_RE.match(line)
+        if match:
+            key = match.group("key").strip()
+            value = match.group("value").strip()
+            if value not in _OMIT_VALUES:
+                result[key] = value
+    return result
+
+
+def _extract_width(raw: str) -> int | None:
+    """Extract integer width from a string like '10 bits'."""
+    match = _WIDTH_RE.match(raw)
+    return int(match.group("width")) if match else None
+
+
+def _extract_numeric(raw: str) -> int | None:
+    """Extract integer from a string like '1111 MB' or '1111 MHz'."""
+    match = _NUMERIC_UNIT_RE.match(raw)
+    return int(match.group("number")) if match else None
+
+
+def _split_sections(output: str) -> list[tuple[str, list[str]]]:
+    """Split dmidecode output into (section_type, lines) pairs."""
+    sections: list[tuple[str, list[str]]] = []
+    current_type: str | None = None
+    current_lines: list[str] = []
+
+    for line in output.splitlines():
+        if _SECTION_HEADER_RE.match(line):
+            if current_type is not None:
+                sections.append((current_type, current_lines))
+            current_type = None
+            current_lines = []
+        elif current_type is None and line and not line.startswith("\t"):
+            current_type = line.strip()
+            current_lines = []
+        elif current_type is not None:
+            current_lines.append(line)
+
+    if current_type is not None:
+        sections.append((current_type, current_lines))
+
+    return sections
+
+
+def _build_physical_memory_array(kv: dict[str, str]) -> PhysicalMemoryArray:
+    """Build a PhysicalMemoryArray from parsed key-value pairs."""
+    array: PhysicalMemoryArray = {
+        "location": kv["Location"],
+        "use": kv["Use"],
+        "maximum_capacity": kv["Maximum Capacity"],
+        "number_of_devices": int(kv["Number Of Devices"]),
+    }
+    if "Error Correction Type" in kv:
+        array["error_correction_type"] = kv["Error Correction Type"]
+    return array
+
+
+def _build_memory_device(kv: dict[str, str]) -> MemoryDevice:
+    """Build a MemoryDevice from parsed key-value pairs."""
+    device: MemoryDevice = {"locator": kv["Locator"]}
+
+    for dmi_key, output_key in _DEVICE_STRING_FIELDS:
+        if dmi_key in kv:
+            device[output_key] = kv[dmi_key]  # type: ignore[literal-required]
+
+    _set_width_fields(kv, device)
+    _set_numeric_fields(kv, device)
+
+    return device
+
+
+def _set_width_fields(kv: dict[str, str], device: MemoryDevice) -> None:
+    """Set total_width_bits and data_width_bits on device if present."""
+    for dmi_key, output_key in (
+        ("Total Width", "total_width_bits"),
+        ("Data Width", "data_width_bits"),
+    ):
+        if dmi_key in kv:
+            width = _extract_width(kv[dmi_key])
+            if width is not None:
+                device[output_key] = width  # type: ignore[literal-required]
+
+
+def _set_numeric_fields(kv: dict[str, str], device: MemoryDevice) -> None:
+    """Set size_mb, speed_mhz, and rank on device if present."""
+    if "Size" in kv:
+        size = _extract_numeric(kv["Size"])
+        if size is not None:
+            device["size_mb"] = size
+
+    if "Speed" in kv:
+        speed = _extract_numeric(kv["Speed"])
+        if speed is not None:
+            device["speed_mhz"] = speed
+
+    if "Rank" in kv:
+        device["rank"] = int(kv["Rank"])
+
+
+@register(OS.LINUX, "dmidecode -t memory")
+class DmidecodeMemoryParser(BaseParser[DmidecodeMemoryResult]):
+    """Parser for 'dmidecode -t memory' command on Linux.
+
+    Parses Physical Memory Array and Memory Device sections from
+    dmidecode output, providing structured memory inventory data.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INVENTORY})
+
+    @classmethod
+    def parse(cls, output: str) -> DmidecodeMemoryResult:
+        """Parse 'dmidecode -t memory' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict with physical_memory_arrays and memory_devices
+            dicts keyed by location and locator respectively.
+
+        Raises:
+            ValueError: If no memory sections found in output.
+        """
+        arrays: dict[str, PhysicalMemoryArray] = {}
+        devices: dict[str, MemoryDevice] = {}
+
+        for section_type, lines in _split_sections(output):
+            kv = _parse_kv_pairs(lines)
+            if section_type == "Physical Memory Array":
+                array = _build_physical_memory_array(kv)
+                arrays[array["location"]] = array
+            elif section_type == "Memory Device":
+                device = _build_memory_device(kv)
+                devices[device["locator"]] = device
+
+        if not arrays and not devices:
+            msg = "No memory information found in output"
+            raise ValueError(msg)
+
+        return DmidecodeMemoryResult(
+            physical_memory_arrays=arrays,
+            memory_devices=devices,
+        )

--- a/src/muninn/parsers/linux/dmidecode_t_memory.py
+++ b/src/muninn/parsers/linux/dmidecode_t_memory.py
@@ -29,6 +29,18 @@ _KV_RE = re.compile(r"^\t(?P<key>[^:]+):\s+(?P<value>.+)$")
 # Pattern to extract numeric value and unit (e.g. "1111 MB", "1111 MHz")
 _NUMERIC_UNIT_RE = re.compile(r"^(?P<number>\d+)\s+\S+$")
 
+# Pattern to extract size value and unit (e.g. "16 GB", "1111 MB", "512 kB")
+_SIZE_RE = re.compile(r"^(?P<number>\d+)\s+(?P<unit>bytes|kB|MB|GB|TB)$")
+
+# Multipliers to convert a dmidecode Size unit to MB.
+_SIZE_UNIT_TO_MB: dict[str, float] = {
+    "bytes": 1 / (1024 * 1024),
+    "kB": 1 / 1024,
+    "MB": 1,
+    "GB": 1024,
+    "TB": 1024 * 1024,
+}
+
 # Pattern for width fields (e.g. "10 bits")
 _WIDTH_RE = re.compile(r"^(?P<width>\d+)\s+bits$")
 
@@ -112,6 +124,16 @@ def _extract_numeric(raw: str) -> int | None:
     return int(match.group("number")) if match else None
 
 
+def _extract_size_mb(raw: str) -> int | None:
+    """Extract size in MB from a dmidecode Size value (e.g. '16 GB')."""
+    match = _SIZE_RE.match(raw)
+    if not match:
+        return None
+    number = int(match.group("number"))
+    unit = match.group("unit")
+    return int(number * _SIZE_UNIT_TO_MB[unit])
+
+
 def _split_sections(output: str) -> list[tuple[str, list[str]]]:
     """Split dmidecode output into (section_type, lines) pairs."""
     sections: list[tuple[str, list[str]]] = []
@@ -178,7 +200,7 @@ def _set_width_fields(kv: dict[str, str], device: dict[str, Any]) -> None:
 def _set_numeric_fields(kv: dict[str, str], device: dict[str, Any]) -> None:
     """Set size_mb, speed_mhz, and rank on device if present."""
     if "Size" in kv:
-        size = _extract_numeric(kv["Size"])
+        size = _extract_size_mb(kv["Size"])
         if size is not None:
             device["size_mb"] = size
 

--- a/src/muninn/parsers/linux/dmidecode_t_memory.py
+++ b/src/muninn/parsers/linux/dmidecode_t_memory.py
@@ -1,7 +1,7 @@
 """Parser for 'dmidecode -t memory' command on Linux."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import Any, ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -150,19 +150,19 @@ def _build_physical_memory_array(kv: dict[str, str]) -> PhysicalMemoryArray:
 
 def _build_memory_device(kv: dict[str, str]) -> MemoryDevice:
     """Build a MemoryDevice from parsed key-value pairs."""
-    device: MemoryDevice = {"locator": kv["Locator"]}
+    device: dict[str, Any] = {"locator": kv["Locator"]}
 
     for dmi_key, output_key in _DEVICE_STRING_FIELDS:
         if dmi_key in kv:
-            device[output_key] = kv[dmi_key]  # type: ignore[literal-required]
+            device[output_key] = kv[dmi_key]
 
     _set_width_fields(kv, device)
     _set_numeric_fields(kv, device)
 
-    return device
+    return cast(MemoryDevice, device)
 
 
-def _set_width_fields(kv: dict[str, str], device: MemoryDevice) -> None:
+def _set_width_fields(kv: dict[str, str], device: dict[str, Any]) -> None:
     """Set total_width_bits and data_width_bits on device if present."""
     for dmi_key, output_key in (
         ("Total Width", "total_width_bits"),
@@ -171,10 +171,10 @@ def _set_width_fields(kv: dict[str, str], device: MemoryDevice) -> None:
         if dmi_key in kv:
             width = _extract_width(kv[dmi_key])
             if width is not None:
-                device[output_key] = width  # type: ignore[literal-required]
+                device[output_key] = width
 
 
-def _set_numeric_fields(kv: dict[str, str], device: MemoryDevice) -> None:
+def _set_numeric_fields(kv: dict[str, str], device: dict[str, Any]) -> None:
     """Set size_mb, speed_mhz, and rank on device if present."""
     if "Size" in kv:
         size = _extract_numeric(kv["Size"])

--- a/tests/parsers/linux/dmidecode_-t_memory/001_basic/expected.json
+++ b/tests/parsers/linux/dmidecode_-t_memory/001_basic/expected.json
@@ -1,0 +1,50 @@
+{
+    "physical_memory_arrays": {
+        "System Board Or Motherboard": {
+            "location": "System Board Or Motherboard",
+            "use": "System Memory",
+            "maximum_capacity": "16 GB",
+            "number_of_devices": 4,
+            "error_correction_type": "Multi-bit ECC"
+        }
+    },
+    "memory_devices": {
+        "DIMM1A": {
+            "locator": "DIMM1A",
+            "array_handle": "0x001A",
+            "error_information_handle": "No Error",
+            "total_width_bits": 10,
+            "data_width_bits": 10,
+            "size_mb": 1111,
+            "form_factor": "DIMM",
+            "set": "1",
+            "type": "DDR2",
+            "type_detail": "Synchronous",
+            "speed_mhz": 1111
+        },
+        "DIMM1C": {
+            "locator": "DIMM1C",
+            "array_handle": "0x001A",
+            "error_information_handle": "No Error",
+            "form_factor": "DIMM",
+            "set": "1",
+            "type_detail": "Synchronous"
+        },
+        "DIMM1B": {
+            "locator": "DIMM1B",
+            "array_handle": "0x001A",
+            "error_information_handle": "No Error",
+            "form_factor": "DIMM",
+            "set": "1",
+            "type_detail": "Synchronous"
+        },
+        "DIMM1D": {
+            "locator": "DIMM1D",
+            "array_handle": "0x001A",
+            "error_information_handle": "No Error",
+            "form_factor": "DIMM",
+            "set": "1",
+            "type_detail": "Synchronous"
+        }
+    }
+}

--- a/tests/parsers/linux/dmidecode_-t_memory/001_basic/input.txt
+++ b/tests/parsers/linux/dmidecode_-t_memory/001_basic/input.txt
@@ -1,0 +1,91 @@
+# dmidecode 1.11
+SMBIOS 1.1 present.
+
+Handle 0x001A, DMI type 11, 11 bytes
+Physical Memory Array
+	Location: System Board Or Motherboard
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 16 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 4
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: 10 bits
+	Data Width: 10 bits
+	Size: 1111 MB
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1A
+	Bank Locator: Not Specified
+	Type: DDR2
+	Type Detail: Synchronous
+	Speed: 1111 MHz
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1C
+	Bank Locator: Not Specified
+	Type: Reserved
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1B
+	Bank Locator: Not Specified
+	Type: Reserved
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+
+Handle 0x001A, DMI type 11, 11 bytes
+Memory Device
+	Array Handle: 0x001A
+	Error Information Handle: No Error
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: No Module Installed
+	Form Factor: DIMM
+	Set: 1
+	Locator: DIMM1D
+	Bank Locator: Not Specified
+	Type: Reserved
+	Type Detail: Synchronous
+	Speed: Unknown
+	Manufacturer: Not Specified
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown

--- a/tests/parsers/linux/dmidecode_-t_memory/001_basic/metadata.yaml
+++ b/tests/parsers/linux/dmidecode_-t_memory/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Physical memory array with one populated DIMM and three empty slots
+platform: linux
+software_version: unknown

--- a/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/expected.json
+++ b/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/expected.json
@@ -1,0 +1,22 @@
+{
+    "physical_memory_arrays": {
+        "Other": {
+            "location": "Other",
+            "use": "System Memory",
+            "maximum_capacity": "16 GB",
+            "number_of_devices": 1,
+            "error_correction_type": "Multi-bit ECC"
+        }
+    },
+    "memory_devices": {
+        "DIMM 0": {
+            "locator": "DIMM 0",
+            "array_handle": "0x1000",
+            "form_factor": "DIMM",
+            "type": "RAM",
+            "type_detail": "Other",
+            "manufacturer": "QEMU",
+            "size_mb": 16
+        }
+    }
+}

--- a/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/expected.json
+++ b/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/expected.json
@@ -16,7 +16,7 @@
             "type": "RAM",
             "type_detail": "Other",
             "manufacturer": "QEMU",
-            "size_mb": 16
+            "size_mb": 16384
         }
     }
 }

--- a/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/input.txt
+++ b/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/input.txt
@@ -1,0 +1,36 @@
+# dmidecode 3.5
+Getting SMBIOS data from sysfs.
+SMBIOS 2.8 present.
+
+Handle 0x1000, DMI type 16, 23 bytes
+Physical Memory Array
+	Location: Other
+	Use: System Memory
+	Error Correction Type: Multi-bit ECC
+	Maximum Capacity: 16 GB
+	Error Information Handle: Not Provided
+	Number Of Devices: 1
+
+Handle 0x1100, DMI type 17, 40 bytes
+Memory Device
+	Array Handle: 0x1000
+	Error Information Handle: Not Provided
+	Total Width: Unknown
+	Data Width: Unknown
+	Size: 16 GB
+	Form Factor: DIMM
+	Set: None
+	Locator: DIMM 0
+	Bank Locator: Not Specified
+	Type: RAM
+	Type Detail: Other
+	Speed: Unknown
+	Manufacturer: QEMU
+	Serial Number: Not Specified
+	Asset Tag: Not Specified
+	Part Number: Not Specified
+	Rank: Unknown
+	Configured Memory Speed: Unknown
+	Minimum Voltage: Unknown
+	Maximum Voltage: Unknown
+	Configured Voltage: Unknown

--- a/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/metadata.yaml
+++ b/tests/parsers/linux/dmidecode_-t_memory/002_qemu_vm/metadata.yaml
@@ -1,0 +1,3 @@
+description: dmidecode 3.5 -t memory output from a QEMU/KVM VM (1 array, 1 DIMM, many Unknown/Not Specified fields)
+platform: linux
+software_version: dmidecode 3.5

--- a/tests/parsers/linux/dmidecode_-t_memory/command.txt
+++ b/tests/parsers/linux/dmidecode_-t_memory/command.txt
@@ -1,0 +1,1 @@
+dmidecode -t memory


### PR DESCRIPTION
## Summary
- Add new parser for `dmidecode -t memory` on Linux, tagged with `ParserTag.INVENTORY`
- Parses both Physical Memory Array and Memory Device sections into structured dicts keyed by location and DIMM locator respectively
- Sentinel values (`Not Specified`, `Unknown`, `No Module Installed`, `Reserved`, `Not Provided`) are omitted per project conventions

## Test plan
- [x] Test fixture `001_basic` with real device output: 1 physical array, 1 populated DIMM, 3 empty slots
- [x] All 9 parametrized tests pass (parser, empty output, JSON conventions, placeholder sentinels)
- [x] Pre-commit hooks pass (ruff check, ruff format, xenon complexity, bandit security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)