### PR TITLE
feat(cisco_iosxr): add parser for `show rsvp neighbors`

### DIFF
--- a/changes/+cisco-iosxr-show-rsvp-neighbors.parser_added
+++ b/changes/+cisco-iosxr-show-rsvp-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show rsvp neighbors` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_rsvp_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_rsvp_neighbors.py
@@ -1,0 +1,90 @@
+"""Parser for 'show rsvp neighbors' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class RsvpInterfaceNeighborEntry(TypedDict):
+    """Schema for a single RSVP interface neighbor within a global neighbor."""
+
+    interface_neighbor: str
+
+
+class RsvpGlobalNeighborEntry(TypedDict):
+    """Schema for a single RSVP global neighbor."""
+
+    interfaces: dict[str, RsvpInterfaceNeighborEntry]
+
+
+# Top-level result keyed by global neighbor address.
+ShowRsvpNeighborsResult = dict[str, RsvpGlobalNeighborEntry]
+
+# "Global Neighbor: 10.100.100.120"
+_GLOBAL_NEIGHBOR_PATTERN = re.compile(
+    rf"^Global\s+Neighbor:\s+(?P<global_neighbor>{IPV4_ADDRESS})\s*$"
+)
+
+# "10.100.100.141       FortyGigE0/0/1/0"
+_INTERFACE_NEIGHBOR_PATTERN = re.compile(
+    rf"^\s+(?P<intf_neighbor>{IPV4_ADDRESS})\s+(?P<interface>\S+(?:\s+\d\S*)?)\s*$"
+)
+
+
+@register(OS.CISCO_IOSXR, "show rsvp neighbors")
+class ShowRsvpNeighborsParser(BaseParser["ShowRsvpNeighborsResult"]):
+    """Parser for 'show rsvp neighbors' command on IOS-XR.
+
+    Parses RSVP neighbor information, grouping interface neighbors
+    under their global neighbor address. Output is keyed by global
+    neighbor address, with interfaces keyed by canonical interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MPLS})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowRsvpNeighborsResult":
+        """Parse 'show rsvp neighbors' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed neighbor data keyed by global neighbor address.
+
+        Raises:
+            ValueError: If no RSVP neighbors found in output.
+        """
+        result: ShowRsvpNeighborsResult = {}
+        current_global: str | None = None
+
+        for line in output.splitlines():
+            global_match = _GLOBAL_NEIGHBOR_PATTERN.match(line.strip())
+            if global_match:
+                current_global = global_match.group("global_neighbor")
+                result[current_global] = {"interfaces": {}}
+                continue
+
+            if current_global is None:
+                continue
+
+            intf_match = _INTERFACE_NEIGHBOR_PATTERN.match(line)
+            if intf_match:
+                interface_raw = intf_match.group("interface").strip()
+                interface = canonical_interface_name(interface_raw, os=OS.CISCO_IOSXR)
+                intf_neighbor = intf_match.group("intf_neighbor")
+                result[current_global]["interfaces"][interface] = {
+                    "interface_neighbor": intf_neighbor,
+                }
+
+        if not result:
+            msg = "No RSVP neighbors found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_rsvp_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_rsvp_neighbors/001_basic/expected.json
@@ -1,0 +1,12 @@
+{
+    "10.100.100.120": {
+        "interfaces": {
+            "FortyGigabitEthernet0/0/1/0": {
+                "interface_neighbor": "10.100.100.141"
+            },
+            "FortyGigabitEthernet0/1/1/0": {
+                "interface_neighbor": "10.100.100.145"
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_rsvp_neighbors/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_rsvp_neighbors/001_basic/input.txt
@@ -1,0 +1,5 @@
+Global Neighbor: 10.100.100.120
+  Interface Neighbor   Interface
+  -------------------- ------------
+  10.100.100.141       FortyGigE0/0/1/0
+  10.100.100.145       FortyGigE0/1/1/0

--- a/tests/parsers/cisco_iosxr/show_rsvp_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_rsvp_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single global neighbor with two interface neighbors
+platform: Unknown
+software_version: IOS-XR Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show rsvp neighbors` on Cisco IOS-XR
- Output is dict-of-dicts keyed by global neighbor address, with interface neighbors keyed by canonical interface name
- Tagged with `ParserTag.MPLS`

## Test plan
- [x] Parser test fixture `001_basic` passes with real device output from ntc-templates
- [x] All fixture sentinel checks pass (no placeholder values)
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)