### PR TITLE
feat(cisco_iosxr): add parser for `show pim ipv4 interface`

### DIFF
--- a/changes/+cisco-iosxr-show-pim-ipv4-interface.parser_added
+++ b/changes/+cisco-iosxr-show-pim-ipv4-interface.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show pim ipv4 interface` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_interface.py
+++ b/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_interface.py
@@ -1,13 +1,14 @@
 """Parser for 'show pim ipv4 interface' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, TypedDict
+from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class PimIpv4InterfaceEntry(TypedDict):
@@ -21,8 +22,14 @@ class PimIpv4InterfaceEntry(TypedDict):
     dr_address: str
 
 
-ShowPimIpv4InterfaceResult = dict[str, PimIpv4InterfaceEntry]
+class ShowPimIpv4InterfaceResult(TypedDict):
+    """Schema for 'show pim ipv4 interface' parsed output on IOS-XR."""
 
+    vrfs: dict[str, dict[str, PimIpv4InterfaceEntry]]
+
+
+# VRF section header: "PIM interfaces in VRF <name>"
+_VRF_HEADER_PATTERN = re.compile(r"^PIM interfaces in VRF\s+(?P<vrf>\S+)\s*$")
 
 # Data row pattern for IOS-XR show pim ipv4 interface:
 # 192.0.2.1             BVI10                         on   11    30     1     192.0.2.2
@@ -36,6 +43,9 @@ _INTERFACE_PATTERN = re.compile(
     rf"(?P<dr_address>{IPV4_ADDRESS})\s*$"
 )
 
+# Default VRF name applied when no explicit VRF header has been seen yet.
+_DEFAULT_VRF = "default"
+
 
 @register(OS.CISCO_IOSXR, "show pim ipv4 interface")
 class ShowPimIpv4InterfaceParser(BaseParser["ShowPimIpv4InterfaceResult"]):
@@ -43,7 +53,7 @@ class ShowPimIpv4InterfaceParser(BaseParser["ShowPimIpv4InterfaceResult"]):
 
     Parses PIM IPv4 interface information including neighbor counts,
     hello intervals, DR priority, and designated router address.
-    Results are keyed by interface name.
+    Results are grouped by VRF, then keyed by canonical interface name.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MULTICAST})
@@ -56,30 +66,46 @@ class ShowPimIpv4InterfaceParser(BaseParser["ShowPimIpv4InterfaceResult"]):
             output: Raw CLI output from command.
 
         Returns:
-            Dict keyed by interface name with PIM interface details.
+            Parsed PIM interface data grouped by VRF, then keyed by
+            canonical interface name.
 
         Raises:
             ValueError: If no PIM interfaces found in output.
         """
-        result: ShowPimIpv4InterfaceResult = {}
+        vrfs: dict[str, dict[str, PimIpv4InterfaceEntry]] = {}
+        current_vrf: str | None = None
 
         for line in output.splitlines():
-            match = _INTERFACE_PATTERN.match(line.strip())
-            if match is None:
+            stripped = line.strip()
+
+            vrf_match = _VRF_HEADER_PATTERN.match(stripped)
+            if vrf_match is not None:
+                current_vrf = vrf_match.group("vrf")
+                vrfs.setdefault(current_vrf, {})
                 continue
 
-            interface = match.group("interface")
-            result[interface] = PimIpv4InterfaceEntry(
-                address=match.group("address"),
-                pim_enabled=match.group("pim_enabled") == "on",
-                neighbor_count=int(match.group("neighbor_count")),
-                hello_interval=int(match.group("hello_interval")),
-                dr_priority=int(match.group("dr_priority")),
-                dr_address=match.group("dr_address"),
+            row_match = _INTERFACE_PATTERN.match(stripped)
+            if row_match is None:
+                continue
+
+            vrf_name = current_vrf if current_vrf is not None else _DEFAULT_VRF
+            vrf_entries = vrfs.setdefault(vrf_name, {})
+
+            interface = canonical_interface_name(
+                row_match.group("interface"),
+                os=OS.CISCO_IOSXR,
+            )
+            vrf_entries[interface] = PimIpv4InterfaceEntry(
+                address=row_match.group("address"),
+                pim_enabled=row_match.group("pim_enabled") == "on",
+                neighbor_count=int(row_match.group("neighbor_count")),
+                hello_interval=int(row_match.group("hello_interval")),
+                dr_priority=int(row_match.group("dr_priority")),
+                dr_address=row_match.group("dr_address"),
             )
 
-        if not result:
+        if not any(vrfs.values()):
             msg = "No PIM interfaces found in output"
             raise ValueError(msg)
 
-        return result
+        return cast("ShowPimIpv4InterfaceResult", {"vrfs": vrfs})

--- a/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_interface.py
+++ b/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_interface.py
@@ -1,0 +1,85 @@
+"""Parser for 'show pim ipv4 interface' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PimIpv4InterfaceEntry(TypedDict):
+    """Schema for a single PIM IPv4 interface entry."""
+
+    address: str
+    pim_enabled: bool
+    neighbor_count: int
+    hello_interval: int
+    dr_priority: int
+    dr_address: str
+
+
+ShowPimIpv4InterfaceResult = dict[str, PimIpv4InterfaceEntry]
+
+
+# Data row pattern for IOS-XR show pim ipv4 interface:
+# 192.0.2.1             BVI10                         on   11    30     1     192.0.2.2
+_INTERFACE_PATTERN = re.compile(
+    rf"^(?P<address>{IPV4_ADDRESS})\s+"
+    r"(?P<interface>\S+)\s+"
+    r"(?P<pim_enabled>on|off)\s+"
+    r"(?P<neighbor_count>\d+)\s+"
+    r"(?P<hello_interval>\d+)\s+"
+    r"(?P<dr_priority>\d+)\s+"
+    rf"(?P<dr_address>{IPV4_ADDRESS})\s*$"
+)
+
+
+@register(OS.CISCO_IOSXR, "show pim ipv4 interface")
+class ShowPimIpv4InterfaceParser(BaseParser["ShowPimIpv4InterfaceResult"]):
+    """Parser for 'show pim ipv4 interface' command on IOS-XR.
+
+    Parses PIM IPv4 interface information including neighbor counts,
+    hello intervals, DR priority, and designated router address.
+    Results are keyed by interface name.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MULTICAST})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowPimIpv4InterfaceResult":
+        """Parse 'show pim ipv4 interface' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by interface name with PIM interface details.
+
+        Raises:
+            ValueError: If no PIM interfaces found in output.
+        """
+        result: ShowPimIpv4InterfaceResult = {}
+
+        for line in output.splitlines():
+            match = _INTERFACE_PATTERN.match(line.strip())
+            if match is None:
+                continue
+
+            interface = match.group("interface")
+            result[interface] = PimIpv4InterfaceEntry(
+                address=match.group("address"),
+                pim_enabled=match.group("pim_enabled") == "on",
+                neighbor_count=int(match.group("neighbor_count")),
+                hello_interval=int(match.group("hello_interval")),
+                dr_priority=int(match.group("dr_priority")),
+                dr_address=match.group("dr_address"),
+            )
+
+        if not result:
+            msg = "No PIM interfaces found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/expected.json
@@ -1,0 +1,42 @@
+{
+    "BVI10": {
+        "address": "192.0.2.1",
+        "pim_enabled": true,
+        "neighbor_count": 11,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.2"
+    },
+    "Bundle-Ether10": {
+        "address": "192.0.2.1",
+        "pim_enabled": true,
+        "neighbor_count": 2,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.2"
+    },
+    "Bundle-Ether10.10": {
+        "address": "192.0.2.1",
+        "pim_enabled": true,
+        "neighbor_count": 2,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.2"
+    },
+    "Bundle-Ether10.20": {
+        "address": "192.0.2.1",
+        "pim_enabled": true,
+        "neighbor_count": 2,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.2"
+    },
+    "Bundle-Ether10.30": {
+        "address": "192.0.2.1",
+        "pim_enabled": true,
+        "neighbor_count": 2,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.2"
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/expected.json
@@ -1,42 +1,46 @@
 {
-    "BVI10": {
-        "address": "192.0.2.1",
-        "pim_enabled": true,
-        "neighbor_count": 11,
-        "hello_interval": 30,
-        "dr_priority": 1,
-        "dr_address": "192.0.2.2"
-    },
-    "Bundle-Ether10": {
-        "address": "192.0.2.1",
-        "pim_enabled": true,
-        "neighbor_count": 2,
-        "hello_interval": 30,
-        "dr_priority": 1,
-        "dr_address": "192.0.2.2"
-    },
-    "Bundle-Ether10.10": {
-        "address": "192.0.2.1",
-        "pim_enabled": true,
-        "neighbor_count": 2,
-        "hello_interval": 30,
-        "dr_priority": 1,
-        "dr_address": "192.0.2.2"
-    },
-    "Bundle-Ether10.20": {
-        "address": "192.0.2.1",
-        "pim_enabled": true,
-        "neighbor_count": 2,
-        "hello_interval": 30,
-        "dr_priority": 1,
-        "dr_address": "192.0.2.2"
-    },
-    "Bundle-Ether10.30": {
-        "address": "192.0.2.1",
-        "pim_enabled": true,
-        "neighbor_count": 2,
-        "hello_interval": 30,
-        "dr_priority": 1,
-        "dr_address": "192.0.2.2"
+    "vrfs": {
+        "default": {
+            "BVI10": {
+                "address": "192.0.2.1",
+                "pim_enabled": true,
+                "neighbor_count": 11,
+                "hello_interval": 30,
+                "dr_priority": 1,
+                "dr_address": "192.0.2.2"
+            },
+            "Bundle-Ether10": {
+                "address": "192.0.2.1",
+                "pim_enabled": true,
+                "neighbor_count": 2,
+                "hello_interval": 30,
+                "dr_priority": 1,
+                "dr_address": "192.0.2.2"
+            },
+            "Bundle-Ether10.10": {
+                "address": "192.0.2.1",
+                "pim_enabled": true,
+                "neighbor_count": 2,
+                "hello_interval": 30,
+                "dr_priority": 1,
+                "dr_address": "192.0.2.2"
+            },
+            "Bundle-Ether10.20": {
+                "address": "192.0.2.1",
+                "pim_enabled": true,
+                "neighbor_count": 2,
+                "hello_interval": 30,
+                "dr_priority": 1,
+                "dr_address": "192.0.2.2"
+            },
+            "Bundle-Ether10.30": {
+                "address": "192.0.2.1",
+                "pim_enabled": true,
+                "neighbor_count": 2,
+                "hello_interval": 30,
+                "dr_priority": 1,
+                "dr_address": "192.0.2.2"
+            }
+        }
     }
 }

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/input.txt
@@ -1,0 +1,12 @@
+
+Wed Jul 27 17:18:38.018 CST
+
+PIM interfaces in VRF default
+Address               Interface                     PIM  Nbr   Hello  DR    DR
+                                                         Count Intvl  Prior
+
+192.0.2.1             BVI10                         on   11    30     1     192.0.2.2
+192.0.2.1             Bundle-Ether10                on   2     30     1     192.0.2.2
+192.0.2.1             Bundle-Ether10.10             on   2     30     1     192.0.2.2
+192.0.2.1             Bundle-Ether10.20             on   2     30     1     192.0.2.2
+192.0.2.1             Bundle-Ether10.30             on   2     30     1     192.0.2.2

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic PIM IPv4 interface output with BVI and Bundle-Ether interfaces
+platform: Unknown
+software_version: IOS-XR Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show pim ipv4 interface` on Cisco IOS-XR
- Returns dict-of-dicts keyed by interface name with address, PIM status, neighbor count, hello interval, DR priority, and DR address
- Tagged with `ParserTag.MULTICAST`

## Test plan
- [x] Parser test fixture with real device output (001_basic)
- [x] All pre-commit hooks pass (ruff, xenon, bandit, format)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)