### PR TITLE
feat(arista_eos): add parser for show environment power

### DIFF
--- a/changes/+arista-eos-show-environment-power.parser_added
+++ b/changes/+arista-eos-show-environment-power.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show environment power` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_environment_power.py
+++ b/src/muninn/parsers/arista_eos/show_environment_power.py
@@ -1,0 +1,88 @@
+"""Parser for 'show environment power' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PowerSupplyEntry(TypedDict):
+    """Schema for a single power supply entry."""
+
+    model: str
+    capacity_watts: int
+    input_current_amps: float
+    output_current_amps: float
+    output_power_watts: float
+    status: str
+    uptime: NotRequired[str]
+
+
+@register(OS.ARISTA_EOS, "show environment power")
+class ShowEnvironmentPowerParser(BaseParser[dict[str, PowerSupplyEntry]]):
+    """Parser for 'show environment power' command on Arista EOS.
+
+    Returns a dict-of-dicts keyed by power supply name (e.g. "1", "2").
+    The summary "Total" row is excluded from the output.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ENVIRONMENT})
+
+    # Matches a power supply data row. The uptime field is optional.
+    # Example: "1   PWR-1011-AC-RED  1000W  0.70A 11.58A 139.0W Ok   68 days, 0:11:28"
+    _PSU_LINE = re.compile(
+        r"^\s*(?P<supply>\d+)"
+        r"\s+(?P<model>\S+)"
+        r"\s+(?P<capacity>\d+)W"
+        r"\s+(?P<input_current>[\d.]+)A"
+        r"\s+(?P<output_current>[\d.]+)A"
+        r"\s+(?P<output_power>[\d.]+)W"
+        r"\s+(?P<status>\S+(?:\s+\S+)*?)"
+        r"(?:\s{2,}(?P<uptime>\d+\s+days?,\s*\d+:\d+:\d+))?"
+        r"\s*$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, PowerSupplyEntry]:
+        """Parse 'show environment power' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict of power supply entries keyed by supply number.
+
+        Raises:
+            ValueError: If no power supply entries are found.
+        """
+        result: dict[str, PowerSupplyEntry] = {}
+
+        for line in output.splitlines():
+            match = cls._PSU_LINE.match(line)
+            if not match:
+                continue
+
+            supply = match.group("supply")
+            entry = PowerSupplyEntry(
+                model=match.group("model"),
+                capacity_watts=int(match.group("capacity")),
+                input_current_amps=float(match.group("input_current")),
+                output_current_amps=float(match.group("output_current")),
+                output_power_watts=float(match.group("output_power")),
+                status=match.group("status"),
+            )
+
+            uptime = match.group("uptime")
+            if uptime:
+                entry["uptime"] = uptime
+
+            result[supply] = entry
+
+        if not result:
+            msg = "No power supply entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/arista_eos/show_environment_power/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_environment_power/001_basic/expected.json
@@ -1,0 +1,20 @@
+{
+    "1": {
+        "model": "PWR-1011-AC-RED",
+        "capacity_watts": 1000,
+        "input_current_amps": 0.7,
+        "output_current_amps": 11.58,
+        "output_power_watts": 139.0,
+        "status": "Ok",
+        "uptime": "68 days, 0:11:28"
+    },
+    "2": {
+        "model": "PWR-1011-AC-RED",
+        "capacity_watts": 1000,
+        "input_current_amps": 0.68,
+        "output_current_amps": 11.31,
+        "output_power_watts": 134.0,
+        "status": "Ok",
+        "uptime": "68 days, 0:11:29"
+    }
+}

--- a/tests/parsers/arista_eos/show_environment_power/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_environment_power/001_basic/input.txt
@@ -1,0 +1,6 @@
+Power              Input Output Output
+Supply Model      Capacity Current Current Power Status      Uptime
+------ --------------- -------- ------- ------- ------ ------ ----------------
+1   PWR-1011-AC-RED  1000W  0.70A 11.58A 139.0W Ok   68 days, 0:11:28
+2   PWR-1011-AC-RED  1000W  0.68A 11.31A 134.0W Ok   68 days, 0:11:29
+Total --         2000W   --   -- 273.0W --          --

--- a/tests/parsers/arista_eos/show_environment_power/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_environment_power/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Dual redundant power supplies with uptime information
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add parser for `show environment power` on Arista EOS, returning a dict-of-dicts keyed by power supply number
- Parses model, capacity (watts), input/output current (amps), output power (watts), status, and optional uptime
- Excludes the summary "Total" row from parsed output
- Tagged with `ParserTag.ENVIRONMENT`

## Test plan
- [x] Test fixture `001_basic` with dual redundant PSUs including uptime (sourced from ntc-templates)
- [x] All sentinel placeholder tests pass (no banned values in expected.json)
- [x] Pre-commit hooks pass (ruff, xenon, json, yaml checks)
- [x] Bandit security scan clean
- [x] Xenon complexity under B threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)