### PR TITLE
feat(arista_eos): add parser for show mlag

### DIFF
--- a/changes/+arista-eos-show-mlag.parser_added
+++ b/changes/+arista-eos-show-mlag.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show mlag` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_mlag.py
+++ b/src/muninn/parsers/arista_eos/show_mlag.py
@@ -7,6 +7,7 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class MlagPortsInfo(TypedDict):
@@ -52,13 +53,14 @@ class ShowMlagParser(BaseParser[ShowMlagResult]):
     _KV_PATTERN = re.compile(r"^(?P<key>[\w\s-]+?)\s*:\s*(?P<value>.+)$")
 
     # Combined map from CLI labels to (section, field_name) pairs.
-    # Section is "str" for string fields, "int" for port counter fields.
+    # Section is "str" for string fields, "intf" for interface fields,
+    # "int" for port counter fields.
     _FIELD_MAP: ClassVar[dict[str, tuple[str, str]]] = {
         # Configuration
         "domain-id": ("str", "domain_id"),
-        "local-interface": ("str", "local_interface"),
+        "local-interface": ("intf", "local_interface"),
         "peer-address": ("str", "peer_address"),
-        "peer-link": ("str", "peer_link"),
+        "peer-link": ("intf", "peer_link"),
         # Status
         "state": ("str", "state"),
         "negotiation status": ("str", "negotiation_status"),
@@ -109,6 +111,8 @@ class ShowMlagParser(BaseParser[ShowMlagResult]):
             kind, field_name = entry
             if kind == "int":
                 ports[field_name] = int(value)
+            elif kind == "intf":
+                result[field_name] = canonical_interface_name(value, os=OS.ARISTA_EOS)
             else:
                 result[field_name] = value
 

--- a/src/muninn/parsers/arista_eos/show_mlag.py
+++ b/src/muninn/parsers/arista_eos/show_mlag.py
@@ -1,0 +1,151 @@
+"""Parser for 'show mlag' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class MlagPortsInfo(TypedDict):
+    """Schema for MLAG port counters."""
+
+    disabled: int
+    configured: int
+    inactive: int
+    active_partial: int
+    active_full: int
+
+
+class ShowMlagResult(TypedDict):
+    """Schema for 'show mlag' parsed output on Arista EOS."""
+
+    # Configuration
+    domain_id: str
+    local_interface: str
+    peer_address: str
+    peer_link: str
+
+    # Status
+    state: str
+    negotiation_status: str
+    peer_link_status: str
+    local_interface_status: str
+    system_id: str
+
+    # Ports
+    ports: MlagPortsInfo
+
+
+@register(OS.ARISTA_EOS, "show mlag")
+class ShowMlagParser(BaseParser[ShowMlagResult]):
+    """Parser for 'show mlag' command on Arista EOS.
+
+    Parses MLAG configuration, status, and port counters.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.LAG})
+
+    # Key-value pattern: label followed by colon and value
+    _KV_PATTERN = re.compile(r"^(?P<key>[\w\s-]+?)\s*:\s*(?P<value>.+)$")
+
+    # Combined map from CLI labels to (section, field_name) pairs.
+    # Section is "str" for string fields, "int" for port counter fields.
+    _FIELD_MAP: ClassVar[dict[str, tuple[str, str]]] = {
+        # Configuration
+        "domain-id": ("str", "domain_id"),
+        "local-interface": ("str", "local_interface"),
+        "peer-address": ("str", "peer_address"),
+        "peer-link": ("str", "peer_link"),
+        # Status
+        "state": ("str", "state"),
+        "negotiation status": ("str", "negotiation_status"),
+        "peer-link status": ("str", "peer_link_status"),
+        "local-int status": ("str", "local_interface_status"),
+        "system-id": ("str", "system_id"),
+        # Ports
+        "disabled": ("int", "disabled"),
+        "configured": ("int", "configured"),
+        "inactive": ("int", "inactive"),
+        "active-partial": ("int", "active_partial"),
+        "active-full": ("int", "active_full"),
+    }
+
+    _REQUIRED_FIELDS: ClassVar[list[str]] = [
+        "domain_id",
+        "local_interface",
+        "peer_address",
+        "peer_link",
+        "state",
+        "negotiation_status",
+        "peer_link_status",
+        "local_interface_status",
+        "system_id",
+        "ports",
+    ]
+
+    @classmethod
+    def _extract_key_value_pairs(
+        cls, output: str
+    ) -> tuple[dict[str, object], dict[str, int]]:
+        """Extract string fields and port counters from raw output."""
+        result: dict[str, object] = {}
+        ports: dict[str, int] = {}
+
+        for line in output.splitlines():
+            match = cls._KV_PATTERN.match(line.strip())
+            if not match:
+                continue
+
+            key = match.group("key").strip().lower()
+            value = match.group("value").strip()
+
+            entry = cls._FIELD_MAP.get(key)
+            if entry is None:
+                continue
+
+            kind, field_name = entry
+            if kind == "int":
+                ports[field_name] = int(value)
+            else:
+                result[field_name] = value
+
+        return result, ports
+
+    @classmethod
+    def _validate(cls, result: dict[str, object]) -> None:
+        """Raise ValueError if any required fields are missing."""
+        missing = [f for f in cls._REQUIRED_FIELDS if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMlagResult:
+        """Parse 'show mlag' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed MLAG configuration, status, and port information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result, ports = cls._extract_key_value_pairs(output)
+
+        if ports:
+            result["ports"] = MlagPortsInfo(
+                disabled=ports.get("disabled", 0),
+                configured=ports.get("configured", 0),
+                inactive=ports.get("inactive", 0),
+                active_partial=ports.get("active_partial", 0),
+                active_full=ports.get("active_full", 0),
+            )
+
+        cls._validate(result)
+
+        return cast(ShowMlagResult, result)

--- a/tests/parsers/arista_eos/show_mlag/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mlag/001_basic/expected.json
@@ -2,7 +2,7 @@
     "domain_id": "mlagDomain",
     "local_interface": "Vlan4094",
     "peer_address": "10.0.0.2",
-    "peer_link": "Port-Channel10",
+    "peer_link": "Port-channel10",
     "state": "Inactive",
     "negotiation_status": "Connecting",
     "peer_link_status": "Lowerlayerdown",

--- a/tests/parsers/arista_eos/show_mlag/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mlag/001_basic/expected.json
@@ -1,0 +1,18 @@
+{
+    "domain_id": "mlagDomain",
+    "local_interface": "Vlan4094",
+    "peer_address": "10.0.0.2",
+    "peer_link": "Port-Channel10",
+    "state": "Inactive",
+    "negotiation_status": "Connecting",
+    "peer_link_status": "Lowerlayerdown",
+    "local_interface_status": "Up",
+    "system_id": "00:00:00:00:00:00",
+    "ports": {
+        "disabled": 0,
+        "configured": 0,
+        "inactive": 0,
+        "active_partial": 0,
+        "active_full": 0
+    }
+}

--- a/tests/parsers/arista_eos/show_mlag/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_mlag/001_basic/input.txt
@@ -1,0 +1,19 @@
+MLAG Configuration:
+domain-id           :          mlagDomain
+local-interface     :            Vlan4094
+peer-address        :            10.0.0.2
+peer-link           :      Port-Channel10
+
+MLAG Status:
+state               :            Inactive
+negotiation status  :          Connecting
+peer-link status    :      Lowerlayerdown
+local-int status    :                  Up
+system-id           :   00:00:00:00:00:00
+
+MLAG Ports:
+Disabled            :                   0
+Configured          :                   0
+Inactive            :                   0
+Active-partial      :                   0
+Active-full         :                   0

--- a/tests/parsers/arista_eos/show_mlag/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_mlag/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic MLAG configuration and status with inactive state
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add new parser for `show mlag` on Arista EOS that extracts MLAG configuration (domain ID, local interface, peer address, peer link), status (state, negotiation status, peer link status, local interface status, system ID), and port counters (disabled, configured, inactive, active-partial, active-full)
- Includes test fixture with real device output from ntc-templates

## Test plan
- [x] Parser test passes against real device fixture (`001_basic`)
- [x] All placeholder sentinel tests pass (no banned values)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)