### PR TITLE
feat(arista_eos): add parser for `show interfaces transceiver`

### DIFF
--- a/changes/+arista-eos-show-interfaces-transceiver.parser_added
+++ b/changes/+arista-eos-show-interfaces-transceiver.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interfaces transceiver` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_interfaces_transceiver.py
+++ b/src/muninn/parsers/arista_eos/show_interfaces_transceiver.py
@@ -1,0 +1,128 @@
+"""Parser for 'show interfaces transceiver' command on Arista EOS."""
+
+import re
+from typing import Any, ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class TransceiverEntry(TypedDict):
+    """Schema for a single interface transceiver entry."""
+
+    temperature_c: NotRequired[float]
+    voltage_v: NotRequired[float]
+    current_ma: NotRequired[float]
+    tx_power_dbm: NotRequired[float]
+    rx_power_dbm: NotRequired[float]
+
+
+class ShowInterfacesTransceiverResult(TypedDict):
+    """Schema for 'show interfaces transceiver' parsed output on Arista EOS."""
+
+    interfaces: dict[str, TransceiverEntry]
+
+
+# Values that indicate no data is available and should be omitted.
+_SKIP_VALUES = frozenset({"N/A", "n/a", "--"})
+
+# Matches transceiver data rows. Arista EOS uses abbreviated interface names
+# like "Et3/1/1", "Et3/17/1", "Ma1", etc.
+#
+# Example rows:
+#   Et3/1/1    27.92      3.23      19.94     N/A      -2.39     0:00:06 ago
+#   Et3/17/1   35.61      3.21      36.64    1.51      -0.10     0:00:03 ago
+#   Et5/29/1   N/A        N/A       N/A       N/A       N/A      N/A
+_ROW_PATTERN = re.compile(
+    r"^(?P<port>[A-Za-z]+[\d/]+)\s+"
+    r"(?P<temp>\S+)\s+"
+    r"(?P<voltage>\S+)\s+"
+    r"(?P<current>\S+)\s+"
+    r"(?P<tx_power>\S+)\s+"
+    r"(?P<rx_power>\S+)\s+"
+    r"(?P<last_update>.+)$"
+)
+
+# Maps regex group names to TransceiverEntry keys.
+_FIELD_MAP: list[tuple[str, str]] = [
+    ("temp", "temperature_c"),
+    ("voltage", "voltage_v"),
+    ("current", "current_ma"),
+    ("tx_power", "tx_power_dbm"),
+    ("rx_power", "rx_power_dbm"),
+]
+
+
+def _parse_float(value: str) -> float | None:
+    """Parse a string to float, returning None for N/A or skip values.
+
+    Args:
+        value: Raw string value from CLI output.
+
+    Returns:
+        Parsed float or None if value should be omitted.
+    """
+    if value in _SKIP_VALUES:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+@register(OS.ARISTA_EOS, "show interfaces transceiver")
+class ShowInterfacesTransceiverParser(
+    BaseParser[ShowInterfacesTransceiverResult],
+):
+    """Parser for 'show interfaces transceiver' on Arista EOS.
+
+    Parses the transceiver summary table including temperature, voltage,
+    bias current, Tx power (dBm), and Rx power (dBm) per interface.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesTransceiverResult:
+        """Parse 'show interfaces transceiver' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed transceiver data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no transceiver entries found.
+        """
+        interfaces: dict[str, TransceiverEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = _ROW_PATTERN.match(stripped)
+            if not match:
+                continue
+
+            port = canonical_interface_name(match.group("port"), os=OS.ARISTA_EOS)
+
+            entry: TransceiverEntry = {}
+            _d = cast(dict[str, Any], entry)
+
+            for group_name, key in _FIELD_MAP:
+                val = _parse_float(match.group(group_name))
+                if val is not None:
+                    _d[key] = val
+
+            interfaces[port] = entry
+
+        if not interfaces:
+            msg = "No transceiver entries found in output"
+            raise ValueError(msg)
+
+        return ShowInterfacesTransceiverResult(interfaces=interfaces)

--- a/src/muninn/parsers/arista_eos/show_interfaces_transceiver.py
+++ b/src/muninn/parsers/arista_eos/show_interfaces_transceiver.py
@@ -18,6 +18,7 @@ class TransceiverEntry(TypedDict):
     current_ma: NotRequired[float]
     tx_power_dbm: NotRequired[float]
     rx_power_dbm: NotRequired[float]
+    last_update: NotRequired[str]
 
 
 class ShowInterfacesTransceiverResult(TypedDict):
@@ -118,6 +119,13 @@ class ShowInterfacesTransceiverParser(
                 val = _parse_float(match.group(group_name))
                 if val is not None:
                     _d[key] = val
+
+            last_update = match.group("last_update").strip()
+            if last_update not in _SKIP_VALUES:
+                _d["last_update"] = last_update
+
+            if not entry:
+                continue
 
             interfaces[port] = entry
 

--- a/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "interfaces": {
+        "Ethernet3/1/1": {
+            "temperature_c": 27.92,
+            "voltage_v": 3.23,
+            "current_ma": 19.94,
+            "rx_power_dbm": -2.39
+        },
+        "Ethernet3/17/1": {
+            "temperature_c": 35.61,
+            "voltage_v": 3.21,
+            "current_ma": 36.64,
+            "tx_power_dbm": 1.51,
+            "rx_power_dbm": -0.1
+        },
+        "Ethernet3/17/2": {
+            "temperature_c": 35.61,
+            "voltage_v": 3.21,
+            "current_ma": 36.94,
+            "tx_power_dbm": -0.2,
+            "rx_power_dbm": -0.2
+        },
+        "Ethernet3/17/3": {
+            "temperature_c": 35.61,
+            "voltage_v": 3.21,
+            "current_ma": 37.42,
+            "tx_power_dbm": 1.65,
+            "rx_power_dbm": -0.72
+        },
+        "Ethernet5/29/1": {}
+    }
+}

--- a/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/expected.json
@@ -4,29 +4,32 @@
             "temperature_c": 27.92,
             "voltage_v": 3.23,
             "current_ma": 19.94,
-            "rx_power_dbm": -2.39
+            "rx_power_dbm": -2.39,
+            "last_update": "0:00:06 ago"
         },
         "Ethernet3/17/1": {
             "temperature_c": 35.61,
             "voltage_v": 3.21,
             "current_ma": 36.64,
             "tx_power_dbm": 1.51,
-            "rx_power_dbm": -0.1
+            "rx_power_dbm": -0.1,
+            "last_update": "0:00:03 ago"
         },
         "Ethernet3/17/2": {
             "temperature_c": 35.61,
             "voltage_v": 3.21,
             "current_ma": 36.94,
             "tx_power_dbm": -0.2,
-            "rx_power_dbm": -0.2
+            "rx_power_dbm": -0.2,
+            "last_update": "0:00:03 ago"
         },
         "Ethernet3/17/3": {
             "temperature_c": 35.61,
             "voltage_v": 3.21,
             "current_ma": 37.42,
             "tx_power_dbm": 1.65,
-            "rx_power_dbm": -0.72
-        },
-        "Ethernet5/29/1": {}
+            "rx_power_dbm": -0.72,
+            "last_update": "0:00:03 ago"
+        }
     }
 }

--- a/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/input.txt
@@ -1,0 +1,12 @@
+If device is externally calibrated, only calibrated values are printed.
+N/A: not applicable, Tx: transmit, Rx: receive.
+mA: milliamperes, dBm: decibels (milliwatts).
+                               Bias      Optical   Optical
+          Temp       Voltage   Current   Tx Power  Rx Power
+Port      (Celsius)  (Volts)   (mA)      (dBm)     (dBm)     Last Update
+-----     ---------  --------  --------  --------  --------  -------------------
+Et3/1/1    27.92      3.23      19.94     N/A      -2.39     0:00:06 ago
+Et3/17/1   35.61      3.21      36.64    1.51      -0.10     0:00:03 ago
+Et3/17/2   35.61      3.21      36.94    -0.20     -0.20     0:00:03 ago
+Et3/17/3   35.61      3.21      37.42    1.65      -0.72     0:00:03 ago
+Et5/29/1   N/A        N/A       N/A       N/A       N/A      N/A

--- a/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic transceiver output with mixed N/A and valid readings
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show interfaces transceiver` on Arista EOS
- Parses transceiver diagnostics per interface: temperature (C), voltage (V), bias current (mA), Tx/Rx power (dBm)
- N/A values are omitted from output rather than carried as placeholder strings
- Dict-of-dicts keyed by canonical interface name (e.g. `Ethernet3/1/1`)

## Test plan
- [x] Fixture `001_basic` with real device output covering mixed N/A and valid readings
- [x] All 6848 tests pass
- [x] Pre-commit hooks pass (ruff, xenon, json formatting, etc.)
- [x] Sentinel placeholder tests pass (no banned N/A, hyphen, empty string values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)