### PR TITLE
feat(arista_eos): add parser for show isis neighbors

### DIFF
--- a/changes/+arista-eos-show-isis-neighbors.parser_added
+++ b/changes/+arista-eos-show-isis-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show isis neighbors` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_isis_neighbors.py
+++ b/src/muninn/parsers/arista_eos/show_isis_neighbors.py
@@ -7,6 +7,7 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class IsisNeighborEntry(TypedDict):
@@ -86,7 +87,9 @@ class ShowIsisNeighborsParser(BaseParser[ShowIsisNeighborsResult]):
 
             instance = match.group("instance")
             system_id = match.group("system_id")
-            interface = match.group("interface")
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.ARISTA_EOS
+            )
 
             entry = IsisNeighborEntry(
                 vrf=match.group("vrf"),

--- a/src/muninn/parsers/arista_eos/show_isis_neighbors.py
+++ b/src/muninn/parsers/arista_eos/show_isis_neighbors.py
@@ -1,0 +1,110 @@
+"""Parser for 'show isis neighbors' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class IsisNeighborEntry(TypedDict):
+    """Schema for a single IS-IS neighbor entry."""
+
+    vrf: str
+    neighbor_type: str
+    snpa: str
+    state: str
+    hold_time: int
+    circuit_id: str
+
+
+class ShowIsisNeighborsResult(TypedDict):
+    """Schema for 'show isis neighbors' parsed output on Arista EOS.
+
+    Keyed by instance -> system_id -> interface.
+    """
+
+    instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]]
+
+
+_SKIP_PATTERN = re.compile(
+    r"^\s*$"
+    r"|^Instance\s+"
+    r"|^-{3,}",
+    re.IGNORECASE,
+)
+
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<instance>\S+)\s+"
+    r"(?P<vrf>\S+)\s+"
+    r"(?P<system_id>[0-9a-fA-F]{4}\.[0-9a-fA-F]{4}\.[0-9a-fA-F]{4})\s+"
+    r"(?P<type>L[12])\s+"
+    r"(?P<interface>\S+)\s+"
+    r"(?P<snpa>\S+)\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<hold_time>\d+)\s+"
+    r"(?P<circuit_id>\S+)\s*$"
+)
+
+
+@register(OS.ARISTA_EOS, "show isis neighbors")
+class ShowIsisNeighborsParser(BaseParser[ShowIsisNeighborsResult]):
+    """Parser for 'show isis neighbors' command on Arista EOS.
+
+    Parses IS-IS neighbor adjacencies including instance, system ID,
+    adjacency type, interface, SNPA, state, hold time, and circuit ID.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.ISIS, ParserTag.ROUTING}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIsisNeighborsResult:
+        """Parse 'show isis neighbors' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IS-IS neighbors keyed by instance, system ID, then interface.
+
+        Raises:
+            ValueError: If no IS-IS neighbors are found in the output.
+        """
+        instances: dict[str, dict[str, dict[str, IsisNeighborEntry]]] = {}
+
+        for line in output.splitlines():
+            if _SKIP_PATTERN.match(line):
+                continue
+
+            match = _NEIGHBOR_PATTERN.match(line)
+            if not match:
+                continue
+
+            instance = match.group("instance")
+            system_id = match.group("system_id")
+            interface = match.group("interface")
+
+            entry = IsisNeighborEntry(
+                vrf=match.group("vrf"),
+                neighbor_type=match.group("type"),
+                snpa=match.group("snpa"),
+                state=match.group("state"),
+                hold_time=int(match.group("hold_time")),
+                circuit_id=match.group("circuit_id"),
+            )
+
+            if instance not in instances:
+                instances[instance] = {}
+            if system_id not in instances[instance]:
+                instances[instance][system_id] = {}
+            instances[instance][system_id][interface] = entry
+
+        if not instances:
+            msg = "No IS-IS neighbors found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIsisNeighborsResult, {"instances": instances})

--- a/tests/parsers/arista_eos/show_isis_neighbors/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_isis_neighbors/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "instances": {
+        "1": {
+            "3333.3333.3333": {
+                "Ethernet2": {
+                    "vrf": "default",
+                    "neighbor_type": "L2",
+                    "snpa": "50:0:0:3:0:3",
+                    "state": "UP",
+                    "hold_time": 30,
+                    "circuit_id": "4444.4444.4444.0e"
+                }
+            },
+            "2222.2222.2222": {
+                "Ethernet3": {
+                    "vrf": "default",
+                    "neighbor_type": "L2",
+                    "snpa": "50:0:0:2:0:2",
+                    "state": "UP",
+                    "hold_time": 30,
+                    "circuit_id": "0F"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_isis_neighbors/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_isis_neighbors/001_basic/input.txt
@@ -1,0 +1,4 @@
+
+Instance  VRF      System Id            Type Interface       SNPA              State Hold time   Circuit Id
+1         default  3333.3333.3333       L2   Ethernet2       50:0:0:3:0:3      UP    30          4444.4444.4444.0e
+1         default  2222.2222.2222       L2   Ethernet3       50:0:0:2:0:2      UP    30          0F

--- a/tests/parsers/arista_eos/show_isis_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_isis_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic IS-IS neighbors with two L2 adjacencies on a single instance
+platform: vEOS
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add new parser for `show isis neighbors` on Arista EOS
- Output uses dict-of-dicts keyed by instance > system_id > interface
- Parses instance, VRF, system ID, neighbor type, interface, SNPA, state, hold time, and circuit ID
- Tagged with `ParserTag.ISIS` and `ParserTag.ROUTING`

## Test plan
- [x] Parser test fixture with real device output (001_basic with two L2 adjacencies)
- [x] All 6710 existing tests pass
- [x] Ruff lint and format checks pass
- [x] Xenon complexity under threshold B
- [x] Bandit security scan clean
- [x] All pre-commit hooks pass
- [x] No banned placeholder sentinels in expected.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)