### PR TITLE
feat(arista_eos): add parser for show environment cooling

### DIFF
--- a/changes/+arista-eos-show-environment-cooling.parser_added
+++ b/changes/+arista-eos-show-environment-cooling.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show environment cooling` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_environment_cooling.py
+++ b/src/muninn/parsers/arista_eos/show_environment_cooling.py
@@ -1,0 +1,128 @@
+"""Parser for 'show environment cooling' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FanEntry(TypedDict):
+    """Schema for an individual fan entry."""
+
+    status: str
+    configured_speed_pct: NotRequired[int]
+    actual_speed_pct: NotRequired[int]
+
+
+class ShowEnvironmentCoolingResult(TypedDict):
+    """Schema for 'show environment cooling' parsed output on Arista EOS."""
+
+    system_status: str
+    ambient_temperature_celsius: int
+    airflow: str
+    fans: dict[str, FanEntry]
+
+
+@register(OS.ARISTA_EOS, "show environment cooling")
+class ShowEnvironmentCoolingParser(BaseParser[ShowEnvironmentCoolingResult]):
+    """Parser for 'show environment cooling' command on Arista EOS.
+
+    Parses system cooling status, ambient temperature, airflow direction,
+    and per-fan status/speed information.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ENVIRONMENT})
+
+    _SYSTEM_STATUS = re.compile(r"^System cooling status is:\s*(?P<status>.+)$")
+    _AMBIENT_TEMP = re.compile(r"^Ambient temperature:\s*(?P<temp>\d+)C$")
+    _AIRFLOW = re.compile(r"^Airflow:\s*(?P<airflow>.+)$")
+    _FAN_LINE = re.compile(
+        r"^(?P<fan>\S+)\s+"
+        r"(?P<status>Ok|Not Inserted|.+?)\s+"
+        r"(?P<configured>\d+%|N/A)\s+"
+        r"(?P<actual>\d+%|N/A)$"
+    )
+
+    @classmethod
+    def _parse_speed(cls, value: str) -> int | None:
+        """Parse a speed percentage string, returning None for N/A."""
+        if value == "N/A":
+            return None
+        return int(value.rstrip("%"))
+
+    @classmethod
+    def _parse_fan_line(cls, line: str) -> tuple[str, FanEntry] | None:
+        """Parse a single fan table row into a (name, entry) pair."""
+        match = cls._FAN_LINE.match(line)
+        if not match:
+            return None
+
+        entry = FanEntry(status=match.group("status").strip())
+
+        configured = cls._parse_speed(match.group("configured"))
+        if configured is not None:
+            entry["configured_speed_pct"] = configured
+
+        actual = cls._parse_speed(match.group("actual"))
+        if actual is not None:
+            entry["actual_speed_pct"] = actual
+
+        return match.group("fan"), entry
+
+    @classmethod
+    def _parse_header(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse system status, ambient temp, or airflow from a header line."""
+        if match := cls._SYSTEM_STATUS.match(line):
+            result["system_status"] = match.group("status").strip()
+            return True
+
+        if match := cls._AMBIENT_TEMP.match(line):
+            result["ambient_temperature_celsius"] = int(match.group("temp"))
+            return True
+
+        if match := cls._AIRFLOW.match(line):
+            result["airflow"] = match.group("airflow").strip()
+            return True
+
+        return False
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEnvironmentCoolingResult:
+        """Parse 'show environment cooling' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed cooling environment information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result: dict[str, object] = {}
+        fans: dict[str, FanEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if cls._parse_header(stripped, result):
+                continue
+
+            fan_pair = cls._parse_fan_line(stripped)
+            if fan_pair:
+                fans[fan_pair[0]] = fan_pair[1]
+
+        result["fans"] = fans
+
+        required = ["system_status", "ambient_temperature_celsius", "airflow", "fans"]
+        missing = [f for f in required if not result.get(f)]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return cast(ShowEnvironmentCoolingResult, result)

--- a/src/muninn/parsers/arista_eos/show_environment_cooling.py
+++ b/src/muninn/parsers/arista_eos/show_environment_cooling.py
@@ -18,12 +18,21 @@ class FanEntry(TypedDict):
 
 
 class ShowEnvironmentCoolingResult(TypedDict):
-    """Schema for 'show environment cooling' parsed output on Arista EOS."""
+    """Schema for 'show environment cooling' parsed output on Arista EOS.
+
+    Note: keys in `fans` mirror the device output. Inserted PSU fans appear
+    as ``PowerSupply{N}/{slot}`` (e.g. ``PowerSupply1/1``) while not-inserted
+    PSU bays appear as just ``PowerSupply{N}`` with no trailing slot.
+    """
 
     system_status: str
     ambient_temperature_celsius: int
     airflow: str
     fans: dict[str, FanEntry]
+
+
+_PERCENT_OR_NA = r"\d+%|N/A"
+_FAN_STATUS = r"Ok|Not Inserted|Failed|Unknown"
 
 
 @register(OS.ARISTA_EOS, "show environment cooling")
@@ -41,9 +50,9 @@ class ShowEnvironmentCoolingParser(BaseParser[ShowEnvironmentCoolingResult]):
     _AIRFLOW = re.compile(r"^Airflow:\s*(?P<airflow>.+)$")
     _FAN_LINE = re.compile(
         r"^(?P<fan>\S+)\s+"
-        r"(?P<status>Ok|Not Inserted|.+?)\s+"
-        r"(?P<configured>\d+%|N/A)\s+"
-        r"(?P<actual>\d+%|N/A)$"
+        rf"(?P<status>{_FAN_STATUS})\s+"
+        rf"(?P<configured>{_PERCENT_OR_NA})\s+"
+        rf"(?P<actual>{_PERCENT_OR_NA})$"
     )
 
     @classmethod
@@ -120,7 +129,7 @@ class ShowEnvironmentCoolingParser(BaseParser[ShowEnvironmentCoolingResult]):
         result["fans"] = fans
 
         required = ["system_status", "ambient_temperature_celsius", "airflow", "fans"]
-        missing = [f for f in required if not result.get(f)]
+        missing = [f for f in required if f not in result]
         if missing:
             msg = f"Missing required fields: {', '.join(missing)}"
             raise ValueError(msg)

--- a/tests/parsers/arista_eos/show_environment_cooling/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_environment_cooling/001_basic/expected.json
@@ -1,0 +1,193 @@
+{
+    "system_status": "Ok",
+    "ambient_temperature_celsius": 22,
+    "airflow": "front-to-back",
+    "fans": {
+        "1/1": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "1/2": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "1/3": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "1/4": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "1/5": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "2/1": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "2/2": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "2/3": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "2/4": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "2/5": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "3/1": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "3/2": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "3/3": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "3/4": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "3/5": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "4/1": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "4/2": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "4/3": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "4/4": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "4/5": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "5/1": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "5/2": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "5/3": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "5/4": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "5/5": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "6/1": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "6/2": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "6/3": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "6/4": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 35
+        },
+        "6/5": {
+            "status": "Ok",
+            "configured_speed_pct": 35,
+            "actual_speed_pct": 34
+        },
+        "PowerSupply1/1": {
+            "status": "Ok",
+            "configured_speed_pct": 70,
+            "actual_speed_pct": 70
+        },
+        "PowerSupply2/1": {
+            "status": "Ok",
+            "configured_speed_pct": 70,
+            "actual_speed_pct": 69
+        },
+        "PowerSupply3/1": {
+            "status": "Ok",
+            "configured_speed_pct": 70,
+            "actual_speed_pct": 70
+        },
+        "PowerSupply4/1": {
+            "status": "Ok",
+            "configured_speed_pct": 70,
+            "actual_speed_pct": 69
+        },
+        "PowerSupply5": {
+            "status": "Not Inserted"
+        },
+        "PowerSupply6/1": {
+            "status": "Ok",
+            "configured_speed_pct": 70,
+            "actual_speed_pct": 69
+        },
+        "PowerSupply7/1": {
+            "status": "Ok",
+            "configured_speed_pct": 70,
+            "actual_speed_pct": 70
+        },
+        "PowerSupply8": {
+            "status": "Not Inserted"
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_environment_cooling/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_environment_cooling/001_basic/input.txt
@@ -1,0 +1,43 @@
+System cooling status is: Ok
+Ambient temperature: 22C
+Airflow: front-to-back
+Fan              Status          Configured Speed     Actual Speed
+---------------- --------------- ---------------- ----------------
+1/1              Ok                           35%              34%
+1/2              Ok                           35%              35%
+1/3              Ok                           35%              35%
+1/4              Ok                           35%              34%
+1/5              Ok                           35%              34%
+2/1              Ok                           35%              34%
+2/2              Ok                           35%              34%
+2/3              Ok                           35%              35%
+2/4              Ok                           35%              34%
+2/5              Ok                           35%              35%
+3/1              Ok                           35%              35%
+3/2              Ok                           35%              34%
+3/3              Ok                           35%              34%
+3/4              Ok                           35%              35%
+3/5              Ok                           35%              34%
+4/1              Ok                           35%              34%
+4/2              Ok                           35%              34%
+4/3              Ok                           35%              35%
+4/4              Ok                           35%              35%
+4/5              Ok                           35%              34%
+5/1              Ok                           35%              35%
+5/2              Ok                           35%              34%
+5/3              Ok                           35%              35%
+5/4              Ok                           35%              34%
+5/5              Ok                           35%              34%
+6/1              Ok                           35%              35%
+6/2              Ok                           35%              34%
+6/3              Ok                           35%              35%
+6/4              Ok                           35%              35%
+6/5              Ok                           35%              34%
+PowerSupply1/1   Ok                           70%              70%
+PowerSupply2/1   Ok                           70%              69%
+PowerSupply3/1   Ok                           70%              70%
+PowerSupply4/1   Ok                           70%              69%
+PowerSupply5     Not Inserted                 N/A              N/A
+PowerSupply6/1   Ok                           70%              69%
+PowerSupply7/1   Ok                           70%              70%
+PowerSupply8     Not Inserted                 N/A              N/A

--- a/tests/parsers/arista_eos/show_environment_cooling/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_environment_cooling/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Cooling status with chassis and power supply fans
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add new parser for `show environment cooling` on Arista EOS
- Parses system cooling status, ambient temperature, airflow direction, and per-fan status/speed information
- Fans with N/A speeds (e.g. not-inserted power supplies) omit speed fields per sentinel policy rather than carrying placeholder strings

## Test plan
- [x] Parser test fixture with real device output (001_basic) passes
- [x] All sentinel/placeholder tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (dict-of-dicts, no pipe keys)
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)