### PR TITLE
feat(arista_eos): add parser for show ipv6 bgp summary

### DIFF
--- a/changes/+arista-eos-show-ipv6-bgp-summary.parser_added
+++ b/changes/+arista-eos-show-ipv6-bgp-summary.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ipv6 bgp summary` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ipv6_bgp_summary.py
+++ b/src/muninn/parsers/arista_eos/show_ipv6_bgp_summary.py
@@ -1,12 +1,22 @@
 """Parser for 'show ipv6 bgp summary' command on Arista EOS.
 
 Arista EOS ``show ipv6 bgp summary`` displays the BGP router identifier,
-local AS number, VRF name, and a neighbor table with per-peer statistics
-including AS number, message counters, uptime, and state or prefix count.
+local AS number, and a neighbor table with per-peer statistics including
+remote AS, message counters, uptime, and either a prefix count (when the
+peer is Established) or a session state string.
+
+The output appears in three observed forms:
+
+* a flat form with no VRF banner and a combined ``State/PfxRcd`` column;
+* a single-VRF form with a ``BGP summary information for VRF <name>``
+  banner and split ``State`` / ``PfxRcd`` / ``PfxAcc`` columns;
+* a multi-VRF form repeating the VRF banner and table per VRF.
+
+The parsed result is keyed by VRF name so the schema covers all forms.
 """
 
 import re
-from typing import ClassVar, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -17,80 +27,188 @@ from muninn.tags import ParserTag
 class NeighborEntry(TypedDict):
     """Schema for a single BGP neighbor in the summary table."""
 
-    address_family_version: int
-    remote_as: int
+    version: int
+    remote_as: str
     msg_rcvd: int
     msg_sent: int
     in_queue: int
     out_queue: int
     up_down: str
-    state_pfxrcd: str
+    state: NotRequired[str]
+    prefix_received: NotRequired[int]
+    prefix_accepted: NotRequired[int]
+
+
+class VrfEntry(TypedDict):
+    """Schema for a single VRF section in the BGP summary."""
+
+    router_id: str
+    local_as: str
+    neighbors: dict[str, NeighborEntry]
 
 
 class ShowIpv6BgpSummaryResult(TypedDict):
     """Schema for 'show ipv6 bgp summary' parsed output on Arista EOS."""
 
-    router_id: str
-    local_as: int
-    vrf: str
-    neighbors: dict[str, NeighborEntry]
+    vrfs: dict[str, VrfEntry]
 
 
+_VRF_BANNER_RE = re.compile(r"^BGP summary information for VRF\s+(?P<vrf>\S+)")
+
+# Matches both "BGP router identifier ..." and "Router identifier ..." forms.
 _ROUTER_ID_RE = re.compile(
-    r"^BGP router identifier\s+(?P<router_id>\S+),\s*"
-    r"local AS number\s+(?P<local_as>\d+)"
+    r"^(?:BGP\s+)?Router identifier\s+(?P<router_id>\S+),\s*"
+    r"local AS number\s+(?P<local_as>\S+)",
+    re.IGNORECASE,
 )
 
-_VRF_RE = re.compile(r"^VRF name:\s*(?P<vrf>\S+)")
-
-_NEIGHBOR_HEADER_RE = re.compile(r"^Neighbor\s+V\s+AS\s+MsgRcvd")
-
-# Neighbor data line: IPv6 address followed by numeric fields and state.
-_NEIGHBOR_RE = re.compile(
-    r"^(?P<neighbor>\S+)\s+"
-    r"(?P<version>\d+)\s+"
-    r"(?P<remote_as>\d+)\s+"
-    r"(?P<msg_rcvd>\d+)\s+"
-    r"(?P<msg_sent>\d+)\s+"
-    r"(?P<in_queue>\d+)\s+"
-    r"(?P<out_queue>\d+)\s+"
-    r"(?P<up_down>\S+)\s+"
-    r"(?P<state_pfxrcd>\S+.*?)\s*$"
+# Combined-trailing-column header: "... Up/Down State/PfxRcd"
+_NEIGHBOR_HEADER_COMBINED_RE = re.compile(
+    r"^Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd\s*$"
 )
 
+# Split-trailing-column header: "... Up/Down State  PfxRcd  PfxAcc"
+_NEIGHBOR_HEADER_SPLIT_RE = re.compile(
+    r"^Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+InQ\s+OutQ\s+Up/Down"
+    r"\s+State\s+PfxRcd\s+PfxAcc\s*$"
+)
 
-def _build_neighbor_entry(match: re.Match[str]) -> NeighborEntry:
-    """Build a NeighborEntry from a regex match on a neighbor line."""
-    return NeighborEntry(
-        address_family_version=int(match.group("version")),
-        remote_as=int(match.group("remote_as")),
-        msg_rcvd=int(match.group("msg_rcvd")),
-        msg_sent=int(match.group("msg_sent")),
-        in_queue=int(match.group("in_queue")),
-        out_queue=int(match.group("out_queue")),
-        up_down=match.group("up_down"),
-        state_pfxrcd=match.group("state_pfxrcd").strip(),
-    )
+_NEIGHBOR_STATUS_CODES_RE = re.compile(r"^Neighbor Status Codes:")
+
+# Number of leading neighbor-row tokens shared by both header variants:
+# address, V, AS, MsgRcvd, MsgSent, InQ, OutQ, Up/Down.
+_NEIGHBOR_LEADING_TOKENS = 8
 
 
-def _parse_neighbors(lines: list[str]) -> dict[str, NeighborEntry]:
-    """Parse neighbor entries from lines following the neighbor header."""
+def _populate_combined_trailing(entry: NeighborEntry, trailing: list[str]) -> None:
+    """Populate state/prefix fields when the table uses State/PfxRcd."""
+    last = " ".join(trailing)
+    if last.isdigit():
+        entry["prefix_received"] = int(last)
+    else:
+        entry["state"] = last
+
+
+def _populate_split_trailing(entry: NeighborEntry, trailing: list[str]) -> None:
+    """Populate state/prefix fields when the table uses State PfxRcd PfxAcc."""
+    entry["state"] = trailing[0]
+    pfxrcd_index = 1
+    pfxacc_index = 2
+    if len(trailing) > pfxrcd_index and trailing[pfxrcd_index].isdigit():
+        entry["prefix_received"] = int(trailing[pfxrcd_index])
+    if len(trailing) > pfxacc_index and trailing[pfxacc_index].isdigit():
+        entry["prefix_accepted"] = int(trailing[pfxacc_index])
+
+
+def _parse_neighbor_row(
+    line: str, *, split_columns: bool
+) -> tuple[str, NeighborEntry] | None:
+    """Parse a single neighbor data line into (address, entry) or None."""
+    tokens = line.split()
+    if len(tokens) <= _NEIGHBOR_LEADING_TOKENS:
+        return None
+    if not tokens[1].isdigit() or not tokens[3].isdigit():
+        return None
+    entry: NeighborEntry = {
+        "version": int(tokens[1]),
+        "remote_as": tokens[2],
+        "msg_rcvd": int(tokens[3]),
+        "msg_sent": int(tokens[4]),
+        "in_queue": int(tokens[5]),
+        "out_queue": int(tokens[6]),
+        "up_down": tokens[7],
+    }
+    trailing = tokens[_NEIGHBOR_LEADING_TOKENS:]
+    if split_columns:
+        _populate_split_trailing(entry, trailing)
+    else:
+        _populate_combined_trailing(entry, trailing)
+    return tokens[0], entry
+
+
+def _detect_header_form(stripped: str) -> bool | None:
+    """Return True for split-column header, False for combined, None otherwise."""
+    if _NEIGHBOR_HEADER_SPLIT_RE.match(stripped):
+        return True
+    if _NEIGHBOR_HEADER_COMBINED_RE.match(stripped):
+        return False
+    return None
+
+
+def _parse_vrf_section(lines: list[str]) -> VrfEntry:
+    """Parse the lines belonging to a single VRF section."""
+    router_id: str | None = None
+    local_as: str | None = None
     neighbors: dict[str, NeighborEntry] = {}
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
+    split_columns: bool | None = None
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or _NEIGHBOR_STATUS_CODES_RE.match(stripped):
             continue
-        if match := _NEIGHBOR_RE.match(stripped):
-            neighbors[match.group("neighbor")] = _build_neighbor_entry(match)
-    return neighbors
+
+        if split_columns is not None:
+            parsed = _parse_neighbor_row(stripped, split_columns=split_columns)
+            if parsed is not None:
+                neighbors[parsed[0]] = parsed[1]
+            continue
+
+        if match := _ROUTER_ID_RE.match(stripped):
+            router_id = match.group("router_id")
+            local_as = match.group("local_as")
+            continue
+
+        header_form = _detect_header_form(stripped)
+        if header_form is not None:
+            split_columns = header_form
+
+    if router_id is None or local_as is None:
+        msg = "Missing BGP router identifier or local AS number"
+        raise ValueError(msg)
+
+    return {
+        "router_id": router_id,
+        "local_as": local_as,
+        "neighbors": neighbors,
+    }
+
+
+def _split_vrf_sections(output: str) -> dict[str, list[str]]:
+    """Split the raw output into a mapping of VRF name to lines.
+
+    If no ``BGP summary information for VRF`` banner is present, the whole
+    output is treated as a single ``default`` VRF section.
+    """
+    sections: dict[str, list[str]] = {}
+    current_vrf: str | None = None
+    current_lines: list[str] = []
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if match := _VRF_BANNER_RE.match(stripped):
+            if current_vrf is not None:
+                sections[current_vrf] = current_lines
+            current_vrf = match.group("vrf")
+            current_lines = []
+            continue
+        current_lines.append(line)
+
+    if current_vrf is not None:
+        sections[current_vrf] = current_lines
+    else:
+        sections["default"] = current_lines
+
+    return sections
 
 
 @register(OS.ARISTA_EOS, "show ipv6 bgp summary")
 class ShowIpv6BgpSummaryParser(BaseParser[ShowIpv6BgpSummaryResult]):
     """Parser for 'show ipv6 bgp summary' command on Arista EOS.
 
-    Parses the BGP router identifier, local AS, VRF, and neighbor table
-    from the command output.
+    Parses the per-VRF BGP router identifier, local AS, and IPv6 neighbor
+    table.  Supports the bannerless form, the single-VRF banner form, and
+    multi-VRF output, as well as both combined ``State/PfxRcd`` and split
+    ``State PfxRcd PfxAcc`` table column variants.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
@@ -103,44 +221,11 @@ class ShowIpv6BgpSummaryParser(BaseParser[ShowIpv6BgpSummaryResult]):
             output: Raw CLI output from the command.
 
         Returns:
-            Parsed BGP IPv6 summary information.
+            Parsed BGP IPv6 summary information keyed by VRF name.
 
         Raises:
             ValueError: If required fields cannot be parsed from the output.
         """
-        router_id: str | None = None
-        local_as: int | None = None
-        vrf = "default"
-        neighbor_lines: list[str] = []
-        in_neighbor_table = False
-
-        for line in output.splitlines():
-            stripped = line.strip()
-            if not stripped:
-                continue
-
-            if in_neighbor_table:
-                neighbor_lines.append(stripped)
-                continue
-
-            if match := _ROUTER_ID_RE.match(stripped):
-                router_id = match.group("router_id")
-                local_as = int(match.group("local_as"))
-            elif match := _VRF_RE.match(stripped):
-                vrf = match.group("vrf")
-            elif _NEIGHBOR_HEADER_RE.match(stripped):
-                in_neighbor_table = True
-
-        if router_id is None or local_as is None:
-            msg = "Missing BGP router identifier or local AS number"
-            raise ValueError(msg)
-
-        return cast(
-            ShowIpv6BgpSummaryResult,
-            {
-                "router_id": router_id,
-                "local_as": local_as,
-                "vrf": vrf,
-                "neighbors": _parse_neighbors(neighbor_lines),
-            },
-        )
+        vrf_sections = _split_vrf_sections(output)
+        vrfs = {name: _parse_vrf_section(lines) for name, lines in vrf_sections.items()}
+        return cast(ShowIpv6BgpSummaryResult, {"vrfs": vrfs})

--- a/src/muninn/parsers/arista_eos/show_ipv6_bgp_summary.py
+++ b/src/muninn/parsers/arista_eos/show_ipv6_bgp_summary.py
@@ -1,0 +1,146 @@
+"""Parser for 'show ipv6 bgp summary' command on Arista EOS.
+
+Arista EOS ``show ipv6 bgp summary`` displays the BGP router identifier,
+local AS number, VRF name, and a neighbor table with per-peer statistics
+including AS number, message counters, uptime, and state or prefix count.
+"""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NeighborEntry(TypedDict):
+    """Schema for a single BGP neighbor in the summary table."""
+
+    address_family_version: int
+    remote_as: int
+    msg_rcvd: int
+    msg_sent: int
+    in_queue: int
+    out_queue: int
+    up_down: str
+    state_pfxrcd: str
+
+
+class ShowIpv6BgpSummaryResult(TypedDict):
+    """Schema for 'show ipv6 bgp summary' parsed output on Arista EOS."""
+
+    router_id: str
+    local_as: int
+    vrf: str
+    neighbors: dict[str, NeighborEntry]
+
+
+_ROUTER_ID_RE = re.compile(
+    r"^BGP router identifier\s+(?P<router_id>\S+),\s*"
+    r"local AS number\s+(?P<local_as>\d+)"
+)
+
+_VRF_RE = re.compile(r"^VRF name:\s*(?P<vrf>\S+)")
+
+_NEIGHBOR_HEADER_RE = re.compile(r"^Neighbor\s+V\s+AS\s+MsgRcvd")
+
+# Neighbor data line: IPv6 address followed by numeric fields and state.
+_NEIGHBOR_RE = re.compile(
+    r"^(?P<neighbor>\S+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<remote_as>\d+)\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<in_queue>\d+)\s+"
+    r"(?P<out_queue>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfxrcd>\S+.*?)\s*$"
+)
+
+
+def _build_neighbor_entry(match: re.Match[str]) -> NeighborEntry:
+    """Build a NeighborEntry from a regex match on a neighbor line."""
+    return NeighborEntry(
+        address_family_version=int(match.group("version")),
+        remote_as=int(match.group("remote_as")),
+        msg_rcvd=int(match.group("msg_rcvd")),
+        msg_sent=int(match.group("msg_sent")),
+        in_queue=int(match.group("in_queue")),
+        out_queue=int(match.group("out_queue")),
+        up_down=match.group("up_down"),
+        state_pfxrcd=match.group("state_pfxrcd").strip(),
+    )
+
+
+def _parse_neighbors(lines: list[str]) -> dict[str, NeighborEntry]:
+    """Parse neighbor entries from lines following the neighbor header."""
+    neighbors: dict[str, NeighborEntry] = {}
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if match := _NEIGHBOR_RE.match(stripped):
+            neighbors[match.group("neighbor")] = _build_neighbor_entry(match)
+    return neighbors
+
+
+@register(OS.ARISTA_EOS, "show ipv6 bgp summary")
+class ShowIpv6BgpSummaryParser(BaseParser[ShowIpv6BgpSummaryResult]):
+    """Parser for 'show ipv6 bgp summary' command on Arista EOS.
+
+    Parses the BGP router identifier, local AS, VRF, and neighbor table
+    from the command output.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpv6BgpSummaryResult:
+        """Parse 'show ipv6 bgp summary' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed BGP IPv6 summary information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed from the output.
+        """
+        router_id: str | None = None
+        local_as: int | None = None
+        vrf = "default"
+        neighbor_lines: list[str] = []
+        in_neighbor_table = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if in_neighbor_table:
+                neighbor_lines.append(stripped)
+                continue
+
+            if match := _ROUTER_ID_RE.match(stripped):
+                router_id = match.group("router_id")
+                local_as = int(match.group("local_as"))
+            elif match := _VRF_RE.match(stripped):
+                vrf = match.group("vrf")
+            elif _NEIGHBOR_HEADER_RE.match(stripped):
+                in_neighbor_table = True
+
+        if router_id is None or local_as is None:
+            msg = "Missing BGP router identifier or local AS number"
+            raise ValueError(msg)
+
+        return cast(
+            ShowIpv6BgpSummaryResult,
+            {
+                "router_id": router_id,
+                "local_as": local_as,
+                "vrf": vrf,
+                "neighbors": _parse_neighbors(neighbor_lines),
+            },
+        )

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/expected.json
@@ -1,27 +1,30 @@
 {
-    "router_id": "10.26.0.22",
-    "local_as": 65533,
-    "vrf": "default",
-    "neighbors": {
-        "2001:DB8:ff11::1": {
-            "address_family_version": 4,
-            "remote_as": 65534,
-            "msg_rcvd": 187,
-            "msg_sent": 191,
-            "in_queue": 0,
-            "out_queue": 0,
-            "up_down": "02:49:40",
-            "state_pfxrcd": "7"
-        },
-        "2001:DB8:ff12::2": {
-            "address_family_version": 4,
-            "remote_as": 65533,
-            "msg_rcvd": 184,
-            "msg_sent": 191,
-            "in_queue": 0,
-            "out_queue": 0,
-            "up_down": "02:59:41",
-            "state_pfxrcd": "7"
+    "vrfs": {
+        "default": {
+            "router_id": "10.26.0.22",
+            "local_as": "65533",
+            "neighbors": {
+                "2001:DB8:ff11::1": {
+                    "version": 4,
+                    "remote_as": "65534",
+                    "msg_rcvd": 187,
+                    "msg_sent": 191,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "02:49:40",
+                    "prefix_received": 7
+                },
+                "2001:DB8:ff12::2": {
+                    "version": 4,
+                    "remote_as": "65533",
+                    "msg_rcvd": 184,
+                    "msg_sent": 191,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "02:59:41",
+                    "prefix_received": 7
+                }
+            }
         }
     }
 }

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/expected.json
@@ -1,0 +1,27 @@
+{
+    "router_id": "10.26.0.22",
+    "local_as": 65533,
+    "vrf": "default",
+    "neighbors": {
+        "2001:DB8:ff11::1": {
+            "address_family_version": 4,
+            "remote_as": 65534,
+            "msg_rcvd": 187,
+            "msg_sent": 191,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "02:49:40",
+            "state_pfxrcd": "7"
+        },
+        "2001:DB8:ff12::2": {
+            "address_family_version": 4,
+            "remote_as": 65533,
+            "msg_rcvd": 184,
+            "msg_sent": 191,
+            "in_queue": 0,
+            "out_queue": 0,
+            "up_down": "02:59:41",
+            "state_pfxrcd": "7"
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/input.txt
@@ -1,0 +1,4 @@
+BGP router identifier 10.26.0.22, local AS number 65533
+Neighbor         V  AS      MsgRcvd   MsgSent  InQ OutQ  Up/Down State/PfxRcd
+2001:DB8:ff11::1    4  65534       187       191    0    0 02:49:40 7
+2001:DB8:ff12::2     4  65533       184       191    0    0 02:59:41 7

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic IPv6 BGP summary with two eBGP/iBGP neighbors
+platform: vEOS
+software_version: EOS

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/002_vrf_banner_split_columns/expected.json
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/002_vrf_banner_split_columns/expected.json
@@ -1,0 +1,42 @@
+{
+    "vrfs": {
+        "default": {
+            "router_id": "10.0.65.72",
+            "local_as": "64911",
+            "neighbors": {
+                "2001:DB8:ffff::1": {
+                    "version": 4,
+                    "remote_as": "65292",
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "79d05h",
+                    "state": "Active"
+                },
+                "2001:DB8:fff1::1": {
+                    "version": 4,
+                    "remote_as": "64832",
+                    "msg_rcvd": 0,
+                    "msg_sent": 0,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "79d05h",
+                    "state": "Idle(NoIf)"
+                },
+                "2001:DB8:fff2::1": {
+                    "version": 4,
+                    "remote_as": "64833",
+                    "msg_rcvd": 114056,
+                    "msg_sent": 118481,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "79d05h",
+                    "state": "Estab",
+                    "prefix_received": 1,
+                    "prefix_accepted": 1
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/002_vrf_banner_split_columns/input.txt
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/002_vrf_banner_split_columns/input.txt
@@ -1,0 +1,7 @@
+BGP summary information for VRF default
+Router identifier 10.0.65.72, local AS number 64911
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  2001:DB8:ffff::1      4  65292              0         0    0    0   79d05h Active
+  2001:DB8:fff1::1     4  64832              0         0    0    0   79d05h Idle(NoIf)
+  2001:DB8:fff2::1     4  64833         114056    118481    0    0   79d05h Estab  1      1

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/002_vrf_banner_split_columns/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/002_vrf_banner_split_columns/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single-VRF banner form with split State PfxRcd PfxAcc columns and non-Established states
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/003_multi_vrf/expected.json
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/003_multi_vrf/expected.json
@@ -1,0 +1,70 @@
+{
+    "vrfs": {
+        "RED": {
+            "router_id": "192.168.1.1",
+            "local_as": "645001",
+            "neighbors": {
+                "2001:DB8:c0de:ff::1": {
+                    "version": 4,
+                    "remote_as": "65002",
+                    "msg_rcvd": 1753556,
+                    "msg_sent": 1761743,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "40d23h",
+                    "state": "Estab",
+                    "prefix_received": 7,
+                    "prefix_accepted": 4
+                }
+            }
+        },
+        "WHITE": {
+            "router_id": "192.168.2.1",
+            "local_as": "65011",
+            "neighbors": {
+                "2001:DB8:c0de:ff1::1": {
+                    "version": 4,
+                    "remote_as": "65012",
+                    "msg_rcvd": 7405942,
+                    "msg_sent": 7406081,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "270d13h",
+                    "state": "Estab",
+                    "prefix_received": 7,
+                    "prefix_accepted": 5
+                }
+            }
+        },
+        "BLUE": {
+            "router_id": "192.168.3.1",
+            "local_as": "65021",
+            "neighbors": {
+                "2001:DB8:c0de:ff2::1": {
+                    "version": 4,
+                    "remote_as": "65022",
+                    "msg_rcvd": 1171721,
+                    "msg_sent": 1171752,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "67d19h",
+                    "state": "Estab",
+                    "prefix_received": 25,
+                    "prefix_accepted": 25
+                },
+                "2001:DB8:c0de:ff3::1": {
+                    "version": 4,
+                    "remote_as": "65023",
+                    "msg_rcvd": 97651,
+                    "msg_sent": 97643,
+                    "in_queue": 0,
+                    "out_queue": 0,
+                    "up_down": "40d23h",
+                    "state": "Estab",
+                    "prefix_received": 18,
+                    "prefix_accepted": 18
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/003_multi_vrf/input.txt
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/003_multi_vrf/input.txt
@@ -1,0 +1,16 @@
+BGP summary information for VRF RED
+Router identifier 192.168.1.1, local AS number 645001
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  2001:DB8:c0de:ff::1      4  65002        1753556   1761743    0    0   40d23h Estab  7      4
+BGP summary information for VRF WHITE
+Router identifier 192.168.2.1, local AS number 65011
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  2001:DB8:c0de:ff1::1      4  65012        7405942   7406081    0    0  270d13h Estab  7      5
+BGP summary information for VRF BLUE
+Router identifier 192.168.3.1, local AS number 65021
+Neighbor Status Codes: m - Under maintenance
+  Neighbor         V  AS           MsgRcvd   MsgSent  InQ OutQ  Up/Down State  PfxRcd PfxAcc
+  2001:DB8:c0de:ff2::1      4  65022        1171721   1171752    0    0   67d19h Estab  25     25
+  2001:DB8:c0de:ff3::1      4  65023          97651     97643    0    0   40d23h Estab  18     18

--- a/tests/parsers/arista_eos/show_ipv6_bgp_summary/003_multi_vrf/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ipv6_bgp_summary/003_multi_vrf/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multi-VRF output with three separate VRF sections (RED, WHITE, BLUE)
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ipv6 bgp summary` on Arista EOS
- Extracts BGP router identifier, local AS, VRF (defaults to "default"), and IPv6 neighbor table as dict-of-dicts keyed by neighbor address
- Includes test fixture with real device output from ntc-templates

## Test plan
- [x] Parser test passes against real device fixture (`001_basic`)
- [x] All fixture sentinel checks pass (no placeholder values)
- [x] JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] ruff lint and format clean
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)