### PR TITLE
feat(arista_eos): add parser for show ip bgp detail

### DIFF
--- a/changes/+arista-eos-show-ip-bgp-detail.parser_added
+++ b/changes/+arista-eos-show-ip-bgp-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ip bgp detail` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ip_bgp_detail.py
+++ b/src/muninn/parsers/arista_eos/show_ip_bgp_detail.py
@@ -1,0 +1,440 @@
+"""Parser for 'show ip bgp detail' command on Arista EOS."""
+
+import re
+from typing import Any, ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class BgpPathEntry(TypedDict):
+    """Schema for a single BGP path within a prefix."""
+
+    as_path: str
+    next_hop: str
+    peer: str
+    router_id: str
+    origin: str
+    metric: int
+    local_preference: int
+    igp_metric: int
+    weight: int
+    received: str
+    flags: str
+    best_path: bool
+    communities: NotRequired[str]
+    extended_communities: NotRequired[str]
+    rx_path_id: NotRequired[str]
+    rx_safi: NotRequired[str]
+
+
+class BgpPrefixEntry(TypedDict):
+    """Schema for a single BGP prefix."""
+
+    path_count: int
+    paths: dict[str, BgpPathEntry]
+
+
+class BgpVrfEntry(TypedDict):
+    """Schema for a single VRF in the BGP detail output."""
+
+    router_id: str
+    local_as: int
+    prefixes: dict[str, BgpPrefixEntry]
+
+
+class ShowIpBgpDetailResult(TypedDict):
+    """Schema for 'show ip bgp detail' parsed output on Arista EOS."""
+
+    vrfs: dict[str, BgpVrfEntry]
+
+
+# --- Compiled regex patterns ---
+
+_VRF_HEADER_RE = re.compile(
+    r"^BGP routing table information for VRF\s+(?P<vrf>\S+)\s*$"
+)
+_ROUTER_ID_RE = re.compile(
+    r"^Router identifier\s+(?P<router_id>\S+),\s+"
+    r"local AS number\s+(?P<local_as>\d+)\s*$"
+)
+_PREFIX_RE = re.compile(r"^BGP routing table entry for\s+(?P<prefix>\S+)\s*$")
+_PATHS_COUNT_RE = re.compile(r"^\s*Paths:\s+(?P<count>\d+)\s+available\s*$")
+_ORIGIN_LINE_RE = re.compile(
+    r"^\s+Origin\s+(?P<origin>\S+),\s+"
+    r"metric\s+(?P<metric>\d+),\s+"
+    r"localpref\s+(?P<localpref>\d+),\s+"
+    r"IGP metric\s+(?P<igp_metric>\d+),\s+"
+    r"weight\s+(?P<weight>\d+),\s+"
+    r"received\s+(?P<received>\S+)\s+ago,\s+"
+    r"(?P<flags>.+?)\s*$"
+)
+_NEXT_HOP_RE = re.compile(
+    r"^\s+(?P<next_hop>\S+)\s+from\s+(?P<peer>\S+)\s+\((?P<router_id>\S+)\)\s*$"
+)
+_COMMUNITY_RE = re.compile(r"^\s+Community:\s+(?P<communities>.+?)\s*$")
+_EXT_COMMUNITY_RE = re.compile(
+    r"^\s+Extended Community:\s+(?P<ext_communities>.+?)\s*$"
+)
+_RX_PATH_ID_RE = re.compile(r"^\s+Rx path id:\s+(?P<rx_path_id>\S+)\s*$")
+_RX_SAFI_RE = re.compile(r"^\s+Rx SAFI:\s+(?P<rx_safi>\S+)\s*$")
+_CONTRIBUTING_ROUTES_RE = re.compile(r"^\s+\d+\s+Contributing routes:")
+# AS path line: indented line that is not a known attribute line
+_AS_PATH_LINE_RE = re.compile(r"^  (?P<as_path>\S.*)$")
+
+
+def _is_best_path(flags: str) -> bool:
+    """Determine if a path is the best path from the flags string."""
+    flag_parts = [f.strip().rstrip(",") for f in flags.split(",")]
+    return "best" in flag_parts
+
+
+class _PathAccumulator:
+    """Mutable accumulator for fields parsed from a single path block."""
+
+    __slots__ = (
+        "as_path",
+        "next_hop",
+        "peer",
+        "router_id",
+        "origin",
+        "metric",
+        "local_preference",
+        "igp_metric",
+        "weight",
+        "received",
+        "flags",
+        "best_path",
+        "communities",
+        "ext_communities",
+        "rx_path_id",
+        "rx_safi",
+    )
+
+    def __init__(self) -> None:
+        self.as_path: str | None = None
+        self.next_hop: str | None = None
+        self.peer: str | None = None
+        self.router_id: str | None = None
+        self.origin: str | None = None
+        self.metric: int = 0
+        self.local_preference: int = 0
+        self.igp_metric: int = 0
+        self.weight: int = 0
+        self.received: str = ""
+        self.flags: str = ""
+        self.best_path: bool = False
+        self.communities: str | None = None
+        self.ext_communities: str | None = None
+        self.rx_path_id: str | None = None
+        self.rx_safi: str | None = None
+
+    def to_entry(self) -> BgpPathEntry:
+        """Build a BgpPathEntry from accumulated state."""
+        entry: BgpPathEntry = {
+            "as_path": self.as_path or "",
+            "next_hop": self.next_hop or "",
+            "peer": self.peer or "",
+            "router_id": self.router_id or "",
+            "origin": self.origin or "",
+            "metric": self.metric,
+            "local_preference": self.local_preference,
+            "igp_metric": self.igp_metric,
+            "weight": self.weight,
+            "received": self.received,
+            "flags": self.flags,
+            "best_path": self.best_path,
+        }
+        _d = cast(dict[str, Any], entry)
+        if self.communities is not None:
+            _d["communities"] = self.communities
+        if self.ext_communities is not None:
+            _d["extended_communities"] = self.ext_communities
+        if self.rx_path_id is not None:
+            _d["rx_path_id"] = self.rx_path_id
+        if self.rx_safi is not None:
+            _d["rx_safi"] = self.rx_safi
+        return entry
+
+
+def _try_parse_origin(line: str, acc: _PathAccumulator) -> bool:
+    """Parse an Origin attributes line. Returns True if matched."""
+    m = _ORIGIN_LINE_RE.match(line)
+    if not m:
+        return False
+    acc.origin = m.group("origin")
+    acc.metric = int(m.group("metric"))
+    acc.local_preference = int(m.group("localpref"))
+    acc.igp_metric = int(m.group("igp_metric"))
+    acc.weight = int(m.group("weight"))
+    acc.received = m.group("received")
+    raw_flags = m.group("flags")
+    acc.flags = raw_flags.strip()
+    acc.best_path = _is_best_path(raw_flags)
+    return True
+
+
+def _try_parse_next_hop(line: str, acc: _PathAccumulator) -> bool:
+    """Parse a next-hop line. Returns True if matched."""
+    m = _NEXT_HOP_RE.match(line)
+    if not m:
+        return False
+    acc.next_hop = m.group("next_hop")
+    acc.peer = m.group("peer")
+    acc.router_id = m.group("router_id")
+    return True
+
+
+def _try_parse_attributes(line: str, acc: _PathAccumulator) -> bool:
+    """Parse community, extended community, Rx path id, or Rx SAFI lines.
+
+    Returns True if matched.
+    """
+    m = _COMMUNITY_RE.match(line)
+    if m:
+        acc.communities = m.group("communities")
+        return True
+    m = _EXT_COMMUNITY_RE.match(line)
+    if m:
+        acc.ext_communities = m.group("ext_communities")
+        return True
+    m = _RX_PATH_ID_RE.match(line)
+    if m:
+        acc.rx_path_id = m.group("rx_path_id")
+        return True
+    m = _RX_SAFI_RE.match(line)
+    if m:
+        acc.rx_safi = m.group("rx_safi")
+        return True
+    return False
+
+
+def _is_known_attribute_line(line: str) -> bool:
+    """Return True if the line matches a known path attribute pattern."""
+    return bool(
+        _ORIGIN_LINE_RE.match(line)
+        or _NEXT_HOP_RE.match(line)
+        or _COMMUNITY_RE.match(line)
+        or _EXT_COMMUNITY_RE.match(line)
+        or _RX_PATH_ID_RE.match(line)
+        or _RX_SAFI_RE.match(line)
+        or _CONTRIBUTING_ROUTES_RE.match(line)
+    )
+
+
+def _extract_as_path(raw_as: str) -> str:
+    """Extract AS path from a raw AS path string, stripping annotations."""
+    # Remove parenthetical annotations like "(aggregated by ...)"
+    # or "(Received from a RR-client)"
+    paren_idx = raw_as.find(" (")
+    if paren_idx >= 0:
+        return raw_as[:paren_idx].strip()
+    return raw_as
+
+
+def _try_start_new_path(
+    line: str,
+    acc: _PathAccumulator | None,
+    paths: list[BgpPathEntry],
+) -> _PathAccumulator | None:
+    """Try to detect an AS path line that starts a new path block.
+
+    Returns a new accumulator if a new path started, otherwise None.
+    """
+    m = _AS_PATH_LINE_RE.match(line)
+    if not m or _is_known_attribute_line(line):
+        return None
+
+    # Flush previous path if it has a next hop
+    if acc is not None and acc.next_hop is not None:
+        paths.append(acc.to_entry())
+
+    new_acc = _PathAccumulator()
+    new_acc.as_path = _extract_as_path(m.group("as_path").strip())
+    return new_acc
+
+
+def _filter_contributing_routes(lines: list[str]) -> list[str]:
+    """Remove contributing routes sections from path lines."""
+    filtered: list[str] = []
+    skip = False
+    for line in lines:
+        if _CONTRIBUTING_ROUTES_RE.match(line):
+            skip = True
+            continue
+        if skip:
+            if line.startswith("        "):
+                continue
+            skip = False
+        filtered.append(line)
+    return filtered
+
+
+def _parse_path_lines(lines: list[str]) -> list[BgpPathEntry]:
+    """Parse path lines for a single prefix into a list of BgpPathEntry dicts."""
+    paths: list[BgpPathEntry] = []
+    acc: _PathAccumulator | None = None
+    filtered = _filter_contributing_routes(lines)
+
+    for line in filtered:
+        new_acc = _try_start_new_path(line, acc, paths)
+        if new_acc is not None:
+            acc = new_acc
+            continue
+
+        if acc is None:
+            continue
+
+        if _try_parse_next_hop(line, acc):
+            continue
+        if _try_parse_origin(line, acc):
+            continue
+        _try_parse_attributes(line, acc)
+
+    # Flush last path
+    if acc is not None and acc.next_hop is not None:
+        paths.append(acc.to_entry())
+
+    return paths
+
+
+@register(OS.ARISTA_EOS, "show ip bgp detail")
+class ShowIpBgpDetailParser(BaseParser["ShowIpBgpDetailResult"]):
+    """Parser for 'show ip bgp detail' command on Arista EOS.
+
+    Parses BGP routing table detail output including paths, AS paths,
+    communities, and path attributes across multiple VRFs.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpBgpDetailResult:
+        """Parse 'show ip bgp detail' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed BGP detail data keyed by VRF and prefix.
+
+        Raises:
+            ValueError: If no VRF data found in output.
+        """
+        vrfs: dict[str, BgpVrfEntry] = {}
+        current_vrf: str | None = None
+        current_router_id: str = ""
+        current_local_as: int = 0
+        current_prefix: str | None = None
+        current_path_count: int = 0
+        path_lines: list[str] = []
+
+        lines = output.splitlines()
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            # VRF header
+            m = _VRF_HEADER_RE.match(stripped)
+            if m:
+                _flush_prefix(
+                    vrfs,
+                    current_vrf,
+                    current_router_id,
+                    current_local_as,
+                    current_prefix,
+                    current_path_count,
+                    path_lines,
+                )
+                current_vrf = m.group("vrf")
+                current_router_id = ""
+                current_local_as = 0
+                current_prefix = None
+                path_lines = []
+                continue
+
+            # Router identifier line
+            m = _ROUTER_ID_RE.match(stripped)
+            if m:
+                current_router_id = m.group("router_id")
+                current_local_as = int(m.group("local_as"))
+                continue
+
+            # New prefix entry
+            m = _PREFIX_RE.match(stripped)
+            if m:
+                _flush_prefix(
+                    vrfs,
+                    current_vrf,
+                    current_router_id,
+                    current_local_as,
+                    current_prefix,
+                    current_path_count,
+                    path_lines,
+                )
+                current_prefix = m.group("prefix")
+                current_path_count = 0
+                path_lines = []
+                continue
+
+            # Path count
+            m = _PATHS_COUNT_RE.match(line)
+            if m:
+                current_path_count = int(m.group("count"))
+                continue
+
+            # Accumulate path lines (preserve original indentation)
+            if current_prefix is not None:
+                path_lines.append(line)
+
+        # Flush last prefix
+        _flush_prefix(
+            vrfs,
+            current_vrf,
+            current_router_id,
+            current_local_as,
+            current_prefix,
+            current_path_count,
+            path_lines,
+        )
+
+        if not vrfs:
+            msg = "No VRF data found in 'show ip bgp detail' output"
+            raise ValueError(msg)
+
+        return {"vrfs": vrfs}
+
+
+def _flush_prefix(
+    vrfs: dict[str, BgpVrfEntry],
+    vrf_name: str | None,
+    router_id: str,
+    local_as: int,
+    prefix: str | None,
+    path_count: int,
+    lines: list[str],
+) -> None:
+    """Parse accumulated prefix lines and add to the vrfs dict."""
+    if not (vrf_name and prefix and lines):
+        return
+
+    if vrf_name not in vrfs:
+        vrfs[vrf_name] = {
+            "router_id": router_id,
+            "local_as": local_as,
+            "prefixes": {},
+        }
+
+    parsed_paths = _parse_path_lines(lines)
+    paths_dict: dict[str, BgpPathEntry] = {}
+    for idx, path_entry in enumerate(parsed_paths, start=1):
+        paths_dict[str(idx)] = path_entry
+
+    if paths_dict:
+        vrfs[vrf_name]["prefixes"][prefix] = {
+            "path_count": path_count,
+            "paths": paths_dict,
+        }

--- a/src/muninn/parsers/arista_eos/show_ip_bgp_detail.py
+++ b/src/muninn/parsers/arista_eos/show_ip_bgp_detail.py
@@ -5,8 +5,18 @@ from typing import Any, ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS, IPV4_PREFIX
 from muninn.registry import register
 from muninn.tags import ParserTag
+
+
+class ContributingRoute(TypedDict):
+    """Schema for a single contributing route under an aggregated path."""
+
+    proto: str
+    origin: str
+    as_path: str
+    communities: NotRequired[str]
 
 
 class BgpPathEntry(TypedDict):
@@ -22,12 +32,13 @@ class BgpPathEntry(TypedDict):
     igp_metric: int
     weight: int
     received: str
-    flags: str
+    flags: list[str]
     best_path: bool
     communities: NotRequired[str]
     extended_communities: NotRequired[str]
     rx_path_id: NotRequired[str]
     rx_safi: NotRequired[str]
+    contributing_routes: NotRequired[dict[str, ContributingRoute]]
 
 
 class BgpPrefixEntry(TypedDict):
@@ -57,10 +68,12 @@ _VRF_HEADER_RE = re.compile(
     r"^BGP routing table information for VRF\s+(?P<vrf>\S+)\s*$"
 )
 _ROUTER_ID_RE = re.compile(
-    r"^Router identifier\s+(?P<router_id>\S+),\s+"
+    rf"^Router identifier\s+(?P<router_id>{IPV4_ADDRESS}),\s+"
     r"local AS number\s+(?P<local_as>\d+)\s*$"
 )
-_PREFIX_RE = re.compile(r"^BGP routing table entry for\s+(?P<prefix>\S+)\s*$")
+_PREFIX_RE = re.compile(
+    rf"^BGP routing table entry for\s+(?P<prefix>{IPV4_PREFIX}|{IPV4_ADDRESS})\s*$"
+)
 _PATHS_COUNT_RE = re.compile(r"^\s*Paths:\s+(?P<count>\d+)\s+available\s*$")
 _ORIGIN_LINE_RE = re.compile(
     r"^\s+Origin\s+(?P<origin>\S+),\s+"
@@ -72,7 +85,8 @@ _ORIGIN_LINE_RE = re.compile(
     r"(?P<flags>.+?)\s*$"
 )
 _NEXT_HOP_RE = re.compile(
-    r"^\s+(?P<next_hop>\S+)\s+from\s+(?P<peer>\S+)\s+\((?P<router_id>\S+)\)\s*$"
+    rf"^\s+(?P<next_hop>{IPV4_ADDRESS})\s+from\s+(?P<peer>{IPV4_ADDRESS})\s+"
+    rf"\((?P<router_id>{IPV4_ADDRESS})\)\s*$"
 )
 _COMMUNITY_RE = re.compile(r"^\s+Community:\s+(?P<communities>.+?)\s*$")
 _EXT_COMMUNITY_RE = re.compile(
@@ -81,14 +95,22 @@ _EXT_COMMUNITY_RE = re.compile(
 _RX_PATH_ID_RE = re.compile(r"^\s+Rx path id:\s+(?P<rx_path_id>\S+)\s*$")
 _RX_SAFI_RE = re.compile(r"^\s+Rx SAFI:\s+(?P<rx_safi>\S+)\s*$")
 _CONTRIBUTING_ROUTES_RE = re.compile(r"^\s+\d+\s+Contributing routes:")
+_CONTRIBUTING_ROUTE_RE = re.compile(
+    rf"^\s{{8}}(?P<prefix>{IPV4_PREFIX}|{IPV4_ADDRESS})\s+"
+    r"Proto:\s+(?P<proto>\S+)\s+"
+    r"Origin:\s+(?P<origin>\S+)\s+"
+    r"AS Path:\s+(?P<as_path>.+?)\s*$"
+)
+_CONTRIBUTING_ROUTE_COMMUNITY_RE = re.compile(
+    r"^\s{10}Community:\s+(?P<communities>.+?)\s*$"
+)
 # AS path line: indented line that is not a known attribute line
 _AS_PATH_LINE_RE = re.compile(r"^  (?P<as_path>\S.*)$")
 
 
-def _is_best_path(flags: str) -> bool:
-    """Determine if a path is the best path from the flags string."""
-    flag_parts = [f.strip().rstrip(",") for f in flags.split(",")]
-    return "best" in flag_parts
+def _split_flags(flags: str) -> list[str]:
+    """Split a comma-separated flags string into a list of trimmed flags."""
+    return [f.strip() for f in flags.split(",") if f.strip()]
 
 
 class _PathAccumulator:
@@ -111,6 +133,7 @@ class _PathAccumulator:
         "ext_communities",
         "rx_path_id",
         "rx_safi",
+        "contributing_routes",
     )
 
     def __init__(self) -> None:
@@ -124,12 +147,13 @@ class _PathAccumulator:
         self.igp_metric: int = 0
         self.weight: int = 0
         self.received: str = ""
-        self.flags: str = ""
+        self.flags: list[str] = []
         self.best_path: bool = False
         self.communities: str | None = None
         self.ext_communities: str | None = None
         self.rx_path_id: str | None = None
         self.rx_safi: str | None = None
+        self.contributing_routes: dict[str, ContributingRoute] = {}
 
     def to_entry(self) -> BgpPathEntry:
         """Build a BgpPathEntry from accumulated state."""
@@ -148,14 +172,17 @@ class _PathAccumulator:
             "best_path": self.best_path,
         }
         _d = cast(dict[str, Any], entry)
-        if self.communities is not None:
-            _d["communities"] = self.communities
-        if self.ext_communities is not None:
-            _d["extended_communities"] = self.ext_communities
-        if self.rx_path_id is not None:
-            _d["rx_path_id"] = self.rx_path_id
-        if self.rx_safi is not None:
-            _d["rx_safi"] = self.rx_safi
+        optional: dict[str, Any] = {
+            "communities": self.communities,
+            "extended_communities": self.ext_communities,
+            "rx_path_id": self.rx_path_id,
+            "rx_safi": self.rx_safi,
+        }
+        for k, v in optional.items():
+            if v is not None:
+                _d[k] = v
+        if self.contributing_routes:
+            _d["contributing_routes"] = self.contributing_routes
         return entry
 
 
@@ -170,9 +197,8 @@ def _try_parse_origin(line: str, acc: _PathAccumulator) -> bool:
     acc.igp_metric = int(m.group("igp_metric"))
     acc.weight = int(m.group("weight"))
     acc.received = m.group("received")
-    raw_flags = m.group("flags")
-    acc.flags = raw_flags.strip()
-    acc.best_path = _is_best_path(raw_flags)
+    acc.flags = _split_flags(m.group("flags"))
+    acc.best_path = "best" in acc.flags
     return True
 
 
@@ -237,7 +263,7 @@ def _extract_as_path(raw_as: str) -> str:
 def _try_start_new_path(
     line: str,
     acc: _PathAccumulator | None,
-    paths: list[BgpPathEntry],
+    paths: list[_PathAccumulator],
 ) -> _PathAccumulator | None:
     """Try to detect an AS path line that starts a new path block.
 
@@ -249,55 +275,109 @@ def _try_start_new_path(
 
     # Flush previous path if it has a next hop
     if acc is not None and acc.next_hop is not None:
-        paths.append(acc.to_entry())
+        paths.append(acc)
 
     new_acc = _PathAccumulator()
     new_acc.as_path = _extract_as_path(m.group("as_path").strip())
     return new_acc
 
 
-def _filter_contributing_routes(lines: list[str]) -> list[str]:
-    """Remove contributing routes sections from path lines."""
-    filtered: list[str] = []
-    skip = False
-    for line in lines:
-        if _CONTRIBUTING_ROUTES_RE.match(line):
-            skip = True
+def _parse_contributing_block(
+    lines: list[str], start: int
+) -> tuple[dict[str, ContributingRoute], int]:
+    """Parse a contributing routes block starting at lines[start].
+
+    Returns (parsed routes, index of first line past the block).
+    """
+    routes: dict[str, ContributingRoute] = {}
+    i = start
+    last_prefix: str | None = None
+    while i < len(lines):
+        line = lines[i]
+        if not line.startswith("        "):
+            break
+        m = _CONTRIBUTING_ROUTE_RE.match(line)
+        if m:
+            prefix = m.group("prefix")
+            route: ContributingRoute = {
+                "proto": m.group("proto"),
+                "origin": m.group("origin"),
+                "as_path": m.group("as_path").strip(),
+            }
+            routes[prefix] = route
+            last_prefix = prefix
+            i += 1
             continue
-        if skip:
-            if line.startswith("        "):
-                continue
-            skip = False
-        filtered.append(line)
-    return filtered
+        cm = _CONTRIBUTING_ROUTE_COMMUNITY_RE.match(line)
+        if cm and last_prefix is not None:
+            cast(dict[str, Any], routes[last_prefix])["communities"] = cm.group(
+                "communities"
+            )
+            i += 1
+            continue
+        # Indented line that doesn't match a contributing-route shape — stop.
+        break
+    return routes, i
 
 
-def _parse_path_lines(lines: list[str]) -> list[BgpPathEntry]:
-    """Parse path lines for a single prefix into a list of BgpPathEntry dicts."""
-    paths: list[BgpPathEntry] = []
+def _parse_path_lines(lines: list[str]) -> list[_PathAccumulator]:
+    """Parse path lines for a single prefix into accumulators."""
+    paths: list[_PathAccumulator] = []
     acc: _PathAccumulator | None = None
-    filtered = _filter_contributing_routes(lines)
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if _CONTRIBUTING_ROUTES_RE.match(line):
+            if acc is not None:
+                routes, next_i = _parse_contributing_block(lines, i + 1)
+                acc.contributing_routes = routes
+                i = next_i
+            else:
+                i += 1
+            continue
 
-    for line in filtered:
         new_acc = _try_start_new_path(line, acc, paths)
         if new_acc is not None:
             acc = new_acc
+            i += 1
             continue
 
         if acc is None:
+            i += 1
             continue
 
         if _try_parse_next_hop(line, acc):
+            i += 1
             continue
         if _try_parse_origin(line, acc):
+            i += 1
             continue
         _try_parse_attributes(line, acc)
+        i += 1
 
-    # Flush last path
     if acc is not None and acc.next_hop is not None:
-        paths.append(acc.to_entry())
+        paths.append(acc)
 
     return paths
+
+
+def _build_path_key(acc: _PathAccumulator, used: set[str]) -> str:
+    """Build a unique natural key for a path entry.
+
+    Prefers next_hop, falls back to next_hop+rx_path_id when collisions exist.
+    """
+    base = acc.next_hop or ""
+    if acc.rx_path_id is not None:
+        candidate = f"{base}#{acc.rx_path_id}"
+    else:
+        candidate = base
+    if candidate not in used:
+        return candidate
+    # Fall back to numeric suffix to guarantee uniqueness without losing data.
+    n = 2
+    while f"{candidate}#{n}" in used:
+        n += 1
+    return f"{candidate}#{n}"
 
 
 @register(OS.ARISTA_EOS, "show ip bgp detail")
@@ -337,7 +417,6 @@ class ShowIpBgpDetailParser(BaseParser["ShowIpBgpDetailResult"]):
             if not stripped:
                 continue
 
-            # VRF header
             m = _VRF_HEADER_RE.match(stripped)
             if m:
                 _flush_prefix(
@@ -356,14 +435,12 @@ class ShowIpBgpDetailParser(BaseParser["ShowIpBgpDetailResult"]):
                 path_lines = []
                 continue
 
-            # Router identifier line
             m = _ROUTER_ID_RE.match(stripped)
             if m:
                 current_router_id = m.group("router_id")
                 current_local_as = int(m.group("local_as"))
                 continue
 
-            # New prefix entry
             m = _PREFIX_RE.match(stripped)
             if m:
                 _flush_prefix(
@@ -380,17 +457,14 @@ class ShowIpBgpDetailParser(BaseParser["ShowIpBgpDetailResult"]):
                 path_lines = []
                 continue
 
-            # Path count
             m = _PATHS_COUNT_RE.match(line)
             if m:
                 current_path_count = int(m.group("count"))
                 continue
 
-            # Accumulate path lines (preserve original indentation)
             if current_prefix is not None:
                 path_lines.append(line)
 
-        # Flush last prefix
         _flush_prefix(
             vrfs,
             current_vrf,
@@ -428,10 +502,13 @@ def _flush_prefix(
             "prefixes": {},
         }
 
-    parsed_paths = _parse_path_lines(lines)
+    parsed = _parse_path_lines(lines)
     paths_dict: dict[str, BgpPathEntry] = {}
-    for idx, path_entry in enumerate(parsed_paths, start=1):
-        paths_dict[str(idx)] = path_entry
+    used_keys: set[str] = set()
+    for acc in parsed:
+        key = _build_path_key(acc, used_keys)
+        used_keys.add(key)
+        paths_dict[key] = acc.to_entry()
 
     if paths_dict:
         vrfs[vrf_name]["prefixes"][prefix] = {

--- a/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/expected.json
@@ -1,0 +1,234 @@
+{
+    "vrfs": {
+        "default": {
+            "router_id": "10.103.1.1",
+            "local_as": 103,
+            "prefixes": {
+                "10.103.1.0/24": {
+                    "path_count": 2,
+                    "paths": {
+                        "1": {
+                            "as_path": "6333 623566 42669611124 4266644366 4266643244",
+                            "next_hop": "10.10.23.2",
+                            "peer": "10.10.23.2",
+                            "router_id": "10.10.1.1",
+                            "origin": "INCOMPLETE",
+                            "metric": 0,
+                            "local_preference": 100,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "19d16h",
+                            "flags": "valid, external, best",
+                            "best_path": true,
+                            "communities": "internet 10050:200 10222:10010 3223:0 1000:17044",
+                            "rx_safi": "Unicast"
+                        },
+                        "2": {
+                            "as_path": "6333 623566 42669.611124 4266644366 4266643244",
+                            "next_hop": "10.10.25.2",
+                            "peer": "10.10.25.2",
+                            "router_id": "10.10.1.1",
+                            "origin": "INCOMPLETE",
+                            "metric": 0,
+                            "local_preference": 100,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "21:13:51",
+                            "flags": "valid, internal",
+                            "best_path": false,
+                            "communities": "10050:200 10222:10010 3223:0 1000:17055",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                },
+                "10.104.1.0/24": {
+                    "path_count": 1,
+                    "paths": {
+                        "1": {
+                            "as_path": "6333 623566 42669611124 {432556}",
+                            "next_hop": "10.10.11.2",
+                            "peer": "10.10.11.2",
+                            "router_id": "10.10.11.1",
+                            "origin": "IGP",
+                            "metric": 0,
+                            "local_preference": 200,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "19:13:51",
+                            "flags": "valid, internal, best",
+                            "best_path": true,
+                            "communities": "10050:300 10222:10010 3223:0 1000:17066",
+                            "extended_communities": "Route-Target-AS:1234:12",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                },
+                "10.105.1.0/24": {
+                    "path_count": 2,
+                    "paths": {
+                        "1": {
+                            "as_path": "6333 623566 42669611124 {432556}",
+                            "next_hop": "10.10.11.2",
+                            "peer": "10.10.11.2",
+                            "router_id": "10.10.11.1",
+                            "origin": "IGP",
+                            "metric": 0,
+                            "local_preference": 300,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "13:43:11",
+                            "flags": "valid, internal, best, atomic-aggregate",
+                            "best_path": true,
+                            "communities": "10050:300 10222:10010 3223:0 1000:17077",
+                            "rx_safi": "Unicast"
+                        },
+                        "2": {
+                            "as_path": "Local",
+                            "next_hop": "10.10.11.3",
+                            "peer": "10.10.11.3",
+                            "router_id": "10.10.11.1",
+                            "origin": "IGP",
+                            "metric": 0,
+                            "local_preference": 200,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "19:34:12",
+                            "flags": "valid, internal, atomic-aggregate",
+                            "best_path": false,
+                            "communities": "10050:300 10222:10010 3223:0 1000:17088",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                },
+                "10.105.100.0": {
+                    "path_count": 2,
+                    "paths": {
+                        "1": {
+                            "as_path": "6333 623566 42669611124 {432556}",
+                            "next_hop": "10.10.11.2",
+                            "peer": "10.10.11.2",
+                            "router_id": "10.10.11.1",
+                            "origin": "IGP",
+                            "metric": 0,
+                            "local_preference": 300,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "13:43:11",
+                            "flags": "valid, internal, best, atomic-aggregate",
+                            "best_path": true,
+                            "communities": "10050:300 10222:10010 3223:0 1000:17077",
+                            "rx_safi": "Unicast"
+                        },
+                        "2": {
+                            "as_path": "Local",
+                            "next_hop": "10.10.11.3",
+                            "peer": "10.10.11.3",
+                            "router_id": "10.10.11.1",
+                            "origin": "IGP",
+                            "metric": 0,
+                            "local_preference": 200,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "19:34:12",
+                            "flags": "valid, internal, atomic-aggregate",
+                            "best_path": false,
+                            "communities": "10050:300 10222:10010 3223:0 1000:17088",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                },
+                "10.106.1.0/24": {
+                    "path_count": 1,
+                    "paths": {
+                        "1": {
+                            "as_path": "Local",
+                            "next_hop": "10.10.12.2",
+                            "peer": "10.10.12.2",
+                            "router_id": "10.10.12.1",
+                            "origin": "INCOMPLETE",
+                            "metric": 0,
+                            "local_preference": 200,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "19:34:12",
+                            "flags": "valid, external, best",
+                            "best_path": true,
+                            "communities": "10050:300 10222:10010 3223:0 1000:17099",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                },
+                "10.107.1.0/24": {
+                    "path_count": 1,
+                    "paths": {
+                        "1": {
+                            "as_path": "Local",
+                            "next_hop": "10.10.13.2",
+                            "peer": "10.10.13.2",
+                            "router_id": "10.10.13.1",
+                            "origin": "IGP",
+                            "metric": 0,
+                            "local_preference": 250,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "19:34:12",
+                            "flags": "valid, internal, best",
+                            "best_path": true,
+                            "communities": "no-export",
+                            "rx_path_id": "0x1",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                }
+            }
+        },
+        "CLOUD": {
+            "router_id": "10.105.1.1",
+            "local_as": 105,
+            "prefixes": {
+                "10.105.1.0/24": {
+                    "path_count": 1,
+                    "paths": {
+                        "1": {
+                            "as_path": "6111 6211566 42669611124 4266644366 4266643244",
+                            "next_hop": "10.99.1.2",
+                            "peer": "10.105.6.2",
+                            "router_id": "10.15.1.1",
+                            "origin": "INCOMPLETE",
+                            "metric": 0,
+                            "local_preference": 200,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "13d11h",
+                            "flags": "valid, external, best",
+                            "best_path": true,
+                            "communities": "internet 10050:200 10222:10010 3223:0 1000:17044",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                },
+                "10.106.1.0/24": {
+                    "path_count": 1,
+                    "paths": {
+                        "1": {
+                            "as_path": "6111 6211566 42669611124 4266644366 4266643244",
+                            "next_hop": "10.99.1.3",
+                            "peer": "10.105.6.3",
+                            "router_id": "10.15.1.2",
+                            "origin": "INCOMPLETE",
+                            "metric": 0,
+                            "local_preference": 100,
+                            "igp_metric": 1,
+                            "weight": 0,
+                            "received": "13d11h",
+                            "flags": "valid, external, backup",
+                            "best_path": false,
+                            "communities": "internet 10050:200 10222:10010 3223:0 1000:17044",
+                            "rx_safi": "Unicast"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/expected.json
@@ -7,7 +7,7 @@
                 "10.103.1.0/24": {
                     "path_count": 2,
                     "paths": {
-                        "1": {
+                        "10.10.23.2": {
                             "as_path": "6333 623566 42669611124 4266644366 4266643244",
                             "next_hop": "10.10.23.2",
                             "peer": "10.10.23.2",
@@ -18,12 +18,16 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "19d16h",
-                            "flags": "valid, external, best",
+                            "flags": [
+                                "valid",
+                                "external",
+                                "best"
+                            ],
                             "best_path": true,
                             "communities": "internet 10050:200 10222:10010 3223:0 1000:17044",
                             "rx_safi": "Unicast"
                         },
-                        "2": {
+                        "10.10.25.2": {
                             "as_path": "6333 623566 42669.611124 4266644366 4266643244",
                             "next_hop": "10.10.25.2",
                             "peer": "10.10.25.2",
@@ -34,7 +38,10 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "21:13:51",
-                            "flags": "valid, internal",
+                            "flags": [
+                                "valid",
+                                "internal"
+                            ],
                             "best_path": false,
                             "communities": "10050:200 10222:10010 3223:0 1000:17055",
                             "rx_safi": "Unicast"
@@ -44,7 +51,7 @@
                 "10.104.1.0/24": {
                     "path_count": 1,
                     "paths": {
-                        "1": {
+                        "10.10.11.2": {
                             "as_path": "6333 623566 42669611124 {432556}",
                             "next_hop": "10.10.11.2",
                             "peer": "10.10.11.2",
@@ -55,7 +62,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "19:13:51",
-                            "flags": "valid, internal, best",
+                            "flags": [
+                                "valid",
+                                "internal",
+                                "best"
+                            ],
                             "best_path": true,
                             "communities": "10050:300 10222:10010 3223:0 1000:17066",
                             "extended_communities": "Route-Target-AS:1234:12",
@@ -66,7 +77,7 @@
                 "10.105.1.0/24": {
                     "path_count": 2,
                     "paths": {
-                        "1": {
+                        "10.10.11.2": {
                             "as_path": "6333 623566 42669611124 {432556}",
                             "next_hop": "10.10.11.2",
                             "peer": "10.10.11.2",
@@ -77,12 +88,41 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "13:43:11",
-                            "flags": "valid, internal, best, atomic-aggregate",
+                            "flags": [
+                                "valid",
+                                "internal",
+                                "best",
+                                "atomic-aggregate"
+                            ],
                             "best_path": true,
                             "communities": "10050:300 10222:10010 3223:0 1000:17077",
-                            "rx_safi": "Unicast"
+                            "rx_safi": "Unicast",
+                            "contributing_routes": {
+                                "10.105.1.59/32": {
+                                    "proto": "Connected",
+                                    "origin": "IGP",
+                                    "as_path": "Local"
+                                },
+                                "10.105.1.6/32": {
+                                    "proto": "Connected",
+                                    "origin": "IGP",
+                                    "as_path": "Local"
+                                },
+                                "10.105.1.29/32": {
+                                    "proto": "BGP",
+                                    "origin": "IGP",
+                                    "as_path": "3245.235",
+                                    "communities": "999:10 347:234 1240:155"
+                                },
+                                "10.105.1.28/32": {
+                                    "proto": "BGP",
+                                    "origin": "IGP",
+                                    "as_path": "3245.235",
+                                    "communities": "999:10 347:234 1240:155"
+                                }
+                            }
                         },
-                        "2": {
+                        "10.10.11.3": {
                             "as_path": "Local",
                             "next_hop": "10.10.11.3",
                             "peer": "10.10.11.3",
@@ -93,7 +133,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "19:34:12",
-                            "flags": "valid, internal, atomic-aggregate",
+                            "flags": [
+                                "valid",
+                                "internal",
+                                "atomic-aggregate"
+                            ],
                             "best_path": false,
                             "communities": "10050:300 10222:10010 3223:0 1000:17088",
                             "rx_safi": "Unicast"
@@ -103,7 +147,7 @@
                 "10.105.100.0": {
                     "path_count": 2,
                     "paths": {
-                        "1": {
+                        "10.10.11.2": {
                             "as_path": "6333 623566 42669611124 {432556}",
                             "next_hop": "10.10.11.2",
                             "peer": "10.10.11.2",
@@ -114,12 +158,41 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "13:43:11",
-                            "flags": "valid, internal, best, atomic-aggregate",
+                            "flags": [
+                                "valid",
+                                "internal",
+                                "best",
+                                "atomic-aggregate"
+                            ],
                             "best_path": true,
                             "communities": "10050:300 10222:10010 3223:0 1000:17077",
-                            "rx_safi": "Unicast"
+                            "rx_safi": "Unicast",
+                            "contributing_routes": {
+                                "10.105.1.59/32": {
+                                    "proto": "Connected",
+                                    "origin": "IGP",
+                                    "as_path": "Local"
+                                },
+                                "10.105.1.6/32": {
+                                    "proto": "Connected",
+                                    "origin": "IGP",
+                                    "as_path": "Local"
+                                },
+                                "10.105.1.29/32": {
+                                    "proto": "BGP",
+                                    "origin": "IGP",
+                                    "as_path": "3245.235",
+                                    "communities": "999:10 347:234 1240:155"
+                                },
+                                "10.105.1.28/32": {
+                                    "proto": "BGP",
+                                    "origin": "IGP",
+                                    "as_path": "3245.235",
+                                    "communities": "999:10 347:234 1240:155"
+                                }
+                            }
                         },
-                        "2": {
+                        "10.10.11.3": {
                             "as_path": "Local",
                             "next_hop": "10.10.11.3",
                             "peer": "10.10.11.3",
@@ -130,7 +203,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "19:34:12",
-                            "flags": "valid, internal, atomic-aggregate",
+                            "flags": [
+                                "valid",
+                                "internal",
+                                "atomic-aggregate"
+                            ],
                             "best_path": false,
                             "communities": "10050:300 10222:10010 3223:0 1000:17088",
                             "rx_safi": "Unicast"
@@ -140,7 +217,7 @@
                 "10.106.1.0/24": {
                     "path_count": 1,
                     "paths": {
-                        "1": {
+                        "10.10.12.2": {
                             "as_path": "Local",
                             "next_hop": "10.10.12.2",
                             "peer": "10.10.12.2",
@@ -151,7 +228,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "19:34:12",
-                            "flags": "valid, external, best",
+                            "flags": [
+                                "valid",
+                                "external",
+                                "best"
+                            ],
                             "best_path": true,
                             "communities": "10050:300 10222:10010 3223:0 1000:17099",
                             "rx_safi": "Unicast"
@@ -161,7 +242,7 @@
                 "10.107.1.0/24": {
                     "path_count": 1,
                     "paths": {
-                        "1": {
+                        "10.10.13.2#0x1": {
                             "as_path": "Local",
                             "next_hop": "10.10.13.2",
                             "peer": "10.10.13.2",
@@ -172,7 +253,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "19:34:12",
-                            "flags": "valid, internal, best",
+                            "flags": [
+                                "valid",
+                                "internal",
+                                "best"
+                            ],
                             "best_path": true,
                             "communities": "no-export",
                             "rx_path_id": "0x1",
@@ -189,7 +274,7 @@
                 "10.105.1.0/24": {
                     "path_count": 1,
                     "paths": {
-                        "1": {
+                        "10.99.1.2": {
                             "as_path": "6111 6211566 42669611124 4266644366 4266643244",
                             "next_hop": "10.99.1.2",
                             "peer": "10.105.6.2",
@@ -200,7 +285,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "13d11h",
-                            "flags": "valid, external, best",
+                            "flags": [
+                                "valid",
+                                "external",
+                                "best"
+                            ],
                             "best_path": true,
                             "communities": "internet 10050:200 10222:10010 3223:0 1000:17044",
                             "rx_safi": "Unicast"
@@ -210,7 +299,7 @@
                 "10.106.1.0/24": {
                     "path_count": 1,
                     "paths": {
-                        "1": {
+                        "10.99.1.3": {
                             "as_path": "6111 6211566 42669611124 4266644366 4266643244",
                             "next_hop": "10.99.1.3",
                             "peer": "10.105.6.3",
@@ -221,7 +310,11 @@
                             "igp_metric": 1,
                             "weight": 0,
                             "received": "13d11h",
-                            "flags": "valid, external, backup",
+                            "flags": [
+                                "valid",
+                                "external",
+                                "backup"
+                            ],
                             "best_path": false,
                             "communities": "internet 10050:200 10222:10010 3223:0 1000:17044",
                             "rx_safi": "Unicast"

--- a/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/input.txt
@@ -1,0 +1,91 @@
+BGP routing table information for VRF default
+Router identifier 10.103.1.1, local AS number 103
+BGP routing table entry for 10.103.1.0/24
+ Paths: 2 available
+  6333 623566 42669611124 4266644366 4266643244
+    10.10.23.2 from 10.10.23.2 (10.10.1.1)
+      Origin INCOMPLETE, metric 0, localpref 100, IGP metric 1, weight 0, received 19d16h ago, valid, external, best
+      Community: internet 10050:200 10222:10010 3223:0 1000:17044
+      Rx SAFI: Unicast
+  6333 623566 42669.611124 4266644366 4266643244
+    10.10.25.2 from 10.10.25.2 (10.10.1.1)
+      Origin INCOMPLETE, metric 0, localpref 100, IGP metric 1, weight 0, received 21:13:51 ago, valid, internal
+      Community: 10050:200 10222:10010 3223:0 1000:17055
+      Rx SAFI: Unicast
+BGP routing table entry for 10.104.1.0/24
+ Paths: 1 available
+  6333 623566 42669611124 {432556}
+    10.10.11.2 from 10.10.11.2 (10.10.11.1)
+      Origin IGP, metric 0, localpref 200, IGP metric 1, weight 0, received 19:13:51 ago, valid, internal, best
+      Community: 10050:300 10222:10010 3223:0 1000:17066
+      Extended Community: Route-Target-AS:1234:12
+      Rx SAFI: Unicast
+BGP routing table entry for 10.105.1.0/24
+ Paths: 2 available
+  6333 623566 42669611124 {432556}
+    10.10.11.2 from 10.10.11.2 (10.10.11.1)
+      Origin IGP, metric 0, localpref 300, IGP metric 1, weight 0, received 13:43:11 ago, valid, internal, best, atomic-aggregate
+      Community: 10050:300 10222:10010 3223:0 1000:17077
+      Rx SAFI: Unicast
+      4 Contributing routes:
+        10.105.1.59/32     Proto: Connected     Origin: IGP          AS Path: Local
+        10.105.1.6/32      Proto: Connected     Origin: IGP          AS Path: Local
+        10.105.1.29/32     Proto: BGP           Origin: IGP          AS Path: 3245.235
+          Community: 999:10 347:234 1240:155
+        10.105.1.28/32     Proto: BGP           Origin: IGP          AS Path: 3245.235
+          Community: 999:10 347:234 1240:155
+  Local (aggregated by 2345223 10.10.11.3)
+    10.10.11.3 from 10.10.11.3 (10.10.11.1)
+      Origin IGP, metric 0, localpref 200, IGP metric 1, weight 0, received 19:34:12 ago, valid, internal, atomic-aggregate
+      Community: 10050:300 10222:10010 3223:0 1000:17088
+      Rx SAFI: Unicast
+BGP routing table entry for 10.105.100.0
+ Paths: 2 available
+  6333 623566 42669611124 {432556}
+    10.10.11.2 from 10.10.11.2 (10.10.11.1)
+      Origin IGP, metric 0, localpref 300, IGP metric 1, weight 0, received 13:43:11 ago, valid, internal, best, atomic-aggregate
+      Community: 10050:300 10222:10010 3223:0 1000:17077
+      Rx SAFI: Unicast
+      4 Contributing routes:
+        10.105.1.59/32     Proto: Connected     Origin: IGP          AS Path: Local
+        10.105.1.6/32      Proto: Connected     Origin: IGP          AS Path: Local
+        10.105.1.29/32     Proto: BGP           Origin: IGP          AS Path: 3245.235
+          Community: 999:10 347:234 1240:155
+        10.105.1.28/32     Proto: BGP           Origin: IGP          AS Path: 3245.235
+          Community: 999:10 347:234 1240:155
+  Local (aggregated by 2345223 10.10.11.3)
+    10.10.11.3 from 10.10.11.3 (10.10.11.1)
+      Origin IGP, metric 0, localpref 200, IGP metric 1, weight 0, received 19:34:12 ago, valid, internal, atomic-aggregate
+      Community: 10050:300 10222:10010 3223:0 1000:17088
+      Rx SAFI: Unicast
+BGP routing table entry for 10.106.1.0/24
+ Paths: 1 available
+  Local
+    10.10.12.2 from 10.10.12.2 (10.10.12.1)
+      Origin INCOMPLETE, metric 0, localpref 200, IGP metric 1, weight 0, received 19:34:12 ago, valid, external, best
+      Community: 10050:300 10222:10010 3223:0 1000:17099
+      Rx SAFI: Unicast
+BGP routing table entry for 10.107.1.0/24
+ Paths: 1 available
+  Local (Received from a RR-client)
+    10.10.13.2 from 10.10.13.2 (10.10.13.1)
+      Origin IGP, metric 0, localpref 250, IGP metric 1, weight 0, received 19:34:12 ago, valid, internal, best
+      Community: no-export
+      Rx path id: 0x1
+      Rx SAFI: Unicast
+BGP routing table information for VRF CLOUD
+Router identifier 10.105.1.1, local AS number 105
+BGP routing table entry for 10.105.1.0/24
+ Paths: 1 available
+  6111 6211566 42669611124 4266644366 4266643244
+    10.99.1.2 from 10.105.6.2 (10.15.1.1)
+      Origin INCOMPLETE, metric 0, localpref 200, IGP metric 1, weight 0, received 13d11h ago, valid, external, best
+      Community: internet 10050:200 10222:10010 3223:0 1000:17044
+      Rx SAFI: Unicast
+BGP routing table entry for 10.106.1.0/24
+ Paths: 1 available
+  6111 6211566 42669611124 4266644366 4266643244
+    10.99.1.3 from 10.105.6.3 (10.15.1.2)
+      Origin INCOMPLETE, metric 0, localpref 100, IGP metric 1, weight 0, received 13d11h ago, valid, external, backup
+      Community: internet 10050:200 10222:10010 3223:0 1000:17044
+      Rx SAFI: Unicast

--- a/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_bgp_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multi-VRF BGP detail with multiple paths, communities, and aggregated routes
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ip bgp detail` on Arista EOS
- Parses multi-VRF BGP routing table detail output into structured dict-of-dicts keyed by VRF and prefix
- Extracts per-path attributes: AS path, next hop, peer, origin, metric, local preference, IGP metric, weight, received time, flags, communities, extended communities, Rx path ID, and Rx SAFI
- Handles edge cases: AS path sets (`{...}`), dotted AS notation, `Local` AS paths, aggregation annotations, contributing routes sections, and RR-client paths

## Test plan
- [x] Parser test fixture with real device output covering multiple VRFs, multiple paths per prefix, extended communities, Rx path ID, aggregated routes with contributing routes, and Local AS paths
- [x] All fixture convention tests pass (no placeholder sentinels, no list-of-dicts, no pipe-in-keys)
- [x] ruff lint and format checks pass
- [x] xenon complexity check passes (max-absolute B)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)