### PR TITLE
feat(paloalto_panos): add parser for `debug swm status`

### DIFF
--- a/changes/+paloalto-panos-debug-swm-status.parser_added
+++ b/changes/+paloalto-panos-debug-swm-status.parser_added
@@ -1,0 +1,1 @@
+Added parser for `debug swm status` on Palo Alto PAN-OS.

--- a/src/muninn/parsers/paloalto_panos/debug_swm_status.py
+++ b/src/muninn/parsers/paloalto_panos/debug_swm_status.py
@@ -1,0 +1,75 @@
+"""Parser for 'debug swm status' command on Palo Alto PAN-OS."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PartitionEntry(TypedDict):
+    """Schema for a single partition entry."""
+
+    state: str
+    version: str
+
+
+# Top-level result keyed by partition name.
+DebugSwmStatusResult = dict[str, PartitionEntry]
+
+
+_HEADER_SEPARATOR = re.compile(r"^-{3,}$")
+_PARTITION_LINE = re.compile(
+    r"^(?P<partition>\S+)\s+(?P<state>\S+)\s+(?P<version>\S+)$"
+)
+
+
+def _extract_table_lines(output: str) -> list[str]:
+    """Return only the data lines after the dash separator."""
+    lines = output.splitlines()
+    for idx, line in enumerate(lines):
+        if _HEADER_SEPARATOR.match(line.strip()):
+            return [ln.strip() for ln in lines[idx + 1 :] if ln.strip()]
+    return []
+
+
+@register(OS.PALOALTO_PANOS, "debug swm status")
+class DebugSwmStatusParser(BaseParser[DebugSwmStatusResult]):
+    """Parser for 'debug swm status' on Palo Alto PAN-OS.
+
+    Parses the software manager partition table into a dict-of-dicts
+    keyed by partition name (e.g. ``sysroot0``, ``sysroot1``, ``maint``).
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> DebugSwmStatusResult:
+        """Parse 'debug swm status' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict of partition entries keyed by partition name.
+
+        Raises:
+            ValueError: If no partition entries are found.
+        """
+        result: DebugSwmStatusResult = {}
+
+        for line in _extract_table_lines(output):
+            match = _PARTITION_LINE.match(line)
+            if match:
+                result[match.group("partition")] = PartitionEntry(
+                    state=match.group("state"),
+                    version=match.group("version"),
+                )
+
+        if not result:
+            msg = "No partition entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/paloalto_panos/debug_swm_status/001_basic/expected.json
+++ b/tests/parsers/paloalto_panos/debug_swm_status/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+    "sysroot0": {
+        "state": "RUNNING-ACTIVE",
+        "version": "9.0.5.xfr"
+    },
+    "sysroot1": {
+        "state": "PENDING-CHANGE",
+        "version": "9.1.2"
+    },
+    "maint": {
+        "state": "READY",
+        "version": "9.1.2"
+    }
+}

--- a/tests/parsers/paloalto_panos/debug_swm_status/001_basic/input.txt
+++ b/tests/parsers/paloalto_panos/debug_swm_status/001_basic/input.txt
@@ -1,0 +1,6 @@
+
+Partition         State             Version
+--------------------------------------------------------------------------------
+sysroot0          RUNNING-ACTIVE    9.0.5.xfr
+sysroot1          PENDING-CHANGE    9.1.2
+maint             READY             9.1.2

--- a/tests/parsers/paloalto_panos/debug_swm_status/001_basic/metadata.yaml
+++ b/tests/parsers/paloalto_panos/debug_swm_status/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic software manager status with three partitions
+platform: PA-VM
+software_version: PAN-OS 9.0.5.xfr


### PR DESCRIPTION
## Summary
- Add new parser for `debug swm status` on Palo Alto PAN-OS
- Parses the software manager partition table into a dict-of-dicts keyed by partition name (e.g. `sysroot0`, `sysroot1`, `maint`), exposing `state` and `version` for each entry
- Includes test fixture from real device output and changelog fragment

## Test plan
- [x] Parser test passes (`tests/parsers/test_parsers.py -k debug_swm_status`)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity under threshold (max-absolute B, max-average A)
- [x] Bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)