### PR TITLE
feat(paloalto_panos): add parser for show high-availability path-monitoring

### DIFF
--- a/changes/+paloalto-panos-show-high-availability-path-monitoring.parser_added
+++ b/changes/+paloalto-panos-show-high-availability-path-monitoring.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show high-availability path-monitoring` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/show_high_availability_path_monitoring.py
+++ b/src/muninn/parsers/paloalto_panos/show_high_availability_path_monitoring.py
@@ -1,0 +1,148 @@
+"""Parser for 'show high-availability path-monitoring' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PathMonitoringEntry(TypedDict):
+    """Schema for a single path monitoring destination entry."""
+
+    group: str
+    name: str
+    type: str
+    destination: str
+    success: int
+    total: int
+    rtt_min: float
+    rtt_max: float
+    rtt_avg: float
+    probe_count: int
+    probe_interval: int
+
+
+class ShowHighAvailabilityPathMonitoringResult(TypedDict):
+    """Schema for 'show high-availability path-monitoring' parsed output."""
+
+    total_paths_monitored: int
+    hold_time_ms: int
+    paths: dict[str, PathMonitoringEntry]
+
+
+# Header line identifying the table columns
+_HEADER_PREFIX = "grp/name/type"
+
+# Separator lines
+_SEPARATOR = re.compile(r"^-{3,}$")
+
+# Total paths monitored
+_TOTAL_PATHS = re.compile(r"^total paths monitored\s*:\s*(\d+)")
+
+# Hold time in ms
+_HOLD_TIME = re.compile(r"^hold time to send probe packets\s*:\s*(\d+)\s*ms")
+
+# Data line: grp/name/type destination suc/total rtt probe_cnt/interval
+_DATA_LINE = re.compile(
+    r"^(?P<group>\S+)/(?P<name>\S+)/(?P<type>\S+)\s+"
+    r"(?P<destination>\S+)\s+"
+    r"(?P<success>\d+)/(?P<total>\d+)\s+"
+    r"(?P<rtt_min>[\d.]+)/(?P<rtt_max>[\d.]+)/(?P<rtt_avg>[\d.]+)\s+"
+    r"(?P<probe_count>\d+)/(?P<probe_interval>\d+)"
+)
+
+
+def _build_entry(match: re.Match[str]) -> PathMonitoringEntry:
+    """Build a PathMonitoringEntry from a regex match."""
+    return PathMonitoringEntry(
+        group=match.group("group"),
+        name=match.group("name"),
+        type=match.group("type"),
+        destination=match.group("destination"),
+        success=int(match.group("success")),
+        total=int(match.group("total")),
+        rtt_min=float(match.group("rtt_min")),
+        rtt_max=float(match.group("rtt_max")),
+        rtt_avg=float(match.group("rtt_avg")),
+        probe_count=int(match.group("probe_count")),
+        probe_interval=int(match.group("probe_interval")),
+    )
+
+
+def _validate_required(
+    total_paths: int | None,
+    hold_time: int | None,
+) -> tuple[int, int]:
+    """Validate that required header fields were parsed."""
+    if total_paths is None:
+        msg = "Could not parse total paths monitored from output"
+        raise ValueError(msg)
+    if hold_time is None:
+        msg = "Could not parse hold time from output"
+        raise ValueError(msg)
+    return total_paths, hold_time
+
+
+@register(OS.PALOALTO_PANOS, "show high-availability path-monitoring")
+class ShowHighAvailabilityPathMonitoringParser(
+    BaseParser[ShowHighAvailabilityPathMonitoringResult],
+):
+    """Parser for 'show high-availability path-monitoring' on PAN-OS.
+
+    Parses path monitoring status including monitored destinations,
+    success/failure counts, RTT statistics, and probe configuration.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.REDUNDANCY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowHighAvailabilityPathMonitoringResult:
+        """Parse 'show high-availability path-monitoring' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed path monitoring information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        total_paths: int | None = None
+        hold_time: int | None = None
+        paths: dict[str, PathMonitoringEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            if not stripped or _SEPARATOR.match(stripped):
+                continue
+
+            total_match = _TOTAL_PATHS.match(stripped)
+            if total_match:
+                total_paths = int(total_match.group(1))
+                continue
+
+            hold_match = _HOLD_TIME.match(stripped)
+            if hold_match:
+                hold_time = int(hold_match.group(1))
+                continue
+
+            data_match = _DATA_LINE.match(stripped)
+            if data_match:
+                entry = _build_entry(data_match)
+                paths[entry["destination"]] = entry
+
+        total, hold = _validate_required(total_paths, hold_time)
+
+        return cast(
+            ShowHighAvailabilityPathMonitoringResult,
+            {
+                "total_paths_monitored": total,
+                "hold_time_ms": hold,
+                "paths": paths,
+            },
+        )

--- a/src/muninn/parsers/paloalto_panos/show_high_availability_path_monitoring.py
+++ b/src/muninn/parsers/paloalto_panos/show_high_availability_path_monitoring.py
@@ -5,6 +5,7 @@ from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_RE
 from muninn.registry import register
 from muninn.tags import ParserTag
 
@@ -18,11 +19,11 @@ class PathMonitoringEntry(TypedDict):
     destination: str
     success: int
     total: int
-    rtt_min: float
-    rtt_max: float
-    rtt_avg: float
+    rtt_min_ms: float
+    rtt_max_ms: float
+    rtt_avg_ms: float
     probe_count: int
-    probe_interval: int
+    probe_interval_ms: int
 
 
 class ShowHighAvailabilityPathMonitoringResult(TypedDict):
@@ -32,12 +33,6 @@ class ShowHighAvailabilityPathMonitoringResult(TypedDict):
     hold_time_ms: int
     paths: dict[str, PathMonitoringEntry]
 
-
-# Header line identifying the table columns
-_HEADER_PREFIX = "grp/name/type"
-
-# Separator lines
-_SEPARATOR = re.compile(r"^-{3,}$")
 
 # Total paths monitored
 _TOTAL_PATHS = re.compile(r"^total paths monitored\s*:\s*(\d+)")
@@ -64,11 +59,11 @@ def _build_entry(match: re.Match[str]) -> PathMonitoringEntry:
         destination=match.group("destination"),
         success=int(match.group("success")),
         total=int(match.group("total")),
-        rtt_min=float(match.group("rtt_min")),
-        rtt_max=float(match.group("rtt_max")),
-        rtt_avg=float(match.group("rtt_avg")),
+        rtt_min_ms=float(match.group("rtt_min")),
+        rtt_max_ms=float(match.group("rtt_max")),
+        rtt_avg_ms=float(match.group("rtt_avg")),
         probe_count=int(match.group("probe_count")),
-        probe_interval=int(match.group("probe_interval")),
+        probe_interval_ms=int(match.group("probe_interval")),
     )
 
 
@@ -118,7 +113,7 @@ class ShowHighAvailabilityPathMonitoringParser(
         for line in output.splitlines():
             stripped = line.strip()
 
-            if not stripped or _SEPARATOR.match(stripped):
+            if not stripped or SEPARATOR_DASH_RE.match(stripped):
                 continue
 
             total_match = _TOTAL_PATHS.match(stripped)

--- a/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "total_paths_monitored": 2,
+    "hold_time_ms": 1000,
+    "paths": {
+        "8.8.8.8": {
+            "group": "HA_PATH_NORTH",
+            "name": "VR_HANDOFF",
+            "type": "virtual-router",
+            "destination": "8.8.8.8",
+            "success": 10,
+            "total": 10,
+            "rtt_min": 3.66,
+            "rtt_max": 4.19,
+            "rtt_avg": 3.9,
+            "probe_count": 10,
+            "probe_interval": 1000
+        },
+        "217.111.187.217": {
+            "group": "HA_PATH_NORTH",
+            "name": "VR_HANDOFF",
+            "type": "virtual-router",
+            "destination": "217.111.187.217",
+            "success": 10,
+            "total": 10,
+            "rtt_min": 2.36,
+            "rtt_max": 2.75,
+            "rtt_avg": 2.58,
+            "probe_count": 10,
+            "probe_interval": 1000
+        }
+    }
+}

--- a/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/expected.json
@@ -9,11 +9,11 @@
             "destination": "8.8.8.8",
             "success": 10,
             "total": 10,
-            "rtt_min": 3.66,
-            "rtt_max": 4.19,
-            "rtt_avg": 3.9,
+            "rtt_min_ms": 3.66,
+            "rtt_max_ms": 4.19,
+            "rtt_avg_ms": 3.9,
             "probe_count": 10,
-            "probe_interval": 1000
+            "probe_interval_ms": 1000
         },
         "217.111.187.217": {
             "group": "HA_PATH_NORTH",
@@ -22,11 +22,11 @@
             "destination": "217.111.187.217",
             "success": 10,
             "total": 10,
-            "rtt_min": 2.36,
-            "rtt_max": 2.75,
-            "rtt_avg": 2.58,
+            "rtt_min_ms": 2.36,
+            "rtt_max_ms": 2.75,
+            "rtt_avg_ms": 2.58,
             "probe_count": 10,
-            "probe_interval": 1000
+            "probe_interval_ms": 1000
         }
     }
 }

--- a/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/input.txt
@@ -1,0 +1,10 @@
+--------------------------------------------------------------------------------
+total paths monitored :                         2
+hold time to send probe packets :               1000 ms
+  (after device becomes active)
+--------------------------------------------------------------------------------
+grp/name/type             destination     suc/total rtt min/max/avg (ms) probe cnt/interval(ms)
+--------------------------------------------------------------------------------
+HA_PATH_NORTH/VR_HANDOFF/virtual-router 8.8.8.8         10/10     3.66/4.19/3.90      10/1000
+HA_PATH_NORTH/VR_HANDOFF/virtual-router 217.111.187.217 10/10     2.36/2.75/2.58      10/1000
+--------------------------------------------------------------------------------

--- a/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two path monitoring destinations with successful probes
+platform: Unknown
+software_version: Unknown

--- a/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/command.txt
+++ b/tests/parsers/paloalto_panos/show_high_availability_path_monitoring/command.txt
@@ -1,0 +1,1 @@
+show high-availability path-monitoring


### PR DESCRIPTION
## Summary
- Add parser for `show high-availability path-monitoring` on Palo Alto PAN-OS
- Extracts total monitored paths, hold time, and per-destination probe results (success/total counts, RTT min/max/avg, probe count/interval)
- Output uses dict-of-dicts keyed by destination IP address
- Tagged with `ParserTag.REDUNDANCY`

## Test plan
- [x] Parser test fixture with real device output passes
- [x] Placeholder sentinel guardrails pass (no banned values in expected.json)
- [x] JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] ruff check and format pass
- [x] xenon complexity under threshold (max-absolute B, max-average A)
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)