### PR TITLE
feat(juniper_junos): add parser for show pfe statistics traffic

### DIFF
--- a/changes/+juniper-junos-show-pfe-statistics-traffic.parser_added
+++ b/changes/+juniper-junos-show-pfe-statistics-traffic.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show pfe statistics traffic` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_pfe_statistics_traffic.py
+++ b/src/muninn/parsers/juniper_junos/show_pfe_statistics_traffic.py
@@ -1,0 +1,357 @@
+"""Parser for 'show pfe statistics traffic' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class TrafficStats(TypedDict):
+    """Schema for PFE traffic statistics (input/output/fabric)."""
+
+    input_packets: int
+    input_pps: int
+    output_packets: int
+    output_pps: int
+    fabric_input: int
+    fabric_input_pps: int
+    fabric_output: int
+    fabric_output_pps: int
+
+
+class LocalTrafficStats(TypedDict):
+    """Schema for PFE local traffic statistics."""
+
+    local_packets_input: int
+    local_packets_output: int
+    software_input_control_plane_drops: int
+    software_input_high_drops: int
+    software_input_medium_drops: int
+    software_input_low_drops: int
+    software_output_drops: int
+    hardware_input_drops: int
+
+
+class LocalProtocolStats(TypedDict):
+    """Schema for PFE local protocol statistics (dict of protocol name to packets)."""
+
+    hdlc_keepalives: int
+    atm_oam: int
+    frame_relay_lmi: int
+    ppp_lcp_ncp: int
+    ospf_hello: int
+    ospf3_hello: int
+    rsvp_hello: int
+    ldp_hello: int
+    bfd: int
+    isis_iih: int
+    lacp: int
+    arp: int
+    ether_oam: int
+    unknown: int
+
+
+class HardwareDiscardStats(TypedDict):
+    """Schema for PFE hardware discard statistics."""
+
+    timeout: int
+    truncated_key: int
+    bits_to_test: int
+    data_error: int
+    tcp_header_length_error: int
+    stack_underflow: int
+    stack_overflow: int
+    normal_discard: int
+    extended_discard: int
+    invalid_interface: int
+    info_cell_drops: int
+    fabric_drops: int
+
+
+class ChecksumMtuStats(TypedDict):
+    """Schema for IPv4 header checksum error and output MTU error statistics."""
+
+    input_checksum: int
+    output_mtu: int
+
+
+class ShowPfeStatisticsTrafficResult(TypedDict):
+    """Schema for 'show pfe statistics traffic' parsed output."""
+
+    traffic: TrafficStats
+    local_traffic: LocalTrafficStats
+    local_protocol: LocalProtocolStats
+    hardware_discard: HardwareDiscardStats
+    checksum_mtu: ChecksumMtuStats
+
+
+# Section header patterns
+_SECTION_TRAFFIC = "Packet Forwarding Engine traffic statistics:"
+_SECTION_LOCAL_TRAFFIC = "Packet Forwarding Engine local traffic statistics:"
+_SECTION_LOCAL_PROTOCOL = "Packet Forwarding Engine local protocol statistics:"
+_SECTION_HW_DISCARD = "Packet Forwarding Engine hardware discard statistics:"
+_SECTION_CHECKSUM_MTU = (
+    "Packet Forwarding Engine Input IPv4 Header Checksum Error"
+    " and Output MTU Error statistics:"
+)
+
+# Mapping from CLI label to dict key for each section
+_TRAFFIC_PATTERNS: list[tuple[re.Pattern[str], str, str | None]] = [
+    (
+        re.compile(r"Input\s+packets:\s+(\d+)\s+(\d+)\s+pps"),
+        "input_packets",
+        "input_pps",
+    ),
+    (
+        re.compile(r"Output\s+packets:\s+(\d+)\s+(\d+)\s+pps"),
+        "output_packets",
+        "output_pps",
+    ),
+    (
+        re.compile(r"Fabric\s+Input\s+:\s+(\d+)\s+(\d+)\s+pps"),
+        "fabric_input",
+        "fabric_input_pps",
+    ),
+    (
+        re.compile(r"Fabric\s+Output\s+:\s+(\d+)\s+(\d+)\s+pps"),
+        "fabric_output",
+        "fabric_output_pps",
+    ),
+]
+
+_LOCAL_TRAFFIC_MAP: list[tuple[str, str]] = [
+    ("Local packets input", "local_packets_input"),
+    ("Local packets output", "local_packets_output"),
+    ("Software input control plane drops", "software_input_control_plane_drops"),
+    ("Software input high drops", "software_input_high_drops"),
+    ("Software input medium drops", "software_input_medium_drops"),
+    ("Software input low drops", "software_input_low_drops"),
+    ("Software output drops", "software_output_drops"),
+    ("Hardware input drops", "hardware_input_drops"),
+]
+
+_LOCAL_PROTOCOL_MAP: list[tuple[str, str]] = [
+    ("HDLC keepalives", "hdlc_keepalives"),
+    ("ATM OAM", "atm_oam"),
+    ("Frame Relay LMI", "frame_relay_lmi"),
+    ("PPP LCP/NCP", "ppp_lcp_ncp"),
+    ("OSPF hello", "ospf_hello"),
+    ("OSPF3 hello", "ospf3_hello"),
+    ("RSVP hello", "rsvp_hello"),
+    ("LDP hello", "ldp_hello"),
+    ("BFD", "bfd"),
+    ("IS-IS IIH", "isis_iih"),
+    ("LACP", "lacp"),
+    ("ARP", "arp"),
+    ("ETHER OAM", "ether_oam"),
+    ("Unknown", "unknown"),
+]
+
+_HW_DISCARD_MAP: list[tuple[str, str]] = [
+    ("Timeout", "timeout"),
+    ("Truncated key", "truncated_key"),
+    ("Bits to test", "bits_to_test"),
+    ("Data error", "data_error"),
+    ("TCP header length error", "tcp_header_length_error"),
+    ("Stack underflow", "stack_underflow"),
+    ("Stack overflow", "stack_overflow"),
+    ("Normal discard", "normal_discard"),
+    ("Extended discard", "extended_discard"),
+    ("Invalid interface", "invalid_interface"),
+    ("Info cell drops", "info_cell_drops"),
+    ("Fabric drops", "fabric_drops"),
+]
+
+_CHECKSUM_MTU_MAP: list[tuple[str, str]] = [
+    ("Input Checksum", "input_checksum"),
+    ("Output MTU", "output_mtu"),
+]
+
+# Generic pattern: label followed by colon and integer value
+_LABEL_VALUE = re.compile(r"^\s*(.+?)\s*:\s+(\d+)\s*$")
+
+
+def _parse_label_value_section(
+    lines: list[str],
+    label_map: list[tuple[str, str]],
+) -> dict[str, int]:
+    """Parse a section of 'label : value' lines into a dict."""
+    result: dict[str, int] = {}
+    for line in lines:
+        match = _LABEL_VALUE.match(line)
+        if not match:
+            continue
+        label = match.group(1).strip()
+        value = int(match.group(2))
+        for cli_label, key in label_map:
+            if label == cli_label:
+                result[key] = value
+                break
+    return result
+
+
+@register(OS.JUNIPER_JUNOS, "show pfe statistics traffic")
+class ShowPfeStatisticsTrafficParser(
+    BaseParser[ShowPfeStatisticsTrafficResult],
+):
+    """Parser for 'show pfe statistics traffic' on Juniper Junos.
+
+    Parses PFE traffic, local traffic, local protocol, hardware discard,
+    and checksum/MTU error statistics into structured data.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    @classmethod
+    def _identify_section(cls, stripped: str) -> str | None:
+        """Return a section identifier if this line is a section header."""
+        if _SECTION_TRAFFIC in stripped:
+            return "traffic"
+        if _SECTION_LOCAL_TRAFFIC in stripped:
+            return "local_traffic"
+        if _SECTION_LOCAL_PROTOCOL in stripped:
+            return "local_protocol"
+        if _SECTION_HW_DISCARD in stripped:
+            return "hardware_discard"
+        if "Header Checksum Error" in stripped and "MTU Error" in stripped:
+            return "checksum_mtu"
+        return None
+
+    @classmethod
+    def _parse_traffic_section(cls, lines: list[str]) -> TrafficStats:
+        """Parse the traffic statistics section with packets and pps."""
+        result: dict[str, int] = {}
+        for line in lines:
+            for pattern, key_packets, key_pps in _TRAFFIC_PATTERNS:
+                match = pattern.search(line)
+                if match:
+                    result[key_packets] = int(match.group(1))
+                    if key_pps is not None:
+                        result[key_pps] = int(match.group(2))
+                    break
+        return TrafficStats(
+            input_packets=result.get("input_packets", 0),
+            input_pps=result.get("input_pps", 0),
+            output_packets=result.get("output_packets", 0),
+            output_pps=result.get("output_pps", 0),
+            fabric_input=result.get("fabric_input", 0),
+            fabric_input_pps=result.get("fabric_input_pps", 0),
+            fabric_output=result.get("fabric_output", 0),
+            fabric_output_pps=result.get("fabric_output_pps", 0),
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPfeStatisticsTrafficResult:
+        """Parse 'show pfe statistics traffic' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed PFE statistics.
+
+        Raises:
+            ValueError: If no recognizable sections are found.
+        """
+        # Split output into sections
+        sections: dict[str, list[str]] = {}
+        current_section: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            section_id = cls._identify_section(stripped)
+            if section_id is not None:
+                current_section = section_id
+                sections[current_section] = []
+                continue
+            if current_section is not None and stripped:
+                sections[current_section].append(line)
+
+        if not sections:
+            msg = "No PFE statistics sections found in output"
+            raise ValueError(msg)
+
+        traffic = cls._parse_traffic_section(sections.get("traffic", []))
+
+        local_traffic_raw = _parse_label_value_section(
+            sections.get("local_traffic", []),
+            _LOCAL_TRAFFIC_MAP,
+        )
+        local_traffic = LocalTrafficStats(
+            local_packets_input=local_traffic_raw.get("local_packets_input", 0),
+            local_packets_output=local_traffic_raw.get("local_packets_output", 0),
+            software_input_control_plane_drops=local_traffic_raw.get(
+                "software_input_control_plane_drops", 0
+            ),
+            software_input_high_drops=local_traffic_raw.get(
+                "software_input_high_drops", 0
+            ),
+            software_input_medium_drops=local_traffic_raw.get(
+                "software_input_medium_drops", 0
+            ),
+            software_input_low_drops=local_traffic_raw.get(
+                "software_input_low_drops", 0
+            ),
+            software_output_drops=local_traffic_raw.get("software_output_drops", 0),
+            hardware_input_drops=local_traffic_raw.get("hardware_input_drops", 0),
+        )
+
+        local_protocol_raw = _parse_label_value_section(
+            sections.get("local_protocol", []),
+            _LOCAL_PROTOCOL_MAP,
+        )
+        local_protocol = LocalProtocolStats(
+            hdlc_keepalives=local_protocol_raw.get("hdlc_keepalives", 0),
+            atm_oam=local_protocol_raw.get("atm_oam", 0),
+            frame_relay_lmi=local_protocol_raw.get("frame_relay_lmi", 0),
+            ppp_lcp_ncp=local_protocol_raw.get("ppp_lcp_ncp", 0),
+            ospf_hello=local_protocol_raw.get("ospf_hello", 0),
+            ospf3_hello=local_protocol_raw.get("ospf3_hello", 0),
+            rsvp_hello=local_protocol_raw.get("rsvp_hello", 0),
+            ldp_hello=local_protocol_raw.get("ldp_hello", 0),
+            bfd=local_protocol_raw.get("bfd", 0),
+            isis_iih=local_protocol_raw.get("isis_iih", 0),
+            lacp=local_protocol_raw.get("lacp", 0),
+            arp=local_protocol_raw.get("arp", 0),
+            ether_oam=local_protocol_raw.get("ether_oam", 0),
+            unknown=local_protocol_raw.get("unknown", 0),
+        )
+
+        hw_discard_raw = _parse_label_value_section(
+            sections.get("hardware_discard", []),
+            _HW_DISCARD_MAP,
+        )
+        hardware_discard = HardwareDiscardStats(
+            timeout=hw_discard_raw.get("timeout", 0),
+            truncated_key=hw_discard_raw.get("truncated_key", 0),
+            bits_to_test=hw_discard_raw.get("bits_to_test", 0),
+            data_error=hw_discard_raw.get("data_error", 0),
+            tcp_header_length_error=hw_discard_raw.get("tcp_header_length_error", 0),
+            stack_underflow=hw_discard_raw.get("stack_underflow", 0),
+            stack_overflow=hw_discard_raw.get("stack_overflow", 0),
+            normal_discard=hw_discard_raw.get("normal_discard", 0),
+            extended_discard=hw_discard_raw.get("extended_discard", 0),
+            invalid_interface=hw_discard_raw.get("invalid_interface", 0),
+            info_cell_drops=hw_discard_raw.get("info_cell_drops", 0),
+            fabric_drops=hw_discard_raw.get("fabric_drops", 0),
+        )
+
+        checksum_mtu_raw = _parse_label_value_section(
+            sections.get("checksum_mtu", []),
+            _CHECKSUM_MTU_MAP,
+        )
+        checksum_mtu = ChecksumMtuStats(
+            input_checksum=checksum_mtu_raw.get("input_checksum", 0),
+            output_mtu=checksum_mtu_raw.get("output_mtu", 0),
+        )
+
+        return ShowPfeStatisticsTrafficResult(
+            traffic=traffic,
+            local_traffic=local_traffic,
+            local_protocol=local_protocol,
+            hardware_discard=hardware_discard,
+            checksum_mtu=checksum_mtu,
+        )

--- a/src/muninn/parsers/juniper_junos/show_pfe_statistics_traffic.py
+++ b/src/muninn/parsers/juniper_junos/show_pfe_statistics_traffic.py
@@ -1,7 +1,7 @@
 """Parser for 'show pfe statistics traffic' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -10,82 +10,108 @@ from muninn.tags import ParserTag
 
 
 class TrafficStats(TypedDict):
-    """Schema for PFE traffic statistics (input/output/fabric)."""
+    """Schema for PFE traffic statistics (input/output/fabric).
 
-    input_packets: int
-    input_pps: int
-    output_packets: int
-    output_pps: int
-    fabric_input: int
-    fabric_input_pps: int
-    fabric_output: int
-    fabric_output_pps: int
+    Every field is optional because individual lines may be absent on
+    some Junos releases or platform variants. Fields are only emitted
+    when the corresponding line is actually present in the device output.
+    """
+
+    input_packets: NotRequired[int]
+    input_pps: NotRequired[int]
+    output_packets: NotRequired[int]
+    output_pps: NotRequired[int]
+    fabric_input: NotRequired[int]
+    fabric_input_pps: NotRequired[int]
+    fabric_output: NotRequired[int]
+    fabric_output_pps: NotRequired[int]
 
 
 class LocalTrafficStats(TypedDict):
-    """Schema for PFE local traffic statistics."""
+    """Schema for PFE local traffic statistics.
 
-    local_packets_input: int
-    local_packets_output: int
-    software_input_control_plane_drops: int
-    software_input_high_drops: int
-    software_input_medium_drops: int
-    software_input_low_drops: int
-    software_output_drops: int
-    hardware_input_drops: int
+    Fields are only emitted when the corresponding label is actually
+    present in the device output.
+    """
+
+    local_packets_input: NotRequired[int]
+    local_packets_output: NotRequired[int]
+    software_input_control_plane_drops: NotRequired[int]
+    software_input_high_drops: NotRequired[int]
+    software_input_medium_drops: NotRequired[int]
+    software_input_low_drops: NotRequired[int]
+    software_output_drops: NotRequired[int]
+    hardware_input_drops: NotRequired[int]
 
 
 class LocalProtocolStats(TypedDict):
-    """Schema for PFE local protocol statistics (dict of protocol name to packets)."""
+    """Schema for PFE local protocol statistics.
 
-    hdlc_keepalives: int
-    atm_oam: int
-    frame_relay_lmi: int
-    ppp_lcp_ncp: int
-    ospf_hello: int
-    ospf3_hello: int
-    rsvp_hello: int
-    ldp_hello: int
-    bfd: int
-    isis_iih: int
-    lacp: int
-    arp: int
-    ether_oam: int
-    unknown: int
+    Fields are only emitted when the corresponding label is actually
+    present in the device output. New protocols seen in future Junos
+    releases that are not in the known label map are ignored.
+    """
+
+    hdlc_keepalives: NotRequired[int]
+    atm_oam: NotRequired[int]
+    frame_relay_lmi: NotRequired[int]
+    ppp_lcp_ncp: NotRequired[int]
+    ospf_hello: NotRequired[int]
+    ospf3_hello: NotRequired[int]
+    rsvp_hello: NotRequired[int]
+    ldp_hello: NotRequired[int]
+    bfd: NotRequired[int]
+    isis_iih: NotRequired[int]
+    lacp: NotRequired[int]
+    arp: NotRequired[int]
+    ether_oam: NotRequired[int]
+    unknown: NotRequired[int]
 
 
 class HardwareDiscardStats(TypedDict):
-    """Schema for PFE hardware discard statistics."""
+    """Schema for PFE hardware discard statistics.
 
-    timeout: int
-    truncated_key: int
-    bits_to_test: int
-    data_error: int
-    tcp_header_length_error: int
-    stack_underflow: int
-    stack_overflow: int
-    normal_discard: int
-    extended_discard: int
-    invalid_interface: int
-    info_cell_drops: int
-    fabric_drops: int
+    Fields are only emitted when the corresponding label is actually
+    present in the device output.
+    """
+
+    timeout: NotRequired[int]
+    truncated_key: NotRequired[int]
+    bits_to_test: NotRequired[int]
+    data_error: NotRequired[int]
+    tcp_header_length_error: NotRequired[int]
+    stack_underflow: NotRequired[int]
+    stack_overflow: NotRequired[int]
+    normal_discard: NotRequired[int]
+    extended_discard: NotRequired[int]
+    invalid_interface: NotRequired[int]
+    info_cell_drops: NotRequired[int]
+    fabric_drops: NotRequired[int]
 
 
 class ChecksumMtuStats(TypedDict):
-    """Schema for IPv4 header checksum error and output MTU error statistics."""
+    """Schema for IPv4 header checksum error and output MTU error statistics.
 
-    input_checksum: int
-    output_mtu: int
+    Fields are only emitted when the corresponding label is actually
+    present in the device output.
+    """
+
+    input_checksum: NotRequired[int]
+    output_mtu: NotRequired[int]
 
 
 class ShowPfeStatisticsTrafficResult(TypedDict):
-    """Schema for 'show pfe statistics traffic' parsed output."""
+    """Schema for 'show pfe statistics traffic' parsed output.
 
-    traffic: TrafficStats
-    local_traffic: LocalTrafficStats
-    local_protocol: LocalProtocolStats
-    hardware_discard: HardwareDiscardStats
-    checksum_mtu: ChecksumMtuStats
+    Each section is only emitted when its header line is present in the
+    device output and at least one of its fields was extracted.
+    """
+
+    traffic: NotRequired[TrafficStats]
+    local_traffic: NotRequired[LocalTrafficStats]
+    local_protocol: NotRequired[LocalProtocolStats]
+    hardware_discard: NotRequired[HardwareDiscardStats]
+    checksum_mtu: NotRequired[ChecksumMtuStats]
 
 
 # Section header patterns
@@ -93,10 +119,6 @@ _SECTION_TRAFFIC = "Packet Forwarding Engine traffic statistics:"
 _SECTION_LOCAL_TRAFFIC = "Packet Forwarding Engine local traffic statistics:"
 _SECTION_LOCAL_PROTOCOL = "Packet Forwarding Engine local protocol statistics:"
 _SECTION_HW_DISCARD = "Packet Forwarding Engine hardware discard statistics:"
-_SECTION_CHECKSUM_MTU = (
-    "Packet Forwarding Engine Input IPv4 Header Checksum Error"
-    " and Output MTU Error statistics:"
-)
 
 # Mapping from CLI label to dict key for each section
 _TRAFFIC_PATTERNS: list[tuple[re.Pattern[str], str, str | None]] = [
@@ -170,6 +192,14 @@ _CHECKSUM_MTU_MAP: list[tuple[str, str]] = [
     ("Output MTU", "output_mtu"),
 ]
 
+# Section id -> (output key, label map). Order matches preferred output order.
+_LABEL_VALUE_SECTIONS: list[tuple[str, str, list[tuple[str, str]]]] = [
+    ("local_traffic", "local_traffic", _LOCAL_TRAFFIC_MAP),
+    ("local_protocol", "local_protocol", _LOCAL_PROTOCOL_MAP),
+    ("hardware_discard", "hardware_discard", _HW_DISCARD_MAP),
+    ("checksum_mtu", "checksum_mtu", _CHECKSUM_MTU_MAP),
+]
+
 # Generic pattern: label followed by colon and integer value
 _LABEL_VALUE = re.compile(r"^\s*(.+?)\s*:\s+(\d+)\s*$")
 
@@ -178,7 +208,11 @@ def _parse_label_value_section(
     lines: list[str],
     label_map: list[tuple[str, str]],
 ) -> dict[str, int]:
-    """Parse a section of 'label : value' lines into a dict."""
+    """Parse a section of 'label : value' lines into a dict.
+
+    Only labels present in ``label_map`` produce dict entries. Labels
+    that do not match are silently skipped.
+    """
     result: dict[str, int] = {}
     for line in lines:
         match = _LABEL_VALUE.match(line)
@@ -222,7 +256,11 @@ class ShowPfeStatisticsTrafficParser(
 
     @classmethod
     def _parse_traffic_section(cls, lines: list[str]) -> TrafficStats:
-        """Parse the traffic statistics section with packets and pps."""
+        """Parse the traffic statistics section with packets and pps.
+
+        Only fields whose source line is actually present in ``lines``
+        are populated in the returned dict.
+        """
         result: dict[str, int] = {}
         for line in lines:
             for pattern, key_packets, key_pps in _TRAFFIC_PATTERNS:
@@ -232,34 +270,13 @@ class ShowPfeStatisticsTrafficParser(
                     if key_pps is not None:
                         result[key_pps] = int(match.group(2))
                     break
-        return TrafficStats(
-            input_packets=result.get("input_packets", 0),
-            input_pps=result.get("input_pps", 0),
-            output_packets=result.get("output_packets", 0),
-            output_pps=result.get("output_pps", 0),
-            fabric_input=result.get("fabric_input", 0),
-            fabric_input_pps=result.get("fabric_input_pps", 0),
-            fabric_output=result.get("fabric_output", 0),
-            fabric_output_pps=result.get("fabric_output_pps", 0),
-        )
+        return cast(TrafficStats, result)
 
     @classmethod
-    def parse(cls, output: str) -> ShowPfeStatisticsTrafficResult:
-        """Parse 'show pfe statistics traffic' output.
-
-        Args:
-            output: Raw CLI output from command.
-
-        Returns:
-            Parsed PFE statistics.
-
-        Raises:
-            ValueError: If no recognizable sections are found.
-        """
-        # Split output into sections
+    def _split_sections(cls, output: str) -> dict[str, list[str]]:
+        """Split raw output into a mapping of section id to its lines."""
         sections: dict[str, list[str]] = {}
         current_section: str | None = None
-
         for line in output.splitlines():
             stripped = line.strip()
             section_id = cls._identify_section(stripped)
@@ -269,89 +286,40 @@ class ShowPfeStatisticsTrafficParser(
                 continue
             if current_section is not None and stripped:
                 sections[current_section].append(line)
+        return sections
 
+    @classmethod
+    def parse(cls, output: str) -> ShowPfeStatisticsTrafficResult:
+        """Parse 'show pfe statistics traffic' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed PFE statistics. Each top-level section key is only
+            present when at least one of its fields was successfully
+            extracted from the input.
+
+        Raises:
+            ValueError: If no recognizable sections are found.
+        """
+        sections = cls._split_sections(output)
         if not sections:
             msg = "No PFE statistics sections found in output"
             raise ValueError(msg)
 
-        traffic = cls._parse_traffic_section(sections.get("traffic", []))
+        result: dict[str, object] = {}
 
-        local_traffic_raw = _parse_label_value_section(
-            sections.get("local_traffic", []),
-            _LOCAL_TRAFFIC_MAP,
-        )
-        local_traffic = LocalTrafficStats(
-            local_packets_input=local_traffic_raw.get("local_packets_input", 0),
-            local_packets_output=local_traffic_raw.get("local_packets_output", 0),
-            software_input_control_plane_drops=local_traffic_raw.get(
-                "software_input_control_plane_drops", 0
-            ),
-            software_input_high_drops=local_traffic_raw.get(
-                "software_input_high_drops", 0
-            ),
-            software_input_medium_drops=local_traffic_raw.get(
-                "software_input_medium_drops", 0
-            ),
-            software_input_low_drops=local_traffic_raw.get(
-                "software_input_low_drops", 0
-            ),
-            software_output_drops=local_traffic_raw.get("software_output_drops", 0),
-            hardware_input_drops=local_traffic_raw.get("hardware_input_drops", 0),
-        )
+        if "traffic" in sections:
+            traffic = cls._parse_traffic_section(sections["traffic"])
+            if traffic:
+                result["traffic"] = traffic
 
-        local_protocol_raw = _parse_label_value_section(
-            sections.get("local_protocol", []),
-            _LOCAL_PROTOCOL_MAP,
-        )
-        local_protocol = LocalProtocolStats(
-            hdlc_keepalives=local_protocol_raw.get("hdlc_keepalives", 0),
-            atm_oam=local_protocol_raw.get("atm_oam", 0),
-            frame_relay_lmi=local_protocol_raw.get("frame_relay_lmi", 0),
-            ppp_lcp_ncp=local_protocol_raw.get("ppp_lcp_ncp", 0),
-            ospf_hello=local_protocol_raw.get("ospf_hello", 0),
-            ospf3_hello=local_protocol_raw.get("ospf3_hello", 0),
-            rsvp_hello=local_protocol_raw.get("rsvp_hello", 0),
-            ldp_hello=local_protocol_raw.get("ldp_hello", 0),
-            bfd=local_protocol_raw.get("bfd", 0),
-            isis_iih=local_protocol_raw.get("isis_iih", 0),
-            lacp=local_protocol_raw.get("lacp", 0),
-            arp=local_protocol_raw.get("arp", 0),
-            ether_oam=local_protocol_raw.get("ether_oam", 0),
-            unknown=local_protocol_raw.get("unknown", 0),
-        )
+        for section_id, out_key, label_map in _LABEL_VALUE_SECTIONS:
+            if section_id not in sections:
+                continue
+            parsed = _parse_label_value_section(sections[section_id], label_map)
+            if parsed:
+                result[out_key] = parsed
 
-        hw_discard_raw = _parse_label_value_section(
-            sections.get("hardware_discard", []),
-            _HW_DISCARD_MAP,
-        )
-        hardware_discard = HardwareDiscardStats(
-            timeout=hw_discard_raw.get("timeout", 0),
-            truncated_key=hw_discard_raw.get("truncated_key", 0),
-            bits_to_test=hw_discard_raw.get("bits_to_test", 0),
-            data_error=hw_discard_raw.get("data_error", 0),
-            tcp_header_length_error=hw_discard_raw.get("tcp_header_length_error", 0),
-            stack_underflow=hw_discard_raw.get("stack_underflow", 0),
-            stack_overflow=hw_discard_raw.get("stack_overflow", 0),
-            normal_discard=hw_discard_raw.get("normal_discard", 0),
-            extended_discard=hw_discard_raw.get("extended_discard", 0),
-            invalid_interface=hw_discard_raw.get("invalid_interface", 0),
-            info_cell_drops=hw_discard_raw.get("info_cell_drops", 0),
-            fabric_drops=hw_discard_raw.get("fabric_drops", 0),
-        )
-
-        checksum_mtu_raw = _parse_label_value_section(
-            sections.get("checksum_mtu", []),
-            _CHECKSUM_MTU_MAP,
-        )
-        checksum_mtu = ChecksumMtuStats(
-            input_checksum=checksum_mtu_raw.get("input_checksum", 0),
-            output_mtu=checksum_mtu_raw.get("output_mtu", 0),
-        )
-
-        return ShowPfeStatisticsTrafficResult(
-            traffic=traffic,
-            local_traffic=local_traffic,
-            local_protocol=local_protocol,
-            hardware_discard=hardware_discard,
-            checksum_mtu=checksum_mtu,
-        )
+        return cast(ShowPfeStatisticsTrafficResult, result)

--- a/tests/parsers/juniper_junos/show_pfe_statistics_traffic/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_pfe_statistics_traffic/001_basic/expected.json
@@ -1,0 +1,56 @@
+{
+    "traffic": {
+        "input_packets": 763584752,
+        "input_pps": 14,
+        "output_packets": 728623201,
+        "output_pps": 16,
+        "fabric_input": 0,
+        "fabric_input_pps": 0,
+        "fabric_output": 0,
+        "fabric_output_pps": 0
+    },
+    "local_traffic": {
+        "local_packets_input": 184259247,
+        "local_packets_output": 370506284,
+        "software_input_control_plane_drops": 0,
+        "software_input_high_drops": 0,
+        "software_input_medium_drops": 0,
+        "software_input_low_drops": 0,
+        "software_output_drops": 0,
+        "hardware_input_drops": 0
+    },
+    "local_protocol": {
+        "hdlc_keepalives": 0,
+        "atm_oam": 0,
+        "frame_relay_lmi": 0,
+        "ppp_lcp_ncp": 0,
+        "ospf_hello": 5732336,
+        "ospf3_hello": 4146329,
+        "rsvp_hello": 7040269,
+        "ldp_hello": 3462026,
+        "bfd": 82347033,
+        "isis_iih": 0,
+        "lacp": 0,
+        "arp": 56818,
+        "ether_oam": 0,
+        "unknown": 0
+    },
+    "hardware_discard": {
+        "timeout": 0,
+        "truncated_key": 0,
+        "bits_to_test": 0,
+        "data_error": 0,
+        "tcp_header_length_error": 0,
+        "stack_underflow": 0,
+        "stack_overflow": 0,
+        "normal_discard": 962415,
+        "extended_discard": 0,
+        "invalid_interface": 0,
+        "info_cell_drops": 0,
+        "fabric_drops": 0
+    },
+    "checksum_mtu": {
+        "input_checksum": 0,
+        "output_mtu": 0
+    }
+}

--- a/tests/parsers/juniper_junos/show_pfe_statistics_traffic/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_pfe_statistics_traffic/001_basic/input.txt
@@ -1,0 +1,47 @@
+
+                show pfe statistics traffic
+        Packet Forwarding Engine traffic statistics:
+            Input  packets:            763584752                   14 pps
+            Output packets:            728623201                   16 pps
+            Fabric Input  :                    0                    0 pps
+            Fabric Output :                    0                    0 pps
+        Packet Forwarding Engine local traffic statistics:
+            Local packets input                 :            184259247
+            Local packets output                :            370506284
+            Software input control plane drops  :                    0
+            Software input high drops           :                    0
+            Software input medium drops         :                    0
+            Software input low drops            :                    0
+            Software output drops               :                    0
+            Hardware input drops                :                    0
+        Packet Forwarding Engine local protocol statistics:
+            HDLC keepalives            :                    0
+            ATM OAM                    :                    0
+            Frame Relay LMI            :                    0
+            PPP LCP/NCP                :                    0
+            OSPF hello                 :              5732336
+            OSPF3 hello                :              4146329
+            RSVP hello                 :              7040269
+            LDP hello                  :              3462026
+            BFD                        :             82347033
+            IS-IS IIH                  :                    0
+            LACP                       :                    0
+            ARP                        :                56818
+            ETHER OAM                  :                    0
+            Unknown                    :                    0
+        Packet Forwarding Engine hardware discard statistics:
+            Timeout                    :                    0
+            Truncated key              :                    0
+            Bits to test               :                    0
+            Data error                 :                    0
+            TCP header length error    :                    0
+            Stack underflow            :                    0
+            Stack overflow             :                    0
+            Normal discard             :               962415
+            Extended discard           :                    0
+            Invalid interface          :                    0
+            Info cell drops            :                    0
+            Fabric drops               :                    0
+        Packet Forwarding Engine Input IPv4 Header Checksum Error and Output MTU Error statistics:
+            Input Checksum             :                    0
+            Output MTU                 :                    0

--- a/tests/parsers/juniper_junos/show_pfe_statistics_traffic/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_pfe_statistics_traffic/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: PFE traffic statistics from MX series router
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show pfe statistics traffic` on Juniper Junos
- Parses all five sections: traffic stats, local traffic, local protocol, hardware discard, and checksum/MTU errors
- All counters parsed as integers; pps rates included for traffic section

## Test plan
- [x] Parser test with real device output fixture passes
- [x] All placeholder sentinel tests pass (no banned values)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)
- [x] ruff check and ruff format pass
- [x] xenon complexity check passes (max-absolute B)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)