### PR TITLE
feat(cisco_iosxr): add parser for `show cdp neighbors detail`

### DIFF
--- a/changes/+cisco-iosxr-show-cdp-neighbors-detail.parser_added
+++ b/changes/+cisco-iosxr-show-cdp-neighbors-detail.parser_added
@@ -1,0 +1,1 @@
+Added `cisco_iosxr` parser for `show cdp neighbors detail`.

--- a/src/muninn/parsers/cisco_iosxr/show_cdp_neighbors_detail.py
+++ b/src/muninn/parsers/cisco_iosxr/show_cdp_neighbors_detail.py
@@ -1,0 +1,220 @@
+"""Parser for 'show cdp neighbors detail' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from netutils.interface import canonical_interface_name
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class CdpNeighborDetailEntry(TypedDict):
+    """Schema for a single CDP neighbor detail entry."""
+
+    device_id: str
+    entry_addresses: list[str]
+    platform: str
+    capabilities: str
+    port_id: str
+    hold_time: int
+    version: str
+    advertisement_version: NotRequired[int]
+    native_vlan: NotRequired[int]
+    duplex: NotRequired[str]
+
+
+class ShowCdpNeighborsDetailResult(TypedDict):
+    """Schema for 'show cdp neighbors detail' parsed output."""
+
+    neighbors: dict[str, dict[str, dict[str, CdpNeighborDetailEntry]]]
+
+
+@register(OS.CISCO_IOSXR, "show cdp neighbors detail")
+class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
+    """Parser for 'show cdp neighbors detail' on IOS-XR.
+
+    Parses detailed CDP neighbor information including software version,
+    platform, capabilities, native VLAN, and duplex settings.
+
+    Output is keyed as: local_interface -> device_id -> port_id -> entry.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.CDP})
+
+    _DEVICE_ID_PATTERN = re.compile(r"Device ID:\s*(.+)")
+    _IP_ADDRESS_PATTERN = re.compile(r"IP(?:v4)? [Aa]ddress:\s*(\S+)")
+    _PLATFORM_CAPABILITIES_PATTERN = re.compile(
+        r"Platform:\s*(.+?),\s+Capabilities:\s*(.+)"
+    )
+    _PLATFORM_ONLY_PATTERN = re.compile(r"Platform:\s*(.+)")
+    _INTERFACE_PATTERN = re.compile(
+        r"Interface:\s*(\S+),?\s+Port ID \(outgoing port\):\s*(\S+)"
+    )
+    _HOLDTIME_PATTERN = re.compile(r"Holdtime\s*:\s*(\d+)")
+    _VERSION_MARKER = re.compile(r"^Version\s*:", re.MULTILINE)
+    _ADV_VERSION_PATTERN = re.compile(r"advertisement version:\s*(\d+)")
+    _NATIVE_VLAN_PATTERN = re.compile(r"Native VLAN:\s*(\d+)")
+    _DUPLEX_PATTERN = re.compile(r"Duplex:\s*(\S+)")
+    _SEPARATOR_PATTERN = SEPARATOR_DASH_RE
+    _ENTRY_ADDR_HEADER = re.compile(r"^Entry address\(es\):")
+
+    _VERSION_END_MARKERS = (
+        "advertisement version:",
+        "Native VLAN:",
+        "Duplex:",
+    )
+
+    @classmethod
+    def _split_into_blocks(cls, output: str) -> list[str]:
+        """Split output into per-neighbor text blocks.
+
+        Splits on separator lines, then keeps only chunks that
+        start with a Device ID line.
+        """
+        chunks = cls._SEPARATOR_PATTERN.split(output)
+        return [
+            chunk.strip() for chunk in chunks if cls._DEVICE_ID_PATTERN.search(chunk)
+        ]
+
+    @classmethod
+    def _extract_entry_addresses(cls, block: str) -> list[str]:
+        """Extract IP addresses following the Entry address(es) header."""
+        addresses: list[str] = []
+        collecting = False
+
+        for line in block.splitlines():
+            stripped = line.strip()
+            if cls._ENTRY_ADDR_HEADER.match(stripped):
+                collecting = True
+                ip_match = cls._IP_ADDRESS_PATTERN.search(stripped)
+                if ip_match:
+                    addresses.append(ip_match.group(1))
+                continue
+
+            if collecting:
+                ip_match = cls._IP_ADDRESS_PATTERN.match(stripped)
+                if ip_match:
+                    addresses.append(ip_match.group(1))
+                elif stripped:
+                    collecting = False
+
+        return addresses
+
+    @classmethod
+    def _extract_version(cls, block: str) -> str:
+        """Extract software version string from block."""
+        version_lines: list[str] = []
+        collecting = False
+
+        for line in block.splitlines():
+            stripped = line.strip()
+
+            if cls._VERSION_MARKER.match(stripped):
+                collecting = True
+                after_marker = stripped.split(":", 1)[1].strip()
+                if after_marker:
+                    version_lines.append(after_marker)
+                continue
+
+            if collecting:
+                if not stripped:
+                    if version_lines:
+                        break
+                    continue
+                if any(
+                    stripped.lower().startswith(m.lower())
+                    for m in cls._VERSION_END_MARKERS
+                ):
+                    break
+                version_lines.append(stripped)
+
+        return "\n".join(version_lines)
+
+    @classmethod
+    def _extract_platform_capabilities(cls, block: str) -> tuple[str, str]:
+        """Extract platform and capabilities strings from a block."""
+        plat_cap_match = cls._PLATFORM_CAPABILITIES_PATTERN.search(block)
+        if plat_cap_match:
+            return plat_cap_match.group(1).strip(), plat_cap_match.group(2).strip()
+
+        plat_match = cls._PLATFORM_ONLY_PATTERN.search(block)
+        if plat_match:
+            return plat_match.group(1).strip().rstrip(","), ""
+
+        return "", ""
+
+    @classmethod
+    def _parse_block(cls, block: str) -> tuple[str, CdpNeighborDetailEntry] | None:
+        """Parse a single neighbor block into (local interface key, entry)."""
+        device_match = cls._DEVICE_ID_PATTERN.search(block)
+        if not device_match:
+            return None
+
+        intf_match = cls._INTERFACE_PATTERN.search(block)
+        if not intf_match:
+            return None
+
+        platform, capabilities = cls._extract_platform_capabilities(block)
+        hold_match = cls._HOLDTIME_PATTERN.search(block)
+
+        local_interface = canonical_interface_name(intf_match.group(1))
+        port_id = canonical_interface_name(intf_match.group(2))
+
+        entry: CdpNeighborDetailEntry = {
+            "device_id": device_match.group(1).strip(),
+            "entry_addresses": cls._extract_entry_addresses(block),
+            "platform": platform,
+            "capabilities": capabilities,
+            "port_id": port_id,
+            "hold_time": int(hold_match.group(1)) if hold_match else 0,
+            "version": cls._extract_version(block),
+        }
+
+        adv_match = cls._ADV_VERSION_PATTERN.search(block)
+        if adv_match:
+            entry["advertisement_version"] = int(adv_match.group(1))
+
+        vlan_match = cls._NATIVE_VLAN_PATTERN.search(block)
+        if vlan_match:
+            entry["native_vlan"] = int(vlan_match.group(1))
+
+        duplex_match = cls._DUPLEX_PATTERN.search(block)
+        if duplex_match:
+            entry["duplex"] = duplex_match.group(1)
+
+        return local_interface, entry
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCdpNeighborsDetailResult:
+        """Parse 'show cdp neighbors detail' output on IOS-XR.
+
+        Returns:
+            Parsed CDP neighbor details nested as
+            ``local_interface -> device_id -> port_id -> entry``.
+
+        Raises:
+            ValueError: If no neighbors found in output.
+        """
+        blocks = cls._split_into_blocks(output)
+        neighbors: dict[str, dict[str, dict[str, CdpNeighborDetailEntry]]] = {}
+
+        for block in blocks:
+            parsed = cls._parse_block(block)
+            if parsed is None:
+                continue
+            local_if, entry = parsed
+            device_id = entry["device_id"]
+            port_key = entry["port_id"]
+            by_local = neighbors.setdefault(local_if, {})
+            by_device = by_local.setdefault(device_id, {})
+            by_device[port_key] = entry
+
+        if not neighbors:
+            msg = "No CDP neighbor details found in output"
+            raise ValueError(msg)
+
+        return ShowCdpNeighborsDetailResult(neighbors=neighbors)

--- a/src/muninn/parsers/cisco_iosxr/show_cdp_neighbors_detail.py
+++ b/src/muninn/parsers/cisco_iosxr/show_cdp_neighbors_detail.py
@@ -22,6 +22,7 @@ class CdpNeighborDetailEntry(TypedDict):
     port_id: str
     hold_time: int
     version: str
+    system_name: NotRequired[str]
     advertisement_version: NotRequired[int]
     native_vlan: NotRequired[int]
     duplex: NotRequired[str]
@@ -46,6 +47,7 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.CDP})
 
     _DEVICE_ID_PATTERN = re.compile(r"Device ID:\s*(.+)")
+    _SYSNAME_PATTERN = re.compile(r"SysName\s*:[ \t]*(\S.*)")
     _IP_ADDRESS_PATTERN = re.compile(r"IP(?:v4)? [Aa]ddress:\s*(\S+)")
     _PLATFORM_CAPABILITIES_PATTERN = re.compile(
         r"Platform:\s*(.+?),\s+Capabilities:\s*(.+)"
@@ -160,6 +162,8 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
 
         platform, capabilities = cls._extract_platform_capabilities(block)
         hold_match = cls._HOLDTIME_PATTERN.search(block)
+        if not hold_match:
+            return None
 
         local_interface = canonical_interface_name(intf_match.group(1))
         port_id = canonical_interface_name(intf_match.group(2))
@@ -170,9 +174,15 @@ class ShowCdpNeighborsDetailParser(BaseParser[ShowCdpNeighborsDetailResult]):
             "platform": platform,
             "capabilities": capabilities,
             "port_id": port_id,
-            "hold_time": int(hold_match.group(1)) if hold_match else 0,
+            "hold_time": int(hold_match.group(1)),
             "version": cls._extract_version(block),
         }
+
+        sysname_match = cls._SYSNAME_PATTERN.search(block)
+        if sysname_match:
+            sysname = sysname_match.group(1).strip()
+            if sysname:
+                entry["system_name"] = sysname
 
         adv_match = cls._ADV_VERSION_PATTERN.search(block)
         if adv_match:

--- a/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/expected.json
@@ -48,6 +48,7 @@
                     "port_id": "FortyGigabitEthernet0/0/0/2",
                     "hold_time": 155,
                     "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c90.ntc.com",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -65,6 +66,7 @@
                     "port_id": "Ethernet6/1",
                     "hold_time": 126,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-d02",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -82,6 +84,7 @@
                     "port_id": "FortyGigabitEthernet0/0/0/0",
                     "hold_time": 170,
                     "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c97",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -99,6 +102,7 @@
                     "port_id": "FortyGigabitEthernet0/0/0/2",
                     "hold_time": 122,
                     "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c91.ntc.com",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -116,6 +120,7 @@
                     "port_id": "FortyGigabitEthernet0/1/0/0",
                     "hold_time": 132,
                     "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c97",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -133,6 +138,7 @@
                     "port_id": "Ethernet6/1",
                     "hold_time": 144,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-d03",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -150,6 +156,7 @@
                     "port_id": "FortyGigabitEthernet0/4/0/2",
                     "hold_time": 174,
                     "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c90.ntc.com",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -167,6 +174,7 @@
                     "port_id": "Ethernet4/3",
                     "hold_time": 153,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-z50a",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -184,6 +192,7 @@
                     "port_id": "Ethernet6/1",
                     "hold_time": 155,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-d04",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -201,6 +210,7 @@
                     "port_id": "FortyGigabitEthernet0/4/0/2",
                     "hold_time": 130,
                     "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c91.ntc.com",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -218,6 +228,7 @@
                     "port_id": "Ethernet6/1",
                     "hold_time": 128,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-d01",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -235,6 +246,7 @@
                     "port_id": "Ethernet4/3",
                     "hold_time": 158,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-z50b",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -269,6 +281,7 @@
                     "port_id": "TenGigE0/2/0/0",
                     "hold_time": 150,
                     "version": "Cisco IOS XR Software, Version 4.3.2[Default]\nCopyright (c) 2013 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-d57",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -286,6 +299,7 @@
                     "port_id": "Ethernet4/1",
                     "hold_time": 171,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-d40b",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -303,6 +317,7 @@
                     "port_id": "Ethernet2/1",
                     "hold_time": 140,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)",
+                    "system_name": "nyc-dc-d80",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -337,6 +352,7 @@
                     "port_id": "TenGigE1/2/0/0",
                     "hold_time": 120,
                     "version": "Cisco IOS XR Software, Version 4.3.2[Default]\nCopyright (c) 2013 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-d57",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -354,6 +370,7 @@
                     "port_id": "Ethernet4/1",
                     "hold_time": 171,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "system_name": "nyc-dc-d40a",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -371,6 +388,7 @@
                     "port_id": "Ethernet1/1",
                     "hold_time": 141,
                     "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)",
+                    "system_name": "nyc-dc-d81",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }
@@ -388,6 +406,7 @@
                     "port_id": "FortyGigabitEthernet0/6/0/0",
                     "hold_time": 163,
                     "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c97",
                     "advertisement_version": 2,
                     "duplex": "full"
                 },
@@ -401,6 +420,7 @@
                     "port_id": "FortyGigabitEthernet0/7/0/0",
                     "hold_time": 140,
                     "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "system_name": "nyc-dc-c97",
                     "advertisement_version": 2,
                     "duplex": "full"
                 }

--- a/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/expected.json
@@ -1,0 +1,410 @@
+{
+    "neighbors": {
+        "MgmtEth0/RSP0/CPU0/0": {
+            "nyc-dc-dcm005.ntc.com": {
+                "GigabitEthernet1/9": {
+                    "device_id": "nyc-dc-dcm005.ntc.com",
+                    "entry_addresses": [
+                        "10.100.1.54"
+                    ],
+                    "platform": "cisco WS-C4948E",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "GigabitEthernet1/9",
+                    "hold_time": 134,
+                    "version": "Cisco IOS Software, Catalyst 4500 L3 Switch Software (cat4500e-ENTSERVICESK9-M), Version 15.0(2)SG10, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Tue 07-Apr-15 10:40 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "native_vlan": 103,
+                    "duplex": "full"
+                }
+            }
+        },
+        "MgmtEth0/RSP1/CPU0/0": {
+            "nyc-dc-dcm006.ntc.com": {
+                "GigabitEthernet1/9": {
+                    "device_id": "nyc-dc-dcm006.ntc.com",
+                    "entry_addresses": [
+                        "10.100.1.55"
+                    ],
+                    "platform": "cisco WS-C4948E",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "GigabitEthernet1/9",
+                    "hold_time": 160,
+                    "version": "Cisco IOS Software, Catalyst 4500 L3 Switch Software (cat4500e-ENTSERVICESK9-M), Version 15.0(2)SG10, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Tue 07-Apr-15 10:40 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "native_vlan": 103,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/0/1/0": {
+            "nyc-dc-c90.ntc.com": {
+                "FortyGigabitEthernet0/0/0/2": {
+                    "device_id": "nyc-dc-c90.ntc.com",
+                    "entry_addresses": [
+                        "10.100.100.141"
+                    ],
+                    "platform": "cisco CRS",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "FortyGigabitEthernet0/0/0/2",
+                    "hold_time": 155,
+                    "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/0/1/1": {
+            "nyc-dc-d02.ntc.com(FXS182XXXXX)": {
+                "Ethernet6/1": {
+                    "device_id": "nyc-dc-d02.ntc.com(FXS182XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.162"
+                    ],
+                    "platform": "N77-C7706",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet6/1",
+                    "hold_time": 126,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/0/0/0": {
+            "nyc-dc-c97": {
+                "FortyGigabitEthernet0/0/0/0": {
+                    "device_id": "nyc-dc-c97",
+                    "entry_addresses": [
+                        "10.100.100.19"
+                    ],
+                    "platform": "cisco ASR9K Series",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/0/0/0",
+                    "hold_time": 170,
+                    "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/0/0/1": {
+            "nyc-dc-c91.ntc.com": {
+                "FortyGigabitEthernet0/0/0/2": {
+                    "device_id": "nyc-dc-c91.ntc.com",
+                    "entry_addresses": [
+                        "10.100.100.125"
+                    ],
+                    "platform": "cisco CRS",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/0/0/2",
+                    "hold_time": 122,
+                    "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/1/0/0": {
+            "nyc-dc-c97": {
+                "FortyGigabitEthernet0/1/0/0": {
+                    "device_id": "nyc-dc-c97",
+                    "entry_addresses": [
+                        "10.100.100.113"
+                    ],
+                    "platform": "cisco ASR9K Series",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/1/0/0",
+                    "hold_time": 132,
+                    "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/1/0/1": {
+            "nyc-dc-d03.ntc.com(FXS182XXXXX)": {
+                "Ethernet6/1": {
+                    "device_id": "nyc-dc-d03.ntc.com(FXS182XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.190"
+                    ],
+                    "platform": "N77-C7706",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet6/1",
+                    "hold_time": 144,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/1/1/0": {
+            "nyc-dc-c90.ntc.com": {
+                "FortyGigabitEthernet0/4/0/2": {
+                    "device_id": "nyc-dc-c90.ntc.com",
+                    "entry_addresses": [
+                        "10.100.100.145"
+                    ],
+                    "platform": "cisco CRS",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/4/0/2",
+                    "hold_time": 174,
+                    "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/1/1/1": {
+            "nyc-dc-z50a.ntc.com(JAF18XXXXX)": {
+                "Ethernet4/3": {
+                    "device_id": "nyc-dc-z50a.ntc.com(JAF18XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.116"
+                    ],
+                    "platform": "N77-C7710",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet4/3",
+                    "hold_time": 153,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/2/1/0": {
+            "nyc-dc-d04.ntc.com(FXS18XXXXXX)": {
+                "Ethernet6/1": {
+                    "device_id": "nyc-dc-d04.ntc.com(FXS18XXXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.194"
+                    ],
+                    "platform": "N77-C7706",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet6/1",
+                    "hold_time": 155,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/2/1/1": {
+            "nyc-dc-c91.ntc.com": {
+                "FortyGigabitEthernet0/4/0/2": {
+                    "device_id": "nyc-dc-c91.ntc.com",
+                    "entry_addresses": [
+                        "10.100.100.129"
+                    ],
+                    "platform": "cisco CRS",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/4/0/2",
+                    "hold_time": 130,
+                    "version": "Cisco IOS XR Software, Version 5.1.2[Default]\nCopyright (c) 2015 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/2/0/0": {
+            "nyc-dc-d01.ntc.com(FXS182XXXXX)": {
+                "Ethernet6/1": {
+                    "device_id": "nyc-dc-d01.ntc.com(FXS182XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.158"
+                    ],
+                    "platform": "N77-C7706",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet6/1",
+                    "hold_time": 128,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/2/0/1": {
+            "nyc-dc-z50b.ntc.com(JAF181XXXXX)": {
+                "Ethernet4/3": {
+                    "device_id": "nyc-dc-z50b.ntc.com(JAF181XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.111"
+                    ],
+                    "platform": "N77-C7710",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet4/3",
+                    "hold_time": 158,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/3/0/0": {
+            "nyc-dc-dcc001.ntc.com": {
+                "TenGigabitEthernet6/1": {
+                    "device_id": "nyc-dc-dcc001.ntc.com",
+                    "entry_addresses": [
+                        "10.100.100.174"
+                    ],
+                    "platform": "cisco WS-C4510R+E",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "TenGigabitEthernet6/1",
+                    "hold_time": 142,
+                    "version": "Cisco IOS Software, Catalyst 4500 L3 Switch  Software (cat4500e-UNIVERSALK9-M), Version 15.2(2)E3, RELEASE SOFTWARE (fc3)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Wed 26-Aug-15 06:05 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/3/0/1": {
+            "nyc-dc-d57": {
+                "TenGigE0/2/0/0": {
+                    "device_id": "nyc-dc-d57",
+                    "entry_addresses": [
+                        "10.100.100.115"
+                    ],
+                    "platform": "cisco ASR9K Series",
+                    "capabilities": "Router",
+                    "port_id": "TenGigE0/2/0/0",
+                    "hold_time": 150,
+                    "version": "Cisco IOS XR Software, Version 4.3.2[Default]\nCopyright (c) 2013 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/3/0/2": {
+            "nyc-dc-d40b.ntc.com(JAF182XXXXX)": {
+                "Ethernet4/1": {
+                    "device_id": "nyc-dc-d40b.ntc.com(JAF182XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.114"
+                    ],
+                    "platform": "N77-C7710",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet4/1",
+                    "hold_time": 171,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/3/0/3": {
+            "nyc-dc-d80.ntc.com(FOC184XXXXX)": {
+                "Ethernet2/1": {
+                    "device_id": "nyc-dc-d80.ntc.com(FOC184XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.117"
+                    ],
+                    "platform": "N5K-C56128P",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "Ethernet2/1",
+                    "hold_time": 140,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/4/0/0": {
+            "nyc-dc-dcc002.ntc.com": {
+                "TenGigabitEthernet6/1": {
+                    "device_id": "nyc-dc-dcc002.ntc.com",
+                    "entry_addresses": [
+                        "10.100.100.178"
+                    ],
+                    "platform": "cisco WS-C4510R+E",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "TenGigabitEthernet6/1",
+                    "hold_time": 147,
+                    "version": "Cisco IOS Software, Catalyst 4500 L3 Switch  Software (cat4500e-UNIVERSALK9-M), Version 15.2(2)E3, RELEASE SOFTWARE (fc3)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2015 by Cisco Systems, Inc.\nCompiled Wed 26-Aug-15 06:05 by prod_rel_team",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/4/0/1": {
+            "nyc-dc-d57": {
+                "TenGigE1/2/0/0": {
+                    "device_id": "nyc-dc-d57",
+                    "entry_addresses": [
+                        "10.100.100.115"
+                    ],
+                    "platform": "cisco ASR9K Series",
+                    "capabilities": "Router",
+                    "port_id": "TenGigE1/2/0/0",
+                    "hold_time": 120,
+                    "version": "Cisco IOS XR Software, Version 4.3.2[Default]\nCopyright (c) 2013 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/4/0/2": {
+            "nyc-dc-d40a.ntc.com(JAF182XXXXX)": {
+                "Ethernet4/1": {
+                    "device_id": "nyc-dc-d40a.ntc.com(JAF182XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.113"
+                    ],
+                    "platform": "N77-C7710",
+                    "capabilities": "Router Switch",
+                    "port_id": "Ethernet4/1",
+                    "hold_time": 171,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "TenGigE0/4/0/3": {
+            "nyc-dc-d81.ntc.com(FOC182XXXXX)": {
+                "Ethernet1/1": {
+                    "device_id": "nyc-dc-d81.ntc.com(FOC182XXXXX)",
+                    "entry_addresses": [
+                        "10.100.100.118"
+                    ],
+                    "platform": "N5K-C56128P",
+                    "capabilities": "Router Switch IGMP",
+                    "port_id": "Ethernet1/1",
+                    "hold_time": 141,
+                    "version": "Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        },
+        "FortyGigabitEthernet0/6/0/0": {
+            "nyc-dc-c97": {
+                "FortyGigabitEthernet0/6/0/0": {
+                    "device_id": "nyc-dc-c97",
+                    "entry_addresses": [
+                        "192.168.169.21"
+                    ],
+                    "platform": "cisco ASR9K Series",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/6/0/0",
+                    "hold_time": 163,
+                    "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                },
+                "FortyGigabitEthernet0/7/0/0": {
+                    "device_id": "nyc-dc-c97",
+                    "entry_addresses": [
+                        "192.168.169.21"
+                    ],
+                    "platform": "cisco ASR9K Series",
+                    "capabilities": "Router",
+                    "port_id": "FortyGigabitEthernet0/7/0/0",
+                    "hold_time": 140,
+                    "version": "Cisco IOS XR Software, Version 5.3.4[Default]\nCopyright (c) 2016 by Cisco Systems, Inc.",
+                    "advertisement_version": 2,
+                    "duplex": "full"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/input.txt
@@ -1,0 +1,407 @@
+-------------------------
+Device ID: nyc-dc-dcm005.ntc.com
+SysName :
+Entry address(es):
+  IPv4 address: 10.100.1.54
+Platform: cisco WS-C4948E,  Capabilities: Router Switch IGMP
+Interface: MgmtEth0/RSP0/CPU0/0
+Port ID (outgoing port): GigabitEthernet1/9
+Holdtime : 134 sec
+
+Version :
+Cisco IOS Software, Catalyst 4500 L3 Switch Software (cat4500e-ENTSERVICESK9-M), Version 15.0(2)SG10, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2015 by Cisco Systems, Inc.
+Compiled Tue 07-Apr-15 10:40 by prod_rel_team
+
+advertisement version: 2
+Native VLAN: 103
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-dcm006.ntc.com
+SysName :
+Entry address(es):
+  IPv4 address: 10.100.1.55
+Platform: cisco WS-C4948E,  Capabilities: Router Switch IGMP
+Interface: MgmtEth0/RSP1/CPU0/0
+Port ID (outgoing port): GigabitEthernet1/9
+Holdtime : 160 sec
+
+Version :
+Cisco IOS Software, Catalyst 4500 L3 Switch Software (cat4500e-ENTSERVICESK9-M), Version 15.0(2)SG10, RELEASE SOFTWARE (fc1)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2015 by Cisco Systems, Inc.
+Compiled Tue 07-Apr-15 10:40 by prod_rel_team
+
+advertisement version: 2
+Native VLAN: 103
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c90.ntc.com
+SysName : nyc-dc-c90.ntc.com
+Entry address(es):
+  IPv4 address: 10.100.100.141
+Platform: cisco CRS,  Capabilities: Router Switch IGMP
+Interface: FortyGigE0/0/1/0
+Port ID (outgoing port): FortyGigE0/0/0/2
+Holdtime : 155 sec
+
+Version :
+Cisco IOS XR Software, Version 5.1.2[Default]
+Copyright (c) 2015 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d02.ntc.com(FXS182XXXXX)
+SysName : nyc-dc-d02
+Entry address(es):
+  IPv4 address: 10.100.100.162
+Platform: N77-C7706,  Capabilities: Router Switch
+Interface: FortyGigE0/0/1/1
+Port ID (outgoing port): Ethernet6/1
+Holdtime : 126 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c97
+SysName : nyc-dc-c97
+Entry address(es):
+  IPv4 address: 10.100.100.19
+Platform: cisco ASR9K Series,  Capabilities: Router
+Interface: FortyGigE0/0/0/0
+Port ID (outgoing port): FortyGigE0/0/0/0
+Holdtime : 170 sec
+
+Version :
+Cisco IOS XR Software, Version 5.3.4[Default]
+Copyright (c) 2016 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c91.ntc.com
+SysName : nyc-dc-c91.ntc.com
+Entry address(es):
+  IPv4 address: 10.100.100.125
+Platform: cisco CRS,  Capabilities: Router
+Interface: FortyGigE0/0/0/1
+Port ID (outgoing port): FortyGigE0/0/0/2
+Holdtime : 122 sec
+
+Version :
+Cisco IOS XR Software, Version 5.1.2[Default]
+Copyright (c) 2015 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c97
+SysName : nyc-dc-c97
+Entry address(es):
+  IPv4 address: 10.100.100.113
+Platform: cisco ASR9K Series,  Capabilities: Router
+Interface: FortyGigE0/1/0/0
+Port ID (outgoing port): FortyGigE0/1/0/0
+Holdtime : 132 sec
+
+Version :
+Cisco IOS XR Software, Version 5.3.4[Default]
+Copyright (c) 2016 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d03.ntc.com(FXS182XXXXX)
+SysName : nyc-dc-d03
+Entry address(es):
+  IPv4 address: 10.100.100.190
+Platform: N77-C7706,  Capabilities: Router Switch
+Interface: FortyGigE0/1/0/1
+Port ID (outgoing port): Ethernet6/1
+Holdtime : 144 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c90.ntc.com
+SysName : nyc-dc-c90.ntc.com
+Entry address(es):
+  IPv4 address: 10.100.100.145
+Platform: cisco CRS,  Capabilities: Router
+Interface: FortyGigE0/1/1/0
+Port ID (outgoing port): FortyGigE0/4/0/2
+Holdtime : 174 sec
+
+Version :
+Cisco IOS XR Software, Version 5.1.2[Default]
+Copyright (c) 2015 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-z50a.ntc.com(JAF18XXXXX)
+SysName : nyc-dc-z50a
+Entry address(es):
+  IPv4 address: 10.100.100.116
+Platform: N77-C7710,  Capabilities: Router Switch
+Interface: FortyGigE0/1/1/1
+Port ID (outgoing port): Ethernet4/3
+Holdtime : 153 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d04.ntc.com(FXS18XXXXXX)
+SysName : nyc-dc-d04
+Entry address(es):
+  IPv4 address: 10.100.100.194
+Platform: N77-C7706,  Capabilities: Router Switch
+Interface: FortyGigE0/2/1/0
+Port ID (outgoing port): Ethernet6/1
+Holdtime : 155 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c91.ntc.com
+SysName : nyc-dc-c91.ntc.com
+Entry address(es):
+  IPv4 address: 10.100.100.129
+Platform: cisco CRS,  Capabilities: Router
+Interface: FortyGigE0/2/1/1
+Port ID (outgoing port): FortyGigE0/4/0/2
+Holdtime : 130 sec
+
+Version :
+Cisco IOS XR Software, Version 5.1.2[Default]
+Copyright (c) 2015 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d01.ntc.com(FXS182XXXXX)
+SysName : nyc-dc-d01
+Entry address(es):
+  IPv4 address: 10.100.100.158
+Platform: N77-C7706,  Capabilities: Router Switch
+Interface: FortyGigE0/2/0/0
+Port ID (outgoing port): Ethernet6/1
+Holdtime : 128 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-z50b.ntc.com(JAF181XXXXX)
+SysName : nyc-dc-z50b
+Entry address(es):
+  IPv4 address: 10.100.100.111
+Platform: N77-C7710,  Capabilities: Router Switch
+Interface: FortyGigE0/2/0/1
+Port ID (outgoing port): Ethernet4/3
+Holdtime : 158 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-dcc001.ntc.com
+SysName :
+Entry address(es):
+  IPv4 address: 10.100.100.174
+Platform: cisco WS-C4510R+E,  Capabilities: Router Switch IGMP
+Interface: TenGigE0/3/0/0
+Port ID (outgoing port): TenGigabitEthernet6/1
+Holdtime : 142 sec
+
+Version :
+Cisco IOS Software, Catalyst 4500 L3 Switch  Software (cat4500e-UNIVERSALK9-M), Version 15.2(2)E3, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2015 by Cisco Systems, Inc.
+Compiled Wed 26-Aug-15 06:05 by prod_rel_team
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d57
+SysName : nyc-dc-d57
+Entry address(es):
+  IPv4 address: 10.100.100.115
+Platform: cisco ASR9K Series,  Capabilities: Router
+Interface: TenGigE0/3/0/1
+Port ID (outgoing port): TenGigE0/2/0/0
+Holdtime : 150 sec
+
+Version :
+Cisco IOS XR Software, Version 4.3.2[Default]
+Copyright (c) 2013 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d40b.ntc.com(JAF182XXXXX)
+SysName : nyc-dc-d40b
+Entry address(es):
+  IPv4 address: 10.100.100.114
+Platform: N77-C7710,  Capabilities: Router Switch
+Interface: TenGigE0/3/0/2
+Port ID (outgoing port): Ethernet4/1
+Holdtime : 171 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d80.ntc.com(FOC184XXXXX)
+SysName : nyc-dc-d80
+Entry address(es):
+  IPv4 address: 10.100.100.117
+Platform: N5K-C56128P,  Capabilities: Router Switch IGMP
+Interface: TenGigE0/3/0/3
+Port ID (outgoing port): Ethernet2/1
+Holdtime : 140 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-dcc002.ntc.com
+SysName :
+Entry address(es):
+  IPv4 address: 10.100.100.178
+Platform: cisco WS-C4510R+E,  Capabilities: Router Switch IGMP
+Interface: TenGigE0/4/0/0
+Port ID (outgoing port): TenGigabitEthernet6/1
+Holdtime : 147 sec
+
+Version :
+Cisco IOS Software, Catalyst 4500 L3 Switch  Software (cat4500e-UNIVERSALK9-M), Version 15.2(2)E3, RELEASE SOFTWARE (fc3)
+Technical Support: http://www.cisco.com/techsupport
+Copyright (c) 1986-2015 by Cisco Systems, Inc.
+Compiled Wed 26-Aug-15 06:05 by prod_rel_team
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d57
+SysName : nyc-dc-d57
+Entry address(es):
+  IPv4 address: 10.100.100.115
+Platform: cisco ASR9K Series,  Capabilities: Router
+Interface: TenGigE0/4/0/1
+Port ID (outgoing port): TenGigE1/2/0/0
+Holdtime : 120 sec
+
+Version :
+Cisco IOS XR Software, Version 4.3.2[Default]
+Copyright (c) 2013 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d40a.ntc.com(JAF182XXXXX)
+SysName : nyc-dc-d40a
+Entry address(es):
+  IPv4 address: 10.100.100.113
+Platform: N77-C7710,  Capabilities: Router Switch
+Interface: TenGigE0/4/0/2
+Port ID (outgoing port): Ethernet4/1
+Holdtime : 171 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 6.2(12)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-d81.ntc.com(FOC182XXXXX)
+SysName : nyc-dc-d81
+Entry address(es):
+  IPv4 address: 10.100.100.118
+Platform: N5K-C56128P,  Capabilities: Router Switch IGMP
+Interface: TenGigE0/4/0/3
+Port ID (outgoing port): Ethernet1/1
+Holdtime : 141 sec
+
+Version :
+Cisco Nexus Operating System (NX-OS) Software, Version 7.0(7)N1(1)
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c97
+SysName : nyc-dc-c97
+Entry address(es):
+  IPv4 address: 192.168.169.21
+Platform: cisco ASR9K Series,  Capabilities: Router
+Interface: FortyGigE0/6/0/0
+Port ID (outgoing port): FortyGigE0/6/0/0
+Holdtime : 163 sec
+
+Version :
+Cisco IOS XR Software, Version 5.3.4[Default]
+Copyright (c) 2016 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full
+
+-------------------------
+Device ID: nyc-dc-c97
+SysName : nyc-dc-c97
+Entry address(es):
+  IPv4 address: 192.168.169.21
+Platform: cisco ASR9K Series,  Capabilities: Router
+Interface: FortyGigE0/6/0/0
+Port ID (outgoing port): FortyGigE0/7/0/0
+Holdtime : 140 sec
+
+Version :
+Cisco IOS XR Software, Version 5.3.4[Default]
+Copyright (c) 2016 by Cisco Systems, Inc.
+
+advertisement version: 2
+Duplex: full

--- a/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_cdp_neighbors_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple CDP neighbors across management, 40GbE, and 10GbE interfaces
+platform: CRS
+software_version: IOS-XR 5.1.2


### PR DESCRIPTION
## Summary
- Add new `cisco_iosxr` parser for `show cdp neighbors detail` command
- Parses device ID, platform, capabilities, entry addresses, software version, hold time, advertisement version, native VLAN, and duplex
- Output structured as dict-of-dicts: `local_interface -> device_id -> port_id -> entry`
- Handles multiple neighbors on same local interface with different remote ports
- Test fixture with 23 CDP neighbors across management, 40GbE, and 10GbE interfaces

## Test plan
- [x] Parser test passes against real device output (CRS, IOS-XR 5.1.2)
- [x] All 6848 tests pass
- [x] All pre-commit hooks pass (ruff, xenon, bandit, etc.)
- [x] Complexity under xenon B threshold
- [x] No placeholder sentinel values in expected.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)