### PR TITLE
feat(arista_eos): add parser for show snmp community

### DIFF
--- a/changes/+arista-eos-show-snmp-community.parser_added
+++ b/changes/+arista-eos-show-snmp-community.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show snmp community` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_snmp_community.py
+++ b/src/muninn/parsers/arista_eos/show_snmp_community.py
@@ -1,0 +1,92 @@
+"""Parser for 'show snmp community' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class SnmpCommunityEntry(TypedDict):
+    """Schema for a single SNMP community entry."""
+
+    access: str
+    community_view: NotRequired[str]
+    access_list: NotRequired[str]
+    ipv6_access_list: NotRequired[str]
+
+
+@register(OS.ARISTA_EOS, "show snmp community")
+class ShowSnmpCommunityParser(BaseParser[dict[str, SnmpCommunityEntry]]):
+    """Parser for 'show snmp community' command on Arista EOS.
+
+    Returns a dict-of-dicts keyed by community name. Each entry contains
+    the access type (read-only/read-write) and optional access list or
+    community view fields.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SNMP})
+
+    _COMMUNITY_NAME = re.compile(r"^Community name:\s*(?P<name>\S+)")
+    _COMMUNITY_ACCESS = re.compile(r"^Community access:\s*(?P<access>.+)$")
+    _COMMUNITY_VIEW = re.compile(r"^Community view:\s*(?P<view>\S+)")
+    _ACCESS_LIST = re.compile(r"^Access list:\s*(?P<acl>\S+)")
+    _IPV6_ACCESS_LIST = re.compile(r"^IPv6 access list:\s*(?P<acl>\S+)")
+
+    # Maps regex pattern attribute names to the dict key and capture group
+    # used when populating a community entry.
+    _FIELD_PATTERNS: ClassVar[tuple[tuple[str, str, str], ...]] = (
+        ("_COMMUNITY_ACCESS", "access", "access"),
+        ("_COMMUNITY_VIEW", "community_view", "view"),
+        ("_ACCESS_LIST", "access_list", "acl"),
+        ("_IPV6_ACCESS_LIST", "ipv6_access_list", "acl"),
+    )
+
+    @classmethod
+    def _parse_entry_line(cls, line: str, entry: dict[str, str]) -> bool:
+        """Try to match a line against community detail patterns.
+
+        Returns True if the line matched a known field pattern.
+        """
+        for attr, key, group in cls._FIELD_PATTERNS:
+            pattern: re.Pattern[str] = getattr(cls, attr)
+            if match := pattern.match(line):
+                entry[key] = match.group(group).strip()
+                return True
+        return False
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, SnmpCommunityEntry]:
+        """Parse 'show snmp community' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict of community entries keyed by community name.
+        """
+        result: dict[str, SnmpCommunityEntry] = {}
+        current_name: str | None = None
+        current_entry: dict[str, str] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._COMMUNITY_NAME.match(stripped):
+                if current_name is not None:
+                    result[current_name] = SnmpCommunityEntry(**current_entry)  # type: ignore[arg-type]
+                current_name = match.group("name")
+                current_entry = {}
+                continue
+
+            cls._parse_entry_line(stripped, current_entry)
+
+        # Save last entry
+        if current_name is not None:
+            result[current_name] = SnmpCommunityEntry(**current_entry)  # type: ignore[arg-type]
+
+        return result

--- a/src/muninn/parsers/arista_eos/show_snmp_community.py
+++ b/src/muninn/parsers/arista_eos/show_snmp_community.py
@@ -1,7 +1,7 @@
 """Parser for 'show snmp community' command on Arista EOS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -78,7 +78,7 @@ class ShowSnmpCommunityParser(BaseParser[dict[str, SnmpCommunityEntry]]):
 
             if match := cls._COMMUNITY_NAME.match(stripped):
                 if current_name is not None:
-                    result[current_name] = SnmpCommunityEntry(**current_entry)  # type: ignore[arg-type]
+                    result[current_name] = cast(SnmpCommunityEntry, current_entry)
                 current_name = match.group("name")
                 current_entry = {}
                 continue
@@ -87,6 +87,6 @@ class ShowSnmpCommunityParser(BaseParser[dict[str, SnmpCommunityEntry]]):
 
         # Save last entry
         if current_name is not None:
-            result[current_name] = SnmpCommunityEntry(**current_entry)  # type: ignore[arg-type]
+            result[current_name] = cast(SnmpCommunityEntry, current_entry)
 
         return result

--- a/tests/parsers/arista_eos/show_snmp_community/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_snmp_community/001_basic/expected.json
@@ -1,0 +1,20 @@
+{
+    "TEST": {
+        "access": "read-only"
+    },
+    "TEST_AGAIN": {
+        "access": "read-only",
+        "community_view": "TEST"
+    },
+    "TEST_ONE_MORE": {
+        "access": "read-only",
+        "access_list": "TEST_ACL"
+    },
+    "TEST_ONE_MORE_TIME": {
+        "access": "read-write",
+        "ipv6_access_list": "IPV6_ACL"
+    },
+    "public": {
+        "access": "read-only"
+    }
+}

--- a/tests/parsers/arista_eos/show_snmp_community/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_snmp_community/001_basic/input.txt
@@ -1,0 +1,17 @@
+Community name: TEST
+Community access: read-only
+
+Community name: TEST_AGAIN
+Community access: read-only
+Community view: TEST (non-existent)
+
+Community name: TEST_ONE_MORE
+Community access: read-only
+Access list: TEST_ACL (non-existent)
+
+Community name: TEST_ONE_MORE_TIME
+Community access: read-write
+IPv6 access list: IPV6_ACL (non-existent)
+
+Community name: public
+Community access: read-only

--- a/tests/parsers/arista_eos/show_snmp_community/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_snmp_community/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple SNMP communities with various access types and access lists
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add parser for `show snmp community` on Arista EOS
- Returns dict-of-dicts keyed by community name with access type, community view, access list, and IPv6 access list fields
- Includes test fixture from real device output with 5 community entries covering all field variants

## Test plan
- [x] Parser test passes (`tests/parsers/test_parsers.py::test_parser[arista_eos/show_snmp_community/001_basic]`)
- [x] Full test suite passes (6848 tests)
- [x] Pre-commit hooks pass (ruff, xenon, bandit, etc.)
- [x] No placeholder sentinel values in expected.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)