### PR TITLE
feat(juniper_junos): add parser for show krt queue

### DIFF
--- a/changes/+juniper-junos-show-krt-queue.parser_added
+++ b/changes/+juniper-junos-show-krt-queue.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show krt queue` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_krt_queue.py
+++ b/src/muninn/parsers/juniper_junos/show_krt_queue.py
@@ -1,0 +1,64 @@
+"""Parser for 'show krt queue' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class KrtQueueEntry(TypedDict):
+    """Schema for a single KRT queue entry."""
+
+    queued: int
+
+
+class ShowKrtQueueResult(TypedDict):
+    """Schema for 'show krt queue' parsed output.
+
+    Dict keyed by queue name, each containing the queued count.
+    """
+
+    queues: dict[str, KrtQueueEntry]
+
+
+@register(OS.JUNIPER_JUNOS, "show krt queue")
+class ShowKrtQueueParser(BaseParser[ShowKrtQueueResult]):
+    """Parser for 'show krt queue' command on Juniper Junos.
+
+    Parses Kernel Routing Table (KRT) queue names and their queued counts.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ROUTING})
+
+    _QUEUE_PATTERN = re.compile(r"^\s*(?P<name>.+?):\s+(?P<queued>\d+)\s+queued\s*$")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowKrtQueueResult:
+        """Parse 'show krt queue' output on Juniper Junos.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed KRT queue information.
+
+        Raises:
+            ValueError: If no queue entries are found.
+        """
+        queues: dict[str, KrtQueueEntry] = {}
+
+        for line in output.splitlines():
+            match = cls._QUEUE_PATTERN.match(line)
+            if match:
+                name = match.group("name")
+                queued = int(match.group("queued"))
+                queues[name] = KrtQueueEntry(queued=queued)
+
+        if not queues:
+            msg = "No KRT queue entries found in output"
+            raise ValueError(msg)
+
+        return ShowKrtQueueResult(queues=queues)

--- a/tests/parsers/juniper_junos/show_krt_queue/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_krt_queue/001_basic/expected.json
@@ -1,0 +1,97 @@
+{
+    "queues": {
+        "Routing table add queue": {
+            "queued": 0
+        },
+        "Interface add/delete/change queue": {
+            "queued": 0
+        },
+        "Top-priority deletion queue": {
+            "queued": 0
+        },
+        "Top-priority change queue": {
+            "queued": 0
+        },
+        "Top-priority add queue": {
+            "queued": 0
+        },
+        "high priority V4oV6 tcnh delete queue": {
+            "queued": 0
+        },
+        "high prioriy anchor gencfg delete queue": {
+            "queued": 0
+        },
+        "High-priority multicast add/change": {
+            "queued": 0
+        },
+        "Indirect next hop top priority add/change": {
+            "queued": 0
+        },
+        "Indirect next hop add/change": {
+            "queued": 0
+        },
+        "high prioriy anchor gencfg add-change queue": {
+            "queued": 0
+        },
+        "MPLS add queue": {
+            "queued": 0
+        },
+        "Indirect next hop delete": {
+            "queued": 0
+        },
+        "High-priority deletion queue": {
+            "queued": 0
+        },
+        "MPLS change queue": {
+            "queued": 0
+        },
+        "High-priority change queue": {
+            "queued": 0
+        },
+        "High-priority add queue": {
+            "queued": 0
+        },
+        "Normal-priority indirect next hop queue": {
+            "queued": 0
+        },
+        "Normal-priority deletion queue": {
+            "queued": 0
+        },
+        "Normal-priority composite next hop deletion queue": {
+            "queued": 0
+        },
+        "Low prioriy Statistics-id-group deletion queue": {
+            "queued": 0
+        },
+        "Normal-priority change queue": {
+            "queued": 0
+        },
+        "Normal-priority add queue": {
+            "queued": 0
+        },
+        "Least-priority delete queue": {
+            "queued": 0
+        },
+        "Least-priority change queue": {
+            "queued": 0
+        },
+        "Least-priority add queue": {
+            "queued": 0
+        },
+        "Normal-priority pfe table nexthop queue": {
+            "queued": 0
+        },
+        "EVPN gencfg queue": {
+            "queued": 0
+        },
+        "Normal-priority gmp queue": {
+            "queued": 0
+        },
+        "Routing table delete queue": {
+            "queued": 0
+        },
+        "Low priority route retry queue": {
+            "queued": 0
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_krt_queue/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_krt_queue/001_basic/input.txt
@@ -1,0 +1,33 @@
+
+        show krt queue
+        Routing table add queue: 0 queued
+        Interface add/delete/change queue: 0 queued
+        Top-priority deletion queue: 0 queued
+        Top-priority change queue: 0 queued
+        Top-priority add queue: 0 queued
+        high priority V4oV6 tcnh delete queue: 0 queued
+        high prioriy anchor gencfg delete queue: 0 queued
+        High-priority multicast add/change: 0 queued
+        Indirect next hop top priority add/change: 0 queued
+        Indirect next hop add/change: 0 queued
+        high prioriy anchor gencfg add-change queue: 0 queued
+        MPLS add queue: 0 queued
+        Indirect next hop delete: 0 queued
+        High-priority deletion queue: 0 queued
+        MPLS change queue: 0 queued
+        High-priority change queue: 0 queued
+        High-priority add queue: 0 queued
+        Normal-priority indirect next hop queue: 0 queued
+        Normal-priority deletion queue: 0 queued
+        Normal-priority composite next hop deletion queue: 0 queued
+        Low prioriy Statistics-id-group deletion queue: 0 queued
+        Normal-priority change queue: 0 queued
+        Normal-priority add queue: 0 queued
+        Least-priority delete queue: 0 queued
+        Least-priority change queue: 0 queued
+        Least-priority add queue: 0 queued
+        Normal-priority pfe table nexthop queue: 0 queued
+        EVPN gencfg queue: 0 queued
+        Normal-priority gmp queue: 0 queued
+        Routing table delete queue: 0 queued
+        Low priority route retry queue: 0 queued

--- a/tests/parsers/juniper_junos/show_krt_queue/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_krt_queue/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic KRT queue output with all queues at zero
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show krt queue` on Juniper Junos
- Parses KRT queue names and queued counts into a dict-of-dicts keyed by queue name
- Tagged with `ROUTING`

## Test plan
- [x] Parser test fixture with real device output passes
- [x] All fixture sentinel/convention tests pass (no placeholder values)
- [x] ruff check + format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)