### PR TITLE
feat(cisco_iosxr): add parser for show pim ipv4 group-map

### DIFF
--- a/changes/+cisco-iosxr-show-pim-ipv4-group-map.parser_added
+++ b/changes/+cisco-iosxr-show-pim-ipv4-group-map.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show pim ipv4 group-map` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_group_map.py
+++ b/src/muninn/parsers/cisco_iosxr/show_pim_ipv4_group_map.py
@@ -1,0 +1,96 @@
+"""Parser for 'show pim ipv4 group-map' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS, IPV4_PREFIX
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PimGroupMapEntry(TypedDict):
+    """Schema for a single PIM group-map entry."""
+
+    protocol: str
+    client: str
+    groups: int
+    rp_address: str
+    active: bool
+    bsr_active_in_mrib: bool
+    info: NotRequired[str]
+
+
+# Parsed output keyed by group range (e.g. '224.0.1.1/32').
+ShowPimIpv4GroupMapResult = dict[str, PimGroupMapEntry]
+
+# Matches a PIM group-map table row.
+# Example: 224.0.1.1/32*       DM    perm     0      0.0.0.0
+#          224.0.0.0/4*+       SM    static   7      0.0.0.0         RPF: Null,0.0.0.0
+_GROUP_MAP_PATTERN = re.compile(
+    rf"^(?P<group_range>{IPV4_PREFIX})"
+    r"(?P<flags>[*+]*)\s+"
+    r"(?P<protocol>\S+)\s+"
+    r"(?P<client>\S+)\s+"
+    r"(?P<groups>\d+)\s+"
+    rf"(?P<rp_address>{IPV4_ADDRESS})"
+    r"(?:\s+(?P<info>\S.*))?$"
+)
+
+
+@register(OS.CISCO_IOSXR, "show pim ipv4 group-map")
+class ShowPimIpv4GroupMapParser(BaseParser["ShowPimIpv4GroupMapResult"]):
+    """Parser for 'show pim ipv4 group-map' command on IOS-XR.
+
+    Parses the PIM IPv4 group mapping table. Entries are keyed by
+    group range (e.g. '224.0.1.1/32').
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MULTICAST})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowPimIpv4GroupMapResult":
+        """Parse 'show pim ipv4 group-map' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed group-map data keyed by group range.
+
+        Raises:
+            ValueError: If no group-map entries found in output.
+        """
+        result: ShowPimIpv4GroupMapResult = {}
+
+        for line in output.splitlines():
+            match = _GROUP_MAP_PATTERN.match(line.strip())
+            if match is None:
+                continue
+
+            group_range = match.group("group_range")
+            flags = match.group("flags")
+
+            entry: PimGroupMapEntry = {
+                "protocol": match.group("protocol"),
+                "client": match.group("client"),
+                "groups": int(match.group("groups")),
+                "rp_address": match.group("rp_address"),
+                "active": "*" in flags,
+                "bsr_active_in_mrib": "+" in flags,
+            }
+
+            info = match.group("info")
+            if info is not None:
+                info = info.strip()
+                if info:
+                    entry["info"] = info
+
+            result[group_range] = entry
+
+        if not result:
+            msg = "No PIM group-map entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/001_basic/expected.json
@@ -1,0 +1,43 @@
+{
+    "224.0.1.1/32": {
+        "protocol": "DM",
+        "client": "perm",
+        "groups": 0,
+        "rp_address": "0.0.0.0",
+        "active": true,
+        "bsr_active_in_mrib": false
+    },
+    "224.0.1.2/32": {
+        "protocol": "DM",
+        "client": "perm",
+        "groups": 1,
+        "rp_address": "0.0.0.0",
+        "active": true,
+        "bsr_active_in_mrib": false
+    },
+    "224.0.0.0/24": {
+        "protocol": "NO",
+        "client": "perm",
+        "groups": 0,
+        "rp_address": "0.0.0.0",
+        "active": true,
+        "bsr_active_in_mrib": false
+    },
+    "232.0.0.0/8": {
+        "protocol": "SSM",
+        "client": "config",
+        "groups": 40,
+        "rp_address": "0.0.0.0",
+        "active": true,
+        "bsr_active_in_mrib": false
+    },
+    "224.0.0.0/4": {
+        "protocol": "SM",
+        "client": "static",
+        "groups": 7,
+        "rp_address": "0.0.0.0",
+        "active": true,
+        "bsr_active_in_mrib": false,
+        "info": "RPF: Null,0.0.0.0"
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/001_basic/input.txt
@@ -1,0 +1,14 @@
+
+Wed Jul 27 17:18:36.472 CST
+
+IP PIM Group Mapping Table
+(* indicates group mappings being used)
+(+ indicates BSR group mappings active in MRIB)
+
+Group Range         Proto Client   Groups RP address      Info
+
+224.0.1.1/32*       DM    perm     0      0.0.0.0
+224.0.1.2/32*       DM    perm     1      0.0.0.0
+224.0.0.0/24*       NO    perm     0      0.0.0.0
+232.0.0.0/8*        SSM   config   40     0.0.0.0
+224.0.0.0/4*        SM    static   7      0.0.0.0         RPF: Null,0.0.0.0

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "PIM IPv4 group-map with DM, SSM, SM, and NO protocol entries"
+platform: "Unknown"
+software_version: "Unknown"

--- a/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/command.txt
+++ b/tests/parsers/cisco_iosxr/show_pim_ipv4_group_map/command.txt
@@ -1,0 +1,1 @@
+show pim ipv4 group-map


### PR DESCRIPTION
## Summary
- Add new parser for `show pim ipv4 group-map` on Cisco IOS-XR
- Outputs dict-of-dicts keyed by group range (e.g. `224.0.1.1/32`)
- Extracts protocol, client, group count, RP address, active/BSR flags, and optional info field
- Tagged with `ParserTag.MULTICAST`

## Test plan
- [x] Test fixture `001_basic` covers DM, SSM, SM, and NO protocol entries
- [x] All pre-commit hooks pass (ruff, xenon, bandit, format)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] Parser test passes against real device output from ntc-templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)