### PR TITLE
feat(arista_eos): add parser for show mac security mka counters

### DIFF
--- a/changes/+arista-eos-show-mac-security-mka-counters.parser_added
+++ b/changes/+arista-eos-show-mac-security-mka-counters.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show mac security mka counters` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_mac_security_mka_counters.py
+++ b/src/muninn/parsers/arista_eos/show_mac_security_mka_counters.py
@@ -1,0 +1,81 @@
+"""Parser for 'show mac security mka counters' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class MkaCountersEntry(TypedDict):
+    """Schema for a single interface's MKA counters."""
+
+    rx_success: int
+    rx_failure: int
+    tx_success: int
+    tx_failure: int
+
+
+@register(OS.ARISTA_EOS, "show mac security mka counters")
+class ShowMacSecurityMkaCountersParser(
+    BaseParser[dict[str, MkaCountersEntry]],
+):
+    """Parser for 'show mac security mka counters' on Arista EOS.
+
+    Returns a dict-of-dicts keyed by interface name containing
+    MKA PDU transmit and receive counters.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MACSEC})
+
+    _COUNTER_LINE = re.compile(
+        r"^(?P<interface>\S+)"
+        r"\s+(?P<rx_success>\d+)"
+        r"\s+(?P<rx_failure>\d+)"
+        r"\s+(?P<tx_success>\d+)"
+        r"\s+(?P<tx_failure>\d+)"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, MkaCountersEntry]:
+        """Parse 'show mac security mka counters' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by interface name with MKA counter values.
+
+        Raises:
+            ValueError: If no counter data is found in output.
+        """
+        result: dict[str, MkaCountersEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            match = cls._COUNTER_LINE.match(stripped)
+            if not match:
+                continue
+
+            interface = match.group("interface")
+            # Skip the header line (starts with "Interface")
+            if interface == "Interface":
+                continue
+
+            result[interface] = MkaCountersEntry(
+                rx_success=int(match.group("rx_success")),
+                rx_failure=int(match.group("rx_failure")),
+                tx_success=int(match.group("tx_success")),
+                tx_failure=int(match.group("tx_failure")),
+            )
+
+        if not result:
+            msg = "No MKA counter data found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/arista_eos/show_mac_security_mka_counters.py
+++ b/src/muninn/parsers/arista_eos/show_mac_security_mka_counters.py
@@ -7,6 +7,7 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class MkaCountersEntry(TypedDict):
@@ -62,10 +63,9 @@ class ShowMacSecurityMkaCountersParser(
             if not match:
                 continue
 
-            interface = match.group("interface")
-            # Skip the header line (starts with "Interface")
-            if interface == "Interface":
-                continue
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.ARISTA_EOS
+            )
 
             result[interface] = MkaCountersEntry(
                 rx_success=int(match.group("rx_success")),

--- a/tests/parsers/arista_eos/show_mac_security_mka_counters/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mac_security_mka_counters/001_basic/expected.json
@@ -1,0 +1,74 @@
+{
+    "Ethernet4/13/1": {
+        "rx_success": 0,
+        "rx_failure": 0,
+        "tx_success": 0,
+        "tx_failure": 0
+    },
+    "Ethernet4/14/1": {
+        "rx_success": 0,
+        "rx_failure": 0,
+        "tx_success": 0,
+        "tx_failure": 0
+    },
+    "Ethernet4/15/1": {
+        "rx_success": 79688,
+        "rx_failure": 0,
+        "tx_success": 79858,
+        "tx_failure": 0
+    },
+    "Ethernet4/16/1": {
+        "rx_success": 0,
+        "rx_failure": 0,
+        "tx_success": 0,
+        "tx_failure": 0
+    },
+    "Ethernet5/13/1": {
+        "rx_success": 79788,
+        "rx_failure": 0,
+        "tx_success": 79854,
+        "tx_failure": 0
+    },
+    "Ethernet5/14/1": {
+        "rx_success": 79878,
+        "rx_failure": 0,
+        "tx_success": 79853,
+        "tx_failure": 0
+    },
+    "Ethernet5/15/1": {
+        "rx_success": 0,
+        "rx_failure": 0,
+        "tx_success": 0,
+        "tx_failure": 0
+    },
+    "Ethernet5/16/1": {
+        "rx_success": 64246,
+        "rx_failure": 0,
+        "tx_success": 79850,
+        "tx_failure": 0
+    },
+    "Ethernet5/17/1": {
+        "rx_success": 79749,
+        "rx_failure": 0,
+        "tx_success": 79848,
+        "tx_failure": 0
+    },
+    "Ethernet5/18/1": {
+        "rx_success": 79756,
+        "rx_failure": 0,
+        "tx_success": 79846,
+        "tx_failure": 0
+    },
+    "Ethernet5/19/1": {
+        "rx_success": 79842,
+        "rx_failure": 0,
+        "tx_success": 79845,
+        "tx_failure": 0
+    },
+    "Ethernet5/20/1": {
+        "rx_success": 68225,
+        "rx_failure": 0,
+        "tx_success": 68188,
+        "tx_failure": 0
+    }
+}

--- a/tests/parsers/arista_eos/show_mac_security_mka_counters/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_mac_security_mka_counters/001_basic/input.txt
@@ -1,0 +1,13 @@
+Interface       Rx Success      Rx Failure      Tx Success      Tx Failure
+Ethernet4/13/1  0               0               0               0
+Ethernet4/14/1  0               0               0               0
+Ethernet4/15/1  79688           0               79858           0
+Ethernet4/16/1  0               0               0               0
+Ethernet5/13/1  79788           0               79854           0
+Ethernet5/14/1  79878           0               79853           0
+Ethernet5/15/1  0               0               0               0
+Ethernet5/16/1  64246           0               79850           0
+Ethernet5/17/1  79749           0               79848           0
+Ethernet5/18/1  79756           0               79846           0
+Ethernet5/19/1  79842           0               79845           0
+Ethernet5/20/1  68225           0               68188           0

--- a/tests/parsers/arista_eos/show_mac_security_mka_counters/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_mac_security_mka_counters/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: MKA counters across multiple Ethernet interfaces with mixed active and inactive sessions
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show mac security mka counters` on Arista EOS
- Returns dict-of-dicts keyed by interface name with MKA PDU TX/RX success and failure counters
- Tagged with `ParserTag.MACSEC`

## Test plan
- [x] Fixture `001_basic` with 12 interfaces covering both active and inactive MKA sessions
- [x] All pre-commit hooks pass (ruff, xenon, bandit, format)
- [x] Placeholder sentinel tests pass (no banned values in expected.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)