### PR TITLE
feat(cisco_iosxr): add parser for show pim ipv4 neighbor

### DIFF
--- a/changes/+cisco-iosxr-show-pim-ipv4-neighbor.parser_added
+++ b/changes/+cisco-iosxr-show-pim-ipv4-neighbor.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show pim ipv4 neighbor` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_neighbor.py
+++ b/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_neighbor.py
@@ -1,0 +1,96 @@
+"""Parser for 'show pim ipv4 neighbor' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PimNeighborEntry(TypedDict):
+    """Schema for a single PIM neighbor entry."""
+
+    interface: str
+    uptime: str
+    expires: str
+    dr_priority: int
+    is_designated_router: bool
+    bidir_capable: bool
+    proxy_capable: bool
+    ecmp_redirect_capable: bool
+    is_self: bool
+    bfd_state: NotRequired[str]
+
+
+ShowPimIpv4NeighborResult = dict[str, PimNeighborEntry]
+
+# Neighbor row pattern for IOS-XR PIM neighbor table:
+# 192.0.2.1*                   Bundle-Ether10.10      1d09h     00:01:29 1      B E
+# 192.0.2.2                    Bundle-Ether10.20      02:26:23  00:01:26 1 (DR)
+_NEIGHBOR_PATTERN = re.compile(
+    rf"^(?P<address>{IPV4_ADDRESS})(?P<self_flag>\*)?\s+"
+    r"(?P<interface>\S+)\s+"
+    r"(?P<uptime>\S+)\s+"
+    r"(?P<expires>\S+)\s+"
+    r"(?P<dr_pri>\d+)\s*"
+    r"(?P<dr_flag>\(DR\))?\s*"
+    r"(?P<flags>[BPDE\s]*)$"
+)
+
+
+@register(OS.CISCO_IOSXR, "show pim ipv4 neighbor")
+class ShowPimIpv4NeighborParser(BaseParser["ShowPimIpv4NeighborResult"]):
+    """Parser for 'show pim ipv4 neighbor' command on IOS-XR.
+
+    Parses PIM neighbor adjacency information. Neighbors are keyed by
+    their IP address.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MULTICAST})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowPimIpv4NeighborResult":
+        """Parse 'show pim ipv4 neighbor' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dictionary keyed by neighbor address with neighbor details.
+
+        Raises:
+            ValueError: If no PIM neighbors found in output.
+        """
+        result: ShowPimIpv4NeighborResult = {}
+
+        for line in output.splitlines():
+            match = _NEIGHBOR_PATTERN.match(line.strip())
+            if match is None:
+                continue
+
+            address = match.group("address")
+            flags = match.group("flags").strip()
+            flag_set = set(flags.split()) if flags else set()
+
+            entry = PimNeighborEntry(
+                interface=match.group("interface"),
+                uptime=match.group("uptime"),
+                expires=match.group("expires"),
+                dr_priority=int(match.group("dr_pri")),
+                is_designated_router=match.group("dr_flag") is not None,
+                bidir_capable="B" in flag_set,
+                proxy_capable="P" in flag_set,
+                ecmp_redirect_capable="E" in flag_set,
+                is_self=match.group("self_flag") is not None,
+            )
+
+            result[address] = entry
+
+        if not result:
+            msg = "No PIM neighbors found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_neighbor.py
+++ b/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_neighbor.py
@@ -1,13 +1,14 @@
 """Parser for 'show pim ipv4 neighbor' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class PimNeighborEntry(TypedDict):
@@ -22,10 +23,16 @@ class PimNeighborEntry(TypedDict):
     proxy_capable: bool
     ecmp_redirect_capable: bool
     is_self: bool
-    bfd_state: NotRequired[str]
 
 
-ShowPimIpv4NeighborResult = dict[str, PimNeighborEntry]
+class ShowPimIpv4NeighborResult(TypedDict):
+    """Schema for 'show pim ipv4 neighbor' parsed output on IOS-XR."""
+
+    vrfs: dict[str, dict[str, PimNeighborEntry]]
+
+
+# VRF context header: "PIM neighbors in VRF default"
+_VRF_HEADER_PATTERN = re.compile(r"^PIM neighbors in VRF\s+(?P<vrf>\S+)\s*$")
 
 # Neighbor row pattern for IOS-XR PIM neighbor table:
 # 192.0.2.1*                   Bundle-Ether10.10      1d09h     00:01:29 1      B E
@@ -40,13 +47,16 @@ _NEIGHBOR_PATTERN = re.compile(
     r"(?P<flags>[BPDE\s]*)$"
 )
 
+# Default VRF name when no explicit VRF header is present in the output.
+_DEFAULT_VRF = "default"
+
 
 @register(OS.CISCO_IOSXR, "show pim ipv4 neighbor")
 class ShowPimIpv4NeighborParser(BaseParser["ShowPimIpv4NeighborResult"]):
     """Parser for 'show pim ipv4 neighbor' command on IOS-XR.
 
-    Parses PIM neighbor adjacency information. Neighbors are keyed by
-    their IP address.
+    Parses PIM neighbor adjacency information.  Neighbors are grouped by
+    VRF (outermost key) and then keyed by neighbor IP address.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MULTICAST})
@@ -59,38 +69,52 @@ class ShowPimIpv4NeighborParser(BaseParser["ShowPimIpv4NeighborResult"]):
             output: Raw CLI output from command.
 
         Returns:
-            Dictionary keyed by neighbor address with neighbor details.
+            Parsed neighbor data grouped by VRF, then keyed by neighbor
+            IP address.
 
         Raises:
             ValueError: If no PIM neighbors found in output.
         """
-        result: ShowPimIpv4NeighborResult = {}
+        vrfs: dict[str, dict[str, PimNeighborEntry]] = {}
+        current_vrf = _DEFAULT_VRF
 
         for line in output.splitlines():
-            match = _NEIGHBOR_PATTERN.match(line.strip())
-            if match is None:
+            stripped = line.strip()
+
+            vrf_match = _VRF_HEADER_PATTERN.match(stripped)
+            if vrf_match is not None:
+                current_vrf = vrf_match.group("vrf")
+                vrfs.setdefault(current_vrf, {})
                 continue
 
-            address = match.group("address")
-            flags = match.group("flags").strip()
-            flag_set = set(flags.split()) if flags else set()
+            neighbor_match = _NEIGHBOR_PATTERN.match(stripped)
+            if neighbor_match is None:
+                continue
 
-            entry = PimNeighborEntry(
-                interface=match.group("interface"),
-                uptime=match.group("uptime"),
-                expires=match.group("expires"),
-                dr_priority=int(match.group("dr_pri")),
-                is_designated_router=match.group("dr_flag") is not None,
-                bidir_capable="B" in flag_set,
-                proxy_capable="P" in flag_set,
-                ecmp_redirect_capable="E" in flag_set,
-                is_self=match.group("self_flag") is not None,
+            address = neighbor_match.group("address")
+            flags = neighbor_match.group("flags").strip()
+            flag_set = set(flags.split()) if flags else set()
+            interface = canonical_interface_name(
+                neighbor_match.group("interface"),
+                os=OS.CISCO_IOSXR,
             )
 
-            result[address] = entry
+            entry: PimNeighborEntry = {
+                "interface": interface,
+                "uptime": neighbor_match.group("uptime"),
+                "expires": neighbor_match.group("expires"),
+                "dr_priority": int(neighbor_match.group("dr_pri")),
+                "is_designated_router": neighbor_match.group("dr_flag") is not None,
+                "bidir_capable": "B" in flag_set,
+                "proxy_capable": "P" in flag_set,
+                "ecmp_redirect_capable": "E" in flag_set,
+                "is_self": neighbor_match.group("self_flag") is not None,
+            }
 
-        if not result:
+            vrfs.setdefault(current_vrf, {})[address] = entry
+
+        if not any(vrfs.values()):
             msg = "No PIM neighbors found in output"
             raise ValueError(msg)
 
-        return result
+        return {"vrfs": vrfs}

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/expected.json
@@ -1,0 +1,68 @@
+{
+    "192.0.2.1": {
+        "interface": "Bundle-Ether10.10",
+        "uptime": "1d09h",
+        "expires": "00:01:29",
+        "dr_priority": 1,
+        "is_designated_router": false,
+        "bidir_capable": true,
+        "proxy_capable": false,
+        "ecmp_redirect_capable": true,
+        "is_self": true
+    },
+    "192.0.2.2": {
+        "interface": "Bundle-Ether10.20",
+        "uptime": "02:26:23",
+        "expires": "00:01:26",
+        "dr_priority": 1,
+        "is_designated_router": true,
+        "bidir_capable": false,
+        "proxy_capable": false,
+        "ecmp_redirect_capable": false,
+        "is_self": false
+    },
+    "192.0.2.3": {
+        "interface": "BVI10",
+        "uptime": "2y51w",
+        "expires": "00:01:27",
+        "dr_priority": 2,
+        "is_designated_router": true,
+        "bidir_capable": true,
+        "proxy_capable": false,
+        "ecmp_redirect_capable": false,
+        "is_self": false
+    },
+    "192.0.2.4": {
+        "interface": "BVI10",
+        "uptime": "2y51w",
+        "expires": "00:01:24",
+        "dr_priority": 0,
+        "is_designated_router": false,
+        "bidir_capable": false,
+        "proxy_capable": false,
+        "ecmp_redirect_capable": false,
+        "is_self": false
+    },
+    "192.0.2.5": {
+        "interface": "BVI10",
+        "uptime": "45w1d",
+        "expires": "00:01:19",
+        "dr_priority": 1,
+        "is_designated_router": false,
+        "bidir_capable": false,
+        "proxy_capable": true,
+        "ecmp_redirect_capable": false,
+        "is_self": false
+    },
+    "192.0.2.6": {
+        "interface": "BVI10",
+        "uptime": "2y51w",
+        "expires": "00:01:25",
+        "dr_priority": 1,
+        "is_designated_router": false,
+        "bidir_capable": true,
+        "proxy_capable": false,
+        "ecmp_redirect_capable": false,
+        "is_self": true
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/expected.json
@@ -1,68 +1,72 @@
 {
-    "192.0.2.1": {
-        "interface": "Bundle-Ether10.10",
-        "uptime": "1d09h",
-        "expires": "00:01:29",
-        "dr_priority": 1,
-        "is_designated_router": false,
-        "bidir_capable": true,
-        "proxy_capable": false,
-        "ecmp_redirect_capable": true,
-        "is_self": true
-    },
-    "192.0.2.2": {
-        "interface": "Bundle-Ether10.20",
-        "uptime": "02:26:23",
-        "expires": "00:01:26",
-        "dr_priority": 1,
-        "is_designated_router": true,
-        "bidir_capable": false,
-        "proxy_capable": false,
-        "ecmp_redirect_capable": false,
-        "is_self": false
-    },
-    "192.0.2.3": {
-        "interface": "BVI10",
-        "uptime": "2y51w",
-        "expires": "00:01:27",
-        "dr_priority": 2,
-        "is_designated_router": true,
-        "bidir_capable": true,
-        "proxy_capable": false,
-        "ecmp_redirect_capable": false,
-        "is_self": false
-    },
-    "192.0.2.4": {
-        "interface": "BVI10",
-        "uptime": "2y51w",
-        "expires": "00:01:24",
-        "dr_priority": 0,
-        "is_designated_router": false,
-        "bidir_capable": false,
-        "proxy_capable": false,
-        "ecmp_redirect_capable": false,
-        "is_self": false
-    },
-    "192.0.2.5": {
-        "interface": "BVI10",
-        "uptime": "45w1d",
-        "expires": "00:01:19",
-        "dr_priority": 1,
-        "is_designated_router": false,
-        "bidir_capable": false,
-        "proxy_capable": true,
-        "ecmp_redirect_capable": false,
-        "is_self": false
-    },
-    "192.0.2.6": {
-        "interface": "BVI10",
-        "uptime": "2y51w",
-        "expires": "00:01:25",
-        "dr_priority": 1,
-        "is_designated_router": false,
-        "bidir_capable": true,
-        "proxy_capable": false,
-        "ecmp_redirect_capable": false,
-        "is_self": true
+    "vrfs": {
+        "default": {
+            "192.0.2.1": {
+                "interface": "Bundle-Ether10.10",
+                "uptime": "1d09h",
+                "expires": "00:01:29",
+                "dr_priority": 1,
+                "is_designated_router": false,
+                "bidir_capable": true,
+                "proxy_capable": false,
+                "ecmp_redirect_capable": true,
+                "is_self": true
+            },
+            "192.0.2.2": {
+                "interface": "Bundle-Ether10.20",
+                "uptime": "02:26:23",
+                "expires": "00:01:26",
+                "dr_priority": 1,
+                "is_designated_router": true,
+                "bidir_capable": false,
+                "proxy_capable": false,
+                "ecmp_redirect_capable": false,
+                "is_self": false
+            },
+            "192.0.2.3": {
+                "interface": "BVI10",
+                "uptime": "2y51w",
+                "expires": "00:01:27",
+                "dr_priority": 2,
+                "is_designated_router": true,
+                "bidir_capable": true,
+                "proxy_capable": false,
+                "ecmp_redirect_capable": false,
+                "is_self": false
+            },
+            "192.0.2.4": {
+                "interface": "BVI10",
+                "uptime": "2y51w",
+                "expires": "00:01:24",
+                "dr_priority": 0,
+                "is_designated_router": false,
+                "bidir_capable": false,
+                "proxy_capable": false,
+                "ecmp_redirect_capable": false,
+                "is_self": false
+            },
+            "192.0.2.5": {
+                "interface": "BVI10",
+                "uptime": "45w1d",
+                "expires": "00:01:19",
+                "dr_priority": 1,
+                "is_designated_router": false,
+                "bidir_capable": false,
+                "proxy_capable": true,
+                "ecmp_redirect_capable": false,
+                "is_self": false
+            },
+            "192.0.2.6": {
+                "interface": "BVI10",
+                "uptime": "2y51w",
+                "expires": "00:01:25",
+                "dr_priority": 1,
+                "is_designated_router": false,
+                "bidir_capable": true,
+                "proxy_capable": false,
+                "ecmp_redirect_capable": false,
+                "is_self": true
+            }
+        }
     }
 }

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/input.txt
@@ -1,0 +1,16 @@
+
+Wed Jul 27 17:18:37.203 CST
+
+PIM neighbors in VRF default
+Flag: B - Bidir capable, P - Proxy capable, DR - Designated Router,
+      E - ECMP Redirect capable
+      * indicates the neighbor created for this router
+
+Neighbor Address             Interface              Uptime    Expires  DR pri   Flags
+
+192.0.2.1*                   Bundle-Ether10.10      1d09h     00:01:29 1      B E
+192.0.2.2                    Bundle-Ether10.20      02:26:23  00:01:26 1 (DR)
+192.0.2.3                    BVI10                  2y51w     00:01:27 2 (DR) B
+192.0.2.4                    BVI10                  2y51w     00:01:24 0
+192.0.2.5                    BVI10                  45w1d     00:01:19 1      P
+192.0.2.6*                   BVI10                  2y51w     00:01:25 1      B

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_neighbor/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Multiple PIM neighbors with mixed flags and DR roles"
+platform: "Unknown"
+software_version: "IOS-XR"


### PR DESCRIPTION
## Summary
- Add parser for `show pim ipv4 neighbor` on Cisco IOS-XR
- Parses PIM neighbor adjacency table: neighbor address, interface, uptime, expiry, DR priority, DR designation, and capability flags (bidir, proxy, ECMP redirect)
- Dict-of-dicts output keyed by neighbor IP address, tagged with `ParserTag.MULTICAST`

## Test plan
- [x] Fixture `001_basic` with 6 neighbors across mixed interfaces, flags, and DR roles
- [x] All sentinel/placeholder guardrail tests pass
- [x] ruff check/format, xenon complexity, bandit security scan all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)