### PR TITLE
feat(arista_eos): add parser for show lldp neighbors detail

### DIFF
--- a/changes/+arista-eos-show-lldp-neighbors-detail.parser_added
+++ b/changes/+arista-eos-show-lldp-neighbors-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show lldp neighbors detail` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_lldp_neighbors_detail.py
+++ b/src/muninn/parsers/arista_eos/show_lldp_neighbors_detail.py
@@ -1,0 +1,292 @@
+"""Parser for 'show lldp neighbors detail' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class LldpNeighborDetailEntry(TypedDict):
+    """Schema for a single LLDP neighbor detail entry."""
+
+    chassis_id: str
+    port_id: str
+    port_description: NotRequired[str]
+    system_name: NotRequired[str]
+    system_description: NotRequired[str]
+    ttl: int
+    system_capabilities: NotRequired[str]
+    enabled_capabilities: NotRequired[str]
+    management_addresses: NotRequired[list[str]]
+
+
+class ShowLldpNeighborsDetailResult(TypedDict):
+    """Schema for 'show lldp neighbors detail' parsed output on Arista EOS.
+
+    Keyed as: local_interface -> chassis_id -> port_id -> entry.
+    """
+
+    neighbors: dict[str, dict[str, dict[str, LldpNeighborDetailEntry]]]
+
+
+# Matches the interface header line: "Interface Ethernet1 detected 2 LLDP neighbors:"
+_INTERFACE_HEADER_RE = re.compile(
+    r"^Interface\s+(?P<intf>\S+)\s+detected\s+\d+\s+LLDP\s+neighbor",
+)
+
+# Field patterns for neighbor detail lines (varying indentation).
+# "Chassis ID type" / "Port ID type" lines must be excluded from the simpler
+# "Chassis ID" / "Port ID" matches, which is handled at the call site.
+_CHASSIS_ID_RE = re.compile(r"^\s*Chassis ID\s*:\s*(?P<v>\S+)")
+_PORT_ID_RE = re.compile(r"^\s*Port ID\s*:\s*(?P<v>.+)$")
+_TTL_RE = re.compile(r"^\s*-\s*Time To Live:\s*(?P<v>\d+)\s+seconds")
+_MGMT_ADDR_RE = re.compile(r"^\s*Management Address\s*:\s*(?P<v>\S+)")
+_NEIGHBOR_HEADER_RE = re.compile(r"^\s*Neighbor\s+\S+")
+
+# Simple single-value patterns: (compiled regex, field key, apply _clean_quoted)
+_SYS_CAP_RE = re.compile(r"^\s*-\s*System Capabilities\s*:\s*(?P<v>.+)$")
+_ENA_CAP_RE = re.compile(r"^\s*Enabled Capabilities\s*:\s*(?P<v>.+)$")
+
+_SIMPLE_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^\s*-\s*Port Description:\s*(?P<v>.+)$"), "port_description"),
+    (re.compile(r"^\s*-\s*System Name:\s*(?P<v>.+)$"), "system_name"),
+    (re.compile(r"^\s*-\s*System Description:\s*(?P<v>.+)$"), "system_description"),
+    (_SYS_CAP_RE, "system_capabilities"),
+    (_ENA_CAP_RE, "enabled_capabilities"),
+)
+
+# Interface-like patterns for port ID canonicalization
+_INTERFACE_PORT_ID_RE = re.compile(
+    r"^(?:Eth(?:ernet)?|Et|Ma(?:nagement)?|Po(?:rt-Channel)?|"
+    r"Lo(?:opback)?|Vl(?:an)?|Tu(?:nnel)?|Gi|Te|Fo|Hu)\d",
+    re.IGNORECASE,
+)
+
+
+def _clean_quoted(value: str) -> str:
+    """Strip surrounding quotes and whitespace from a value."""
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == '"' and stripped[-1] == '"':
+        return stripped[1:-1]
+    return stripped
+
+
+def _normalize_port_id(port_id: str) -> str:
+    """Canonicalize port_id if it looks like an interface name."""
+    if _INTERFACE_PORT_ID_RE.match(port_id):
+        return canonical_interface_name(port_id, os=OS.ARISTA_EOS)
+    return port_id
+
+
+def _build_entry(
+    fields: dict[str, str | int | list[str] | None],
+) -> LldpNeighborDetailEntry | None:
+    """Build a typed entry dict from collected fields.
+
+    Returns None if required fields (chassis_id, port_id, ttl) are missing.
+    """
+    chassis_id = fields.get("chassis_id")
+    port_id = fields.get("port_id")
+    ttl = fields.get("ttl")
+
+    if chassis_id is None or port_id is None or ttl is None:
+        return None
+
+    entry: LldpNeighborDetailEntry = {
+        "chassis_id": str(chassis_id),
+        "port_id": _normalize_port_id(str(port_id)),
+        "ttl": int(str(ttl)),
+    }
+
+    optional_str_keys: tuple[str, ...] = (
+        "port_description",
+        "system_name",
+        "system_description",
+        "system_capabilities",
+        "enabled_capabilities",
+    )
+    for key in optional_str_keys:
+        val = fields.get(key)
+        if val is not None:
+            entry[key] = str(val)  # type: ignore[literal-required]
+
+    mgmt = fields.get("management_addresses")
+    if mgmt:
+        entry["management_addresses"] = cast(list[str], mgmt)
+
+    return entry
+
+
+def _try_match_simple_fields(
+    line: str,
+    fields: dict[str, str | int | list[str] | None],
+) -> bool:
+    """Try to match simple single-value fields. Returns True if matched."""
+    for pattern, key in _SIMPLE_FIELD_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            fields[key] = _clean_quoted(m.group("v"))
+            return True
+    return False
+
+
+def _try_match_special_fields(
+    line: str,
+    fields: dict[str, str | int | list[str] | None],
+    mgmt_addrs: list[str],
+) -> bool:
+    """Match chassis_id, port_id, ttl, and management address fields.
+
+    Returns True if the line was consumed.
+    """
+    m = _CHASSIS_ID_RE.match(line)
+    if m and "Chassis ID type" not in line and "chassis_id" not in fields:
+        fields["chassis_id"] = m.group("v").strip()
+        return True
+
+    m = _PORT_ID_RE.match(line)
+    if m and "Port ID type" not in line and "port_id" not in fields:
+        fields["port_id"] = _clean_quoted(m.group("v"))
+        return True
+
+    m = _TTL_RE.match(line)
+    if m:
+        fields["ttl"] = int(m.group("v"))
+        return True
+
+    m = _MGMT_ADDR_RE.match(line)
+    if m:
+        mgmt_addrs.append(m.group("v").strip())
+        return True
+
+    return False
+
+
+@register(OS.ARISTA_EOS, "show lldp neighbors detail")
+class ShowLldpNeighborsDetailParser(
+    BaseParser[ShowLldpNeighborsDetailResult],
+):
+    """Parser for 'show lldp neighbors detail' command on Arista EOS.
+
+    Output is keyed as:
+    ``local_interface -> chassis_id -> port_id -> entry``.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.LLDP})
+
+    @classmethod
+    def _parse_neighbor_fields(
+        cls,
+        lines: list[str],
+    ) -> dict[str, str | int | list[str] | None]:
+        """Extract fields from a single neighbor's lines."""
+        fields: dict[str, str | int | list[str] | None] = {}
+        mgmt_addrs: list[str] = []
+
+        for line in lines:
+            if _try_match_simple_fields(line, fields):
+                continue
+            _try_match_special_fields(line, fields, mgmt_addrs)
+
+        if mgmt_addrs:
+            fields["management_addresses"] = mgmt_addrs
+
+        return fields
+
+    @classmethod
+    def _flush_interface(
+        cls,
+        result: list[tuple[str, list[list[str]]]],
+        intf: str | None,
+        neighbor_blocks: list[list[str]],
+        current_lines: list[str],
+    ) -> None:
+        """Append accumulated neighbor lines to the interface block list."""
+        if current_lines and intf is not None:
+            neighbor_blocks.append(current_lines)
+        if intf is not None and neighbor_blocks:
+            result.append((intf, neighbor_blocks))
+
+    @classmethod
+    def _split_into_interface_blocks(
+        cls,
+        output: str,
+    ) -> list[tuple[str, list[list[str]]]]:
+        """Split output into (local_interface, [neighbor_lines, ...]) tuples.
+
+        Each interface block starts with "Interface X detected N LLDP neighbors:"
+        and contains zero or more neighbor sub-blocks starting with "Neighbor ...".
+        """
+        result: list[tuple[str, list[list[str]]]] = []
+        current_intf: str | None = None
+        neighbor_blocks: list[list[str]] = []
+        current_neighbor_lines: list[str] = []
+
+        for line in output.splitlines():
+            m = _INTERFACE_HEADER_RE.match(line)
+            if m:
+                cls._flush_interface(
+                    result, current_intf, neighbor_blocks, current_neighbor_lines
+                )
+                current_intf = canonical_interface_name(
+                    m.group("intf"), os=OS.ARISTA_EOS
+                )
+                neighbor_blocks = []
+                current_neighbor_lines = []
+                continue
+
+            if current_intf is None:
+                continue
+
+            # Detect start of a new neighbor sub-block
+            if _NEIGHBOR_HEADER_RE.match(line):
+                if current_neighbor_lines:
+                    neighbor_blocks.append(current_neighbor_lines)
+                current_neighbor_lines = [line]
+                continue
+
+            if current_neighbor_lines:
+                current_neighbor_lines.append(line)
+
+        cls._flush_interface(
+            result, current_intf, neighbor_blocks, current_neighbor_lines
+        )
+        return result
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLldpNeighborsDetailResult:
+        """Parse 'show lldp neighbors detail' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed LLDP neighbor details nested as
+            ``local_interface -> chassis_id -> port_id -> entry``.
+
+        Raises:
+            ValueError: If no LLDP neighbor details are found in output.
+        """
+        neighbors: dict[str, dict[str, dict[str, LldpNeighborDetailEntry]]] = {}
+
+        for local_intf, neighbor_blocks in cls._split_into_interface_blocks(output):
+            for block_lines in neighbor_blocks:
+                fields = cls._parse_neighbor_fields(block_lines)
+                entry = _build_entry(fields)
+                if entry is None:
+                    continue
+                chassis = entry["chassis_id"]
+                port = entry["port_id"]
+                neighbors.setdefault(local_intf, {}).setdefault(chassis, {})[port] = (
+                    entry
+                )
+
+        if not neighbors:
+            msg = "No LLDP neighbor details found in output"
+            raise ValueError(msg)
+
+        return cast(ShowLldpNeighborsDetailResult, {"neighbors": neighbors})

--- a/tests/parsers/arista_eos/show_lldp_neighbors_detail/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_lldp_neighbors_detail/001_basic/expected.json
@@ -1,0 +1,313 @@
+{
+    "neighbors": {
+        "Ethernet1": {
+            "2cc2.6081.eaf9": {
+                "Ethernet1": {
+                    "chassis_id": "2cc2.6081.eaf9",
+                    "port_id": "Ethernet1",
+                    "ttl": 120,
+                    "system_name": "spine2.company.com",
+                    "system_description": "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "2cc2.6081.eaf9"
+                    ]
+                }
+            }
+        },
+        "Ethernet2": {
+            "2cc2.6081.eaf9": {
+                "Ethernet2": {
+                    "chassis_id": "2cc2.6081.eaf9",
+                    "port_id": "Ethernet2",
+                    "ttl": 120,
+                    "system_name": "spine2.company.com",
+                    "system_description": "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "2cc2.6081.eaf9"
+                    ]
+                }
+            }
+        },
+        "Ethernet3": {
+            "2cc2.6081.eaf9": {
+                "Ethernet3": {
+                    "chassis_id": "2cc2.6081.eaf9",
+                    "port_id": "Ethernet3",
+                    "ttl": 120,
+                    "system_name": "spine2.company.com",
+                    "system_description": "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "2cc2.6081.eaf9"
+                    ]
+                }
+            }
+        },
+        "Ethernet4": {
+            "2cc2.6081.eaf9": {
+                "Ethernet4": {
+                    "chassis_id": "2cc2.6081.eaf9",
+                    "port_id": "Ethernet4",
+                    "ttl": 120,
+                    "system_name": "spine2.company.com",
+                    "system_description": "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "2cc2.6081.eaf9"
+                    ]
+                }
+            }
+        },
+        "Management1": {
+            "0005.8671.4ec0": {
+                "fxp0": {
+                    "chassis_id": "0005.8671.4ec0",
+                    "port_id": "fxp0",
+                    "ttl": 120,
+                    "port_description": "fxp0",
+                    "system_name": "vmx1",
+                    "system_description": "Juniper Networks, Inc. vmx internet router, kernel JUNOS 15.1F4.15, Build date: 2015-12-23 19:22:55 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "10.0.0.31"
+                    ]
+                }
+            },
+            "2cc2.6081.eaf9": {
+                "Management1": {
+                    "chassis_id": "2cc2.6081.eaf9",
+                    "port_id": "Management1",
+                    "ttl": 120,
+                    "system_name": "spine2.company.com",
+                    "system_description": "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "2cc2.6081.eaf9"
+                    ]
+                }
+            },
+            "0cca.01c0.e8e1": {
+                "Management1": {
+                    "chassis_id": "0cca.01c0.e8e1",
+                    "port_id": "Management1",
+                    "ttl": 120,
+                    "system_name": "test-host.domain.com",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge",
+                    "management_addresses": [
+                        "172.16.208.5"
+                    ]
+                }
+            }
+        },
+        "Ethernet8": {
+            "0050.56eb.3ef3": {
+                "Management1": {
+                    "chassis_id": "0050.56eb.3ef3",
+                    "port_id": "Management1",
+                    "ttl": 120,
+                    "system_name": "cvx",
+                    "system_description": "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge",
+                    "management_addresses": [
+                        "172.16.2.141"
+                    ]
+                }
+            },
+            "0050.568b.67c8": {
+                "Ethernet1": {
+                    "chassis_id": "0050.568b.67c8",
+                    "port_id": "Ethernet1",
+                    "ttl": 120,
+                    "system_name": "cvx-client-1",
+                    "system_description": "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge",
+                    "management_addresses": [
+                        "172.16.2.142"
+                    ]
+                },
+                "Management1": {
+                    "chassis_id": "0050.568b.67c8",
+                    "port_id": "Management1",
+                    "ttl": 120,
+                    "system_name": "cvx-client-1",
+                    "system_description": "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge",
+                    "management_addresses": [
+                        "172.16.2.142"
+                    ]
+                }
+            }
+        },
+        "Ethernet9": {
+            "7c0e.cecb.659b": {
+                "Ethernet1/23": {
+                    "chassis_id": "7c0e.cecb.659b",
+                    "port_id": "Ethernet1/23",
+                    "ttl": 120,
+                    "port_description": "topology/pod-1/paths-101/pathep-[AVS_Policy_Group]",
+                    "system_name": "Leaf1.cliqr.com",
+                    "system_description": "topology/pod-1/node-101",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "7c0e.cecb.659b"
+                    ]
+                }
+            }
+        },
+        "Ethernet10": {
+            "7c0e.cecb.659c": {
+                "Ethernet1/24": {
+                    "chassis_id": "7c0e.cecb.659c",
+                    "port_id": "Ethernet1/24",
+                    "ttl": 120,
+                    "port_description": "topology/pod-1/paths-101/pathep-[AVS_Policy_Group]",
+                    "system_name": "Leaf1.cliqr.com",
+                    "system_description": "topology/pod-1/node-101",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "7c0e.cecb.659c"
+                    ]
+                }
+            }
+        },
+        "Ethernet23": {
+            "3c8a.b089.9898": {
+                "527": {
+                    "chassis_id": "3c8a.b089.9898",
+                    "port_id": "527",
+                    "ttl": 120,
+                    "port_description": "ge-1/1/1",
+                    "system_name": "MX",
+                    "system_description": "Juniper Networks, Inc. mx5-t internet router, kernel JUNOS 14.2R5.8, Build date: 2015-11-25 01:57:41 UTC Copyright (c) 1996-2015 Juniper Networks, Inc.",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router"
+                }
+            }
+        },
+        "Ethernet33": {
+            "0050.560b.66ea": {
+                "Management1": {
+                    "chassis_id": "0050.560b.66ea",
+                    "port_id": "Management1",
+                    "ttl": 120,
+                    "system_name": "cvx-client-2",
+                    "system_description": "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge",
+                    "management_addresses": [
+                        "172.16.2.143"
+                    ]
+                },
+                "Ethernet1": {
+                    "chassis_id": "0050.560b.66ea",
+                    "port_id": "Ethernet1",
+                    "ttl": 120,
+                    "system_name": "cvx-client-2",
+                    "system_description": "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge",
+                    "management_addresses": [
+                        "172.16.2.143"
+                    ]
+                }
+            },
+            "0050.56ac.4cd9": {
+                "0050.56ac.4cd9": {
+                    "chassis_id": "0050.56ac.4cd9",
+                    "port_id": "0050.56ac.4cd9",
+                    "ttl": 120,
+                    "port_description": "ens192",
+                    "system_name": "aci-compute",
+                    "system_description": "Red Hat Enterprise Linux Linux 3.10.0-327.13.1.el7.x86_64 #1 SMP Mon Feb 29 13:22:02 EST 2016 x86_64",
+                    "system_capabilities": "Bridge, WLAN Access Point, Router, Station Only",
+                    "enabled_capabilities": "Router, Station Only",
+                    "management_addresses": [
+                        "172.16.2.222",
+                        "fe80::250:56ff:feac:4cd9"
+                    ]
+                }
+            },
+            "0050.56ac.4e29": {
+                "0050.56ac.4e29": {
+                    "chassis_id": "0050.56ac.4e29",
+                    "port_id": "0050.56ac.4e29",
+                    "ttl": 120,
+                    "port_description": "ens192",
+                    "system_name": "aci-control",
+                    "system_description": "Red Hat Enterprise Linux Linux 3.10.0-327.13.1.el7.x86_64 #1 SMP Mon Feb 29 13:22:02 EST 2016 x86_64",
+                    "system_capabilities": "Bridge, WLAN Access Point, Router, Station Only",
+                    "enabled_capabilities": "Router, Station Only",
+                    "management_addresses": [
+                        "172.16.2.221",
+                        "fe80::250:56ff:feac:4e29"
+                    ]
+                }
+            }
+        },
+        "Ethernet49/1": {
+            "001c.737d.77fb": {
+                "Ethernet49/1": {
+                    "chassis_id": "001c.737d.77fb",
+                    "port_id": "Ethernet49/1",
+                    "ttl": 120,
+                    "port_description": "\" To R4-Arista-L2-SDNLAB -DC1\"",
+                    "system_name": "R4-Arista-L3-SDNLAB-SW1",
+                    "system_description": "Arista Networks EOS version 4.15.0FXA running on an Arista Networks DCS-7050SX-64",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "2.2.2.2"
+                    ]
+                }
+            }
+        },
+        "Ethernet51/1": {
+            "001c.737d.745f": {
+                "Ethernet49/1": {
+                    "chassis_id": "001c.737d.745f",
+                    "port_id": "Ethernet49/1",
+                    "ttl": 120,
+                    "port_description": "\"Connected to DC1-AristaL2SW-R4\"",
+                    "system_name": "R4-Arista-L3-SDNLAB-SW2",
+                    "system_description": "Arista Networks EOS version 4.15.0FXA running on an Arista Networks DCS-7050SX-64",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "172.16.1.3"
+                    ]
+                }
+            }
+        },
+        "Ethernet52/1": {
+            "001c.737d.745f": {
+                "Ethernet50/1": {
+                    "chassis_id": "001c.737d.745f",
+                    "port_id": "Ethernet50/1",
+                    "ttl": 120,
+                    "port_description": "\"Connected to DC1-AristaL2SW-R4\"",
+                    "system_name": "R4-Arista-L3-SDNLAB-SW2",
+                    "system_description": "Arista Networks EOS version 4.15.0FXA running on an Arista Networks DCS-7050SX-64",
+                    "system_capabilities": "Bridge, Router",
+                    "enabled_capabilities": "Bridge, Router",
+                    "management_addresses": [
+                        "172.16.1.3"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_lldp_neighbors_detail/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_lldp_neighbors_detail/001_basic/input.txt
@@ -1,0 +1,659 @@
+Interface Ethernet1 detected 1 LLDP neighbors:
+
+  Neighbor 2cc2.6081.eaf9/"Ethernet1", age 12 seconds
+  Discovered 0:01:11 ago; Last changed 0:01:11 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 2cc2.6081.eaf9
+  - Port ID type: Interface name (5)
+    Port ID     : "Ethernet1"
+  - Time To Live: 120 seconds
+  - System Name: "spine2.company.com"
+  - System Description: "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS"
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge, Router
+  - Management Address Subtype: Ethernet
+    Management Address        : 2cc2.6081.eaf9
+    Interface Number Subtype  : Unknown (1)
+    Interface Number          : 0
+    OID String                :
+  - IEEE802.1 Port VLAN ID: 1
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Capable, Disabled (0x01)
+    Port ID                : 0
+  - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet2 detected 1 LLDP neighbors:
+
+  Neighbor 2cc2.6081.eaf9/"Ethernet2", age 12 seconds
+  Discovered 0:01:11 ago; Last changed 0:01:11 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 2cc2.6081.eaf9
+  - Port ID type: Interface name (5)
+    Port ID     : "Ethernet2"
+  - Time To Live: 120 seconds
+  - System Name: "spine2.company.com"
+  - System Description: "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS"
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge, Router
+  - Management Address Subtype: Ethernet
+    Management Address        : 2cc2.6081.eaf9
+    Interface Number Subtype  : Unknown (1)
+    Interface Number          : 0
+    OID String                :
+  - IEEE802.1 Port VLAN ID: 1
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Capable, Disabled (0x01)
+    Port ID                : 0
+  - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet3 detected 1 LLDP neighbors:
+
+  Neighbor 2cc2.6081.eaf9/"Ethernet3", age 12 seconds
+  Discovered 0:01:11 ago; Last changed 0:01:11 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 2cc2.6081.eaf9
+  - Port ID type: Interface name (5)
+    Port ID     : "Ethernet3"
+  - Time To Live: 120 seconds
+  - System Name: "spine2.company.com"
+  - System Description: "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS"
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge, Router
+  - Management Address Subtype: Ethernet
+    Management Address        : 2cc2.6081.eaf9
+    Interface Number Subtype  : Unknown (1)
+    Interface Number          : 0
+    OID String                :
+  - IEEE802.1 Port VLAN ID: 1
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Capable, Disabled (0x01)
+    Port ID                : 0
+  - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet4 detected 1 LLDP neighbors:
+
+  Neighbor 2cc2.6081.eaf9/"Ethernet4", age 12 seconds
+  Discovered 0:01:11 ago; Last changed 0:01:11 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 2cc2.6081.eaf9
+  - Port ID type: Interface name (5)
+    Port ID     : "Ethernet4"
+  - Time To Live: 120 seconds
+  - System Name: "spine2.company.com"
+  - System Description: "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS"
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge, Router
+  - Management Address Subtype: Ethernet
+    Management Address        : 2cc2.6081.eaf9
+    Interface Number Subtype  : Unknown (1)
+    Interface Number          : 0
+    OID String                :
+  - IEEE802.1 Port VLAN ID: 1
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Capable, Disabled (0x01)
+    Port ID                : 0
+  - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet5 detected 0 LLDP neighbors:
+
+Interface Ethernet6 detected 0 LLDP neighbors:
+
+Interface Ethernet7 detected 0 LLDP neighbors:
+
+Interface Management1 detected 2 LLDP neighbors:
+
+  Neighbor 0005.8671.4ec0/"fxp0", age 27 seconds
+  Discovered 0:02:21 ago; Last changed 0:02:21 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 0005.8671.4ec0
+  - Port ID type: Interface name (5)
+    Port ID     : "fxp0"
+  - Time To Live: 120 seconds
+  - Port Description: "fxp0"
+  - System Name: "vmx1"
+  - System Description: "Juniper Networks, Inc. vmx internet router, kernel JUNOS 15.1F4.15, Build date: 2015-12-23 19:22:55 UTC Copyright (c) 1996-2015 Juniper Networks, Inc."
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge, Router
+  - Management Address Subtype: IPv4
+    Management Address        : 10.0.0.31
+    Interface Number Subtype  : ifIndex (2)
+    Interface Number          : 1
+    OID String                : 0.1.3.6.1.2.1.31.1.1.1.1.1
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Capable, Disabled (0x01)
+    Port ID                : 0
+  - IEEE802.3 MAC/PHY Configuration/Status
+    Auto-negotiation       : Supported, Disabled
+                             10BASE-T (half-duplex)
+                             10BASE-T (full-duplex)
+                             100BASE-TX (half-duplex)
+                             100BASE-TX (full-duplex)
+                             1000BASE-X (half-duplex)
+                             1000BASE-X (full-duplex)
+                             1000BASE-T (full-duplex)
+    Operational MAU Type   : Unknown
+  - IEEE802.3 Maximum Frame Size: 1514 bytes
+
+  Neighbor 2cc2.6081.eaf9/"Management1", age 17 seconds
+  Discovered 0:01:17 ago; Last changed 0:01:17 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 2cc2.6081.eaf9
+  - Port ID type: Interface name (5)
+    Port ID     : "Management1"
+  - Time To Live: 120 seconds
+  - System Name: "spine2.company.com"
+  - System Description: "Arista Networks EOS version 4.15.2F running on an Arista Networks vEOS"
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge, Router
+  - Management Address Subtype: Ethernet
+    Management Address        : 2cc2.6081.eaf9
+    Interface Number Subtype  : Unknown (1)
+    Interface Number          : 0
+    OID String                :
+  - IEEE802.1 Port VLAN ID: 0
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Not Capable (0x00)
+    Port ID                : 0
+  - IEEE802.3 Maximum Frame Size: 1518 bytes
+
+Interface Ethernet8 detected 3 LLDP neighbors:
+
+  Neighbor 0050.56eb.3ef3/Management1, age 4 seconds
+  Discovered 34 days, 19:40:42 ago; Last changed 34 days, 19:40:42 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.56eb.3ef3
+    - Port ID type: Interface name (5)
+      Port ID     : "Management1"
+    - Time To Live: 120 seconds
+    - System Name: "cvx"
+    - System Description: "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.141
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 999001
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 0
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Not Capable (0x00)
+      Port ID                : 0
+    - IEEE802.3 Maximum Frame Size: 1518 bytes
+
+  Neighbor 0050.568b.67c8/Ethernet1, age 29 seconds
+  Discovered 34 days, 19:40:24 ago; Last changed 34 days, 19:40:24 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.568b.67c8
+    - Port ID type: Interface name (5)
+      Port ID     : "Ethernet1"
+    - Time To Live: 120 seconds
+    - System Name: "cvx-client-1"
+    - System Description: "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.142
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 999001
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 1
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Disabled (0x01)
+      Port ID                : 0
+    - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+  Neighbor 0050.568b.67c8/Management1, age 30 seconds
+  Discovered 34 days, 19:40:22 ago; Last changed 34 days, 19:40:22 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.568b.67c8
+    - Port ID type: Interface name (5)
+      Port ID     : "Management1"
+    - Time To Live: 120 seconds
+    - System Name: "cvx-client-1"
+    - System Description: "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.142
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 999001
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 0
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Not Capable (0x00)
+      Port ID                : 0
+    - IEEE802.3 Maximum Frame Size: 1518 bytes
+
+Interface Ethernet9 detected 1 LLDP neighbors:
+
+  Neighbor 7c0e.cecb.659b/Eth1/23, age 29 seconds
+  Discovered 11 days, 1:32:12 ago; Last changed 11 days, 1:32:12 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 7c0e.cecb.659b
+    - Port ID type: Locally assigned (7)
+      Port ID     : "Eth1/23"
+    - Time To Live: 120 seconds
+    - Port Description: "topology/pod-1/paths-101/pathep-[AVS_Policy_Group]"
+    - System Name: "Leaf1.cliqr.com"
+    - System Description: "topology/pod-1/node-101"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge, Router
+    - Management Address Subtype: Ethernet (6)
+      Management Address        : 7c0e.cecb.659b
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 83886080
+      OID String                :
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 201):
+          01
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 202):
+          01
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 203):
+          00 00 00 65
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 205):
+          00 01
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 206):
+          41 43 49 20 46 61 62 72 69 63 31
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 207):
+          01 0a 00 00 01 34 61 36 39 62 63 37 61 2d 63 61
+          36 64 2d 31 31 65 35 2d 38 39 32 61 2d 38 39 35
+          66 31 37 62 38 35 61 39 64 02 0a 00 00 02 37 38
+          66 64 30 30 64 32 2d 63 61 37 33 2d 31 31 65 35
+          2d 39 34 39 63 2d 38 64 33 35 34 65 39 30 32 31
+          38 38 03 0a 00 00 03 38 61 31 65 64 39 32 63 2d
+          63 61 36 38 2d 31 31 65 35 2d 61 66 37 66 2d 31
+          64 65 39 36 64 38 65 36 64 32 62
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 208):
+          0a 00 c8 5f
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 210):
+          6e 39 30 30 30 2d 31 31 2e 32 28 32 67 29
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 212):
+          53 41 4c 31 38 33 37 30 4e 5a 41
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 214):
+          4e 39 4b 2d 43 39 33 39 36 54 58
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 215):
+          4c 65 61 66 31
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 216):
+          00 00
+
+Interface Ethernet10 detected 1 LLDP neighbors:
+
+  Neighbor 7c0e.cecb.659c/Eth1/24, age 29 seconds
+  Discovered 11 days, 1:32:12 ago; Last changed 11 days, 1:32:12 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 7c0e.cecb.659c
+    - Port ID type: Locally assigned (7)
+      Port ID     : "Eth1/24"
+    - Time To Live: 120 seconds
+    - Port Description: "topology/pod-1/paths-101/pathep-[AVS_Policy_Group]"
+    - System Name: "Leaf1.cliqr.com"
+    - System Description: "topology/pod-1/node-101"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge, Router
+    - Management Address Subtype: Ethernet (6)
+      Management Address        : 7c0e.cecb.659c
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 83886080
+      OID String                :
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 201):
+          01
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 202):
+          01
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 203):
+          00 00 00 65
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 205):
+          00 01
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 206):
+          41 43 49 20 46 61 62 72 69 63 31
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 207):
+          01 0a 00 00 01 34 61 36 39 62 63 37 61 2d 63 61
+          36 64 2d 31 31 65 35 2d 38 39 32 61 2d 38 39 35
+          66 31 37 62 38 35 61 39 64 02 0a 00 00 02 37 38
+          66 64 30 30 64 32 2d 63 61 37 33 2d 31 31 65 35
+          2d 39 34 39 63 2d 38 64 33 35 34 65 39 30 32 31
+          38 38 03 0a 00 00 03 38 61 31 65 64 39 32 63 2d
+          63 61 36 38 2d 31 31 65 35 2d 61 66 37 66 2d 31
+          64 65 39 36 64 38 65 36 64 32 62
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 208):
+          0a 00 c8 5f
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 210):
+          6e 39 30 30 30 2d 31 31 2e 32 28 32 67 29
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 212):
+          53 41 4c 31 38 33 37 30 4e 5a 41
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 214):
+          4e 39 4b 2d 43 39 33 39 36 54 58
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 215):
+          4c 65 61 66 31
+    - Unknown organizationally-defined TLV (OUI 00-01-42, subtype 216):
+          00 00
+
+Interface Ethernet11 detected 0 LLDP neighbors:
+
+Interface Ethernet12 detected 0 LLDP neighbors:
+
+Interface Ethernet13 detected 0 LLDP neighbors:
+
+Interface Ethernet14 detected 0 LLDP neighbors:
+
+Interface Ethernet15 detected 0 LLDP neighbors:
+
+Interface Ethernet16 detected 0 LLDP neighbors:
+
+Interface Ethernet17 detected 0 LLDP neighbors:
+
+Interface Ethernet18 detected 0 LLDP neighbors:
+
+Interface Ethernet19 detected 0 LLDP neighbors:
+
+Interface Ethernet20 detected 0 LLDP neighbors:
+
+Interface Ethernet21 detected 0 LLDP neighbors:
+
+Interface Ethernet22 detected 0 LLDP neighbors:
+
+Interface Ethernet23 detected 1 LLDP neighbors:
+
+  Neighbor 3c8a.b089.9898/527, age 21 seconds
+  Discovered 19 days, 18:20:22 ago; Last changed 19 days, 18:20:22 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 3c8a.b089.9898
+    - Port ID type: Locally assigned (7)
+      Port ID     : "527"
+    - Time To Live: 120 seconds
+    - Port Description: "ge-1/1/1"
+    - System Name: "MX"
+    - System Description: "Juniper Networks, Inc. mx5-t internet router, kernel JUNOS 14.2R5.8, Build date: 2015-11-25 01:57:41 UTC Copyright (c) 1996-2015 Juniper Networks, Inc."
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge, Router
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Disabled (0x01)
+      Port ID                : 0
+    - IEEE802.3 MAC/PHY Configuration/Status
+      Auto-negotiation       : Supported, Enabled
+      Advertised Capabilities: Asymmetric and Symmetric PAUSE
+                               10BASE-T (half-duplex)
+                               10BASE-T (full-duplex)
+                               100BASE-TX (half-duplex)
+                               100BASE-TX (full-duplex)
+                               1000BASE-X (half-duplex)
+                               1000BASE-X (full-duplex)
+                               1000BASE-T (full-duplex)
+      Operational MAU Type   : Unknown (0)
+    - IEEE802.3 Maximum Frame Size: 1514 bytes
+
+Interface Ethernet24 detected 0 LLDP neighbors:
+
+Interface Ethernet25 detected 0 LLDP neighbors:
+
+Interface Ethernet26 detected 0 LLDP neighbors:
+
+Interface Ethernet27 detected 0 LLDP neighbors:
+
+Interface Ethernet28 detected 0 LLDP neighbors:
+
+Interface Ethernet29 detected 0 LLDP neighbors:
+
+Interface Ethernet30 detected 0 LLDP neighbors:
+
+Interface Ethernet31 detected 0 LLDP neighbors:
+
+Interface Ethernet32 detected 0 LLDP neighbors:
+
+Interface Ethernet33 detected 4 LLDP neighbors:
+
+  Neighbor 0050.560b.66ea/Management1, age 29 seconds
+  Discovered 33 days, 23:34:56 ago; Last changed 33 days, 23:34:56 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.560b.66ea
+    - Port ID type: Interface name (5)
+      Port ID     : "Management1"
+    - Time To Live: 120 seconds
+    - System Name: "cvx-client-2"
+    - System Description: "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.143
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 999001
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 0
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Not Capable (0x00)
+      Port ID                : 0
+    - IEEE802.3 Maximum Frame Size: 1518 bytes
+
+  Neighbor 0050.560b.66ea/Ethernet1, age 29 seconds
+  Discovered 33 days, 23:34:56 ago; Last changed 33 days, 23:34:56 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.560b.66ea
+    - Port ID type: Interface name (5)
+      Port ID     : "Ethernet1"
+    - Time To Live: 120 seconds
+    - System Name: "cvx-client-2"
+    - System Description: "Arista Networks EOS version 4.15.5M running on an Arista Networks CVX"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.143
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 999001
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 1
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Disabled (0x01)
+      Port ID                : 0
+    - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+  Neighbor 0050.56ac.4cd9/0050.56ac.4cd9, age 29 seconds
+  Discovered 33 days, 23:34:56 ago; Last changed 13:58:03 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.56ac.4cd9
+    - Port ID type: MAC address (3)
+      Port ID     : 0050.56ac.4cd9
+    - Time To Live: 120 seconds
+    - Port Description: "ens192"
+    - System Name: "aci-compute"
+    - System Description: "Red Hat Enterprise Linux Linux 3.10.0-327.13.1.el7.x86_64 #1 SMP Mon Feb 29 13:22:02 EST 2016 x86_64"
+    - System Capabilities : Bridge, WLAN Access Point, Router, Station Only
+      Enabled Capabilities: Router, Station Only
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.222
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 2
+      OID String                :
+    - Management Address Subtype: IPv6 (2)
+      Management Address        : fe80::250:56ff:feac:4cd9
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 2
+      OID String                :
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Disabled (0x01)
+      Port ID                : 0
+    - IEEE802.3 MAC/PHY Configuration/Status
+      Auto-negotiation       : Not Supported
+      Advertised Capabilities: None
+      Operational MAU Type   : 10GBASE-R (33)
+
+  Neighbor 0050.56ac.4e29/0050.56ac.4e29, age 29 seconds
+  Discovered 5 days, 19:11:29 ago; Last changed 5 days, 19:01:28 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 0050.56ac.4e29
+    - Port ID type: MAC address (3)
+      Port ID     : 0050.56ac.4e29
+    - Time To Live: 120 seconds
+    - Port Description: "ens192"
+    - System Name: "aci-control"
+    - System Description: "Red Hat Enterprise Linux Linux 3.10.0-327.13.1.el7.x86_64 #1 SMP Mon Feb 29 13:22:02 EST 2016 x86_64"
+    - System Capabilities : Bridge, WLAN Access Point, Router, Station Only
+      Enabled Capabilities: Router, Station Only
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.2.221
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 2
+      OID String                :
+    - Management Address Subtype: IPv6 (2)
+      Management Address        : fe80::250:56ff:feac:4e29
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 2
+      OID String                :
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Disabled (0x01)
+      Port ID                : 0
+    - IEEE802.3 MAC/PHY Configuration/Status
+      Auto-negotiation       : Not Supported
+      Advertised Capabilities: None
+      Operational MAU Type   : 10GBASE-R (33)
+
+Interface Ethernet34 detected 0 LLDP neighbors:
+
+Interface Ethernet35 detected 0 LLDP neighbors:
+
+Interface Ethernet36 detected 0 LLDP neighbors:
+
+Interface Ethernet37 detected 0 LLDP neighbors:
+
+Interface Ethernet38 detected 0 LLDP neighbors:
+
+Interface Ethernet39 detected 0 LLDP neighbors:
+
+Interface Ethernet40 detected 0 LLDP neighbors:
+
+Interface Ethernet41 detected 0 LLDP neighbors:
+
+Interface Ethernet42 detected 0 LLDP neighbors:
+
+Interface Ethernet43 detected 0 LLDP neighbors:
+
+Interface Ethernet44 detected 0 LLDP neighbors:
+
+Interface Ethernet45 detected 0 LLDP neighbors:
+
+Interface Ethernet46 detected 0 LLDP neighbors:
+
+Interface Ethernet47 detected 0 LLDP neighbors:
+
+Interface Ethernet48 detected 0 LLDP neighbors:
+
+Interface Ethernet49/1 detected 1 LLDP neighbors:
+
+  Neighbor 001c.737d.77fb/Ethernet49/1, age 19 seconds
+  Discovered 117 days, 19:38:50 ago; Last changed 33 days, 3:31:32 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 001c.737d.77fb
+    - Port ID type: Interface name (5)
+      Port ID     : "Ethernet49/1"
+    - Time To Live: 120 seconds
+    - Port Description: "" To R4-Arista-L2-SDNLAB -DC1""
+    - System Name: "R4-Arista-L3-SDNLAB-SW1"
+    - System Description: "Arista Networks EOS version 4.15.0FXA running on an Arista Networks DCS-7050SX-64"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge, Router
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 2.2.2.2
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 5000000
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 1
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Enabled (0x03)
+      Port ID                : 1000010
+    - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet49/2 detected 0 LLDP neighbors:
+
+Interface Ethernet49/3 detected 0 LLDP neighbors:
+
+Interface Ethernet49/4 detected 0 LLDP neighbors:
+
+Interface Ethernet50/1 detected 0 LLDP neighbors:
+
+Interface Ethernet50/2 detected 0 LLDP neighbors:
+
+Interface Ethernet50/3 detected 0 LLDP neighbors:
+
+Interface Ethernet50/4 detected 0 LLDP neighbors:
+
+Interface Ethernet51/1 detected 1 LLDP neighbors:
+
+  Neighbor 001c.737d.745f/Ethernet49/1, age 28 seconds
+  Discovered 117 days, 15:20:04 ago; Last changed 61 days, 23:05:42 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 001c.737d.745f
+    - Port ID type: Interface name (5)
+      Port ID     : "Ethernet49/1"
+    - Time To Live: 120 seconds
+    - Port Description: ""Connected to DC1-AristaL2SW-R4""
+    - System Name: "R4-Arista-L3-SDNLAB-SW2"
+    - System Description: "Arista Networks EOS version 4.15.0FXA running on an Arista Networks DCS-7050SX-64"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge, Router
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.1.3
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 2000201
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 1
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Enabled (0x03)
+      Port ID                : 1000010
+    - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet51/2 detected 0 LLDP neighbors:
+
+Interface Ethernet51/3 detected 0 LLDP neighbors:
+
+Interface Ethernet51/4 detected 0 LLDP neighbors:
+
+Interface Ethernet52/1 detected 1 LLDP neighbors:
+
+  Neighbor 001c.737d.745f/Ethernet50/1, age 28 seconds
+  Discovered 117 days, 18:25:48 ago; Last changed 61 days, 23:03:48 ago
+    - Chassis ID type: MAC address (4)
+      Chassis ID     : 001c.737d.745f
+    - Port ID type: Interface name (5)
+      Port ID     : "Ethernet50/1"
+    - Time To Live: 120 seconds
+    - Port Description: ""Connected to DC1-AristaL2SW-R4""
+    - System Name: "R4-Arista-L3-SDNLAB-SW2"
+    - System Description: "Arista Networks EOS version 4.15.0FXA running on an Arista Networks DCS-7050SX-64"
+    - System Capabilities : Bridge, Router
+      Enabled Capabilities: Bridge, Router
+    - Management Address Subtype: IPv4 (1)
+      Management Address        : 172.16.1.3
+      Interface Number Subtype  : ifIndex (2)
+      Interface Number          : 2000201
+      OID String                :
+    - IEEE802.1 Port VLAN ID: 1
+    - IEEE802.1/IEEE802.3 Link Aggregation
+      Link Aggregation Status: Capable, Enabled (0x03)
+      Port ID                : 1000010
+    - IEEE802.3 Maximum Frame Size: 9236 bytes
+
+Interface Ethernet52/2 detected 0 LLDP neighbors:
+
+Interface Ethernet52/3 detected 0 LLDP neighbors:
+
+Interface Ethernet52/4 detected 0 LLDP neighbors:
+
+Interface Management1 detected 1 LLDP neighbors:
+
+  Neighbor 0cca.01c0.e8e1/"Management1", age 2 seconds
+  Discovered 1:11:08 ago; Last changed 1:11:08 ago
+  - Chassis ID type: MAC address (4)
+    Chassis ID     : 0cca.01c0.e8e1
+  - Port ID type: Interface name(5)
+    Port ID     : "Management1"
+  - Time To Live: 120 seconds
+  - System Name: "test-host.domain.com"
+  - System Capabilities : Bridge, Router
+    Enabled Capabilities: Bridge
+  - Management Address Subtype: IPv4
+    Management Address        : 172.16.208.5
+    Interface Number Subtype  : ifIndex (2)
+    Interface Number          : 999001
+    OID String                :
+  - IEEE802.1 Port VLAN ID: 0
+  - IEEE802.1/IEEE802.3 Link Aggregation
+    Link Aggregation Status: Not Capable (0x00)
+    Port ID                : 0
+  - IEEE802.3 Maximum Frame Size: 1518 bytes

--- a/tests/parsers/arista_eos/show_lldp_neighbors_detail/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_lldp_neighbors_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces with varied neighbor types including multi-neighbor interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show lldp neighbors detail` on Arista EOS
- Output is a dict-of-dicts keyed as `local_interface -> chassis_id -> port_id -> entry`
- Handles multiple neighbors per interface, varied port ID types (interface name, MAC address, locally assigned), multi-address management blocks, and canonicalizes interface-like port IDs

## Test plan
- [x] Test fixture with real device output covering 15+ interfaces and diverse neighbor types
- [x] All 6848 tests pass (including placeholder sentinel, JSON convention, and parser tests)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity check passes (max-absolute B)
- [x] Bandit security scan passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)