### PR TITLE
feat(juniper_junos): add parser for show ospf3 neighbor

### DIFF
--- a/changes/+juniper-junos-show-ospf3-neighbor.parser_added
+++ b/changes/+juniper-junos-show-ospf3-neighbor.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ospf3 neighbor` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_ospf3_neighbor.py
+++ b/src/muninn/parsers/juniper_junos/show_ospf3_neighbor.py
@@ -1,7 +1,7 @@
 """Parser for 'show ospf3 neighbor' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -19,7 +19,9 @@ class Ospf3NeighborEntry(TypedDict):
         state: Adjacency state (e.g., ``Full``, ``2Way``, ``Init``).
         priority: Neighbor priority value.
         dead_time: Dead timer countdown in seconds.
-        neighbor_address: IPv6 link-local address of the neighbor.
+        neighbor_address: IPv6 link-local address of the neighbor. Omitted when
+            the device does not emit a ``Neighbor-address`` continuation line
+            for this entry.
     """
 
     neighbor_id: str
@@ -27,7 +29,7 @@ class Ospf3NeighborEntry(TypedDict):
     state: str
     priority: int
     dead_time: int
-    neighbor_address: str
+    neighbor_address: NotRequired[str]
 
 
 class ShowOspf3NeighborResult(TypedDict):
@@ -108,7 +110,6 @@ class ShowOspf3NeighborParser(BaseParser[ShowOspf3NeighborResult]):
                     state=neighbor_match.group("state"),
                     priority=int(neighbor_match.group("priority")),
                     dead_time=int(neighbor_match.group("dead_time")),
-                    neighbor_address="",
                 )
                 continue
 

--- a/src/muninn/parsers/juniper_junos/show_ospf3_neighbor.py
+++ b/src/muninn/parsers/juniper_junos/show_ospf3_neighbor.py
@@ -1,0 +1,126 @@
+"""Parser for 'show ospf3 neighbor' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class Ospf3NeighborEntry(TypedDict):
+    """Schema for a single Junos OSPFv3 neighbor entry.
+
+    Attributes:
+        neighbor_id: OSPF router ID of the neighbor.
+        interface: Local interface name (e.g., ``ge-0/0/0.0``).
+        state: Adjacency state (e.g., ``Full``, ``2Way``, ``Init``).
+        priority: Neighbor priority value.
+        dead_time: Dead timer countdown in seconds.
+        neighbor_address: IPv6 link-local address of the neighbor.
+    """
+
+    neighbor_id: str
+    interface: str
+    state: str
+    priority: int
+    dead_time: int
+    neighbor_address: str
+
+
+class ShowOspf3NeighborResult(TypedDict):
+    """Schema for 'show ospf3 neighbor' parsed output.
+
+    Top-level dict-of-dicts keyed by neighbor router ID.
+    """
+
+    neighbors: dict[str, Ospf3NeighborEntry]
+
+
+# Junos 'show ospf3 neighbor' output format:
+# ID               Interface              State     Pri   Dead
+# 10.189.5.253     ge-0/0/0.0             Full      128     35
+#   Neighbor-address fe80::250:56ff:fe8d:53c0
+_NEIGHBOR_PATTERN = re.compile(
+    rf"^(?P<neighbor_id>{IPV4_ADDRESS})\s+"
+    r"(?P<interface>\S+)\s+"
+    r"(?P<state>\S+)\s+"
+    r"(?P<priority>\d+)\s+"
+    r"(?P<dead_time>\d+)\s*$"
+)
+
+_NEIGHBOR_ADDRESS_PATTERN = re.compile(
+    r"^\s+Neighbor-address\s+(?P<neighbor_address>\S+)\s*$"
+)
+
+# Junos prompt lines like "{master:0}" or "{primary:node0}"
+_PROMPT_PATTERN = re.compile(r"^\{.+\}\s*$")
+
+
+@register(OS.JUNIPER_JUNOS, "show ospf3 neighbor")
+class ShowOspf3NeighborParser(BaseParser[ShowOspf3NeighborResult]):
+    """Parser for 'show ospf3 neighbor' command on Juniper Junos.
+
+    Parses OSPFv3 neighbor adjacency information from the neighbor table.
+    Neighbors are keyed by their router ID.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.OSPF,
+            ParserTag.ROUTING,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowOspf3NeighborResult:
+        """Parse 'show ospf3 neighbor' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed neighbor data keyed by neighbor router ID.
+
+        Raises:
+            ValueError: If no neighbors found in output.
+        """
+        neighbors: dict[str, Ospf3NeighborEntry] = {}
+        last_neighbor_id: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if _PROMPT_PATTERN.match(stripped):
+                continue
+
+            neighbor_match = _NEIGHBOR_PATTERN.match(stripped)
+            if neighbor_match:
+                neighbor_id = neighbor_match.group("neighbor_id")
+                last_neighbor_id = neighbor_id
+                neighbors[neighbor_id] = Ospf3NeighborEntry(
+                    neighbor_id=neighbor_id,
+                    interface=neighbor_match.group("interface"),
+                    state=neighbor_match.group("state"),
+                    priority=int(neighbor_match.group("priority")),
+                    dead_time=int(neighbor_match.group("dead_time")),
+                    neighbor_address="",
+                )
+                continue
+
+            addr_match = _NEIGHBOR_ADDRESS_PATTERN.match(line)
+            if addr_match and last_neighbor_id is not None:
+                neighbors[last_neighbor_id]["neighbor_address"] = addr_match.group(
+                    "neighbor_address"
+                )
+                continue
+
+        if not neighbors:
+            msg = "No OSPFv3 neighbors found in output"
+            raise ValueError(msg)
+
+        return cast(ShowOspf3NeighborResult, {"neighbors": neighbors})

--- a/tests/parsers/juniper_junos/show_ospf3_neighbor/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_ospf3_neighbor/001_basic/expected.json
@@ -1,0 +1,20 @@
+{
+    "neighbors": {
+        "10.189.5.253": {
+            "neighbor_id": "10.189.5.253",
+            "interface": "ge-0/0/0.0",
+            "state": "Full",
+            "priority": 128,
+            "dead_time": 35,
+            "neighbor_address": "fe80::250:56ff:fe8d:53c0"
+        },
+        "10.169.14.240": {
+            "neighbor_id": "10.169.14.240",
+            "interface": "ge-0/0/1.0",
+            "state": "Full",
+            "priority": 128,
+            "dead_time": 33,
+            "neighbor_address": "fe80::250:56ff:fe8d:72bd"
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_ospf3_neighbor/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_ospf3_neighbor/001_basic/input.txt
@@ -1,0 +1,5 @@
+ID               Interface              State     Pri   Dead
+10.189.5.253     ge-0/0/0.0             Full      128     35
+  Neighbor-address fe80::250:56ff:fe8d:53c0
+10.169.14.240   ge-0/0/1.0             Full      128     33
+  Neighbor-address fe80::250:56ff:fe8d:72bd

--- a/tests/parsers/juniper_junos/show_ospf3_neighbor/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_ospf3_neighbor/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two OSPFv3 neighbors on separate interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ospf3 neighbor` on Juniper Junos
- Parses OSPFv3 neighbor table: neighbor ID, interface, state, priority, dead time, and IPv6 link-local neighbor address
- Dict-of-dicts output keyed by neighbor router ID, tagged with OSPF and Routing

## Test plan
- [x] Test fixture with two OSPFv3 neighbors from real device output (Genie golden output)
- [x] All 7 parametrized tests pass (parser, JSON conventions, placeholder sentinels)
- [x] Pre-commit hooks pass (ruff, xenon, format, JSON)
- [x] Complexity under xenon B threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)