### PR TITLE
feat(arista_eos): add parser for show port-channel summary

### DIFF
--- a/changes/+arista-eos-show-port-channel-summary.parser_added
+++ b/changes/+arista-eos-show-port-channel-summary.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show port-channel summary` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_port_channel_summary.py
+++ b/src/muninn/parsers/arista_eos/show_port_channel_summary.py
@@ -1,0 +1,144 @@
+"""Parser for 'show port-channel summary' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class PortChannelMember(TypedDict):
+    """Schema for a port-channel member interface."""
+
+    flags: str
+
+
+class PortChannelEntry(TypedDict):
+    """Schema for a single port-channel entry."""
+
+    group: int
+    status: str
+    protocol: str
+    protocol_flags: str
+    members: dict[str, PortChannelMember]
+
+
+class ShowPortChannelSummaryResult(TypedDict):
+    """Schema for 'show port-channel summary' parsed output."""
+
+    port_channels: dict[str, PortChannelEntry]
+
+
+# Port-channel status flag to human-readable status mapping.
+_PO_STATUS_MAP: dict[str, str] = {
+    "U": "up",
+    "D": "down",
+}
+
+
+@register(OS.ARISTA_EOS, "show port-channel summary")
+class ShowPortChannelSummaryParser(BaseParser[ShowPortChannelSummaryResult]):
+    """Parser for 'show port-channel summary' command on Arista EOS.
+
+    Parses port-channel summary including member interfaces and their flags.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+            ParserTag.LAG,
+        }
+    )
+
+    # Port-channel line:
+    #    Po105(D)           LACP(aF*)    Et5(D)
+    #    Po2000(U)          LACP(a)      Et54/1(PG+)
+    _PORT_CHANNEL_PATTERN = re.compile(
+        r"^\s+Po(?P<group>\d+)\((?P<status>[A-Z])\)\s+"
+        r"(?P<protocol>[A-Z]+)\((?P<proto_flags>[^)]*)\)\s+"
+        r"(?P<members>.*)$"
+    )
+
+    # Continuation line (indented member ports with no port-channel name).
+    _CONTINUATION_PATTERN = re.compile(r"^\s{20,}(?P<members>.+)$")
+
+    # Individual member port: Et5(D), Et54/1(PG+), Et1(siI)
+    _MEMBER_PATTERN = re.compile(r"(?P<interface>Et\S+?)\((?P<flags>[^)]+)\)")
+
+    @classmethod
+    def _parse_members(cls, members_str: str) -> dict[str, PortChannelMember]:
+        """Parse member ports string into dictionary.
+
+        Args:
+            members_str: Raw member ports string.
+
+        Returns:
+            Dictionary of member interfaces keyed by canonical interface name.
+        """
+        members: dict[str, PortChannelMember] = {}
+
+        for match in cls._MEMBER_PATTERN.finditer(members_str):
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.ARISTA_EOS
+            )
+            flags = match.group("flags")
+            members[interface] = PortChannelMember(flags=flags)
+
+        return members
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPortChannelSummaryResult:
+        """Parse 'show port-channel summary' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed port-channel summary data keyed by port-channel name.
+
+        Raises:
+            ValueError: If no port-channels found in output.
+        """
+        port_channels: dict[str, PortChannelEntry] = {}
+        current_po: str | None = None
+
+        for line in output.splitlines():
+            # Try to match a new port-channel line
+            po_match = cls._PORT_CHANNEL_PATTERN.match(line)
+            if po_match:
+                group = int(po_match.group("group"))
+                name = canonical_interface_name(f"Po{group}", os=OS.ARISTA_EOS)
+                status_flag = po_match.group("status")
+                protocol = po_match.group("protocol")
+                proto_flags = po_match.group("proto_flags")
+                members_str = po_match.group("members")
+
+                status = _PO_STATUS_MAP.get(status_flag, status_flag.lower())
+                members = cls._parse_members(members_str)
+
+                port_channels[name] = PortChannelEntry(
+                    group=group,
+                    status=status,
+                    protocol=protocol,
+                    protocol_flags=proto_flags,
+                    members=members,
+                )
+                current_po = name
+                continue
+
+            # Try to match continuation line (wrapped member ports)
+            cont_match = cls._CONTINUATION_PATTERN.match(line)
+            if cont_match and current_po:
+                members_str = cont_match.group("members")
+                additional_members = cls._parse_members(members_str)
+                port_channels[current_po]["members"].update(additional_members)
+                continue
+
+        if not port_channels:
+            msg = "No port-channels found in output"
+            raise ValueError(msg)
+
+        return ShowPortChannelSummaryResult(port_channels=port_channels)

--- a/tests/parsers/arista_eos/show_port-channel_summary/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_port-channel_summary/001_basic/expected.json
@@ -1,0 +1,297 @@
+{
+    "port_channels": {
+        "Port-channel105": {
+            "group": 105,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet5": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel106": {
+            "group": 106,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet6": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel107": {
+            "group": 107,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet7": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel108": {
+            "group": 108,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet8": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel109": {
+            "group": 109,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet9": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel110": {
+            "group": 110,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet10": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel111": {
+            "group": 111,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet11": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel112": {
+            "group": 112,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet12": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel113": {
+            "group": 113,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet13": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel114": {
+            "group": 114,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet14": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel115": {
+            "group": 115,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet15": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel116": {
+            "group": 116,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet16": {
+                    "flags": "D"
+                },
+                "Ethernet17": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel118": {
+            "group": 118,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet18": {
+                    "flags": "D"
+                },
+                "Ethernet19": {
+                    "flags": "D"
+                },
+                "Ethernet20": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel121": {
+            "group": 121,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet21": {
+                    "flags": "D"
+                },
+                "Ethernet22": {
+                    "flags": "D"
+                },
+                "Ethernet23": {
+                    "flags": "D"
+                },
+                "Ethernet24": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel125": {
+            "group": 125,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet25": {
+                    "flags": "D"
+                },
+                "Ethernet26": {
+                    "flags": "D"
+                },
+                "Ethernet27": {
+                    "flags": "D"
+                },
+                "Ethernet28": {
+                    "flags": "D"
+                },
+                "Ethernet29": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel130": {
+            "group": 130,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet30": {
+                    "flags": "D"
+                },
+                "Ethernet31": {
+                    "flags": "D"
+                },
+                "Ethernet32": {
+                    "flags": "D"
+                },
+                "Ethernet33": {
+                    "flags": "D"
+                },
+                "Ethernet34": {
+                    "flags": "D"
+                },
+                "Ethernet35": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel136": {
+            "group": 136,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet36": {
+                    "flags": "D"
+                },
+                "Ethernet37": {
+                    "flags": "D"
+                },
+                "Ethernet38": {
+                    "flags": "D"
+                },
+                "Ethernet39": {
+                    "flags": "D"
+                },
+                "Ethernet40": {
+                    "flags": "D"
+                },
+                "Ethernet41": {
+                    "flags": "D"
+                },
+                "Ethernet42": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel146": {
+            "group": 146,
+            "status": "down",
+            "protocol": "LACP",
+            "protocol_flags": "aF*",
+            "members": {
+                "Ethernet43": {
+                    "flags": "D"
+                },
+                "Ethernet44": {
+                    "flags": "D"
+                },
+                "Ethernet45": {
+                    "flags": "D"
+                },
+                "Ethernet46": {
+                    "flags": "D"
+                },
+                "Ethernet47": {
+                    "flags": "D"
+                },
+                "Ethernet48": {
+                    "flags": "D"
+                },
+                "Ethernet49": {
+                    "flags": "D"
+                },
+                "Ethernet50": {
+                    "flags": "D"
+                }
+            }
+        },
+        "Port-channel2000": {
+            "group": 2000,
+            "status": "up",
+            "protocol": "LACP",
+            "protocol_flags": "a",
+            "members": {
+                "Ethernet54/1": {
+                    "flags": "PG+"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_port-channel_summary/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_port-channel_summary/001_basic/input.txt
@@ -1,0 +1,37 @@
+Flags
+-------------------------- ----------------------------- -------------------------
+   a - LACP Active            p - LACP Passive           * - static fallback
+   F - Fallback enabled       f - Fallback configured    ^ - individual fallback
+   U - In Use                 D - Down
+   + - In-Sync                - - Out-of-Sync            i - incompatible with agg
+   P - bundled in Po          s - suspended              G - Aggregable
+   I - Individual             S - ShortTimeout           w - wait for agg
+
+Number of channels in use: 1
+Number of aggregators: 1
+
+   Port-Channel       Protocol     Ports
+------------------ --------------- --------------------------------
+   Po105(D)           LACP(aF*)    Et5(D)
+   Po106(D)           LACP(aF*)    Et6(D)
+   Po107(D)           LACP(aF*)    Et7(D)
+   Po108(D)           LACP(aF*)    Et8(D)
+   Po109(D)           LACP(aF*)    Et9(D)
+   Po110(D)           LACP(aF*)    Et10(D)
+   Po111(D)           LACP(aF*)    Et11(D)
+   Po112(D)           LACP(aF*)    Et12(D)
+   Po113(D)           LACP(aF*)    Et13(D)
+   Po114(D)           LACP(aF*)    Et14(D)
+   Po115(D)           LACP(aF*)    Et15(D)
+   Po116(D)           LACP(aF*)    Et16(D) Et17(D)
+   Po118(D)           LACP(aF*)    Et18(D) Et19(D) Et20(D)
+   Po121(D)           LACP(aF*)    Et21(D) Et22(D) Et23(D) Et24(D)
+   Po125(D)           LACP(aF*)    Et25(D) Et26(D) Et27(D) Et28(D)
+                                   Et29(D)
+   Po130(D)           LACP(aF*)    Et30(D) Et31(D) Et32(D) Et33(D)
+                                   Et34(D) Et35(D)
+   Po136(D)           LACP(aF*)    Et36(D) Et37(D) Et38(D) Et39(D)
+                                   Et40(D) Et41(D) Et42(D)
+   Po146(D)           LACP(aF*)    Et43(D) Et44(D) Et45(D) Et46(D)
+                                   Et47(D) Et48(D) Et49(D) Et50(D)
+   Po2000(U)          LACP(a)      Et54/1(PG+)

--- a/tests/parsers/arista_eos/show_port-channel_summary/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_port-channel_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple port-channels with LACP, mixed member counts and wrapped lines
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/arista_eos/show_port-channel_summary/command.txt
+++ b/tests/parsers/arista_eos/show_port-channel_summary/command.txt
@@ -1,0 +1,1 @@
+show port-channel summary


### PR DESCRIPTION
## Summary

- Add new parser for `show port-channel summary` on Arista EOS
- Parses port-channel group, status (up/down), LACP protocol flags, and member interfaces with their flags
- Handles continuation lines for port-channels with many member interfaces
- Tagged with `LAG` and `Interfaces`

## Test plan

- [x] Parser test with real device output (19 port-channels, including wrapped lines and multi-flag members)
- [x] All 6848 tests pass
- [x] Pre-commit hooks pass (ruff, xenon, JSON conventions, placeholder sentinels)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)