### PR TITLE
feat(cisco_iosxr): add parser for `show lldp neighbors`

### DIFF
--- a/changes/+cisco-iosxr-show-lldp-neighbors.parser_added
+++ b/changes/+cisco-iosxr-show-lldp-neighbors.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show lldp neighbors` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_lldp_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_lldp_neighbors.py
@@ -1,0 +1,125 @@
+"""Parser for 'show lldp neighbors' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class LldpNeighborEntry(TypedDict):
+    """Schema for a single LLDP neighbor entry."""
+
+    device_id: str
+    hold_time: int
+    capability: str
+    port_id: str
+
+
+class ShowLldpNeighborsResult(TypedDict):
+    """Schema for 'show lldp neighbors' parsed output on Cisco IOS-XR.
+
+    Keyed by local interface name (canonical form).
+    """
+
+    neighbors: dict[str, dict[str, LldpNeighborEntry]]
+
+
+# IOS-XR LLDP neighbor table format:
+#
+# Device ID       Local Intf          Hold-time  Capability     Port ID
+# ASR-OCC-P1      Gi0/0/0/0           120        R               Gi0/0/0/2
+#
+# Lines to skip: blank, header, separator, capability legend, total/timestamp.
+_SKIP_PATTERNS = re.compile(
+    r"^\s*$"
+    r"|^Device\s+ID\s+"
+    r"|^-{3,}"
+    r"|^Capability\s+codes:"
+    r"|^\s+\("
+    r"|^Total\s+entries"
+    r"|^\w{3}\s+\w{3}\s+\d+",
+    re.IGNORECASE,
+)
+
+# IOS-XR local interface abbreviations: Gi, Te, Hu, Fo, Be, Lo, Mg, Nu, TenGigE, etc.
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<device_id>\S+)\s+"
+    r"(?P<local_intf>\S+)\s+"
+    r"(?P<hold_time>\d+)\s+"
+    r"(?P<capability>\S+)\s+"
+    r"(?P<port_id>\S+)\s*$"
+)
+
+# Port ID that looks like an interface name and should be canonicalized.
+_INTERFACE_PORT_ID_PATTERN = re.compile(
+    r"^(?:Eth(?:ernet)?|Et|Gi|Te|Fo|Hu|Be|Lo|Mg|Nu|Po|Ma"
+    r"|GigabitEthernet|TenGigE|FortyGigE|HundredGigE"
+    r"|Bundle-Ether|MgmtEth|Loopback|Null)\d",
+    re.IGNORECASE,
+)
+
+
+@register(OS.CISCO_IOSXR, "show lldp neighbors")
+class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
+    """Parser for 'show lldp neighbors' command on Cisco IOS-XR."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.LLDP})
+
+    @classmethod
+    def _normalize_port_id(cls, port_id: str) -> str:
+        """Normalize port_id if it looks like an interface name."""
+        if _INTERFACE_PORT_ID_PATTERN.match(port_id):
+            return canonical_interface_name(port_id, os=OS.CISCO_IOSXR)
+        return port_id
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLldpNeighborsResult:
+        """Parse 'show lldp neighbors' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed LLDP neighbors keyed by local interface, then device ID.
+
+        Raises:
+            ValueError: If no LLDP neighbors are found in the output.
+        """
+        neighbors: dict[str, dict[str, LldpNeighborEntry]] = {}
+
+        for line in output.splitlines():
+            if _SKIP_PATTERNS.match(line):
+                continue
+
+            match = _NEIGHBOR_PATTERN.match(line)
+            if not match:
+                continue
+
+            local_intf = canonical_interface_name(
+                match.group("local_intf"), os=OS.CISCO_IOSXR
+            )
+            device_id = match.group("device_id")
+            port_id = cls._normalize_port_id(match.group("port_id"))
+            hold_time = int(match.group("hold_time"))
+            capability = match.group("capability")
+
+            entry: LldpNeighborEntry = {
+                "device_id": device_id,
+                "hold_time": hold_time,
+                "capability": capability,
+                "port_id": port_id,
+            }
+
+            if local_intf not in neighbors:
+                neighbors[local_intf] = {}
+            neighbors[local_intf][device_id] = entry
+
+        if not neighbors:
+            msg = "No LLDP neighbors found in output"
+            raise ValueError(msg)
+
+        return cast(ShowLldpNeighborsResult, {"neighbors": neighbors})

--- a/src/muninn/parsers/cisco_iosxr/show_lldp_neighbors.py
+++ b/src/muninn/parsers/cisco_iosxr/show_lldp_neighbors.py
@@ -1,7 +1,7 @@
 """Parser for 'show lldp neighbors' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -15,17 +15,18 @@ class LldpNeighborEntry(TypedDict):
 
     device_id: str
     hold_time: int
-    capability: str
+    capabilities: NotRequired[str]
     port_id: str
 
 
 class ShowLldpNeighborsResult(TypedDict):
     """Schema for 'show lldp neighbors' parsed output on Cisco IOS-XR.
 
-    Keyed by local interface name (canonical form).
+    Keyed by local interface name (canonical form), then device ID.
     """
 
     neighbors: dict[str, dict[str, LldpNeighborEntry]]
+    total_entries: NotRequired[int]
 
 
 # IOS-XR LLDP neighbor table format:
@@ -40,17 +41,23 @@ _SKIP_PATTERNS = re.compile(
     r"|^-{3,}"
     r"|^Capability\s+codes:"
     r"|^\s+\("
-    r"|^Total\s+entries"
     r"|^\w{3}\s+\w{3}\s+\d+",
     re.IGNORECASE,
 )
 
+# Capture the trailing "Total entries displayed: N" footer.
+_TOTAL_PATTERN = re.compile(
+    r"^Total\s+entries\s+displayed:\s*(?P<total>\d+)\s*$",
+    re.IGNORECASE,
+)
+
 # IOS-XR local interface abbreviations: Gi, Te, Hu, Fo, Be, Lo, Mg, Nu, TenGigE, etc.
+# Capability is optional - some neighbors may not advertise capabilities.
 _NEIGHBOR_PATTERN = re.compile(
     r"^(?P<device_id>\S+)\s+"
     r"(?P<local_intf>\S+)\s+"
     r"(?P<hold_time>\d+)\s+"
-    r"(?P<capability>\S+)\s+"
+    r"(?:(?P<capability>[A-Za-z,]+)\s+)?"
     r"(?P<port_id>\S+)\s*$"
 )
 
@@ -90,8 +97,14 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
             ValueError: If no LLDP neighbors are found in the output.
         """
         neighbors: dict[str, dict[str, LldpNeighborEntry]] = {}
+        total_entries: int | None = None
 
         for line in output.splitlines():
+            total_match = _TOTAL_PATTERN.match(line)
+            if total_match:
+                total_entries = int(total_match.group("total"))
+                continue
+
             if _SKIP_PATTERNS.match(line):
                 continue
 
@@ -110,9 +123,10 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
             entry: LldpNeighborEntry = {
                 "device_id": device_id,
                 "hold_time": hold_time,
-                "capability": capability,
                 "port_id": port_id,
             }
+            if capability:
+                entry["capabilities"] = capability
 
             if local_intf not in neighbors:
                 neighbors[local_intf] = {}
@@ -122,4 +136,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
             msg = "No LLDP neighbors found in output"
             raise ValueError(msg)
 
-        return cast(ShowLldpNeighborsResult, {"neighbors": neighbors})
+        result: ShowLldpNeighborsResult = {"neighbors": neighbors}
+        if total_entries is not None:
+            result["total_entries"] = total_entries
+        return result

--- a/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/expected.json
@@ -4,7 +4,7 @@
             "ASR-OCC-P1": {
                 "device_id": "ASR-OCC-P1",
                 "hold_time": 120,
-                "capability": "R",
+                "capabilities": "R",
                 "port_id": "GigabitEthernet0/0/0/2"
             }
         },
@@ -12,9 +12,10 @@
             "ASR-LON-P1": {
                 "device_id": "ASR-LON-P1",
                 "hold_time": 120,
-                "capability": "R",
+                "capabilities": "R",
                 "port_id": "GigabitEthernet0/0/0/2"
             }
         }
-    }
+    },
+    "total_entries": 2
 }

--- a/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/expected.json
@@ -1,0 +1,20 @@
+{
+    "neighbors": {
+        "GigabitEthernet0/0/0/0": {
+            "ASR-OCC-P1": {
+                "device_id": "ASR-OCC-P1",
+                "hold_time": 120,
+                "capability": "R",
+                "port_id": "GigabitEthernet0/0/0/2"
+            }
+        },
+        "GigabitEthernet0/0/0/3": {
+            "ASR-LON-P1": {
+                "device_id": "ASR-LON-P1",
+                "hold_time": 120,
+                "capability": "R",
+                "port_id": "GigabitEthernet0/0/0/2"
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/input.txt
@@ -1,0 +1,10 @@
+Mon Jan 29 19:06:33.768 UTC
+Capability codes:
+        (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+        (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+
+Device ID       Local Intf          Hold-time  Capability     Port ID
+ASR-OCC-P1      Gi0/0/0/0           120        R               Gi0/0/0/2
+ASR-LON-P1      Gi0/0/0/3           120        R               Gi0/0/0/2
+
+Total entries displayed: 2

--- a/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_lldp_neighbors/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic LLDP neighbors with two router peers
+platform: Unknown
+software_version: IOS-XR Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show lldp neighbors` on Cisco IOS-XR
- Output is dict-of-dicts keyed by canonical local interface name, then device ID
- Each entry includes `device_id`, `hold_time`, `capability`, and `port_id` (with interface canonicalization)
- Tagged with `ParserTag.LLDP`

## Test plan
- [x] Fixture `001_basic` uses real device output from ntc-templates (2 router peers on GigabitEthernet interfaces)
- [x] All 7 parser tests pass (fixture conventions, placeholder sentinels, parser correctness)
- [x] Pre-commit hooks pass (ruff, xenon, json, yaml, etc.)
- [x] Bandit security scan clean
- [x] Changelog fragment added

🤖 Generated with [Claude Code](https://claude.com/claude-code)