### PR TITLE
feat(arista_eos): add parser for show ip ospf interface brief

### DIFF
--- a/changes/+arista-eos-show-ip-ospf-interface-brief.parser_added
+++ b/changes/+arista-eos-show-ip-ospf-interface-brief.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ip ospf interface brief` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ip_ospf_interface_brief.py
+++ b/src/muninn/parsers/arista_eos/show_ip_ospf_interface_brief.py
@@ -5,6 +5,7 @@ from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS, IPV4_PREFIX
 from muninn.registry import register
 from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
@@ -48,8 +49,8 @@ class ShowIpOspfInterfaceBriefParser(
         r"^\s*(?P<interface>\S+)\s+"
         r"(?P<instance>\d+)\s+"
         r"(?P<vrf>\S+)\s+"
-        r"(?P<area>\d+\.\d+\.\d+\.\d+)\s+"
-        r"(?P<ip_address>\S+)\s+"
+        rf"(?P<area>{IPV4_ADDRESS})\s+"
+        rf"(?P<ip_address>{IPV4_PREFIX})\s+"
         r"(?P<cost>\d+)\s+"
         r"(?P<state>\S+)\s+"
         r"(?P<nbrs>\d+)\s*$"

--- a/src/muninn/parsers/arista_eos/show_ip_ospf_interface_brief.py
+++ b/src/muninn/parsers/arista_eos/show_ip_ospf_interface_brief.py
@@ -1,0 +1,95 @@
+"""Parser for 'show ip ospf interface brief' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class OspfInterfaceEntry(TypedDict):
+    """Schema for a single OSPF interface entry."""
+
+    instance: int
+    vrf: str
+    area: str
+    ip_address: str
+    cost: int
+    state: str
+    neighbor_count: int
+
+
+class ShowIpOspfInterfaceBriefResult(TypedDict):
+    """Schema for 'show ip ospf interface brief' parsed output on Arista EOS."""
+
+    interfaces: dict[str, OspfInterfaceEntry]
+
+
+@register(OS.ARISTA_EOS, "show ip ospf interface brief")
+class ShowIpOspfInterfaceBriefParser(
+    BaseParser[ShowIpOspfInterfaceBriefResult],
+):
+    """Parser for 'show ip ospf interface brief' command on Arista EOS.
+
+    Parses OSPF interface summary including area, cost, state, and
+    neighbor counts. Returns a dict-of-dicts keyed by interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.ROUTING}
+    )
+
+    # Matches data lines in the table output.
+    # Example: Lo0  1  default  0.0.0.10  192.0.2.1/32  10  DR  0
+    _ENTRY_PATTERN = re.compile(
+        r"^\s*(?P<interface>\S+)\s+"
+        r"(?P<instance>\d+)\s+"
+        r"(?P<vrf>\S+)\s+"
+        r"(?P<area>\d+\.\d+\.\d+\.\d+)\s+"
+        r"(?P<ip_address>\S+)\s+"
+        r"(?P<cost>\d+)\s+"
+        r"(?P<state>\S+)\s+"
+        r"(?P<nbrs>\d+)\s*$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfInterfaceBriefResult:
+        """Parse 'show ip ospf interface brief' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed OSPF interface entries keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no OSPF interface entries found.
+        """
+        interfaces: dict[str, OspfInterfaceEntry] = {}
+
+        for line in output.splitlines():
+            match = cls._ENTRY_PATTERN.match(line)
+            if not match:
+                continue
+
+            raw_name = match.group("interface")
+            name = canonical_interface_name(raw_name, os=OS.ARISTA_EOS)
+
+            interfaces[name] = OspfInterfaceEntry(
+                instance=int(match.group("instance")),
+                vrf=match.group("vrf"),
+                area=match.group("area"),
+                ip_address=match.group("ip_address"),
+                cost=int(match.group("cost")),
+                state=match.group("state"),
+                neighbor_count=int(match.group("nbrs")),
+            )
+
+        if not interfaces:
+            msg = "No OSPF interface entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpOspfInterfaceBriefResult, {"interfaces": interfaces})

--- a/src/muninn/utils.py
+++ b/src/muninn/utils.py
@@ -25,11 +25,40 @@ _IOSXR_PREFIX_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Arista EOS abbreviated prefixes that netutils expands incorrectly.
+# netutils maps "Vl" -> "VLAN" but Arista's canonical form is "Vlan".
+_ARISTA_EOS_PREFIX_MAP: dict[str, str] = {
+    "vl": "Vlan",
+}
+_ARISTA_EOS_PREFIX_PATTERN = re.compile(
+    r"^(?P<prefix>" + "|".join(_ARISTA_EOS_PREFIX_MAP) + r")(?P<suffix>\d.*)$",
+    re.IGNORECASE,
+)
+
 # Platforms where netutils canonicalization is incorrect — these use their
 # own naming conventions (e.g. lo0, eth0, ge-0/0/0) that must not be rewritten.
 _NETUTILS_PASSTHROUGH_OSES = frozenset(
     {OS.JUNIPER_JUNOS, OS.NOKIA_SROS, OS.PALOALTO_PANOS, OS.LINUX}
 )
+
+
+def _apply_prefix_map(
+    name: str,
+    pattern: re.Pattern[str],
+    prefix_map: dict[str, str],
+) -> str:
+    """Rewrite an interface name using a prefix lookup table.
+
+    If *name* matches *pattern*, the captured ``prefix`` group is
+    looked up (case-insensitively) in *prefix_map* and the name is
+    rebuilt as ``<canonical_prefix><suffix>``.  Otherwise *name* is
+    returned unchanged.
+    """
+    match = pattern.match(name)
+    if match:
+        canonical = prefix_map[match.group("prefix").lower()]
+        return f"{canonical}{match.group('suffix')}"
+    return name
 
 
 def canonical_interface_name(name: str, *, os: OS | None = None) -> str:
@@ -61,10 +90,12 @@ def canonical_interface_name(name: str, *, os: OS | None = None) -> str:
         if match:
             name = f"FourHundredGigabitEthernet{match.group('suffix')}"
 
+    if os is OS.ARISTA_EOS:
+        name = _apply_prefix_map(
+            name, _ARISTA_EOS_PREFIX_PATTERN, _ARISTA_EOS_PREFIX_MAP
+        )
+
     if os is OS.CISCO_IOSXR:
-        match = _IOSXR_PREFIX_PATTERN.match(name)
-        if match:
-            canonical_prefix = _IOSXR_PREFIX_MAP[match.group("prefix").lower()]
-            name = f"{canonical_prefix}{match.group('suffix')}"
+        name = _apply_prefix_map(name, _IOSXR_PREFIX_PATTERN, _IOSXR_PREFIX_MAP)
 
     return _upstream_canonical(name)

--- a/tests/parsers/arista_eos/show_ip_ospf_interface_brief/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_ospf_interface_brief/001_basic/expected.json
@@ -1,0 +1,67 @@
+{
+    "interfaces": {
+        "Loopback0": {
+            "instance": 1,
+            "vrf": "default",
+            "area": "0.0.0.10",
+            "ip_address": "192.0.2.1/32",
+            "cost": 10,
+            "state": "DR",
+            "neighbor_count": 0
+        },
+        "Vlan100": {
+            "instance": 1,
+            "vrf": "default",
+            "area": "0.0.0.10",
+            "ip_address": "192.0.2.1/32",
+            "cost": 10,
+            "state": "DR",
+            "neighbor_count": 0
+        },
+        "Vlan200": {
+            "instance": 1,
+            "vrf": "default",
+            "area": "0.0.0.10",
+            "ip_address": "192.0.2.1/32",
+            "cost": 10,
+            "state": "DR",
+            "neighbor_count": 0
+        },
+        "Ethernet10": {
+            "instance": 1,
+            "vrf": "default",
+            "area": "0.0.0.10",
+            "ip_address": "192.0.2.1/32",
+            "cost": 10,
+            "state": "DR",
+            "neighbor_count": 0
+        },
+        "Ethernet20/1": {
+            "instance": 1,
+            "vrf": "default",
+            "area": "0.0.0.10",
+            "ip_address": "192.0.2.1/32",
+            "cost": 50,
+            "state": "P2P",
+            "neighbor_count": 1
+        },
+        "Ethernet20/1.10": {
+            "instance": 2,
+            "vrf": "mgmtVrf",
+            "area": "0.0.0.0",
+            "ip_address": "192.0.2.1/32",
+            "cost": 10,
+            "state": "P2P",
+            "neighbor_count": 1
+        },
+        "Port-channel1.10": {
+            "instance": 2,
+            "vrf": "mgmtVrf",
+            "area": "0.0.0.0",
+            "ip_address": "192.0.2.1/32",
+            "cost": 10,
+            "state": "P2P",
+            "neighbor_count": 1
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_ospf_interface_brief/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ip_ospf_interface_brief/001_basic/input.txt
@@ -1,0 +1,8 @@
+   Interface    Instance VRF        Area            IP Address         Cost  State      Nbrs
+   Lo0          1        default    0.0.0.10        192.0.2.1/32       10    DR         0
+   Vl100        1        default    0.0.0.10        192.0.2.1/32       10    DR         0
+   Vl200        1        default    0.0.0.10        192.0.2.1/32       10    DR         0
+   Et10         1        default    0.0.0.10        192.0.2.1/32       10    DR         0
+   Et20/1       1        default    0.0.0.10        192.0.2.1/32       50    P2P        1
+   Et20/1.10    2        mgmtVrf    0.0.0.0         192.0.2.1/32       10    P2P        1
+   Po1.10       2        mgmtVrf    0.0.0.0         192.0.2.1/32       10    P2P        1

--- a/tests/parsers/arista_eos/show_ip_ospf_interface_brief/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_ospf_interface_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple OSPF interfaces across default and non-default VRFs with mixed states
+platform: vEOS
+software_version: EOS

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""Tests for muninn.utils — interface name canonicalization."""
+
+import pytest
+
+from muninn.os import OS
+from muninn.utils import canonical_interface_name
+
+
+class TestCanonicalInterfaceNameAristaEOS:
+    """Tests for Arista EOS-specific canonicalization quirks."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Vl100", "Vlan100"),
+            ("vl1", "Vlan1"),
+            ("VL4094", "Vlan4094"),
+            ("Vlan200", "Vlan200"),
+        ],
+    )
+    def test_vlan_prefix_rewrite(self, raw: str, expected: str) -> None:
+        """``Vl``/``vl`` is rewritten to ``Vlan`` (not netutils' ``VLAN``)."""
+        assert canonical_interface_name(raw, os=OS.ARISTA_EOS) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("Et10", "Ethernet10"),
+            ("Et20/1", "Ethernet20/1"),
+            ("Et20/1.10", "Ethernet20/1.10"),
+            ("Lo0", "Loopback0"),
+            ("Po1.10", "Port-channel1.10"),
+        ],
+    )
+    def test_non_vlan_passthrough(self, raw: str, expected: str) -> None:
+        """Non-Vlan abbreviations defer to netutils canonicalization."""
+        assert canonical_interface_name(raw, os=OS.ARISTA_EOS) == expected


### PR DESCRIPTION
## Summary
- Add parser for `show ip ospf interface brief` on Arista EOS, returning a dict-of-dicts keyed by canonical interface name with instance, VRF, area, IP address, cost, state, and neighbor count fields
- Fix `canonical_interface_name` for Arista EOS where netutils incorrectly expands the `Vl` abbreviation to `VLAN` instead of `Vlan`
- Refactor IOS-XR prefix rewriting in `utils.py` to share a common `_apply_prefix_map` helper, reducing complexity

## Test plan
- [x] Parser test fixture `001_basic` covers loopbacks, VLANs, Ethernet, sub-interfaces, and port-channels across default and non-default VRFs
- [x] All 6848 tests pass including fixture sentinel, JSON convention, and parser correctness checks
- [x] Ruff lint and format pass
- [x] Xenon complexity check passes (max-absolute B)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)