### PR TITLE
feat(cisco_iosxr): add parser for `show controller fabric plane all`

### DIFF
--- a/changes/+cisco-iosxr-show-controller-fabric-plane-all.parser_added
+++ b/changes/+cisco-iosxr-show-controller-fabric-plane-all.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show controller fabric plane all` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_controller_fabric_plane_all.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controller_fabric_plane_all.py
@@ -1,0 +1,74 @@
+"""Parser for 'show controller fabric plane all' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FabricPlaneEntry(TypedDict):
+    """Schema for a single fabric plane entry."""
+
+    admin_state: str
+    plane_state: str
+    up_to_dn_counter: int
+    up_to_mcast_counter: int
+
+
+ShowControllerFabricPlaneAllResult = dict[str, FabricPlaneEntry]
+
+
+@register(OS.CISCO_IOSXR, "show controller fabric plane all")
+class ShowControllerFabricPlaneAllParser(
+    BaseParser[ShowControllerFabricPlaneAllResult],
+):
+    """Parser for 'show controller fabric plane all' command.
+
+    Parses fabric plane status including admin state, plane state,
+    and error counters for each plane ID.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    _PLANE_LINE = re.compile(
+        r"^(?P<id>\d+)\s+"
+        r"(?P<admin_state>\S+)\s+"
+        r"(?P<plane_state>\S+)\s+"
+        r"(?P<up_to_dn>\d+)\s+"
+        r"(?P<up_to_mcast>\d+)\s*$",
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControllerFabricPlaneAllResult:
+        """Parse 'show controller fabric plane all' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by plane ID with plane state information.
+
+        Raises:
+            ValueError: If no fabric plane entries are found.
+        """
+        result: ShowControllerFabricPlaneAllResult = {}
+
+        for line in output.splitlines():
+            match = cls._PLANE_LINE.match(line.strip())
+            if match:
+                plane_id = match.group("id")
+                result[plane_id] = FabricPlaneEntry(
+                    admin_state=match.group("admin_state"),
+                    plane_state=match.group("plane_state"),
+                    up_to_dn_counter=int(match.group("up_to_dn")),
+                    up_to_mcast_counter=int(match.group("up_to_mcast")),
+                )
+
+        if not result:
+            msg = "No fabric plane entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_controller_fabric_plane_all/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_controller_fabric_plane_all/001_basic/expected.json
@@ -1,0 +1,38 @@
+{
+    "0": {
+        "admin_state": "UP",
+        "plane_state": "UP",
+        "up_to_dn_counter": 0,
+        "up_to_mcast_counter": 0
+    },
+    "1": {
+        "admin_state": "UP",
+        "plane_state": "UP",
+        "up_to_dn_counter": 0,
+        "up_to_mcast_counter": 0
+    },
+    "2": {
+        "admin_state": "UP",
+        "plane_state": "DN",
+        "up_to_dn_counter": 0,
+        "up_to_mcast_counter": 0
+    },
+    "3": {
+        "admin_state": "UP",
+        "plane_state": "UP",
+        "up_to_dn_counter": 0,
+        "up_to_mcast_counter": 0
+    },
+    "4": {
+        "admin_state": "UP",
+        "plane_state": "UP",
+        "up_to_dn_counter": 0,
+        "up_to_mcast_counter": 0
+    },
+    "5": {
+        "admin_state": "UP",
+        "plane_state": "UP",
+        "up_to_dn_counter": 0,
+        "up_to_mcast_counter": 0
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_controller_fabric_plane_all/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_controller_fabric_plane_all/001_basic/input.txt
@@ -1,0 +1,11 @@
+Sun Feb  25 06:32:34.404 UTC
+
+Plane Admin Plane    up->dn  up->mcast
+Id    State State    counter   counter
+--------------------------------------
+0     UP    UP             0         0
+1     UP    UP             0         0
+2     UP    DN             0         0
+3     UP    UP             0         0
+4     UP    UP             0         0
+5     UP    UP             0         0

--- a/tests/parsers/cisco_iosxr/show_controller_fabric_plane_all/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_controller_fabric_plane_all/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Basic fabric plane status with six planes, one in DN state"
+platform: "ASR 9006"
+software_version: "IOS-XR 6.1.4"


### PR DESCRIPTION
## Summary
- Add parser for `show controller fabric plane all` on Cisco IOS-XR
- Parses fabric plane status: admin state, plane state, up->dn counter, up->mcast counter
- Dict-of-dicts output keyed by plane ID, tagged with `ParserTag.PLATFORM`

## Test plan
- [x] Fixture `001_basic` with 6 planes (including one DN plane) from real ASR 9006 output
- [x] All pre-commit hooks pass (ruff, xenon, bandit, json, yaml)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] CI should pass all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)