### PR TITLE
feat(arista_eos): add parser for show mac security interface

### DIFF
--- a/changes/+arista-eos-show-mac-security-interface.parser_added
+++ b/changes/+arista-eos-show-mac-security-interface.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show mac security interface` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_mac_security_interface.py
+++ b/src/muninn/parsers/arista_eos/show_mac_security_interface.py
@@ -1,0 +1,92 @@
+"""Parser for 'show mac security interface' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_CONTROLLED_PORT_TRUE = "True"
+
+
+class MacSecurityInterfaceEntry(TypedDict):
+    """Schema for a single MACsec interface entry."""
+
+    sci: str
+    controlled_port: bool
+    key_in_use: str
+
+
+@register(OS.ARISTA_EOS, "show mac security interface")
+class ShowMacSecurityInterfaceParser(
+    BaseParser[dict[str, MacSecurityInterfaceEntry]],
+):
+    """Parser for 'show mac security interface' command on Arista EOS.
+
+    Returns a dict-of-dicts keyed by interface name, each containing
+    SCI, controlled port status, and key in use.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MACSEC})
+
+    _HEADER_PATTERN = re.compile(
+        r"^Interface\s+SCI\s+Controlled\s+Port\s+Key\s+in\s+Use",
+    )
+
+    _ROW_PATTERN = re.compile(
+        r"^(?P<interface>\S+)"
+        r"\s+(?P<sci>\S+)"
+        r"\s+(?P<controlled_port>True|False)"
+        r"\s+(?P<key_in_use>\S+)",
+    )
+
+    @classmethod
+    def _parse_row(cls, match: re.Match[str]) -> tuple[str, MacSecurityInterfaceEntry]:
+        """Extract interface name and entry from a regex match."""
+        return match.group("interface"), cast(
+            MacSecurityInterfaceEntry,
+            {
+                "sci": match.group("sci"),
+                "controlled_port": match.group("controlled_port")
+                == _CONTROLLED_PORT_TRUE,
+                "key_in_use": match.group("key_in_use"),
+            },
+        )
+
+    @classmethod
+    def _find_data_lines(cls, output: str) -> list[str]:
+        """Return lines after the header row, skipping blanks."""
+        lines = output.splitlines()
+        for idx, line in enumerate(lines):
+            if cls._HEADER_PATTERN.match(line.strip()):
+                return [ln for ln in lines[idx + 1 :] if ln.strip()]
+        return []
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, MacSecurityInterfaceEntry]:
+        """Parse 'show mac security interface' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by interface name with MACsec interface details.
+
+        Raises:
+            ValueError: If no valid entries are found in the output.
+        """
+        result: dict[str, MacSecurityInterfaceEntry] = {}
+
+        for line in cls._find_data_lines(output):
+            match = cls._ROW_PATTERN.match(line.strip())
+            if match:
+                interface, entry = cls._parse_row(match)
+                result[interface] = entry
+
+        if not result:
+            msg = "No MACsec interface entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/arista_eos/show_mac_security_interface.py
+++ b/src/muninn/parsers/arista_eos/show_mac_security_interface.py
@@ -7,6 +7,7 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 _CONTROLLED_PORT_TRUE = "True"
 
@@ -45,7 +46,8 @@ class ShowMacSecurityInterfaceParser(
     @classmethod
     def _parse_row(cls, match: re.Match[str]) -> tuple[str, MacSecurityInterfaceEntry]:
         """Extract interface name and entry from a regex match."""
-        return match.group("interface"), cast(
+        interface = canonical_interface_name(match.group("interface"), os=OS.ARISTA_EOS)
+        return interface, cast(
             MacSecurityInterfaceEntry,
             {
                 "sci": match.group("sci"),

--- a/tests/parsers/arista_eos/show_mac_security_interface/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mac_security_interface/001_basic/expected.json
@@ -1,0 +1,42 @@
+{
+    "Ethernet4/15/1": {
+        "sci": "ch:99:3h:69:76:cc::661",
+        "controlled_port": true,
+        "key_in_use": "changed77f1j42e246kf05b:45"
+    },
+    "Ethernet5/13/1": {
+        "sci": "ch:99:3h:69:72:d4::803",
+        "controlled_port": true,
+        "key_in_use": "changedf1e9j62b5a9keac3:45"
+    },
+    "Ethernet5/14/1": {
+        "sci": "ch:99:3h:69:72:d8::807",
+        "controlled_port": true,
+        "key_in_use": "changeda62bjb9cdadk246e:45"
+    },
+    "Ethernet5/16/1": {
+        "sci": "ch:99:3h:69:72:e0::815",
+        "controlled_port": true,
+        "key_in_use": "changede693j033b28k810e:56"
+    },
+    "Ethernet5/17/1": {
+        "sci": "ch:99:3h:69:72:e4::819",
+        "controlled_port": true,
+        "key_in_use": "changed5778j794bf3k611c:45"
+    },
+    "Ethernet5/18/1": {
+        "sci": "ch:99:3h:69:72:e8::823",
+        "controlled_port": true,
+        "key_in_use": "changed532dj3307f2k610e:45"
+    },
+    "Ethernet5/19/1": {
+        "sci": "ch:99:3h:69:72:ec::827",
+        "controlled_port": true,
+        "key_in_use": "changed046bjdb206eka327:45"
+    },
+    "Ethernet5/20/1": {
+        "sci": "ch:99:3h:69:72:f0::831",
+        "controlled_port": true,
+        "key_in_use": "changedd888jc35359kbd0c:39"
+    }
+}

--- a/tests/parsers/arista_eos/show_mac_security_interface/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_mac_security_interface/001_basic/input.txt
@@ -1,0 +1,9 @@
+Interface       SCI                       Controlled Port      Key in Use
+Ethernet4/15/1  ch:99:3h:69:76:cc::661    True                 changed77f1j42e246kf05b:45
+Ethernet5/13/1  ch:99:3h:69:72:d4::803    True                 changedf1e9j62b5a9keac3:45
+Ethernet5/14/1  ch:99:3h:69:72:d8::807    True                 changeda62bjb9cdadk246e:45
+Ethernet5/16/1  ch:99:3h:69:72:e0::815    True                 changede693j033b28k810e:56
+Ethernet5/17/1  ch:99:3h:69:72:e4::819    True                 changed5778j794bf3k611c:45
+Ethernet5/18/1  ch:99:3h:69:72:e8::823    True                 changed532dj3307f2k610e:45
+Ethernet5/19/1  ch:99:3h:69:72:ec::827    True                 changed046bjdb206eka327:45
+Ethernet5/20/1  ch:99:3h:69:72:f0::831    True                 changedd888jc35359kbd0c:39

--- a/tests/parsers/arista_eos/show_mac_security_interface/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_mac_security_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple interfaces with MACsec enabled and controlled ports
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add new parser for `show mac security interface` on Arista EOS
- Returns dict-of-dicts keyed by interface name with SCI, controlled port status, and key in use
- Tagged with `ParserTag.MACSEC`

## Test plan
- [x] Parser test with real device output fixture (001_basic, 8 interfaces)
- [x] All fixture sentinel checks pass (no placeholder values)
- [x] JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] Ruff lint and format clean
- [x] Xenon complexity under threshold (all methods rank A)
- [x] Bandit security scan clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)