### PR TITLE
feat(cisco_iosxr): add parser for `show configuration commit list`

### DIFF
--- a/changes/+cisco-iosxr-show-configuration-commit-list.parser_added
+++ b/changes/+cisco-iosxr-show-configuration-commit-list.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show configuration commit list` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_configuration_commit_list.py
+++ b/src/muninn/parsers/cisco_iosxr/show_configuration_commit_list.py
@@ -1,0 +1,110 @@
+"""Parser for 'show configuration commit list' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class CommitEntry(TypedDict):
+    """Schema for a single configuration commit entry."""
+
+    sno: int
+    user: str
+    line: str
+    client: str
+    timestamp: str
+    comment: NotRequired[str]
+
+
+# Dict-of-dicts keyed by commit ID (Label/ID column).
+ShowConfigurationCommitListResult = dict[str, CommitEntry]
+
+
+@register(OS.CISCO_IOSXR, "show configuration commit list")
+class ShowConfigurationCommitListParser(
+    BaseParser[ShowConfigurationCommitListResult],
+):
+    """Parser for 'show configuration commit list' on Cisco IOS-XR.
+
+    Parses the commit history table into a dict keyed by commit ID.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    # Header separator line of tildes
+    _SEPARATOR = re.compile(r"^~{4,}")
+
+    # Data line: sequence number, label/ID, user, line, client, timestamp
+    # Columns are whitespace-separated; timestamp consumes the rest.
+    _ENTRY = re.compile(
+        r"^\s*(?P<sno>\d+)\s+"
+        r"(?P<label_id>\d+)\s+"
+        r"(?P<user>\S+)\s+"
+        r"(?P<line>\S+)\s+"
+        r"(?P<client>\S+)\s+"
+        r"(?P<timestamp>.+?)\s*$",
+    )
+
+    # Comment line follows the entry with leading whitespace and no SNo
+    _COMMENT = re.compile(r"^\s{2,}(?P<comment>\S.*)$")
+
+    @classmethod
+    def _extract_data_lines(cls, output: str) -> list[str]:
+        """Return lines after the tilde separator header."""
+        lines = output.splitlines()
+        for idx, line in enumerate(lines):
+            if cls._SEPARATOR.match(line):
+                return lines[idx + 1 :]
+        return []
+
+    @classmethod
+    def _build_entry(cls, match: re.Match[str]) -> CommitEntry:
+        """Construct a CommitEntry from a regex match."""
+        return CommitEntry(
+            sno=int(match.group("sno")),
+            user=match.group("user"),
+            line=match.group("line"),
+            client=match.group("client"),
+            timestamp=match.group("timestamp"),
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowConfigurationCommitListResult:
+        """Parse 'show configuration commit list' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict keyed by commit ID with commit metadata.
+
+        Raises:
+            ValueError: If no commit entries are found.
+        """
+        result: ShowConfigurationCommitListResult = {}
+        last_commit_id: str | None = None
+
+        for line in cls._extract_data_lines(output):
+            match = cls._ENTRY.match(line)
+            if match:
+                commit_id = match.group("label_id")
+                result[commit_id] = cls._build_entry(match)
+                last_commit_id = commit_id
+                continue
+
+            if last_commit_id is not None:
+                comment_match = cls._COMMENT.match(line)
+                if comment_match:
+                    result[last_commit_id]["comment"] = comment_match.group(
+                        "comment"
+                    ).strip()
+
+        if not result:
+            msg = "No commit entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_configuration_commit_list/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_configuration_commit_list/001_basic/expected.json
@@ -1,0 +1,79 @@
+{
+    "1000000093": {
+        "sno": 1,
+        "user": "fred",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Tue Jun  7 14:42:19 2016"
+    },
+    "1000000092": {
+        "sno": 2,
+        "user": "john",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Tue Jun  7 14:40:05 2016"
+    },
+    "1000000091": {
+        "sno": 3,
+        "user": "john",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Tue Jun  7 14:33:52 2016"
+    },
+    "1000000090": {
+        "sno": 4,
+        "user": "john",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Tue Jun  7 14:33:05 2016"
+    },
+    "1000000089": {
+        "sno": 5,
+        "user": "fred",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Tue Jun  7 14:31:39 2016"
+    },
+    "1000000088": {
+        "sno": 6,
+        "user": "patrick",
+        "line": "vty1:node0_RSP0_CP",
+        "client": "Rollback",
+        "timestamp": "Tue Jun  7 14:29:12 2016"
+    },
+    "1000000087": {
+        "sno": 7,
+        "user": "john",
+        "line": "vty1:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Fri Jun  3 14:33:27 2016"
+    },
+    "1000000086": {
+        "sno": 8,
+        "user": "admin",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Wed May 25 13:43:18 2016"
+    },
+    "1000000085": {
+        "sno": 9,
+        "user": "admin",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Fri May 20 10:06:01 2016"
+    },
+    "1000000084": {
+        "sno": 10,
+        "user": "admin",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Wed May 11 13:32:10 2016"
+    },
+    "1000000083": {
+        "sno": 11,
+        "user": "patrick",
+        "line": "vty0:node0_RSP0_CP",
+        "client": "CLI",
+        "timestamp": "Tue May 10 14:18:59 2016"
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_configuration_commit_list/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_configuration_commit_list/001_basic/input.txt
@@ -1,0 +1,13 @@
+SNo. Label/ID    User      Line                Client      Time Stamp
+~~~~ ~~~~~~~~    ~~~~      ~~~~                ~~~~~~      ~~~~~~~~~~
+1    1000000093  fred      vty0:node0_RSP0_CP  CLI         Tue Jun  7 14:42:19 2016
+2    1000000092  john      vty0:node0_RSP0_CP  CLI         Tue Jun  7 14:40:05 2016
+3    1000000091  john      vty0:node0_RSP0_CP  CLI         Tue Jun  7 14:33:52 2016
+4    1000000090  john      vty0:node0_RSP0_CP  CLI         Tue Jun  7 14:33:05 2016
+5    1000000089  fred      vty0:node0_RSP0_CP  CLI         Tue Jun  7 14:31:39 2016
+6    1000000088  patrick   vty1:node0_RSP0_CP  Rollback    Tue Jun  7 14:29:12 2016
+7    1000000087  john      vty1:node0_RSP0_CP  CLI         Fri Jun  3 14:33:27 2016
+8    1000000086  admin     vty0:node0_RSP0_CP  CLI         Wed May 25 13:43:18 2016
+9    1000000085  admin     vty0:node0_RSP0_CP  CLI         Fri May 20 10:06:01 2016
+10   1000000084  admin     vty0:node0_RSP0_CP  CLI         Wed May 11 13:32:10 2016
+11   1000000083  patrick   vty0:node0_RSP0_CP  CLI         Tue May 10 14:18:59 2016

--- a/tests/parsers/cisco_iosxr/show_configuration_commit_list/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_configuration_commit_list/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Basic commit list with multiple users and clients"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show configuration commit list` on Cisco IOS-XR
- Returns dict-of-dicts keyed by commit ID with sequence number, user, line, client, and timestamp
- Tagged with `ParserTag.SYSTEM`

## Test plan
- [x] Parser test with real device output fixture passes
- [x] All 6710 existing tests continue to pass
- [x] ruff check/format, bandit, xenon all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)