### PR TITLE
feat(cisco_iosxr): add parser for `show vrf all detail`

### DIFF
--- a/changes/+cisco-iosxr-show-vrf-all-detail.parser_added
+++ b/changes/+cisco-iosxr-show-vrf-all-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show vrf all detail` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_vrf_all_detail.py
+++ b/src/muninn/parsers/cisco_iosxr/show_vrf_all_detail.py
@@ -1,0 +1,223 @@
+"""Parser for 'show vrf all detail' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class VrfAddressFamily(TypedDict):
+    """Schema for a single address family within a VRF."""
+
+    import_route_targets: list[str]
+    export_route_targets: list[str]
+    import_route_policy: NotRequired[str]
+    export_route_policy: NotRequired[str]
+
+
+class VrfEntry(TypedDict):
+    """Schema for a single VRF entry."""
+
+    route_distinguisher: NotRequired[str]
+    vpn_id: NotRequired[str]
+    vrf_mode: NotRequired[str]
+    description: NotRequired[str]
+    interfaces: list[str]
+    address_families: dict[str, VrfAddressFamily]
+
+
+ShowVrfAllDetailResult = dict[str, VrfEntry]
+
+
+@register(OS.CISCO_IOSXR, "show vrf all detail")
+class ShowVrfAllDetailParser(BaseParser[ShowVrfAllDetailResult]):
+    """Parser for 'show vrf all detail' command on Cisco IOS-XR.
+
+    Returns a dict-of-dicts keyed by VRF name. Each entry contains
+    route distinguisher, VPN ID, VRF mode, description, interfaces,
+    and address family configuration including route targets.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.VRF})
+
+    _VRF_HEADER = re.compile(
+        r"^VRF\s+(?P<name>\S+);\s+"
+        r"RD\s+(?P<rd>.+?);\s+"
+        r"VPN ID\s+(?P<vpn_id>.+?)$"
+    )
+    _VRF_MODE = re.compile(r"^VRF mode:\s+(?P<mode>\S+)")
+    _DESCRIPTION = re.compile(r"^Description\s+(?P<desc>.+)$")
+    _INTERFACES_HEADER = re.compile(r"^Interfaces:$")
+    _AF_HEADER = re.compile(r"^Address family\s+(?P<af>.+)$")
+    _IMPORT_RT_HEADER = re.compile(r"^\s+Import VPN route-target communities:")
+    _EXPORT_RT_HEADER = re.compile(r"^\s+Export VPN route-target communities:")
+    _NO_IMPORT_RT = re.compile(r"^\s+No import VPN route-target communities")
+    _NO_EXPORT_RT = re.compile(r"^\s+No export VPN route-target communities")
+    _IMPORT_POLICY = re.compile(r"^\s+Import route policy:\s+(?P<policy>\S+)")
+    _EXPORT_POLICY = re.compile(r"^\s+Export route policy:\s+(?P<policy>\S+)")
+    _RT_VALUE = re.compile(r"^\s+RT:(?P<rt>\S+)")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVrfAllDetailResult:
+        """Parse 'show vrf all detail' output on Cisco IOS-XR."""
+        result: ShowVrfAllDetailResult = {}
+        lines = output.splitlines()
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx].rstrip()
+
+            match = cls._VRF_HEADER.match(line)
+            if match:
+                entry, idx = cls._parse_vrf_block(lines, idx, match)
+                result[match.group("name")] = entry
+            else:
+                idx += 1
+
+        return result
+
+    @classmethod
+    def _parse_vrf_block(
+        cls,
+        lines: list[str],
+        start: int,
+        header_match: re.Match[str],
+    ) -> tuple[VrfEntry, int]:
+        """Parse a single VRF block starting at the header line."""
+        entry: VrfEntry = {
+            "interfaces": [],
+            "address_families": {},
+        }
+
+        rd = header_match.group("rd").strip()
+        if rd != "not set":
+            entry["route_distinguisher"] = rd
+
+        vpn_id = header_match.group("vpn_id").strip()
+        if vpn_id != "not set":
+            entry["vpn_id"] = vpn_id
+
+        idx = start + 1
+
+        while idx < len(lines):
+            line = lines[idx].rstrip()
+
+            # Stop at next VRF header
+            if cls._VRF_HEADER.match(line):
+                break
+
+            if match := cls._VRF_MODE.match(line):
+                entry["vrf_mode"] = match.group("mode")
+                idx += 1
+            elif match := cls._DESCRIPTION.match(line):
+                desc = match.group("desc").strip()
+                if desc != "not set":
+                    entry["description"] = desc
+                idx += 1
+            elif cls._INTERFACES_HEADER.match(line):
+                idx += 1
+                idx = cls._parse_interfaces(lines, idx, entry)
+            elif match := cls._AF_HEADER.match(line):
+                af_name = match.group("af")
+                idx += 1
+                af_entry, idx = cls._parse_address_family(lines, idx)
+                entry["address_families"][af_name] = af_entry
+            else:
+                idx += 1
+
+        return entry, idx
+
+    @classmethod
+    def _parse_interfaces(
+        cls,
+        lines: list[str],
+        idx: int,
+        entry: VrfEntry,
+    ) -> int:
+        """Parse indented interface lines following 'Interfaces:'."""
+        while idx < len(lines):
+            line = lines[idx].rstrip()
+            # Interface lines are indented; stop on non-indented or empty
+            if not line or not line.startswith("  "):
+                break
+            stripped = line.strip()
+            # Stop if this is an AF or RT line rather than an interface name
+            if stripped.startswith(("Address family", "No ", "Import ", "Export ")):
+                break
+            entry["interfaces"].append(stripped)
+            idx += 1
+        return idx
+
+    @classmethod
+    def _is_af_boundary(cls, line: str) -> bool:
+        """Return True if line marks the end of an address family block."""
+        if not line:
+            return True
+        return bool(cls._VRF_HEADER.match(line) or cls._AF_HEADER.match(line))
+
+    @classmethod
+    def _parse_af_line(
+        cls,
+        line: str,
+        lines: list[str],
+        idx: int,
+        af: VrfAddressFamily,
+    ) -> int:
+        """Parse a single line within an address family block. Returns next index."""
+        if cls._IMPORT_RT_HEADER.match(line):
+            return cls._parse_rt_list(lines, idx + 1, af["import_route_targets"])
+
+        if cls._EXPORT_RT_HEADER.match(line):
+            return cls._parse_rt_list(lines, idx + 1, af["export_route_targets"])
+
+        if match := cls._IMPORT_POLICY.match(line):
+            af["import_route_policy"] = match.group("policy")
+        elif match := cls._EXPORT_POLICY.match(line):
+            af["export_route_policy"] = match.group("policy")
+
+        return idx + 1
+
+    @classmethod
+    def _parse_address_family(
+        cls,
+        lines: list[str],
+        idx: int,
+    ) -> tuple[VrfAddressFamily, int]:
+        """Parse address family details (route targets and policies)."""
+        af: VrfAddressFamily = {
+            "import_route_targets": [],
+            "export_route_targets": [],
+        }
+
+        while idx < len(lines):
+            line = lines[idx].rstrip()
+
+            if cls._is_af_boundary(line):
+                if not line:
+                    idx += 1
+                break
+
+            idx = cls._parse_af_line(line, lines, idx, af)
+
+        return af, idx
+
+    @classmethod
+    def _parse_rt_list(
+        cls,
+        lines: list[str],
+        idx: int,
+        rt_list: list[str],
+    ) -> int:
+        """Parse indented RT:x:y lines into a list."""
+        while idx < len(lines):
+            line = lines[idx].rstrip()
+            match = cls._RT_VALUE.match(line)
+            if match:
+                rt_list.append(match.group("rt"))
+                idx += 1
+            else:
+                break
+        return idx

--- a/src/muninn/parsers/cisco_iosxr/show_vrf_all_detail.py
+++ b/src/muninn/parsers/cisco_iosxr/show_vrf_all_detail.py
@@ -7,6 +7,7 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class VrfAddressFamily(TypedDict):
@@ -147,7 +148,9 @@ class ShowVrfAllDetailParser(BaseParser[ShowVrfAllDetailResult]):
             # Stop if this is an AF or RT line rather than an interface name
             if stripped.startswith(("Address family", "No ", "Import ", "Export ")):
                 break
-            entry["interfaces"].append(stripped)
+            entry["interfaces"].append(
+                canonical_interface_name(stripped, os=OS.CISCO_IOSXR)
+            )
             idx += 1
         return idx
 

--- a/tests/parsers/cisco_iosxr/show_vrf_all_detail/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_vrf_all_detail/001_basic/expected.json
@@ -1,0 +1,126 @@
+{
+    "red": {
+        "vrf_mode": "Regular",
+        "interfaces": [],
+        "address_families": {
+            "IPV4 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            },
+            "IPV6 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            }
+        }
+    },
+    "blue": {
+        "vrf_mode": "Regular",
+        "interfaces": [
+            "BVI10"
+        ],
+        "address_families": {
+            "IPV4 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            },
+            "IPV6 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            }
+        }
+    },
+    "green": {
+        "vrf_mode": "Regular",
+        "interfaces": [
+            "GigabitEthernet200/0/0/1",
+            "GigabitEthernet200/0/0/2",
+            "GigabitEthernet300/0/0/1",
+            "GigabitEthernet300/0/0/2",
+            "TenGigE0/0/0/10.10",
+            "Bundle-Ether10.10",
+            "Bundle-Ether10.20",
+            "Bundle-Ether20.10",
+            "Bundle-Ether20.20",
+            "Bundle-Ether30.10",
+            "Bundle-Ether40.10",
+            "Bundle-Ether50.10",
+            "Loopback0"
+        ],
+        "address_families": {
+            "IPV4 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            },
+            "IPV6 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            }
+        }
+    },
+    "purple": {
+        "vrf_mode": "Regular",
+        "interfaces": [
+            "Loopback1",
+            "Bundle-Ether10.10",
+            "Bundle-Ether10.20",
+            "Bundle-Ether10.30",
+            "GigabitEthernet100/0/0/10.10",
+            "GigabitEthernet100/0/0/10.20",
+            "GigabitEthernet200/0/0/20.10",
+            "GigabitEthernet200/0/0/20.20",
+            "GigabitEthernet300/0/0/30.10",
+            "GigabitEthernet300/0/0/30.20",
+            "TenGigE0/0/0/10.10",
+            "TenGigE0/2/0/20.10",
+            "TenGigE0/2/0/20.20"
+        ],
+        "address_families": {
+            "IPV4 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            },
+            "IPV6 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            }
+        }
+    },
+    "brown": {
+        "vrf_mode": "Regular",
+        "interfaces": [
+            "GigabitEthernet100/0/0/10",
+            "GigabitEthernet300/0/0/20",
+            "Bundle-Ether10.10",
+            "Bundle-Ether10.20"
+        ],
+        "address_families": {
+            "IPV4 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            },
+            "IPV6 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            }
+        }
+    },
+    "vrf-test": {
+        "vrf_mode": "Regular",
+        "description": "this is a description",
+        "interfaces": [],
+        "address_families": {
+            "IPV4 Unicast": {
+                "import_route_targets": [
+                    "65000:42"
+                ],
+                "export_route_targets": [
+                    "65000:43"
+                ]
+            },
+            "IPV6 Unicast": {
+                "import_route_targets": [],
+                "export_route_targets": []
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_vrf_all_detail/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_vrf_all_detail/001_basic/input.txt
@@ -1,0 +1,123 @@
+
+Wed Jul 27 17:18:32.001 CST
+
+VRF red; RD not set; VPN ID not set
+VRF mode: Regular
+Description not set
+Address family IPV4 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF blue; RD not set; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  BVI10
+Address family IPV4 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF green; RD not set; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  GigabitEthernet200/0/0/1
+  GigabitEthernet200/0/0/2
+  GigabitEthernet300/0/0/1
+  GigabitEthernet300/0/0/2
+  TenGigE0/0/0/10.10
+  Bundle-Ether10.10
+  Bundle-Ether10.20
+  Bundle-Ether20.10
+  Bundle-Ether20.20
+  Bundle-Ether30.10
+  Bundle-Ether40.10
+  Bundle-Ether50.10
+  Loopback0
+Address family IPV4 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF purple; RD not set; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  Loopback1
+  Bundle-Ether10.10
+  Bundle-Ether10.20
+  Bundle-Ether10.30
+  GigabitEthernet100/0/0/10.10
+  GigabitEthernet100/0/0/10.20
+  GigabitEthernet200/0/0/20.10
+  GigabitEthernet200/0/0/20.20
+  GigabitEthernet300/0/0/30.10
+  GigabitEthernet300/0/0/30.20
+  TenGigE0/0/0/10.10
+  TenGigE0/2/0/20.10
+  TenGigE0/2/0/20.20
+Address family IPV4 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF brown; RD not set; VPN ID not set
+VRF mode: Regular
+Description not set
+Interfaces:
+  GigabitEthernet100/0/0/10
+  GigabitEthernet300/0/0/20
+  Bundle-Ether10.10
+  Bundle-Ether10.20
+Address family IPV4 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy
+
+VRF vrf-test; RD not set; VPN ID not set
+VRF mode: Regular
+Description this is a description
+Address family IPV4 Unicast
+  Import VPN route-target communities:
+    RT:65000:42
+  Export VPN route-target communities:
+    RT:65000:43
+  No import route policy
+  No export route policy
+Address family IPV6 Unicast
+  No import VPN route-target communities
+  No export VPN route-target communities
+  No import route policy
+  No export route policy

--- a/tests/parsers/cisco_iosxr/show_vrf_all_detail/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_vrf_all_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Multiple VRFs with varying interfaces, route targets, and descriptions"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add parser for `show vrf all detail` on Cisco IOS-XR
- Returns dict-of-dicts keyed by VRF name with route distinguisher, VPN ID, VRF mode, description, interfaces, and address family configuration (import/export route targets and route policies)
- Tagged with `ParserTag.VRF`

## Test plan
- [x] Parser test with real device output covering 6 VRFs (empty interfaces, multiple interfaces, route targets, description)
- [x] All placeholder sentinel tests pass (no banned values)
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)