### PR TITLE
feat(linux): add parser for top

### DIFF
--- a/changes/+linux-top.parser_added
+++ b/changes/+linux-top.parser_added
@@ -1,0 +1,1 @@
+Added parser for `top` on Linux.

--- a/src/muninn/parsers/linux/top.py
+++ b/src/muninn/parsers/linux/top.py
@@ -316,25 +316,38 @@ class _ParseState:
             raise ValueError(msg)
 
     def to_result(self) -> TopResult:
-        """Build the final TopResult after validation."""
+        """Build the final TopResult after validation.
+
+        Raises:
+            ValueError: If any required summary section is missing.
+        """
         self.validate()
-        # After validate(), all fields are guaranteed non-None
-        assert self.header is not None  # noqa: S101
-        assert self.tasks is not None  # noqa: S101
-        assert self.cpu is not None  # noqa: S101
-        assert self.memory is not None  # noqa: S101
-        assert self.swap is not None  # noqa: S101
+        # validate() guarantees these are non-None; re-check for the type checker
+        header = self.header
+        tasks = self.tasks
+        cpu = self.cpu
+        memory = self.memory
+        swap = self.swap
+        if (
+            header is None
+            or tasks is None
+            or cpu is None
+            or memory is None
+            or swap is None
+        ):
+            msg = "Required section missing after validation"
+            raise ValueError(msg)
         return TopResult(
-            current_time=self.header["current_time"],
-            uptime=self.header["uptime"],
-            users=self.header["users"],
-            load_avg_1=self.header["load_avg_1"],
-            load_avg_5=self.header["load_avg_5"],
-            load_avg_15=self.header["load_avg_15"],
-            tasks=self.tasks,
-            cpu=self.cpu,
-            memory=self.memory,
-            swap=self.swap,
+            current_time=header["current_time"],
+            uptime=header["uptime"],
+            users=header["users"],
+            load_avg_1=header["load_avg_1"],
+            load_avg_5=header["load_avg_5"],
+            load_avg_15=header["load_avg_15"],
+            tasks=tasks,
+            cpu=cpu,
+            memory=memory,
+            swap=swap,
             processes=self.processes,
         )
 

--- a/src/muninn/parsers/linux/top.py
+++ b/src/muninn/parsers/linux/top.py
@@ -1,0 +1,337 @@
+"""Parser for 'top' command on Linux."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class TasksSummary(TypedDict):
+    """Schema for tasks summary line."""
+
+    total: int
+    running: int
+    sleeping: int
+    stopped: int
+    zombie: int
+
+
+class CpuSummary(TypedDict):
+    """Schema for CPU usage percentages."""
+
+    user: float
+    system: float
+    nice: float
+    idle: float
+    io_wait: float
+    hardware_irq: float
+    software_irq: float
+    steal: float
+
+
+class MemorySummary(TypedDict):
+    """Schema for memory usage in MiB."""
+
+    total: float
+    free: float
+    used: float
+    buff_cache: float
+
+
+class SwapSummary(TypedDict):
+    """Schema for swap usage in MiB."""
+
+    total: float
+    free: float
+    used: float
+    avail_mem: float
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single process entry."""
+
+    user: str
+    priority: str
+    nice: int
+    virtual_mem: str
+    resident_mem: int
+    shared_mem: int
+    status: str
+    cpu_percent: float
+    mem_percent: float
+    time: str
+    command: str
+    nice_raw: NotRequired[str]
+
+
+class TopResult(TypedDict):
+    """Schema for 'top' parsed output."""
+
+    current_time: str
+    uptime: str
+    users: int
+    load_avg_1: float
+    load_avg_5: float
+    load_avg_15: float
+    tasks: TasksSummary
+    cpu: CpuSummary
+    memory: MemorySummary
+    swap: SwapSummary
+    processes: dict[str, ProcessEntry]
+
+
+# top - 12:33:53 up  2:11,  5 users,  load average: 0.12, 0.40, 0.66
+_HEADER_RE = re.compile(
+    r"top\s+-\s+(?P<time>\S+)\s+up\s+(?P<uptime>.+?),\s+"
+    r"(?P<users>\d+)\s+users?,\s+"
+    r"load average:\s*(?P<la1>[\d.]+),\s*(?P<la5>[\d.]+),\s*(?P<la15>[\d.]+)"
+)
+
+# Tasks: 200 total,   1 running, 189 sleeping,   5 stopped,   5 zombie
+_TASKS_RE = re.compile(
+    r"Tasks:\s*(?P<total>\d+)\s+total,\s*"
+    r"(?P<running>\d+)\s+running,\s*"
+    r"(?P<sleeping>\d+)\s+sleeping,\s*"
+    r"(?P<stopped>\d+)\s+stopped,\s*"
+    r"(?P<zombie>\d+)\s+zombie"
+)
+
+# %Cpu(s): 12.5 us, 12.5 sy,  0.0 ni, 62.5 id, 12.5 wa,  0.0 hi,  0.0 si,  0.0 st
+_CPU_RE = re.compile(
+    r"%Cpu\(s\):\s*(?P<us>[\d.]+)\s+us,\s*"
+    r"(?P<sy>[\d.]+)\s+sy,\s*"
+    r"(?P<ni>[\d.]+)\s+ni,\s*"
+    r"(?P<id>[\d.]+)\s+id,\s*"
+    r"(?P<wa>[\d.]+)\s+wa,\s*"
+    r"(?P<hi>[\d.]+)\s+hi,\s*"
+    r"(?P<si>[\d.]+)\s+si,\s*"
+    r"(?P<st>[\d.]+)\s+st"
+)
+
+# MiB Mem :   7809.9 total,   4753.7 free,   2052.9 used,   1126.5 buff/cache
+_MEM_RE = re.compile(
+    r"MiB Mem\s*:\s*(?P<total>[\d.]+)\s+total,\s*"
+    r"(?P<free>[\d.]+)\s+free,\s*"
+    r"(?P<used>[\d.]+)\s+used,\s*"
+    r"(?P<buff_cache>[\d.]+)\s+buff/cache"
+)
+
+# MiB Swap:    512.0 total,    512.0 free,      0.0 used.   5757.0 avail Mem
+_SWAP_RE = re.compile(
+    r"MiB Swap\s*:\s*(?P<total>[\d.]+)\s+total,\s*"
+    r"(?P<free>[\d.]+)\s+free,\s*"
+    r"(?P<used>[\d.]+)\s+used\.\s*"
+    r"(?P<avail>[\d.]+)\s+avail\s+Mem"
+)
+
+# Process line: fields are positional based on the column header
+# PID USER PR NI VIRT RES SHR S %CPU %MEM TIME+ COMMAND
+_PROCESS_RE = re.compile(
+    r"^\s*(?P<pid>\d+)\s+"
+    r"(?P<user>\S+)\s+"
+    r"(?P<pr>\S+)\s+"
+    r"(?P<ni>-?\d+)\s+"
+    r"(?P<virt>\S+)\s+"
+    r"(?P<res>\d+)\s+"
+    r"(?P<shr>\d+)\s+"
+    r"(?P<status>[A-Z])\s+"
+    r"(?P<cpu>[\d.]+)\s+"
+    r"(?P<mem>[\d.]+)\s+"
+    r"(?P<time>\S+)\s+"
+    r"(?P<command>.+)$"
+)
+
+
+def _parse_header(line: str) -> dict[str, object] | None:
+    """Parse the top header line with uptime and load averages."""
+    match = _HEADER_RE.search(line)
+    if not match:
+        return None
+    return {
+        "current_time": match.group("time"),
+        "uptime": match.group("uptime").strip(),
+        "users": int(match.group("users")),
+        "load_avg_1": float(match.group("la1")),
+        "load_avg_5": float(match.group("la5")),
+        "load_avg_15": float(match.group("la15")),
+    }
+
+
+def _parse_tasks(line: str) -> TasksSummary | None:
+    """Parse the tasks summary line."""
+    match = _TASKS_RE.search(line)
+    if not match:
+        return None
+    return TasksSummary(
+        total=int(match.group("total")),
+        running=int(match.group("running")),
+        sleeping=int(match.group("sleeping")),
+        stopped=int(match.group("stopped")),
+        zombie=int(match.group("zombie")),
+    )
+
+
+def _parse_cpu(line: str) -> CpuSummary | None:
+    """Parse the CPU summary line."""
+    match = _CPU_RE.search(line)
+    if not match:
+        return None
+    return CpuSummary(
+        user=float(match.group("us")),
+        system=float(match.group("sy")),
+        nice=float(match.group("ni")),
+        idle=float(match.group("id")),
+        io_wait=float(match.group("wa")),
+        hardware_irq=float(match.group("hi")),
+        software_irq=float(match.group("si")),
+        steal=float(match.group("st")),
+    )
+
+
+def _parse_memory(line: str) -> MemorySummary | None:
+    """Parse the memory summary line."""
+    match = _MEM_RE.search(line)
+    if not match:
+        return None
+    return MemorySummary(
+        total=float(match.group("total")),
+        free=float(match.group("free")),
+        used=float(match.group("used")),
+        buff_cache=float(match.group("buff_cache")),
+    )
+
+
+def _parse_swap(line: str) -> SwapSummary | None:
+    """Parse the swap summary line."""
+    match = _SWAP_RE.search(line)
+    if not match:
+        return None
+    return SwapSummary(
+        total=float(match.group("total")),
+        free=float(match.group("free")),
+        used=float(match.group("used")),
+        avail_mem=float(match.group("avail")),
+    )
+
+
+def _parse_process(line: str) -> tuple[str, ProcessEntry] | None:
+    """Parse a single process line into (pid, ProcessEntry)."""
+    match = _PROCESS_RE.match(line)
+    if not match:
+        return None
+    pid = match.group("pid")
+    return pid, ProcessEntry(
+        user=match.group("user"),
+        priority=match.group("pr"),
+        nice=int(match.group("ni")),
+        virtual_mem=match.group("virt"),
+        resident_mem=int(match.group("res")),
+        shared_mem=int(match.group("shr")),
+        status=match.group("status"),
+        cpu_percent=float(match.group("cpu")),
+        mem_percent=float(match.group("mem")),
+        time=match.group("time"),
+        command=match.group("command").strip(),
+    )
+
+
+# Summary section parsers in the order they appear in top output.
+# Each entry is (section_name, parser_function).
+_SUMMARY_PARSERS: list[tuple[str, object]] = [
+    ("header", _parse_header),
+    ("tasks", _parse_tasks),
+    ("cpu", _parse_cpu),
+    ("memory", _parse_memory),
+    ("swap", _parse_swap),
+]
+
+
+def _parse_summary_sections(
+    lines: list[str],
+) -> tuple[dict[str, object], dict[str, ProcessEntry]]:
+    """Parse summary header sections and process list from top output lines.
+
+    Returns:
+        Tuple of (summary_dict, processes_dict).
+
+    Raises:
+        ValueError: If any required summary section is missing.
+    """
+    summary: dict[str, object] = {}
+    processes: dict[str, ProcessEntry] = {}
+    parser_idx = 0
+
+    for line in lines:
+        # Try the next expected summary parser
+        if parser_idx < len(_SUMMARY_PARSERS):
+            name, parser_fn = _SUMMARY_PARSERS[parser_idx]
+            result = parser_fn(line)  # type: ignore[operator]
+            if result is not None:
+                summary[name] = result
+                parser_idx += 1
+                continue
+
+        proc = _parse_process(line)
+        if proc is not None:
+            pid, entry = proc
+            processes[pid] = entry
+
+    # Validate all summary sections were found
+    for name, _ in _SUMMARY_PARSERS:
+        if name not in summary:
+            msg = f"No {name} section found in output"
+            raise ValueError(msg)
+
+    return summary, processes
+
+
+def _build_result(
+    summary: dict[str, object], processes: dict[str, ProcessEntry]
+) -> TopResult:
+    """Assemble the final TopResult from parsed summary and processes."""
+    header = summary["header"]
+    # header is a plain dict from _parse_header
+    h = header  # type: ignore[assignment]
+    return TopResult(
+        current_time=str(h["current_time"]),  # type: ignore[index]
+        uptime=str(h["uptime"]),  # type: ignore[index]
+        users=int(str(h["users"])),  # type: ignore[index]
+        load_avg_1=float(str(h["load_avg_1"])),  # type: ignore[index]
+        load_avg_5=float(str(h["load_avg_5"])),  # type: ignore[index]
+        load_avg_15=float(str(h["load_avg_15"])),  # type: ignore[index]
+        tasks=summary["tasks"],  # type: ignore[arg-type]
+        cpu=summary["cpu"],  # type: ignore[arg-type]
+        memory=summary["memory"],  # type: ignore[arg-type]
+        swap=summary["swap"],  # type: ignore[arg-type]
+        processes=processes,
+    )
+
+
+@register(OS.LINUX, "top")
+class TopParser(BaseParser[TopResult]):
+    """Parser for 'top' command on Linux.
+
+    Parses the summary header (uptime, load averages, tasks, CPU%,
+    memory/swap) and the process list.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> TopResult:
+        """Parse 'top' output on Linux.
+
+        Args:
+            output: Raw CLI output from the top command.
+
+        Returns:
+            Structured dict with system summary and process list.
+
+        Raises:
+            ValueError: If required sections cannot be parsed.
+        """
+        summary, processes = _parse_summary_sections(output.splitlines())
+        return _build_result(summary, processes)

--- a/src/muninn/parsers/linux/top.py
+++ b/src/muninn/parsers/linux/top.py
@@ -1,7 +1,8 @@
 """Parser for 'top' command on Linux."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from dataclasses import dataclass, field
+from typing import ClassVar, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -64,7 +65,6 @@ class ProcessEntry(TypedDict):
     mem_percent: float
     time: str
     command: str
-    nice_raw: NotRequired[str]
 
 
 class TopResult(TypedDict):
@@ -82,6 +82,20 @@ class TopResult(TypedDict):
     swap: SwapSummary
     processes: dict[str, ProcessEntry]
 
+
+# -- Header TypedDict for intermediate parsing --
+
+
+class _HeaderInfo(TypedDict):
+    current_time: str
+    uptime: str
+    users: int
+    load_avg_1: float
+    load_avg_5: float
+    load_avg_15: float
+
+
+# -- Regex patterns --
 
 # top - 12:33:53 up  2:11,  5 users,  load average: 0.12, 0.40, 0.66
 _HEADER_RE = re.compile(
@@ -145,19 +159,22 @@ _PROCESS_RE = re.compile(
 )
 
 
-def _parse_header(line: str) -> dict[str, object] | None:
+# -- Line-level parsers --
+
+
+def _parse_header(line: str) -> _HeaderInfo | None:
     """Parse the top header line with uptime and load averages."""
     match = _HEADER_RE.search(line)
     if not match:
         return None
-    return {
-        "current_time": match.group("time"),
-        "uptime": match.group("uptime").strip(),
-        "users": int(match.group("users")),
-        "load_avg_1": float(match.group("la1")),
-        "load_avg_5": float(match.group("la5")),
-        "load_avg_15": float(match.group("la15")),
-    }
+    return _HeaderInfo(
+        current_time=match.group("time"),
+        uptime=match.group("uptime").strip(),
+        users=int(match.group("users")),
+        load_avg_1=float(match.group("la1")),
+        load_avg_5=float(match.group("la5")),
+        load_avg_15=float(match.group("la15")),
+    )
 
 
 def _parse_tasks(line: str) -> TasksSummary | None:
@@ -238,76 +255,88 @@ def _parse_process(line: str) -> tuple[str, ProcessEntry] | None:
     )
 
 
-# Summary section parsers in the order they appear in top output.
-# Each entry is (section_name, parser_function).
-_SUMMARY_PARSERS: list[tuple[str, object]] = [
-    ("header", _parse_header),
-    ("tasks", _parse_tasks),
-    ("cpu", _parse_cpu),
-    ("memory", _parse_memory),
-    ("swap", _parse_swap),
-]
+# -- Stateful parser --
 
 
-def _parse_summary_sections(
-    lines: list[str],
-) -> tuple[dict[str, object], dict[str, ProcessEntry]]:
-    """Parse summary header sections and process list from top output lines.
+@dataclass
+class _ParseState:
+    """Mutable accumulator for the line-by-line parsing loop."""
 
-    Returns:
-        Tuple of (summary_dict, processes_dict).
+    header: _HeaderInfo | None = None
+    tasks: TasksSummary | None = None
+    cpu: CpuSummary | None = None
+    memory: MemorySummary | None = None
+    swap: SwapSummary | None = None
+    processes: dict[str, ProcessEntry] = field(default_factory=dict)
 
-    Raises:
-        ValueError: If any required summary section is missing.
-    """
-    summary: dict[str, object] = {}
-    processes: dict[str, ProcessEntry] = {}
-    parser_idx = 0
+    def _try_summary(self, line: str) -> bool:
+        """Attempt to parse the next missing summary section. Returns True on match."""
+        if self.header is None:
+            self.header = _parse_header(line)
+            return self.header is not None
+        if self.tasks is None:
+            self.tasks = _parse_tasks(line)
+            return self.tasks is not None
+        if self.cpu is None:
+            self.cpu = _parse_cpu(line)
+            return self.cpu is not None
+        if self.memory is None:
+            self.memory = _parse_memory(line)
+            return self.memory is not None
+        if self.swap is None:
+            self.swap = _parse_swap(line)
+            return self.swap is not None
+        return False
 
-    for line in lines:
-        # Try the next expected summary parser
-        if parser_idx < len(_SUMMARY_PARSERS):
-            name, parser_fn = _SUMMARY_PARSERS[parser_idx]
-            result = parser_fn(line)  # type: ignore[operator]
-            if result is not None:
-                summary[name] = result
-                parser_idx += 1
-                continue
-
+    def handle_line(self, line: str) -> None:
+        """Dispatch a single line to the appropriate sub-parser."""
+        if self._try_summary(line):
+            return
         proc = _parse_process(line)
         if proc is not None:
             pid, entry = proc
-            processes[pid] = entry
+            self.processes[pid] = entry
 
-    # Validate all summary sections were found
-    for name, _ in _SUMMARY_PARSERS:
-        if name not in summary:
-            msg = f"No {name} section found in output"
+    def validate(self) -> None:
+        """Raise ValueError if any required summary section is missing."""
+        if self.header is None:
+            msg = "No top header line found in output"
+            raise ValueError(msg)
+        if self.tasks is None:
+            msg = "No tasks summary found in output"
+            raise ValueError(msg)
+        if self.cpu is None:
+            msg = "No CPU summary found in output"
+            raise ValueError(msg)
+        if self.memory is None:
+            msg = "No memory summary found in output"
+            raise ValueError(msg)
+        if self.swap is None:
+            msg = "No swap summary found in output"
             raise ValueError(msg)
 
-    return summary, processes
-
-
-def _build_result(
-    summary: dict[str, object], processes: dict[str, ProcessEntry]
-) -> TopResult:
-    """Assemble the final TopResult from parsed summary and processes."""
-    header = summary["header"]
-    # header is a plain dict from _parse_header
-    h = header  # type: ignore[assignment]
-    return TopResult(
-        current_time=str(h["current_time"]),  # type: ignore[index]
-        uptime=str(h["uptime"]),  # type: ignore[index]
-        users=int(str(h["users"])),  # type: ignore[index]
-        load_avg_1=float(str(h["load_avg_1"])),  # type: ignore[index]
-        load_avg_5=float(str(h["load_avg_5"])),  # type: ignore[index]
-        load_avg_15=float(str(h["load_avg_15"])),  # type: ignore[index]
-        tasks=summary["tasks"],  # type: ignore[arg-type]
-        cpu=summary["cpu"],  # type: ignore[arg-type]
-        memory=summary["memory"],  # type: ignore[arg-type]
-        swap=summary["swap"],  # type: ignore[arg-type]
-        processes=processes,
-    )
+    def to_result(self) -> TopResult:
+        """Build the final TopResult after validation."""
+        self.validate()
+        # After validate(), all fields are guaranteed non-None
+        assert self.header is not None  # noqa: S101
+        assert self.tasks is not None  # noqa: S101
+        assert self.cpu is not None  # noqa: S101
+        assert self.memory is not None  # noqa: S101
+        assert self.swap is not None  # noqa: S101
+        return TopResult(
+            current_time=self.header["current_time"],
+            uptime=self.header["uptime"],
+            users=self.header["users"],
+            load_avg_1=self.header["load_avg_1"],
+            load_avg_5=self.header["load_avg_5"],
+            load_avg_15=self.header["load_avg_15"],
+            tasks=self.tasks,
+            cpu=self.cpu,
+            memory=self.memory,
+            swap=self.swap,
+            processes=self.processes,
+        )
 
 
 @register(OS.LINUX, "top")
@@ -333,5 +362,7 @@ class TopParser(BaseParser[TopResult]):
         Raises:
             ValueError: If required sections cannot be parsed.
         """
-        summary, processes = _parse_summary_sections(output.splitlines())
-        return _build_result(summary, processes)
+        state = _ParseState()
+        for line in output.splitlines():
+            state.handle_line(line)
+        return state.to_result()

--- a/tests/parsers/linux/top/001_basic/expected.json
+++ b/tests/parsers/linux/top/001_basic/expected.json
@@ -1,0 +1,143 @@
+{
+    "current_time": "12:33:53",
+    "uptime": "2:11",
+    "users": 5,
+    "load_avg_1": 0.12,
+    "load_avg_5": 0.4,
+    "load_avg_15": 0.66,
+    "tasks": {
+        "total": 200,
+        "running": 1,
+        "sleeping": 189,
+        "stopped": 5,
+        "zombie": 5
+    },
+    "cpu": {
+        "user": 12.5,
+        "system": 12.5,
+        "nice": 0.0,
+        "idle": 62.5,
+        "io_wait": 12.5,
+        "hardware_irq": 0.0,
+        "software_irq": 0.0,
+        "steal": 0.0
+    },
+    "memory": {
+        "total": 7809.9,
+        "free": 4753.7,
+        "used": 2052.9,
+        "buff_cache": 1126.5
+    },
+    "swap": {
+        "total": 512.0,
+        "free": 512.0,
+        "used": 0.0,
+        "avail_mem": 5757.0
+    },
+    "processes": {
+        "19516": {
+            "user": "admin",
+            "priority": "20",
+            "nice": 0,
+            "virtual_mem": "28.7g",
+            "resident_mem": 880836,
+            "shared_mem": 52224,
+            "status": "S",
+            "cpu_percent": 12.5,
+            "mem_percent": 11.0,
+            "time": "6:51.26",
+            "command": "node"
+        },
+        "30427": {
+            "user": "admin",
+            "priority": "20",
+            "nice": 0,
+            "virtual_mem": "11708",
+            "resident_mem": 4864,
+            "shared_mem": 2816,
+            "status": "R",
+            "cpu_percent": 6.2,
+            "mem_percent": 0.1,
+            "time": "0:00.03",
+            "command": "top"
+        },
+        "1": {
+            "user": "root",
+            "priority": "20",
+            "nice": 0,
+            "virtual_mem": "168332",
+            "resident_mem": 11152,
+            "shared_mem": 8400,
+            "status": "S",
+            "cpu_percent": 0.0,
+            "mem_percent": 0.1,
+            "time": "0:01.14",
+            "command": "systemd"
+        },
+        "4": {
+            "user": "root",
+            "priority": "0",
+            "nice": -20,
+            "virtual_mem": "0",
+            "resident_mem": 0,
+            "shared_mem": 0,
+            "status": "I",
+            "cpu_percent": 0.0,
+            "mem_percent": 0.0,
+            "time": "0:00.00",
+            "command": "kworker/R-rcu_g"
+        },
+        "395": {
+            "user": "systemd+",
+            "priority": "20",
+            "nice": 0,
+            "virtual_mem": "90708",
+            "resident_mem": 6784,
+            "shared_mem": 5888,
+            "status": "S",
+            "cpu_percent": 0.0,
+            "mem_percent": 0.1,
+            "time": "0:00.18",
+            "command": "systemd-timesyn"
+        },
+        "397": {
+            "user": "root",
+            "priority": "0",
+            "nice": -20,
+            "virtual_mem": "0",
+            "resident_mem": 0,
+            "shared_mem": 0,
+            "status": "I",
+            "cpu_percent": 0.0,
+            "mem_percent": 0.0,
+            "time": "0:00.68",
+            "command": "kworker/u13:1-brcmf_wq/mmc1:0001:1"
+        },
+        "402": {
+            "user": "root",
+            "priority": "-51",
+            "nice": 0,
+            "virtual_mem": "0",
+            "resident_mem": 0,
+            "shared_mem": 0,
+            "status": "S",
+            "cpu_percent": 0.0,
+            "mem_percent": 0.0,
+            "time": "0:00.00",
+            "command": "irq/41-vc4 hdmi hpd connected"
+        },
+        "30343": {
+            "user": "admin",
+            "priority": "20",
+            "nice": 0,
+            "virtual_mem": "5200",
+            "resident_mem": 1408,
+            "shared_mem": 1408,
+            "status": "S",
+            "cpu_percent": 0.0,
+            "mem_percent": 0.0,
+            "time": "0:00.00",
+            "command": "sleep"
+        }
+    }
+}

--- a/tests/parsers/linux/top/001_basic/input.txt
+++ b/tests/parsers/linux/top/001_basic/input.txt
@@ -1,0 +1,15 @@
+top - 12:33:53 up  2:11,  5 users,  load average: 0.12, 0.40, 0.66
+Tasks: 200 total,   1 running, 189 sleeping,   5 stopped,   5 zombie
+%Cpu(s): 12.5 us, 12.5 sy,  0.0 ni, 62.5 id, 12.5 wa,  0.0 hi,  0.0 si,  0.0 st
+MiB Mem :   7809.9 total,   4753.7 free,   2052.9 used,   1126.5 buff/cache
+MiB Swap:    512.0 total,    512.0 free,      0.0 used.   5757.0 avail Mem
+
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
+  19516 admin     20   0   28.7g 880836  52224 S  12.5  11.0   6:51.26 node
+  30427 admin     20   0   11708   4864   2816 R   6.2   0.1   0:00.03 top
+      1 root      20   0  168332  11152   8400 S   0.0   0.1   0:01.14 systemd
+      4 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker/R-rcu_g
+    395 systemd+  20   0   90708   6784   5888 S   0.0   0.1   0:00.18 systemd-timesyn
+    397 root       0 -20       0      0      0 I   0.0   0.0   0:00.68 kworker/u13:1-brcmf_wq/mmc1:0001:1
+    402 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 irq/41-vc4 hdmi hpd connected
+  30343 admin     20   0    5200   1408   1408 S   0.0   0.0   0:00.00 sleep

--- a/tests/parsers/linux/top/001_basic/metadata.yaml
+++ b/tests/parsers/linux/top/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic top output with summary header and process list
+platform: Raspberry Pi 5
+software_version: Debian GNU/Linux 12 (bookworm)


### PR DESCRIPTION
## Summary
- Add new parser for `top` command on Linux (`OS.LINUX`, tagged `ParserTag.SYSTEM`)
- Parses summary header (uptime, load averages, tasks, CPU%, memory, swap) and the full process list keyed by PID
- Includes test fixture with real device output from a Raspberry Pi 5 running Debian 12

## Test plan
- [x] Parser test passes (`tests/parsers/test_parsers.py::test_parser[linux/top/001_basic]`)
- [x] Empty output raises ValueError (auto-tested by `test_empty_output`)
- [x] Fixture passes all placeholder sentinel checks (no `-`, `N/A`, `None`, or empty string values)
- [x] Fixture passes JSON convention checks (no list-of-dicts, no pipe-in-keys)
- [x] `ruff check` and `ruff format` pass
- [x] `xenon` complexity under B threshold
- [x] `bandit` security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)