### PR TITLE
feat(cisco_iosxr): add parser for show lpts pifib hardware police location

### DIFF
--- a/changes/+cisco-iosxr-show-lpts-pifib-hardware-police-location.parser_added
+++ b/changes/+cisco-iosxr-show-lpts-pifib-hardware-police-location.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show lpts pifib hardware police location` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
@@ -117,7 +117,10 @@ def _parse_statistics_line(
     return False
 
 
-@register(OS.CISCO_IOSXR, "show lpts pifib hardware police location")
+@register(
+    OS.CISCO_IOSXR,
+    r"show lpts pifib hardware police location (?P<location>\S+)",
+)
 class ShowLptsPifibHardwarePoliceLocationParser(
     BaseParser["ShowLptsPifibHardwarePoliceLocationResult"],
 ):

--- a/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
@@ -1,0 +1,213 @@
+"""Parser for 'show lpts pifib hardware police location' on Cisco IOS-XR.
+
+Displays per-flow-type LPTS (Local Packet Transport Services) policer
+statistics from the hardware PIFIB (Pre-IFIB) table on a given line card.
+
+Each flow type has a policer with a current rate, default rate, and
+accepted/dropped packet counters.  The output also includes summary
+statistics for deleted entries.
+"""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FlowTypeEntry(TypedDict):
+    """Schema for a single LPTS flow type policer entry."""
+
+    policer_type: int
+    type: str
+    current_rate: int
+    default_rate: int
+    accepted: int
+    dropped: int
+    tos_value: str
+
+
+class StatisticsEntry(TypedDict):
+    """Schema for the summary statistics block."""
+
+    packets_accepted_by_deleted_entries: int
+    packets_dropped_by_deleted_entries: int
+    run_out_of_statistics_counter_errors: int
+
+
+class ShowLptsPifibHardwarePoliceLocationResult(TypedDict):
+    """Schema for 'show lpts pifib hardware police location' parsed output."""
+
+    node: str
+    burst_ms: int
+    flow_types: dict[str, FlowTypeEntry]
+    statistics: NotRequired[StatisticsEntry]
+
+
+# Header: "Node 0/7/CPU0:"
+_NODE_RE = re.compile(r"^\s*Node\s+(?P<node>\S+?):\s*$")
+
+# Burst line: "Burst = 100ms for all flow types"
+_BURST_RE = re.compile(r"^\s*Burst\s*=\s*(?P<burst>\d+)ms\b")
+
+# Flow type data line — columns are whitespace-separated:
+# FlowType  PolicerNum  PolicerType  CurRate  DefRate  Accepted  Dropped  TOS
+_FLOW_RE = re.compile(
+    r"^(?P<flow>\S+)"
+    r"\s+(?P<policer_type>\d+)"
+    r"\s+(?P<type>Static|Dynamic)"
+    r"\s+(?P<cur_rate>\d+)"
+    r"\s+(?P<def_rate>\d+)"
+    r"\s+(?P<accepted>\d+)"
+    r"\s+(?P<dropped>\d+)"
+    r"\s+(?P<tos>\S+)\s*$",
+    re.I,
+)
+
+# Statistics lines
+_STAT_ACCEPTED_RE = re.compile(r"^Packets accepted by deleted entries:\s*(?P<val>\d+)")
+_STAT_DROPPED_RE = re.compile(r"^Packets dropped by deleted entries:\s*(?P<val>\d+)")
+_STAT_COUNTER_ERR_RE = re.compile(
+    r"^Run out of statistics counter errors:\s*(?P<val>\d+)"
+)
+
+
+_STAT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (_STAT_ACCEPTED_RE, "packets_accepted_by_deleted_entries"),
+    (_STAT_DROPPED_RE, "packets_dropped_by_deleted_entries"),
+    (_STAT_COUNTER_ERR_RE, "run_out_of_statistics_counter_errors"),
+]
+
+
+def _parse_flow_entry(stripped: str, flow_types: dict[str, FlowTypeEntry]) -> bool:
+    """Try to parse a flow type data line and add it to *flow_types*.
+
+    Returns True if the line was consumed.
+    """
+    m = _FLOW_RE.match(stripped)
+    if not m:
+        return False
+    flow_types[m.group("flow")] = FlowTypeEntry(
+        policer_type=int(m.group("policer_type")),
+        type=m.group("type"),
+        current_rate=int(m.group("cur_rate")),
+        default_rate=int(m.group("def_rate")),
+        accepted=int(m.group("accepted")),
+        dropped=int(m.group("dropped")),
+        tos_value=m.group("tos"),
+    )
+    return True
+
+
+def _parse_statistics_line(
+    stripped: str,
+    statistics: StatisticsEntry,
+) -> bool:
+    """Try to parse a statistics line and update *statistics*.
+
+    Returns True if the line was consumed.
+    """
+    for pattern, key in _STAT_PATTERNS:
+        m = pattern.match(stripped)
+        if m:
+            statistics[key] = int(m.group("val"))  # type: ignore[literal-required]
+            return True
+    return False
+
+
+@register(OS.CISCO_IOSXR, "show lpts pifib hardware police location")
+class ShowLptsPifibHardwarePoliceLocationParser(
+    BaseParser["ShowLptsPifibHardwarePoliceLocationResult"],
+):
+    """Parser for 'show lpts pifib hardware police location' on IOS-XR.
+
+    Parses per-flow-type LPTS policer entries and summary statistics
+    from the hardware PIFIB table.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    @classmethod
+    def _parse_header(cls, lines: list[str]) -> tuple[str, int]:
+        """Extract node identifier and burst value from header lines.
+
+        Returns:
+            Tuple of (node, burst_ms).
+
+        Raises:
+            ValueError: If node or burst cannot be found.
+        """
+        node: str | None = None
+        burst_ms: int | None = None
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if node is None:
+                if m := _NODE_RE.match(stripped):
+                    node = m.group("node")
+                    continue
+            if burst_ms is None:
+                if m := _BURST_RE.match(stripped):
+                    burst_ms = int(m.group("burst"))
+                    break
+
+        if node is None:
+            msg = "No node identifier found in output"
+            raise ValueError(msg)
+        if burst_ms is None:
+            msg = "No burst value found in output"
+            raise ValueError(msg)
+
+        return node, burst_ms
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLptsPifibHardwarePoliceLocationResult:
+        """Parse LPTS PIFIB hardware police location output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed LPTS policer information keyed by flow type name.
+
+        Raises:
+            ValueError: If required fields (node, burst) cannot be parsed.
+        """
+        lines = output.splitlines()
+        node, burst_ms = cls._parse_header(lines)
+
+        flow_types: dict[str, FlowTypeEntry] = {}
+        statistics: StatisticsEntry = {
+            "packets_accepted_by_deleted_entries": 0,
+            "packets_dropped_by_deleted_entries": 0,
+            "run_out_of_statistics_counter_errors": 0,
+        }
+        has_statistics = False
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if _parse_flow_entry(stripped, flow_types):
+                continue
+            if _parse_statistics_line(stripped, statistics):
+                has_statistics = True
+
+        if not flow_types:
+            msg = "No flow type entries found in output"
+            raise ValueError(msg)
+
+        result: ShowLptsPifibHardwarePoliceLocationResult = {
+            "node": node,
+            "burst_ms": burst_ms,
+            "flow_types": flow_types,
+        }
+
+        if has_statistics:
+            result["statistics"] = statistics
+
+        return cast(ShowLptsPifibHardwarePoliceLocationResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
@@ -103,7 +103,7 @@ def _parse_flow_entry(stripped: str, flow_types: dict[str, FlowTypeEntry]) -> bo
 
 def _parse_statistics_line(
     stripped: str,
-    statistics: StatisticsEntry,
+    statistics: dict[str, int],
 ) -> bool:
     """Try to parse a statistics line and update *statistics*.
 
@@ -112,7 +112,7 @@ def _parse_statistics_line(
     for pattern, key in _STAT_PATTERNS:
         m = pattern.match(stripped)
         if m:
-            statistics[key] = int(m.group("val"))  # type: ignore[literal-required]
+            statistics[key] = int(m.group("val"))
             return True
     return False
 
@@ -181,7 +181,7 @@ class ShowLptsPifibHardwarePoliceLocationParser(
         node, burst_ms = cls._parse_header(lines)
 
         flow_types: dict[str, FlowTypeEntry] = {}
-        statistics: StatisticsEntry = {
+        statistics: dict[str, int] = {
             "packets_accepted_by_deleted_entries": 0,
             "packets_dropped_by_deleted_entries": 0,
             "run_out_of_statistics_counter_errors": 0,
@@ -208,6 +208,6 @@ class ShowLptsPifibHardwarePoliceLocationParser(
         }
 
         if has_statistics:
-            result["statistics"] = statistics
+            result["statistics"] = cast(StatisticsEntry, statistics)
 
         return cast(ShowLptsPifibHardwarePoliceLocationResult, result)

--- a/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/001_basic/expected.json
@@ -1,0 +1,875 @@
+{
+    "node": "0/7/CPU0",
+    "burst_ms": 100,
+    "flow_types": {
+        "unconfigured-default": {
+            "policer_type": 100,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "L2TPv2-fragment": {
+            "policer_type": 185,
+            "type": "Static",
+            "current_rate": 10000,
+            "default_rate": 10000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "Fragment": {
+            "policer_type": 101,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "OSPF-mc-known": {
+            "policer_type": 102,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 111663351,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "OSPF-mc-default": {
+            "policer_type": 103,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "OSPF-uc-known": {
+            "policer_type": 104,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 3618098,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "OSPF-uc-default": {
+            "policer_type": 105,
+            "type": "Static",
+            "current_rate": 1000,
+            "default_rate": 1000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ISIS-known": {
+            "policer_type": 143,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ISIS-default": {
+            "policer_type": 144,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-known": {
+            "policer_type": 150,
+            "type": "Static",
+            "current_rate": 9600,
+            "default_rate": 9600,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-default": {
+            "policer_type": 160,
+            "type": "Static",
+            "current_rate": 45340,
+            "default_rate": 9600,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-MP-known": {
+            "policer_type": 178,
+            "type": "Static",
+            "current_rate": 11520,
+            "default_rate": 11520,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-MP-0": {
+            "policer_type": 179,
+            "type": "Static",
+            "current_rate": 128,
+            "default_rate": 128,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-BLB-known": {
+            "policer_type": 183,
+            "type": "Static",
+            "current_rate": 11520,
+            "default_rate": 11520,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-BLB-0": {
+            "policer_type": 184,
+            "type": "Static",
+            "current_rate": 128,
+            "default_rate": 128,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BFD-SP-0": {
+            "policer_type": 182,
+            "type": "Static",
+            "current_rate": 512,
+            "default_rate": 512,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BGP-known": {
+            "policer_type": 106,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 1203286,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BGP-cfg-peer": {
+            "policer_type": 107,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "BGP-default": {
+            "policer_type": 108,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "PIM-mcast-default": {
+            "policer_type": 109,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "PIM-mcast-known": {
+            "policer_type": 176,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 26046391,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "PIM-ucast": {
+            "policer_type": 110,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "IGMP": {
+            "policer_type": 111,
+            "type": "Static",
+            "current_rate": 3000,
+            "default_rate": 3000,
+            "accepted": 7944769,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ICMP-local": {
+            "policer_type": 112,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ICMP-app": {
+            "policer_type": 152,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ICMP-control": {
+            "policer_type": 140,
+            "type": "Static",
+            "current_rate": 1000,
+            "default_rate": 1000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ICMP-default": {
+            "policer_type": 153,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 11,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ICMP-app-default": {
+            "policer_type": 190,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LDP-TCP-known": {
+            "policer_type": 113,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 1258061,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LDP-TCP-cfg-peer": {
+            "policer_type": 114,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LDP-TCP-default": {
+            "policer_type": 115,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LDP-UDP": {
+            "policer_type": 116,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 7282839,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "All-routers": {
+            "policer_type": 117,
+            "type": "Static",
+            "current_rate": 1000,
+            "default_rate": 1000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LMP-TCP-known": {
+            "policer_type": 168,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LMP-TCP-cfg-peer": {
+            "policer_type": 169,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LMP-TCP-default": {
+            "policer_type": 170,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "LMP-UDP": {
+            "policer_type": 171,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RSVP-UDP": {
+            "policer_type": 118,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RSVP-default": {
+            "policer_type": 154,
+            "type": "Static",
+            "current_rate": 500,
+            "default_rate": 500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RSVP-known": {
+            "policer_type": 177,
+            "type": "Static",
+            "current_rate": 7000,
+            "default_rate": 7000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "IKE": {
+            "policer_type": 119,
+            "type": "Static",
+            "current_rate": 1000,
+            "default_rate": 1000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "IPSEC-known": {
+            "policer_type": 120,
+            "type": "Static",
+            "current_rate": 400,
+            "default_rate": 400,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "IPSEC-default": {
+            "policer_type": 121,
+            "type": "Static",
+            "current_rate": 100,
+            "default_rate": 100,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "IPSEC-fragment": {
+            "policer_type": 194,
+            "type": "Static",
+            "current_rate": 10000,
+            "default_rate": 10000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "MSDP-known": {
+            "policer_type": 122,
+            "type": "Static",
+            "current_rate": 300,
+            "default_rate": 300,
+            "accepted": 24233712,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "MSDP-cfg-peer": {
+            "policer_type": 123,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 4,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "MSDP-default": {
+            "policer_type": 124,
+            "type": "Static",
+            "current_rate": 100,
+            "default_rate": 100,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "SNMP": {
+            "policer_type": 125,
+            "type": "Static",
+            "current_rate": 300,
+            "default_rate": 300,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "SSH-known": {
+            "policer_type": 127,
+            "type": "Static",
+            "current_rate": 300,
+            "default_rate": 300,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "SSH-default": {
+            "policer_type": 128,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "HTTP-known": {
+            "policer_type": 129,
+            "type": "Static",
+            "current_rate": 400,
+            "default_rate": 400,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "HTTP-default": {
+            "policer_type": 130,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "SHTTP-known": {
+            "policer_type": 161,
+            "type": "Static",
+            "current_rate": 400,
+            "default_rate": 400,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "IFIB_FT_SHTTP_DEFAULT": {
+            "policer_type": 162,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TELNET-known": {
+            "policer_type": 131,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TELNET-default": {
+            "policer_type": 132,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "CSS-known": {
+            "policer_type": 133,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "CSS-default": {
+            "policer_type": 134,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RSH-known": {
+            "policer_type": 135,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RSH-default": {
+            "policer_type": 136,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "UDP-known": {
+            "policer_type": 137,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "UDP-listen": {
+            "policer_type": 138,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "UDP-cfg-peer": {
+            "policer_type": 155,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "UDP-default": {
+            "policer_type": 163,
+            "type": "Static",
+            "current_rate": 3500,
+            "default_rate": 3500,
+            "accepted": 1,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TCP-known": {
+            "policer_type": 156,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TCP-listen": {
+            "policer_type": 157,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TCP-cfg-peer": {
+            "policer_type": 158,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TCP-default": {
+            "policer_type": 164,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 123,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "Mcast-known": {
+            "policer_type": 159,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "Mcast-default": {
+            "policer_type": 165,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "Raw-listen": {
+            "policer_type": 166,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "Raw-default": {
+            "policer_type": 167,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "Ip-Sla": {
+            "policer_type": 139,
+            "type": "Static",
+            "current_rate": 1000,
+            "default_rate": 1000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "EIGRP": {
+            "policer_type": 145,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RIP": {
+            "policer_type": 146,
+            "type": "Static",
+            "current_rate": 1500,
+            "default_rate": 1500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "L2TPv3": {
+            "policer_type": 141,
+            "type": "Static",
+            "current_rate": 400,
+            "default_rate": 400,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "PCEP": {
+            "policer_type": 142,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "GRE": {
+            "policer_type": 147,
+            "type": "Static",
+            "current_rate": 10000,
+            "default_rate": 10000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "VRRP": {
+            "policer_type": 148,
+            "type": "Static",
+            "current_rate": 1000,
+            "default_rate": 1000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "HSRP": {
+            "policer_type": 149,
+            "type": "Static",
+            "current_rate": 400,
+            "default_rate": 400,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "MPLS-oam": {
+            "policer_type": 151,
+            "type": "Static",
+            "current_rate": 250,
+            "default_rate": 250,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "L2TPv2-default": {
+            "policer_type": 172,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "L2TPv2-known": {
+            "policer_type": 181,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "DNS": {
+            "policer_type": 173,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RADIUS": {
+            "policer_type": 174,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "TACACS": {
+            "policer_type": 175,
+            "type": "Static",
+            "current_rate": 2000,
+            "default_rate": 2000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "NTP-default": {
+            "policer_type": 126,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "NTP-known": {
+            "policer_type": 180,
+            "type": "Static",
+            "current_rate": 200,
+            "default_rate": 200,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "MIPv6": {
+            "policer_type": 188,
+            "type": "Static",
+            "current_rate": 5000,
+            "default_rate": 5000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "AMT": {
+            "policer_type": 186,
+            "type": "Static",
+            "current_rate": 4000,
+            "default_rate": 4000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "SDAC-TCP": {
+            "policer_type": 187,
+            "type": "Static",
+            "current_rate": 5000,
+            "default_rate": 5000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "RADIUS-COA": {
+            "policer_type": 189,
+            "type": "Static",
+            "current_rate": 400,
+            "default_rate": 400,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "REL-UDP": {
+            "policer_type": 191,
+            "type": "Static",
+            "current_rate": 50000,
+            "default_rate": 50000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "DHCPv4": {
+            "policer_type": 192,
+            "type": "Static",
+            "current_rate": 4000,
+            "default_rate": 4000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "DHCPv6": {
+            "policer_type": 193,
+            "type": "Static",
+            "current_rate": 4000,
+            "default_rate": 4000,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        },
+        "ONEPK": {
+            "policer_type": 100,
+            "type": "Static",
+            "current_rate": 2500,
+            "default_rate": 2500,
+            "accepted": 0,
+            "dropped": 0,
+            "tos_value": "01234567"
+        }
+    },
+    "statistics": {
+        "packets_accepted_by_deleted_entries": 437191,
+        "packets_dropped_by_deleted_entries": 0,
+        "run_out_of_statistics_counter_errors": 0
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/001_basic/input.txt
@@ -1,0 +1,109 @@
+-------------------------------------------------------------
+                Node 0/7/CPU0:
+-------------------------------------------------------------
+ Burst = 100ms for all flow types
+-------------------------------------------------------------
+FlowType               Policer Type    Cur. Rate  Def. Rate  Accepted             Dropped              TOS Value
+---------------------- ------- ------- ---------- ---------- -------------------- -------------------- ----------
+unconfigured-default   100     Static  2500       2500       0                    0                    01234567
+L2TPv2-fragment        185     Static  10000      10000      0                    0                    01234567
+Fragment               101     Static  2500       2500       0                    0                    01234567
+OSPF-mc-known          102     Static  2000       2000       111663351            0                    01234567
+OSPF-mc-default        103     Static  1500       1500       0                    0                    01234567
+OSPF-uc-known          104     Static  2000       2000       3618098              0                    01234567
+OSPF-uc-default        105     Static  1000       1000       0                    0                    01234567
+ISIS-known             143     Static  2000       2000       0                    0                    01234567
+ISIS-default           144     Static  1500       1500       0                    0                    01234567
+BFD-known              150     Static  9600       9600       0                    0                    01234567
+BFD-default            160     Static  45340      9600       0                    0                    01234567
+BFD-MP-known           178     Static  11520      11520      0                    0                    01234567
+BFD-MP-0               179     Static  128        128        0                    0                    01234567
+BFD-BLB-known          183     Static  11520      11520      0                    0                    01234567
+BFD-BLB-0              184     Static  128        128        0                    0                    01234567
+BFD-SP-0               182     Static  512        512        0                    0                    01234567
+BGP-known              106     Static  2500       2500       1203286              0                    01234567
+BGP-cfg-peer           107     Static  2000       2000       0                    0                    01234567
+BGP-default            108     Static  1500       1500       0                    0                    01234567
+PIM-mcast-default      109     Static  2000       2000       0                    0                    01234567
+PIM-mcast-known        176     Static  2000       2000       26046391             0                    01234567
+PIM-ucast              110     Static  1500       1500       0                    0                    01234567
+IGMP                   111     Static  3000       3000       7944769              0                    01234567
+ICMP-local             112     Static  1500       1500       0                    0                    01234567
+ICMP-app               152     Static  1500       1500       0                    0                    01234567
+ICMP-control           140     Static  1000       1000       0                    0                    01234567
+ICMP-default           153     Static  1500       1500       11                   0                    01234567
+ICMP-app-default       190     Static  1500       1500       0                    0                    01234567
+LDP-TCP-known          113     Static  2500       2500       1258061              0                    01234567
+LDP-TCP-cfg-peer       114     Static  2000       2000       0                    0                    01234567
+LDP-TCP-default        115     Static  1500       1500       0                    0                    01234567
+LDP-UDP                116     Static  2000       2000       7282839              0                    01234567
+All-routers            117     Static  1000       1000       0                    0                    01234567
+LMP-TCP-known          168     Static  2500       2500       0                    0                    01234567
+LMP-TCP-cfg-peer       169     Static  2000       2000       0                    0                    01234567
+LMP-TCP-default        170     Static  1500       1500       0                    0                    01234567
+LMP-UDP                171     Static  2000       2000       0                    0                    01234567
+RSVP-UDP               118     Static  2000       2000       0                    0                    01234567
+RSVP-default           154     Static  500        500        0                    0                    01234567
+RSVP-known             177     Static  7000       7000       0                    0                    01234567
+IKE                    119     Static  1000       1000       0                    0                    01234567
+IPSEC-known            120     Static  400        400        0                    0                    01234567
+IPSEC-default          121     Static  100        100        0                    0                    01234567
+IPSEC-fragment         194     Static  10000      10000      0                    0                    01234567
+MSDP-known             122     Static  300        300        24233712             0                    01234567
+MSDP-cfg-peer          123     Static  200        200        4                    0                    01234567
+MSDP-default           124     Static  100        100        0                    0                    01234567
+SNMP                   125     Static  300        300        0                    0                    01234567
+SSH-known              127     Static  300        300        0                    0                    01234567
+SSH-default            128     Static  200        200        0                    0                    01234567
+HTTP-known             129     Static  400        400        0                    0                    01234567
+HTTP-default           130     Static  200        200        0                    0                    01234567
+SHTTP-known            161     Static  400        400        0                    0                    01234567
+IFIB_FT_SHTTP_DEFAULT  162     Static  200        200        0                    0                    01234567
+TELNET-known           131     Static  200        200        0                    0                    01234567
+TELNET-default         132     Static  200        200        0                    0                    01234567
+CSS-known              133     Static  200        200        0                    0                    01234567
+CSS-default            134     Static  200        200        0                    0                    01234567
+RSH-known              135     Static  200        200        0                    0                    01234567
+RSH-default            136     Static  200        200        0                    0                    01234567
+UDP-known              137     Static  2500       2500       0                    0                    01234567
+UDP-listen             138     Static  2500       2500       0                    0                    01234567
+UDP-cfg-peer           155     Static  2500       2500       0                    0                    01234567
+UDP-default            163     Static  3500       3500       1                    0                    01234567
+TCP-known              156     Static  2500       2500       0                    0                    01234567
+TCP-listen             157     Static  2500       2500       0                    0                    01234567
+TCP-cfg-peer           158     Static  2000       2000       0                    0                    01234567
+TCP-default            164     Static  2000       2000       123                  0                    01234567
+Mcast-known            159     Static  2500       2500       0                    0                    01234567
+Mcast-default          165     Static  2000       2000       0                    0                    01234567
+Raw-listen             166     Static  2500       2500       0                    0                    01234567
+Raw-default            167     Static  2500       2500       0                    0                    01234567
+Ip-Sla                 139     Static  1000       1000       0                    0                    01234567
+EIGRP                  145     Static  1500       1500       0                    0                    01234567
+RIP                    146     Static  1500       1500       0                    0                    01234567
+L2TPv3                 141     Static  400        400        0                    0                    01234567
+PCEP                   142     Static  200        200        0                    0                    01234567
+GRE                    147     Static  10000      10000      0                    0                    01234567
+VRRP                   148     Static  1000       1000       0                    0                    01234567
+HSRP                   149     Static  400        400        0                    0                    01234567
+MPLS-oam               151     Static  250        250        0                    0                    01234567
+L2TPv2-default         172     Static  2000       2000       0                    0                    01234567
+L2TPv2-known           181     Static  2500       2500       0                    0                    01234567
+DNS                    173     Static  2000       2000       0                    0                    01234567
+RADIUS                 174     Static  2000       2000       0                    0                    01234567
+TACACS                 175     Static  2000       2000       0                    0                    01234567
+NTP-default            126     Static  200        200        0                    0                    01234567
+NTP-known              180     Static  200        200        0                    0                    01234567
+MIPv6                  188     Static  5000       5000       0                    0                    01234567
+AMT                    186     Static  4000       4000       0                    0                    01234567
+SDAC-TCP               187     Static  5000       5000       0                    0                    01234567
+RADIUS-COA             189     Static  400        400        0                    0                    01234567
+REL-UDP                191     Static  50000      50000      0                    0                    01234567
+DHCPv4                 192     Static  4000       4000       0                    0                    01234567
+DHCPv6                 193     Static  4000       4000       0                    0                    01234567
+ONEPK                  100     Static  2500       2500       0                    0                    01234567
+
+------------------------
+statistics:
+Packets accepted by deleted entries: 437191
+Packets dropped by deleted entries: 0
+Run out of statistics counter errors: 0

--- a/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "LPTS PIFIB hardware policer table with all static flow types and summary statistics"
+platform: "ASR 9006"
+software_version: "Unknown"

--- a/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/command.txt
+++ b/tests/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location/command.txt
@@ -1,0 +1,1 @@
+show lpts pifib hardware police location 0/7/CPU0


### PR DESCRIPTION
## Summary

- Add new parser for `show lpts pifib hardware police location` on Cisco IOS-XR
- Parses per-flow-type LPTS policer entries (policer type, current/default rate, accepted/dropped counters, TOS value) into a dict-of-dicts keyed by flow type name
- Includes node identifier, burst value, and optional summary statistics for deleted entries
- Tagged with `ParserTag.PLATFORM`

## Test plan

- [x] Parser test passes against real device output from ASR 9006 (96 flow types)
- [x] All 6848 existing tests continue to pass
- [x] ruff check/format, xenon complexity, bandit security scan all pass
- [x] pre-commit hooks all pass
- [x] No banned placeholder values in expected.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)