### PR TITLE
feat(cisco_iosxr): add parser for `show cef drops location`

### DIFF
--- a/changes/+cisco-iosxr-show-cef-drops-location.parser_added
+++ b/changes/+cisco-iosxr-show-cef-drops-location.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show cef drops location` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_cef_drops_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_cef_drops_location.py
@@ -25,7 +25,7 @@ class CefDropNodeEntry(TypedDict):
 ShowCefDropsLocationResult = dict[str, CefDropNodeEntry]
 
 
-@register(OS.CISCO_IOSXR, "show cef drops location")
+@register(OS.CISCO_IOSXR, r"show cef drops location (?P<location>\S+)")
 class ShowCefDropsLocationParser(BaseParser[ShowCefDropsLocationResult]):
     """Parser for 'show cef drops location' on Cisco IOS-XR.
 

--- a/src/muninn/parsers/cisco_iosxr/show_cef_drops_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_cef_drops_location.py
@@ -1,0 +1,80 @@
+"""Parser for 'show cef drops location' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class CefDropEntry(TypedDict):
+    """Schema for a single CEF drop counter within a node."""
+
+    packets: int
+
+
+class CefDropNodeEntry(TypedDict):
+    """Schema for a single node's CEF drop statistics."""
+
+    drops: dict[str, CefDropEntry]
+
+
+# Top-level result keyed by node location (e.g. '0/RSP0/CPU0').
+ShowCefDropsLocationResult = dict[str, CefDropNodeEntry]
+
+
+@register(OS.CISCO_IOSXR, "show cef drops location")
+class ShowCefDropsLocationParser(BaseParser[ShowCefDropsLocationResult]):
+    """Parser for 'show cef drops location' on Cisco IOS-XR.
+
+    Parses per-node CEF drop counters into a dict-of-dicts keyed by
+    node location, then by drop reason.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    _NODE_HEADER = re.compile(r"^Node:\s+(?P<node>\S+)")
+    _DROP_LINE = re.compile(r"^\s+(?P<reason>.+?)\s+packets\s*:\s+(?P<packets>\d+)\s*$")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCefDropsLocationResult:
+        """Parse 'show cef drops location' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by node location, each containing a drops dict
+            keyed by drop reason name.
+
+        Raises:
+            ValueError: If no node data is found in the output.
+        """
+        result: ShowCefDropsLocationResult = {}
+        current_node: str | None = None
+
+        for line in output.splitlines():
+            node_match = cls._NODE_HEADER.match(line)
+            if node_match:
+                current_node = node_match.group("node")
+                result[current_node] = CefDropNodeEntry(drops={})
+                continue
+
+            if current_node is None:
+                continue
+
+            drop_match = cls._DROP_LINE.match(line)
+            if drop_match:
+                reason = drop_match.group("reason").strip()
+                packets = int(drop_match.group("packets"))
+                result[current_node]["drops"][reason] = CefDropEntry(
+                    packets=packets,
+                )
+
+        if not result:
+            msg = "No CEF drop statistics found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_cef_drops_location/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_cef_drops_location/001_basic/expected.json
@@ -1,0 +1,198 @@
+{
+    "0/RSP0/CPU0": {
+        "drops": {
+            "Unresolved drops": {
+                "packets": 11
+            },
+            "Unsupported drops": {
+                "packets": 22
+            },
+            "Null0 drops": {
+                "packets": 33
+            },
+            "No route drops": {
+                "packets": 44
+            },
+            "No Adjacency drops": {
+                "packets": 55
+            },
+            "Checksum error drops": {
+                "packets": 66
+            },
+            "RPF drops": {
+                "packets": 77
+            },
+            "RPF suppressed drops": {
+                "packets": 0
+            },
+            "RP destined drops": {
+                "packets": 0
+            },
+            "Discard drops": {
+                "packets": 0
+            },
+            "GRE lookup drops": {
+                "packets": 0
+            },
+            "GRE processing drops": {
+                "packets": 0
+            },
+            "LISP punt drops": {
+                "packets": 999999
+            },
+            "LISP encap err drops": {
+                "packets": 0
+            },
+            "LISP decap err drops": {
+                "packets": 0
+            }
+        }
+    },
+    "0/RSP1/CPU0": {
+        "drops": {
+            "Unresolved drops": {
+                "packets": 0
+            },
+            "Unsupported drops": {
+                "packets": 0
+            },
+            "Null0 drops": {
+                "packets": 0
+            },
+            "No route drops": {
+                "packets": 79
+            },
+            "No Adjacency drops": {
+                "packets": 0
+            },
+            "Checksum error drops": {
+                "packets": 0
+            },
+            "RPF drops": {
+                "packets": 0
+            },
+            "RPF suppressed drops": {
+                "packets": 0
+            },
+            "RP destined drops": {
+                "packets": 0
+            },
+            "Discard drops": {
+                "packets": 0
+            },
+            "GRE lookup drops": {
+                "packets": 0
+            },
+            "GRE processing drops": {
+                "packets": 0
+            },
+            "LISP punt drops": {
+                "packets": 0
+            },
+            "LISP encap err drops": {
+                "packets": 0
+            },
+            "LISP decap err drops": {
+                "packets": 0
+            }
+        }
+    },
+    "0/0/CPU0": {
+        "drops": {
+            "Unresolved drops": {
+                "packets": 0
+            },
+            "Unsupported drops": {
+                "packets": 0
+            },
+            "Null0 drops": {
+                "packets": 0
+            },
+            "No route drops": {
+                "packets": 0
+            },
+            "No Adjacency drops": {
+                "packets": 0
+            },
+            "Checksum error drops": {
+                "packets": 0
+            },
+            "RPF drops": {
+                "packets": 0
+            },
+            "RPF suppressed drops": {
+                "packets": 0
+            },
+            "RP destined drops": {
+                "packets": 0
+            },
+            "Discard drops": {
+                "packets": 97
+            },
+            "GRE lookup drops": {
+                "packets": 0
+            },
+            "GRE processing drops": {
+                "packets": 0
+            },
+            "LISP punt drops": {
+                "packets": 0
+            },
+            "LISP encap err drops": {
+                "packets": 0
+            },
+            "LISP decap err drops": {
+                "packets": 0
+            }
+        }
+    },
+    "0/7/CPU0": {
+        "drops": {
+            "Unresolved drops": {
+                "packets": 0
+            },
+            "Unsupported drops": {
+                "packets": 0
+            },
+            "Null0 drops": {
+                "packets": 0
+            },
+            "No route drops": {
+                "packets": 9
+            },
+            "No Adjacency drops": {
+                "packets": 0
+            },
+            "Checksum error drops": {
+                "packets": 0
+            },
+            "RPF drops": {
+                "packets": 0
+            },
+            "RPF suppressed drops": {
+                "packets": 0
+            },
+            "RP destined drops": {
+                "packets": 0
+            },
+            "Discard drops": {
+                "packets": 106
+            },
+            "GRE lookup drops": {
+                "packets": 0
+            },
+            "GRE processing drops": {
+                "packets": 0
+            },
+            "LISP punt drops": {
+                "packets": 0
+            },
+            "LISP encap err drops": {
+                "packets": 0
+            },
+            "LISP decap err drops": {
+                "packets": 0
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_cef_drops_location/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_cef_drops_location/001_basic/input.txt
@@ -1,0 +1,65 @@
+CEF Drop Statistics
+Node: 0/RSP0/CPU0
+  Unresolved drops     packets :              11
+  Unsupported drops    packets :              22
+  Null0 drops          packets :              33
+  No route drops       packets :              44
+  No Adjacency drops   packets :              55
+  Checksum error drops packets :              66
+  RPF drops            packets :              77
+  RPF suppressed drops packets :               0
+  RP destined drops    packets :               0
+  Discard drops        packets :               0
+  GRE lookup drops     packets :               0
+  GRE processing drops packets :               0
+  LISP punt drops      packets :          999999
+  LISP encap err drops packets :               0
+  LISP decap err drops packets :               0
+Node: 0/RSP1/CPU0
+  Unresolved drops     packets :               0
+  Unsupported drops    packets :               0
+  Null0 drops          packets :               0
+  No route drops       packets :              79
+  No Adjacency drops   packets :               0
+  Checksum error drops packets :               0
+  RPF drops            packets :               0
+  RPF suppressed drops packets :               0
+  RP destined drops    packets :               0
+  Discard drops        packets :               0
+  GRE lookup drops     packets :               0
+  GRE processing drops packets :               0
+  LISP punt drops      packets :               0
+  LISP encap err drops packets :               0
+  LISP decap err drops packets :               0
+Node: 0/0/CPU0
+  Unresolved drops     packets :               0
+  Unsupported drops    packets :               0
+  Null0 drops          packets :               0
+  No route drops       packets :               0
+  No Adjacency drops   packets :               0
+  Checksum error drops packets :               0
+  RPF drops            packets :               0
+  RPF suppressed drops packets :               0
+  RP destined drops    packets :               0
+  Discard drops        packets :              97
+  GRE lookup drops     packets :               0
+  GRE processing drops packets :               0
+  LISP punt drops      packets :               0
+  LISP encap err drops packets :               0
+  LISP decap err drops packets :               0
+Node: 0/7/CPU0
+  Unresolved drops     packets :               0
+  Unsupported drops    packets :               0
+  Null0 drops          packets :               0
+  No route drops       packets :               9
+  No Adjacency drops   packets :               0
+  Checksum error drops packets :               0
+  RPF drops            packets :               0
+  RPF suppressed drops packets :               0
+  RP destined drops    packets :               0
+  Discard drops        packets :             106
+  GRE lookup drops     packets :               0
+  GRE processing drops packets :               0
+  LISP punt drops      packets :               0
+  LISP encap err drops packets :               0
+  LISP decap err drops packets :               0

--- a/tests/parsers/cisco_iosxr/show_cef_drops_location/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_cef_drops_location/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: CEF drop statistics across multiple nodes with non-zero counters
+platform: Unknown
+software_version: IOS-XR Unknown

--- a/tests/parsers/cisco_iosxr/show_cef_drops_location/command.txt
+++ b/tests/parsers/cisco_iosxr/show_cef_drops_location/command.txt
@@ -1,0 +1,1 @@
+show cef drops location all


### PR DESCRIPTION
## Summary
- Add new parser for `show cef drops location` on Cisco IOS-XR
- Parses per-node CEF drop statistics into a dict-of-dicts keyed by node location, with each node containing a `drops` dict keyed by drop reason name
- Tagged with `ParserTag.PLATFORM`

## Test plan
- [x] Test fixture `001_basic` with multi-node output including non-zero counters
- [x] All pre-commit hooks pass (ruff, xenon, bandit, format)
- [x] Sentinel/placeholder tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)