### PR TITLE
feat(arista_eos): add parser for show interfaces transceiver detail

### DIFF
--- a/changes/+arista-eos-show-interfaces-transceiver-detail.parser_added
+++ b/changes/+arista-eos-show-interfaces-transceiver-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show interfaces transceiver detail` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_interfaces_transceiver_detail.py
+++ b/src/muninn/parsers/arista_eos/show_interfaces_transceiver_detail.py
@@ -90,7 +90,7 @@ class ShowInterfacesTransceiverDetailParser(
         line: str,
         section_value_key: str,
         section_threshold_key: str,
-        interfaces: dict[str, TransceiverEntry],
+        interfaces: dict[str, dict[str, object]],
     ) -> None:
         """Parse a single data row and merge into the interfaces dict."""
         match = cls._DATA_PATTERN.match(line)
@@ -100,11 +100,11 @@ class ShowInterfacesTransceiverDetailParser(
         port = canonical_interface_name(match.group("port"), os=OS.ARISTA_EOS)
 
         if port not in interfaces:
-            interfaces[port] = TransceiverEntry()
+            interfaces[port] = {}
 
         entry = interfaces[port]
-        entry[section_value_key] = float(match.group("value"))  # type: ignore[literal-required]
-        entry[section_threshold_key] = ThresholdInfo(  # type: ignore[literal-required]
+        entry[section_value_key] = float(match.group("value"))
+        entry[section_threshold_key] = ThresholdInfo(
             high_alarm=float(match.group("high_alarm")),
             high_warning=float(match.group("high_warn")),
             low_alarm=float(match.group("low_alarm")),
@@ -124,7 +124,7 @@ class ShowInterfacesTransceiverDetailParser(
         Raises:
             ValueError: If no transceiver data found in output.
         """
-        interfaces: dict[str, TransceiverEntry] = {}
+        interfaces: dict[str, dict[str, object]] = {}
         current_section: tuple[str, str] | None = None
 
         for line in output.splitlines():
@@ -156,7 +156,6 @@ class ShowInterfacesTransceiverDetailParser(
             msg = "No transceiver data found in output"
             raise ValueError(msg)
 
-        return cast(
-            ShowInterfacesTransceiverDetailResult,
-            {"interfaces": interfaces},
+        return ShowInterfacesTransceiverDetailResult(
+            interfaces={k: cast(TransceiverEntry, v) for k, v in interfaces.items()},
         )

--- a/src/muninn/parsers/arista_eos/show_interfaces_transceiver_detail.py
+++ b/src/muninn/parsers/arista_eos/show_interfaces_transceiver_detail.py
@@ -1,0 +1,162 @@
+"""Parser for 'show interfaces transceiver detail' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class ThresholdInfo(TypedDict):
+    """Schema for alarm and warning thresholds."""
+
+    high_alarm: float
+    high_warning: float
+    low_alarm: float
+    low_warning: float
+
+
+class TransceiverEntry(TypedDict):
+    """Schema for a single transceiver interface entry."""
+
+    temperature_celsius: NotRequired[float]
+    temperature_thresholds: NotRequired[ThresholdInfo]
+    voltage_volts: NotRequired[float]
+    voltage_thresholds: NotRequired[ThresholdInfo]
+    current_ma: NotRequired[float]
+    current_thresholds: NotRequired[ThresholdInfo]
+    tx_power_dbm: NotRequired[float]
+    tx_power_thresholds: NotRequired[ThresholdInfo]
+    rx_power_dbm: NotRequired[float]
+    rx_power_thresholds: NotRequired[ThresholdInfo]
+
+
+class ShowInterfacesTransceiverDetailResult(TypedDict):
+    """Schema for 'show interfaces transceiver detail' parsed output."""
+
+    interfaces: dict[str, TransceiverEntry]
+
+
+# Section names as they appear in the CLI output, mapped to field prefixes.
+_SECTION_MAP: dict[str, tuple[str, str]] = {
+    "Temperature": ("temperature_celsius", "temperature_thresholds"),
+    "Voltage": ("voltage_volts", "voltage_thresholds"),
+    "Current": ("current_ma", "current_thresholds"),
+    "Tx Power": ("tx_power_dbm", "tx_power_thresholds"),
+    "Rx Power": ("rx_power_dbm", "rx_power_thresholds"),
+}
+
+
+@register(OS.ARISTA_EOS, "show interfaces transceiver detail")
+class ShowInterfacesTransceiverDetailParser(
+    BaseParser[ShowInterfacesTransceiverDetailResult],
+):
+    """Parser for 'show interfaces transceiver detail' command on Arista EOS.
+
+    Parses per-lane transceiver diagnostics including temperature, voltage,
+    bias current, TX/RX optical power, and their alarm/warning thresholds.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    # Detects the measurement label line that identifies each section.
+    # Examples: "           Temperature   Threshold   ..."
+    #           "           Voltage       Threshold   ..."
+    #           "           Tx Power      Threshold   ..."
+    _SECTION_PATTERN = re.compile(
+        r"^\s+(?P<section>Temperature|Voltage|Current|Tx Power|Rx Power)\s+",
+    )
+
+    # Data row: port, value, high_alarm, high_warn, low_alarm, low_warn
+    # Optional alarm/warning indicators (++, +, -, --) may follow values.
+    _DATA_PATTERN = re.compile(
+        r"^(?P<port>(?:Et|Ma)\S+)\s+"
+        r"(?P<value>-?[\d.]+)\s*(?:[+\-]{0,2})\s+"
+        r"(?P<high_alarm>-?[\d.]+)\s+"
+        r"(?P<high_warn>-?[\d.]+)\s+"
+        r"(?P<low_alarm>-?[\d.]+)\s+"
+        r"(?P<low_warn>-?[\d.]+)",
+    )
+
+    # Separator line of dashes
+    _SEPARATOR_PATTERN = re.compile(r"^-{3,}")
+
+    @classmethod
+    def _parse_data_row(
+        cls,
+        line: str,
+        section_value_key: str,
+        section_threshold_key: str,
+        interfaces: dict[str, TransceiverEntry],
+    ) -> None:
+        """Parse a single data row and merge into the interfaces dict."""
+        match = cls._DATA_PATTERN.match(line)
+        if not match:
+            return
+
+        port = canonical_interface_name(match.group("port"), os=OS.ARISTA_EOS)
+
+        if port not in interfaces:
+            interfaces[port] = TransceiverEntry()
+
+        entry = interfaces[port]
+        entry[section_value_key] = float(match.group("value"))  # type: ignore[literal-required]
+        entry[section_threshold_key] = ThresholdInfo(  # type: ignore[literal-required]
+            high_alarm=float(match.group("high_alarm")),
+            high_warning=float(match.group("high_warn")),
+            low_alarm=float(match.group("low_alarm")),
+            low_warning=float(match.group("low_warn")),
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesTransceiverDetailResult:
+        """Parse 'show interfaces transceiver detail' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed transceiver detail data keyed by interface name.
+
+        Raises:
+            ValueError: If no transceiver data found in output.
+        """
+        interfaces: dict[str, TransceiverEntry] = {}
+        current_section: tuple[str, str] | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            # Detect section header
+            section_match = cls._SECTION_PATTERN.match(line)
+            if section_match:
+                section_name = section_match.group("section")
+                current_section = _SECTION_MAP.get(section_name)
+                continue
+
+            # Skip separator and header lines
+            if cls._SEPARATOR_PATTERN.match(stripped) or stripped.startswith("Port"):
+                continue
+
+            # Parse data rows when inside a section
+            if current_section:
+                cls._parse_data_row(
+                    stripped,
+                    current_section[0],
+                    current_section[1],
+                    interfaces,
+                )
+
+        if not interfaces:
+            msg = "No transceiver data found in output"
+            raise ValueError(msg)
+
+        return cast(
+            ShowInterfacesTransceiverDetailResult,
+            {"interfaces": interfaces},
+        )

--- a/tests/parsers/arista_eos/show_interfaces_transceiver_detail/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver_detail/001_basic/expected.json
@@ -1,0 +1,169 @@
+{
+    "interfaces": {
+        "Ethernet6/1": {
+            "temperature_celsius": 27.48,
+            "temperature_thresholds": {
+                "high_alarm": 80.0,
+                "high_warning": 75.0,
+                "low_alarm": -5.0,
+                "low_warning": 0.0
+            },
+            "voltage_volts": 3.3,
+            "voltage_thresholds": {
+                "high_alarm": 3.6,
+                "high_warning": 3.5,
+                "low_alarm": 3.0,
+                "low_warning": 3.1
+            },
+            "tx_power_dbm": -2.39,
+            "tx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -9.6,
+                "low_warning": -8.6
+            },
+            "rx_power_dbm": -0.9,
+            "rx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -11.5,
+                "low_warning": -10.5
+            }
+        },
+        "Ethernet6/2": {
+            "temperature_celsius": 27.48,
+            "temperature_thresholds": {
+                "high_alarm": 80.0,
+                "high_warning": 75.0,
+                "low_alarm": -5.0,
+                "low_warning": 0.0
+            },
+            "voltage_volts": 3.3,
+            "voltage_thresholds": {
+                "high_alarm": 3.6,
+                "high_warning": 3.5,
+                "low_alarm": 3.0,
+                "low_warning": 3.1
+            },
+            "tx_power_dbm": -2.33,
+            "tx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -9.6,
+                "low_warning": -8.6
+            },
+            "rx_power_dbm": -0.94,
+            "rx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -11.5,
+                "low_warning": -10.5
+            }
+        },
+        "Ethernet6/3": {
+            "temperature_celsius": 27.48,
+            "temperature_thresholds": {
+                "high_alarm": 80.0,
+                "high_warning": 75.0,
+                "low_alarm": -5.0,
+                "low_warning": 0.0
+            },
+            "voltage_volts": 3.3,
+            "voltage_thresholds": {
+                "high_alarm": 3.6,
+                "high_warning": 3.5,
+                "low_alarm": 3.0,
+                "low_warning": 3.1
+            },
+            "tx_power_dbm": -0.78,
+            "tx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -9.6,
+                "low_warning": -8.6
+            },
+            "rx_power_dbm": -1.0,
+            "rx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -11.5,
+                "low_warning": -10.5
+            }
+        },
+        "Ethernet6/4": {
+            "temperature_celsius": 27.48,
+            "temperature_thresholds": {
+                "high_alarm": 80.0,
+                "high_warning": 75.0,
+                "low_alarm": -5.0,
+                "low_warning": 0.0
+            },
+            "voltage_volts": 3.3,
+            "voltage_thresholds": {
+                "high_alarm": 3.6,
+                "high_warning": 3.5,
+                "low_alarm": 3.0,
+                "low_warning": 3.1
+            },
+            "tx_power_dbm": -0.93,
+            "tx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -9.6,
+                "low_warning": -8.6
+            },
+            "rx_power_dbm": -0.83,
+            "rx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -11.5,
+                "low_warning": -10.5
+            }
+        },
+        "Ethernet29/1": {
+            "current_ma": 21.9,
+            "current_thresholds": {
+                "high_alarm": 38.3,
+                "high_warning": 37.35,
+                "low_alarm": 0.0,
+                "low_warning": 0.0
+            }
+        },
+        "Ethernet29/2": {
+            "current_ma": 21.9,
+            "current_thresholds": {
+                "high_alarm": 38.3,
+                "high_warning": 37.35,
+                "low_alarm": 0.0,
+                "low_warning": 0.0
+            }
+        },
+        "Ethernet29/3": {
+            "current_ma": 21.9,
+            "current_thresholds": {
+                "high_alarm": 38.3,
+                "high_warning": 37.35,
+                "low_alarm": 0.0,
+                "low_warning": 0.0
+            }
+        },
+        "Ethernet29/4": {
+            "current_ma": 21.9,
+            "current_thresholds": {
+                "high_alarm": 38.3,
+                "high_warning": 37.35,
+                "low_alarm": 0.0,
+                "low_warning": 0.0
+            }
+        },
+        "Ethernet7/1": {
+            "rx_power_dbm": -1.15,
+            "rx_power_thresholds": {
+                "high_alarm": 4.4,
+                "high_warning": 3.4,
+                "low_alarm": -11.5,
+                "low_warning": -10.5
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_interfaces_transceiver_detail/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver_detail/001_basic/input.txt
@@ -1,0 +1,45 @@
+mA: milliamperes, dBm: decibels (milliwatts), NA or N/A: not applicable.
+++ : high alarm, +  : high warning, -  : low warning, -- : low alarm.
+A2D readouts (if they differ), are reported in parentheses.
+The threshold values are calibrated.
+                         High Alarm  High Warn   Low Alarm   Low Warn
+           Temperature   Threshold   Threshold   Threshold   Threshold
+Port       (Celsius)     (Celsius)   (Celsius)   (Celsius)   (Celsius)
+-------    ------------  ----------  ----------  ----------  ----------
+Et6/1      27.48         80.00       75.00       -5.00       0.00
+Et6/2      27.48         80.00       75.00       -5.00       0.00
+Et6/3      27.48         80.00       75.00       -5.00       0.00
+Et6/4      27.48         80.00       75.00       -5.00       0.00
+                         High Alarm  High Warn   Low Alarm   Low Warn
+           Voltage       Threshold   Threshold   Threshold   Threshold
+Port       (Volts)       (Volts)     (Volts)     (Volts)     (Volts)
+-------    ------------  ----------  ----------  ----------  ----------
+Et6/1      3.30          3.60        3.50        3.00        3.10
+Et6/2      3.30          3.60        3.50        3.00        3.10
+Et6/3      3.30          3.60        3.50        3.00        3.10
+Et6/4      3.30          3.60        3.50        3.00        3.10
+                         High Alarm  High Warn   Low Alarm   Low Warn
+           Current       Threshold   Threshold   Threshold   Threshold
+Port       (mA)          (mA)        (mA)        (mA)        (mA)
+-------    ------------  ----------  ----------  ----------  ----------
+Et29/1     21.90         38.30       37.35       0.00        0.00
+Et29/2     21.90         38.30       37.35       0.00        0.00
+Et29/3     21.90         38.30       37.35       0.00        0.00
+Et29/4     21.90         38.30       37.35       0.00        0.00
+                         High Alarm  High Warn   Low Alarm   Low Warn
+           Tx Power      Threshold   Threshold   Threshold   Threshold
+Port       (dBm)         (dBm)       (dBm)       (dBm)       (dBm)
+-------    ------------  ----------  ----------  ----------  ----------
+Et6/1      -2.39         4.40        3.40        -9.60       -8.60
+Et6/2      -2.33         4.40        3.40        -9.60       -8.60
+Et6/3      -0.78         4.40        3.40        -9.60       -8.60
+Et6/4      -0.93         4.40        3.40        -9.60       -8.60
+                         High Alarm  High Warn   Low Alarm   Low Warn
+           Rx Power      Threshold   Threshold   Threshold   Threshold
+Port       (dBm)         (dBm)       (dBm)       (dBm)       (dBm)
+-------    ------------  ----------  ----------  ----------  ----------
+Et6/1      -0.90         4.40        3.40        -11.50      -10.50
+Et6/2      -0.94         4.40        3.40        -11.50      -10.50
+Et6/3      -1.00         4.40        3.40        -11.50      -10.50
+Et6/4      -0.83         4.40        3.40        -11.50      -10.50
+Et7/1      -1.15         4.40        3.40        -11.50      -10.50

--- a/tests/parsers/arista_eos/show_interfaces_transceiver_detail/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_interfaces_transceiver_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Transceiver detail with temperature, voltage, current, TX/RX power across multiple lanes
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show interfaces transceiver detail` on Arista EOS
- Parses per-lane transceiver diagnostics: temperature, voltage, bias current, TX/RX optical power, and alarm/warning thresholds
- Returns dict-of-dicts keyed by canonical interface name (e.g. `Ethernet6/1`), with each section's data merged per interface

## Test plan
- [x] Test fixture with real device output covering all 5 measurement sections (temperature, voltage, current, TX power, RX power)
- [x] Interfaces that appear in only some sections (Et29/x only in current, Et7/1 only in RX power) are handled correctly
- [x] All sentinel/placeholder checks pass (no N/A, empty strings, or hyphen placeholders)
- [x] `ruff check`, `ruff format`, `xenon`, `bandit`, and `pre-commit` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)