### PR TITLE
feat(juniper_junos): add parser for show vlans

### DIFF
--- a/changes/+juniper-junos-show-vlans.parser_added
+++ b/changes/+juniper-junos-show-vlans.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show vlans` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_vlans.py
+++ b/src/muninn/parsers/juniper_junos/show_vlans.py
@@ -1,0 +1,88 @@
+"""Parser for 'show vlans' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowVlansEntry(TypedDict):
+    """Schema for a single VLAN entry."""
+
+    tag: int
+    routing_instance: str
+    description: NotRequired[str]
+    interfaces: list[str]
+
+
+# Dict keyed by VLAN name, each value is a ShowVlansEntry.
+ShowVlansResult = dict[str, ShowVlansEntry]
+
+
+@register(OS.JUNIPER_JUNOS, "show vlans")
+class ShowVlansParser(BaseParser[ShowVlansResult]):
+    """Parser for 'show vlans' command on Juniper Junos.
+
+    Parses VLAN name, tag (ID), routing instance, and member interfaces
+    from the tabular output of EX and QFX series switches.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.VLAN})
+
+    # First line of a VLAN block: routing-instance, VLAN name, tag
+    _VLAN_HEADER = re.compile(r"^(?P<instance>\S+)\s+(?P<name>\S+)\s+(?P<tag>\d+)\s*$")
+
+    # Continuation line with only an interface name
+    _INTERFACE_LINE = re.compile(r"^\s+(?P<iface>\S+)\s*$")
+
+    # Junos prompt lines like "{master:0}" or "{primary:node0}"
+    _PROMPT = re.compile(r"^\{.+\}\s*$")
+
+    @classmethod
+    def _is_skippable(cls, stripped: str) -> bool:
+        """Return True if the line should be skipped entirely."""
+        if not stripped:
+            return True
+        if cls._PROMPT.match(stripped):
+            return True
+        return stripped.startswith("Routing instance")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVlansResult:
+        """Parse 'show vlans' output on Juniper Junos.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by VLAN name with tag, routing instance,
+            and interface membership.
+        """
+        result: ShowVlansResult = {}
+        current_entry: ShowVlansEntry | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            if cls._is_skippable(stripped):
+                continue
+
+            header_match = cls._VLAN_HEADER.match(stripped)
+            if header_match:
+                entry = ShowVlansEntry(
+                    tag=int(header_match.group("tag")),
+                    routing_instance=header_match.group("instance"),
+                    interfaces=[],
+                )
+                result[header_match.group("name")] = entry
+                current_entry = entry
+                continue
+
+            iface_match = cls._INTERFACE_LINE.match(line)
+            if iface_match and current_entry is not None:
+                current_entry["interfaces"].append(iface_match.group("iface"))
+
+        return result

--- a/src/muninn/parsers/juniper_junos/show_vlans.py
+++ b/src/muninn/parsers/juniper_junos/show_vlans.py
@@ -7,19 +7,48 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
-class ShowVlansEntry(TypedDict):
+class VlanInterfaceEntry(TypedDict):
+    """Schema for a VLAN member interface."""
+
+    active: bool
+
+
+class VlanEntry(TypedDict):
     """Schema for a single VLAN entry."""
 
     tag: int
     routing_instance: str
     description: NotRequired[str]
-    interfaces: list[str]
+    interfaces: dict[str, VlanInterfaceEntry]
 
 
-# Dict keyed by VLAN name, each value is a ShowVlansEntry.
-ShowVlansResult = dict[str, ShowVlansEntry]
+class ShowVlansResult(TypedDict):
+    """Schema for 'show vlans' parsed output."""
+
+    vlans: dict[str, VlanEntry]
+
+
+# First line of a VLAN block: routing-instance, VLAN name, tag
+_VLAN_HEADER = re.compile(r"^(?P<instance>\S+)\s+(?P<name>\S+)\s+(?P<tag>\d+)\s*$")
+
+# Continuation line with only an interface name; trailing `*` indicates the
+# interface is currently active/up in the VLAN.
+_INTERFACE_LINE = re.compile(r"^\s+(?P<iface>\S+?)(?P<active>\*?)\s*$")
+
+# Junos prompt lines like "{master:0}" or "{primary:node0}"
+_PROMPT = re.compile(r"^\{.+\}\s*$")
+
+
+def _is_skippable(stripped: str) -> bool:
+    """Return True if the line should be skipped entirely."""
+    if not stripped:
+        return True
+    if _PROMPT.match(stripped):
+        return True
+    return stripped.startswith("Routing instance")
 
 
 @register(OS.JUNIPER_JUNOS, "show vlans")
@@ -27,28 +56,13 @@ class ShowVlansParser(BaseParser[ShowVlansResult]):
     """Parser for 'show vlans' command on Juniper Junos.
 
     Parses VLAN name, tag (ID), routing instance, and member interfaces
-    from the tabular output of EX and QFX series switches.
+    from the tabular output of EX and QFX series switches. A trailing
+    asterisk (``*``) on an interface indicates the interface is currently
+    active in the VLAN; this is captured as ``active: bool`` rather than
+    being kept in the interface name.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.VLAN})
-
-    # First line of a VLAN block: routing-instance, VLAN name, tag
-    _VLAN_HEADER = re.compile(r"^(?P<instance>\S+)\s+(?P<name>\S+)\s+(?P<tag>\d+)\s*$")
-
-    # Continuation line with only an interface name
-    _INTERFACE_LINE = re.compile(r"^\s+(?P<iface>\S+)\s*$")
-
-    # Junos prompt lines like "{master:0}" or "{primary:node0}"
-    _PROMPT = re.compile(r"^\{.+\}\s*$")
-
-    @classmethod
-    def _is_skippable(cls, stripped: str) -> bool:
-        """Return True if the line should be skipped entirely."""
-        if not stripped:
-            return True
-        if cls._PROMPT.match(stripped):
-            return True
-        return stripped.startswith("Routing instance")
 
     @classmethod
     def parse(cls, output: str) -> ShowVlansResult:
@@ -61,28 +75,31 @@ class ShowVlansParser(BaseParser[ShowVlansResult]):
             Dict keyed by VLAN name with tag, routing instance,
             and interface membership.
         """
-        result: ShowVlansResult = {}
-        current_entry: ShowVlansEntry | None = None
+        vlans: dict[str, VlanEntry] = {}
+        current_entry: VlanEntry | None = None
 
         for line in output.splitlines():
             stripped = line.strip()
 
-            if cls._is_skippable(stripped):
+            if _is_skippable(stripped):
                 continue
 
-            header_match = cls._VLAN_HEADER.match(stripped)
+            header_match = _VLAN_HEADER.match(stripped)
             if header_match:
-                entry = ShowVlansEntry(
-                    tag=int(header_match.group("tag")),
-                    routing_instance=header_match.group("instance"),
-                    interfaces=[],
-                )
-                result[header_match.group("name")] = entry
+                entry: VlanEntry = {
+                    "tag": int(header_match.group("tag")),
+                    "routing_instance": header_match.group("instance"),
+                    "interfaces": {},
+                }
+                vlans[header_match.group("name")] = entry
                 current_entry = entry
                 continue
 
-            iface_match = cls._INTERFACE_LINE.match(line)
+            iface_match = _INTERFACE_LINE.match(line)
             if iface_match and current_entry is not None:
-                current_entry["interfaces"].append(iface_match.group("iface"))
+                raw_iface = iface_match.group("iface")
+                active = bool(iface_match.group("active"))
+                iface_name = canonical_interface_name(raw_iface, os=OS.JUNIPER_JUNOS)
+                current_entry["interfaces"][iface_name] = {"active": active}
 
-        return result
+        return {"vlans": vlans}

--- a/tests/parsers/juniper_junos/show_vlans/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_vlans/001_basic/expected.json
@@ -1,0 +1,42 @@
+{
+    "v100-Control": {
+        "tag": 100,
+        "routing_instance": "default-switch",
+        "interfaces": [
+            "ae0.0*",
+            "et-0/0/24.0*",
+            "ge-0/0/3.0",
+            "xe-0/0/13.0*",
+            "xe-0/0/15.0*",
+            "xe-0/0/17.0*",
+            "xe-0/0/9.0*"
+        ]
+    },
+    "v1005-HelpDesk": {
+        "tag": 1005,
+        "routing_instance": "default-switch",
+        "interfaces": [
+            "ae0.0*",
+            "et-0/0/24.0*",
+            "ge-0/0/7.0",
+            "xe-0/0/13.0*",
+            "xe-0/0/15.0*",
+            "xe-0/0/17.0*",
+            "xe-0/0/9.0*"
+        ]
+    },
+    "v109-TEMP-Project-Data": {
+        "tag": 109,
+        "routing_instance": "default-switch",
+        "interfaces": [
+            "ae0.0*",
+            "et-0/0/24.0*",
+            "ge-0/0/7.0",
+            "xe-0/0/13.0*",
+            "xe-0/0/15.0*",
+            "xe-0/0/17.0*",
+            "xe-0/0/22.0",
+            "xe-0/0/9.0*"
+        ]
+    }
+}

--- a/tests/parsers/juniper_junos/show_vlans/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_vlans/001_basic/expected.json
@@ -1,42 +1,88 @@
 {
-    "v100-Control": {
-        "tag": 100,
-        "routing_instance": "default-switch",
-        "interfaces": [
-            "ae0.0*",
-            "et-0/0/24.0*",
-            "ge-0/0/3.0",
-            "xe-0/0/13.0*",
-            "xe-0/0/15.0*",
-            "xe-0/0/17.0*",
-            "xe-0/0/9.0*"
-        ]
-    },
-    "v1005-HelpDesk": {
-        "tag": 1005,
-        "routing_instance": "default-switch",
-        "interfaces": [
-            "ae0.0*",
-            "et-0/0/24.0*",
-            "ge-0/0/7.0",
-            "xe-0/0/13.0*",
-            "xe-0/0/15.0*",
-            "xe-0/0/17.0*",
-            "xe-0/0/9.0*"
-        ]
-    },
-    "v109-TEMP-Project-Data": {
-        "tag": 109,
-        "routing_instance": "default-switch",
-        "interfaces": [
-            "ae0.0*",
-            "et-0/0/24.0*",
-            "ge-0/0/7.0",
-            "xe-0/0/13.0*",
-            "xe-0/0/15.0*",
-            "xe-0/0/17.0*",
-            "xe-0/0/22.0",
-            "xe-0/0/9.0*"
-        ]
+    "vlans": {
+        "v100-Control": {
+            "tag": 100,
+            "routing_instance": "default-switch",
+            "interfaces": {
+                "ae0.0": {
+                    "active": true
+                },
+                "et-0/0/24.0": {
+                    "active": true
+                },
+                "ge-0/0/3.0": {
+                    "active": false
+                },
+                "xe-0/0/13.0": {
+                    "active": true
+                },
+                "xe-0/0/15.0": {
+                    "active": true
+                },
+                "xe-0/0/17.0": {
+                    "active": true
+                },
+                "xe-0/0/9.0": {
+                    "active": true
+                }
+            }
+        },
+        "v1005-HelpDesk": {
+            "tag": 1005,
+            "routing_instance": "default-switch",
+            "interfaces": {
+                "ae0.0": {
+                    "active": true
+                },
+                "et-0/0/24.0": {
+                    "active": true
+                },
+                "ge-0/0/7.0": {
+                    "active": false
+                },
+                "xe-0/0/13.0": {
+                    "active": true
+                },
+                "xe-0/0/15.0": {
+                    "active": true
+                },
+                "xe-0/0/17.0": {
+                    "active": true
+                },
+                "xe-0/0/9.0": {
+                    "active": true
+                }
+            }
+        },
+        "v109-TEMP-Project-Data": {
+            "tag": 109,
+            "routing_instance": "default-switch",
+            "interfaces": {
+                "ae0.0": {
+                    "active": true
+                },
+                "et-0/0/24.0": {
+                    "active": true
+                },
+                "ge-0/0/7.0": {
+                    "active": false
+                },
+                "xe-0/0/13.0": {
+                    "active": true
+                },
+                "xe-0/0/15.0": {
+                    "active": true
+                },
+                "xe-0/0/17.0": {
+                    "active": true
+                },
+                "xe-0/0/22.0": {
+                    "active": false
+                },
+                "xe-0/0/9.0": {
+                    "active": true
+                }
+            }
+        }
     }
 }

--- a/tests/parsers/juniper_junos/show_vlans/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_vlans/001_basic/input.txt
@@ -1,0 +1,28 @@
+Routing instance        VLAN name             Tag          Interfaces
+default-switch          v100-Control           100
+                                                           ae0.0*
+                                                           et-0/0/24.0*
+                                                           ge-0/0/3.0
+                                                           xe-0/0/13.0*
+                                                           xe-0/0/15.0*
+                                                           xe-0/0/17.0*
+                                                           xe-0/0/9.0*
+default-switch          v1005-HelpDesk        1005
+                                                           ae0.0*
+                                                           et-0/0/24.0*
+                                                           ge-0/0/7.0
+                                                           xe-0/0/13.0*
+                                                           xe-0/0/15.0*
+                                                           xe-0/0/17.0*
+                                                           xe-0/0/9.0*
+default-switch          v109-TEMP-Project-Data 109
+                                                           ae0.0*
+                                                           et-0/0/24.0*
+                                                           ge-0/0/7.0
+                                                           xe-0/0/13.0*
+                                                           xe-0/0/15.0*
+                                                           xe-0/0/17.0*
+                                                           xe-0/0/22.0
+                                                           xe-0/0/9.0*
+
+{master:0}

--- a/tests/parsers/juniper_junos/show_vlans/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_vlans/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VLANs with trunk and access interfaces
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add a new parser for `show vlans` on Juniper Junos (EX/QFX switches)
- Parses VLAN name, tag (ID), routing instance, and member interfaces into a dict-of-dicts keyed by VLAN name
- Tagged with `ParserTag.VLAN`

## Test plan
- [x] Test fixture `001_basic` with 3 VLANs and multiple interfaces per VLAN
- [x] All pre-commit hooks pass (ruff, xenon, bandit, format)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (dict-of-dicts, no pipe keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)