### PR TITLE
feat(arista_eos): add parser for show ip ospf summary

### DIFF
--- a/changes/+arista-eos-show-ip-ospf-summary.parser_added
+++ b/changes/+arista-eos-show-ip-ospf-summary.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ip ospf summary` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ip_ospf_summary.py
+++ b/src/muninn/parsers/arista_eos/show_ip_ospf_summary.py
@@ -1,10 +1,11 @@
 """Parser for 'show ip ospf summary' command on Arista EOS."""
 
 import re
-from typing import ClassVar, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 
@@ -28,17 +29,15 @@ class OspfInstanceInfo(TypedDict):
 
     router_id: str
     vrf: str
-    role: str
-    time_since_last_spf_seconds: int
-    max_lsas: int
-    total_lsas: int
-    type5_external_lsas: int
+    role: NotRequired[str]
+    time_since_last_spf_seconds: NotRequired[int]
+    max_lsas: NotRequired[int]
+    total_lsas: NotRequired[int]
+    type5_external_lsas: NotRequired[int]
     areas: dict[str, OspfAreaInfo]
 
 
 ShowIpOspfSummaryResult = dict[str, OspfInstanceInfo]
-
-_DEFAULT_ROLE = "internal"
 
 
 @register(OS.ARISTA_EOS, "show ip ospf summary")
@@ -54,9 +53,13 @@ class ShowIpOspfSummaryParser(BaseParser[ShowIpOspfSummaryResult]):
     )
 
     _INSTANCE_HEADER = re.compile(
-        r"^OSPF instance (?P<instance>\d+) with ID (?P<router_id>\S+),"
+        r"^OSPF instance (?P<instance>\d+) with ID (?P<router_id>"
+        + IPV4_ADDRESS
+        + r"),"
         r"\s+VRF (?P<vrf>\S+?)(?:,\s*(?P<role>\S+))?$"
     )
+
+    _AREA_HEADER = re.compile(r"^ID\s+Type\s+Intf\s+Nbrs")
 
     _TIME_SINCE_SPF = re.compile(r"^Time since last SPF:\s*(?P<seconds>\d+)\s*s$")
 
@@ -67,7 +70,7 @@ class ShowIpOspfSummaryParser(BaseParser[ShowIpOspfSummaryResult]):
     _TYPE5_EXT = re.compile(r"^Type-5 Ext LSAs:\s*(?P<count>\d+)$")
 
     _AREA_LINE = re.compile(
-        r"^(?P<area_id>\d+\.\d+\.\d+\.\d+)\s+"
+        r"^(?P<area_id>" + IPV4_ADDRESS + r")\s+"
         r"(?P<type>\S+)\s+"
         r"(?P<intf>\d+)\s+"
         r"(?P<nbrs>\d+)\s+"
@@ -89,21 +92,21 @@ class ShowIpOspfSummaryParser(BaseParser[ShowIpOspfSummaryResult]):
         match = cls._INSTANCE_HEADER.match(line)
         if not match:
             return None
-        role = match.group("role") or _DEFAULT_ROLE
-        info = cast(
-            OspfInstanceInfo,
-            {
-                "router_id": match.group("router_id"),
-                "vrf": match.group("vrf"),
-                "role": role,
-                "areas": {},
-            },
-        )
+        info: OspfInstanceInfo = {
+            "router_id": match.group("router_id"),
+            "vrf": match.group("vrf"),
+            "areas": {},
+        }
+        if role := match.group("role"):
+            info["role"] = role
         return match.group("instance"), info
 
     @classmethod
     def _parse_instance_detail(cls, line: str, inst: OspfInstanceInfo) -> None:
         """Parse SPF timing, LSA counts, and area lines into an instance dict."""
+        if cls._AREA_HEADER.match(line):
+            return
+
         if match := cls._TIME_SINCE_SPF.match(line):
             inst["time_since_last_spf_seconds"] = int(match.group("seconds"))
             return

--- a/src/muninn/parsers/arista_eos/show_ip_ospf_summary.py
+++ b/src/muninn/parsers/arista_eos/show_ip_ospf_summary.py
@@ -1,0 +1,168 @@
+"""Parser for 'show ip ospf summary' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class OspfAreaInfo(TypedDict):
+    """Schema for per-area OSPF information."""
+
+    type: str
+    interfaces: int
+    neighbors: int
+    neighbors_full: int
+    router_lsa: int
+    network_lsa: int
+    summary_lsa: int
+    asbr_lsa: int
+    type7_lsa: int
+
+
+class OspfInstanceInfo(TypedDict):
+    """Schema for a single OSPF instance."""
+
+    router_id: str
+    vrf: str
+    role: str
+    time_since_last_spf_seconds: int
+    max_lsas: int
+    total_lsas: int
+    type5_external_lsas: int
+    areas: dict[str, OspfAreaInfo]
+
+
+ShowIpOspfSummaryResult = dict[str, OspfInstanceInfo]
+
+_DEFAULT_ROLE = "internal"
+
+
+@register(OS.ARISTA_EOS, "show ip ospf summary")
+class ShowIpOspfSummaryParser(BaseParser[ShowIpOspfSummaryResult]):
+    """Parser for 'show ip ospf summary' command on Arista EOS.
+
+    Parses OSPF process summary including instance info, SPF timing,
+    LSA counts, and per-area statistics.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.ROUTING}
+    )
+
+    _INSTANCE_HEADER = re.compile(
+        r"^OSPF instance (?P<instance>\d+) with ID (?P<router_id>\S+),"
+        r"\s+VRF (?P<vrf>\S+?)(?:,\s*(?P<role>\S+))?$"
+    )
+
+    _TIME_SINCE_SPF = re.compile(r"^Time since last SPF:\s*(?P<seconds>\d+)\s*s$")
+
+    _LSA_SUMMARY = re.compile(
+        r"^Max LSAs:\s*(?P<max>\d+),\s*Total LSAs:\s*(?P<total>\d+)$"
+    )
+
+    _TYPE5_EXT = re.compile(r"^Type-5 Ext LSAs:\s*(?P<count>\d+)$")
+
+    _AREA_LINE = re.compile(
+        r"^(?P<area_id>\d+\.\d+\.\d+\.\d+)\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<intf>\d+)\s+"
+        r"(?P<nbrs>\d+)\s+"
+        r"\((?P<full>\d+)\s*\)\s+"
+        r"(?P<rtr>\d+)\s+"
+        r"(?P<nw>\d+)\s+"
+        r"(?P<sum>\d+)\s+"
+        r"(?P<asbr>\d+)\s+"
+        r"(?P<type7>\d+)$"
+    )
+
+    @classmethod
+    def _parse_instance_header(cls, line: str) -> tuple[str, OspfInstanceInfo] | None:
+        """Parse an OSPF instance header line.
+
+        Returns:
+            Tuple of (instance_id, partial instance info) or None if no match.
+        """
+        match = cls._INSTANCE_HEADER.match(line)
+        if not match:
+            return None
+        role = match.group("role") or _DEFAULT_ROLE
+        info = cast(
+            OspfInstanceInfo,
+            {
+                "router_id": match.group("router_id"),
+                "vrf": match.group("vrf"),
+                "role": role,
+                "areas": {},
+            },
+        )
+        return match.group("instance"), info
+
+    @classmethod
+    def _parse_instance_detail(cls, line: str, inst: OspfInstanceInfo) -> None:
+        """Parse SPF timing, LSA counts, and area lines into an instance dict."""
+        if match := cls._TIME_SINCE_SPF.match(line):
+            inst["time_since_last_spf_seconds"] = int(match.group("seconds"))
+            return
+
+        if match := cls._LSA_SUMMARY.match(line):
+            inst["max_lsas"] = int(match.group("max"))
+            inst["total_lsas"] = int(match.group("total"))
+            return
+
+        if match := cls._TYPE5_EXT.match(line):
+            inst["type5_external_lsas"] = int(match.group("count"))
+            return
+
+        if match := cls._AREA_LINE.match(line):
+            area_id = match.group("area_id")
+            inst["areas"][area_id] = OspfAreaInfo(
+                type=match.group("type"),
+                interfaces=int(match.group("intf")),
+                neighbors=int(match.group("nbrs")),
+                neighbors_full=int(match.group("full")),
+                router_lsa=int(match.group("rtr")),
+                network_lsa=int(match.group("nw")),
+                summary_lsa=int(match.group("sum")),
+                asbr_lsa=int(match.group("asbr")),
+                type7_lsa=int(match.group("type7")),
+            )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfSummaryResult:
+        """Parse 'show ip ospf summary' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by OSPF instance number with instance details and areas.
+
+        Raises:
+            ValueError: If no OSPF instances are found in output.
+        """
+        result: dict[str, OspfInstanceInfo] = {}
+        current_instance: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            header = cls._parse_instance_header(stripped)
+            if header:
+                current_instance, info = header
+                result[current_instance] = info
+                continue
+
+            if current_instance is not None:
+                cls._parse_instance_detail(stripped, result[current_instance])
+
+        if not result:
+            msg = "No OSPF instances found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/arista_eos/show_ip_ospf_summary/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_ospf_summary/001_basic/expected.json
@@ -1,0 +1,46 @@
+{
+    "1": {
+        "router_id": "65.87.229.70",
+        "vrf": "default",
+        "role": "ASBR",
+        "time_since_last_spf_seconds": 14,
+        "max_lsas": 12000,
+        "total_lsas": 6,
+        "type5_external_lsas": 3,
+        "areas": {
+            "0.0.0.10": {
+                "type": "normal",
+                "interfaces": 6,
+                "neighbors": 2,
+                "neighbors_full": 2,
+                "router_lsa": 3,
+                "network_lsa": 0,
+                "summary_lsa": 0,
+                "asbr_lsa": 0,
+                "type7_lsa": 0
+            }
+        }
+    },
+    "2": {
+        "router_id": "192.168.28.193",
+        "vrf": "mgmtVrf",
+        "role": "ASBR",
+        "time_since_last_spf_seconds": 1673,
+        "max_lsas": 12000,
+        "total_lsas": 357,
+        "type5_external_lsas": 152,
+        "areas": {
+            "0.0.0.0": {
+                "type": "normal",
+                "interfaces": 2,
+                "neighbors": 2,
+                "neighbors_full": 2,
+                "router_lsa": 113,
+                "network_lsa": 92,
+                "summary_lsa": 0,
+                "asbr_lsa": 0,
+                "type7_lsa": 0
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_ospf_summary/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ip_ospf_summary/001_basic/input.txt
@@ -1,0 +1,13 @@
+OSPF instance 1 with ID 65.87.229.70, VRF default, ASBR
+Time since last SPF: 14 s
+Max LSAs: 12000, Total LSAs: 6
+Type-5 Ext LSAs: 3
+ID               Type   Intf   Nbrs (full) RTR LSA NW LSA  SUM LSA ASBR LSA TYPE-7 LSA
+0.0.0.10         normal 6      2    (2   ) 3       0       0       0       0
+
+OSPF instance 2 with ID 192.168.28.193, VRF mgmtVrf, ASBR
+Time since last SPF: 1673 s
+Max LSAs: 12000, Total LSAs: 357
+Type-5 Ext LSAs: 152
+ID               Type   Intf   Nbrs (full) RTR LSA NW LSA  SUM LSA ASBR LSA TYPE-7 LSA
+0.0.0.0          normal 2      2    (2   ) 113     92      0       0       0

--- a/tests/parsers/arista_eos/show_ip_ospf_summary/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_ospf_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two OSPF instances across default and mgmtVrf with ASBR role
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add new parser for `show ip ospf summary` on Arista EOS
- Parses multiple OSPF instances with router ID, VRF, role, SPF timing, LSA counts, and per-area statistics (neighbor counts, LSA type breakdowns)
- Uses dict-of-dicts keyed by instance number and area ID

## Test plan
- [x] Fixture `001_basic` with two OSPF instances across default and mgmtVrf
- [x] All sentinel/placeholder tests pass
- [x] JSON convention tests pass
- [x] ruff check/format, xenon complexity, bandit security scan all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)