### PR TITLE
feat(cisco_iosxr): add parser for show controllers fabric fia drops ingress location

### DIFF
--- a/changes/+cisco-iosxr-show-controllers-fabric-fia-drops-ingress-location.parser_added
+++ b/changes/+cisco-iosxr-show-controllers-fabric-fia-drops-ingress-location.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show controllers fabric fia drops ingress location` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location.py
@@ -30,7 +30,10 @@ class FiaInstanceEntry(TypedDict):
 ShowControllersFabricFiaDropsIngressLocationResult = dict[str, FiaInstanceEntry]
 
 
-@register(OS.CISCO_IOSXR, "show controllers fabric fia drops ingress location")
+@register(
+    OS.CISCO_IOSXR,
+    r"show controllers fabric fia drops ingress location (?P<location>\S+)",
+)
 class ShowControllersFabricFiaDropsIngressLocationParser(
     BaseParser[ShowControllersFabricFiaDropsIngressLocationResult],
 ):

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location.py
@@ -1,0 +1,99 @@
+"""Parser for 'show controllers fabric fia drops ingress location' on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FiaCounterEntry(TypedDict):
+    """Schema for an individual drop counter within a FIA instance."""
+
+    count: int
+
+
+class FiaInstanceEntry(TypedDict):
+    """Schema for a single FIA instance's drop counters.
+
+    Keys are counter names (e.g. "From Spaui Drop-0", "sp0 crc err").
+    Values are dicts with a ``count`` field.
+    """
+
+    category: str
+    counters: dict[str, FiaCounterEntry]
+
+
+# Top-level result keyed by FIA instance name (e.g. "FIA-0", "FIA-1").
+ShowControllersFabricFiaDropsIngressLocationResult = dict[str, FiaInstanceEntry]
+
+
+@register(OS.CISCO_IOSXR, "show controllers fabric fia drops ingress location")
+class ShowControllersFabricFiaDropsIngressLocationParser(
+    BaseParser[ShowControllersFabricFiaDropsIngressLocationResult],
+):
+    """Parser for 'show controllers fabric fia drops ingress location'.
+
+    Extracts per-FIA-instance ingress drop counters including category
+    and individual counter name/value pairs.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    _FIA_HEADER = re.compile(r"^\s*\*{10}\s+(?P<fia>FIA-\d+)\s+\*{10}\s*$")
+    _CATEGORY = re.compile(r"^Category:\s+(?P<category>\S+)")
+    _COUNTER = re.compile(r"^(?P<name>.+?)\s{2,}(?P<count>\d+)\s*$")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControllersFabricFiaDropsIngressLocationResult:
+        """Parse FIA ingress drop counters from raw CLI output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict keyed by FIA instance name, each containing a category
+            string and a counters dict mapping counter names to counts.
+
+        Raises:
+            ValueError: If no FIA instances are found in the output.
+        """
+        result: ShowControllersFabricFiaDropsIngressLocationResult = {}
+        current_fia: str | None = None
+        current_entry: FiaInstanceEntry | None = None
+
+        for line in output.splitlines():
+            # Check for FIA header
+            if match := cls._FIA_HEADER.match(line):
+                current_fia = match.group("fia")
+                current_entry = FiaInstanceEntry(category="", counters={})
+                result[current_fia] = current_entry
+                continue
+
+            if current_entry is None:
+                continue
+
+            # Check for category line
+            if match := cls._CATEGORY.match(line):
+                current_entry["category"] = match.group("category")
+                continue
+
+            # Check for counter line
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._COUNTER.match(stripped):
+                counter_name = match.group("name").strip()
+                counter_value = int(match.group("count"))
+                current_entry["counters"][counter_name] = FiaCounterEntry(
+                    count=counter_value,
+                )
+
+        if not result:
+            msg = "No FIA instances found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/001_basic/expected.json
@@ -1,0 +1,346 @@
+{
+    "FIA-0": {
+        "category": "in_drop-0",
+        "counters": {
+            "From Spaui Drop-0": {
+                "count": 11
+            },
+            "accpt tbl-0": {
+                "count": 22
+            },
+            "ctl len-0": {
+                "count": 33
+            },
+            "short pkt-0": {
+                "count": 44
+            },
+            "max pkt len-0": {
+                "count": 55
+            },
+            "min pkt len-0": {
+                "count": 66
+            },
+            "From Spaui Drop-1": {
+                "count": 77
+            },
+            "accpt tbl-1": {
+                "count": 88
+            },
+            "ctl len-1": {
+                "count": 99
+            },
+            "short pkt-1": {
+                "count": 0
+            },
+            "max pkt len-1": {
+                "count": 12
+            },
+            "min pkt len-1": {
+                "count": 13
+            },
+            "Tail drp": {
+                "count": 4
+            },
+            "Vqi drp": {
+                "count": 1
+            },
+            "Header parsing drp": {
+                "count": 2
+            },
+            "pw to ni drp": {
+                "count": 3
+            },
+            "ni from pw drp": {
+                "count": 4
+            },
+            "sp0 crc err": {
+                "count": 12
+            },
+            "sp0 bad align": {
+                "count": 5
+            },
+            "sp0 bad code": {
+                "count": 1
+            },
+            "sp0 align fail": {
+                "count": 3
+            },
+            "sp0 prot err": {
+                "count": 1
+            },
+            "sp1 crc err": {
+                "count": 1
+            },
+            "sp1 bad align": {
+                "count": 0
+            },
+            "sp1 bad code": {
+                "count": 0
+            },
+            "sp1 align fail": {
+                "count": 3
+            },
+            "sp1 prot err": {
+                "count": 0
+            }
+        }
+    },
+    "FIA-1": {
+        "category": "in_drop-1",
+        "counters": {
+            "From Spaui Drop-0": {
+                "count": 0
+            },
+            "accpt tbl-0": {
+                "count": 0
+            },
+            "ctl len-0": {
+                "count": 0
+            },
+            "short pkt-0": {
+                "count": 0
+            },
+            "max pkt len-0": {
+                "count": 0
+            },
+            "min pkt len-0": {
+                "count": 0
+            },
+            "From Spaui Drop-1": {
+                "count": 0
+            },
+            "accpt tbl-1": {
+                "count": 0
+            },
+            "ctl len-1": {
+                "count": 0
+            },
+            "short pkt-1": {
+                "count": 0
+            },
+            "max pkt len-1": {
+                "count": 0
+            },
+            "min pkt len-1": {
+                "count": 0
+            },
+            "Tail drp": {
+                "count": 0
+            },
+            "Vqi drp": {
+                "count": 0
+            },
+            "Header parsing drp": {
+                "count": 0
+            },
+            "pw to ni drp": {
+                "count": 0
+            },
+            "ni from pw drp": {
+                "count": 0
+            },
+            "sp0 crc err": {
+                "count": 8
+            },
+            "sp0 bad align": {
+                "count": 0
+            },
+            "sp0 bad code": {
+                "count": 5
+            },
+            "sp0 align fail": {
+                "count": 3
+            },
+            "sp0 prot err": {
+                "count": 1
+            },
+            "sp1 crc err": {
+                "count": 12
+            },
+            "sp1 bad align": {
+                "count": 0
+            },
+            "sp1 bad code": {
+                "count": 8
+            },
+            "sp1 align fail": {
+                "count": 3
+            },
+            "sp1 prot err": {
+                "count": 0
+            }
+        }
+    },
+    "FIA-2": {
+        "category": "in_drop-2",
+        "counters": {
+            "From Spaui Drop-0": {
+                "count": 0
+            },
+            "accpt tbl-0": {
+                "count": 0
+            },
+            "ctl len-0": {
+                "count": 0
+            },
+            "short pkt-0": {
+                "count": 0
+            },
+            "max pkt len-0": {
+                "count": 0
+            },
+            "min pkt len-0": {
+                "count": 0
+            },
+            "From Spaui Drop-1": {
+                "count": 0
+            },
+            "accpt tbl-1": {
+                "count": 0
+            },
+            "ctl len-1": {
+                "count": 0
+            },
+            "short pkt-1": {
+                "count": 0
+            },
+            "max pkt len-1": {
+                "count": 0
+            },
+            "min pkt len-1": {
+                "count": 0
+            },
+            "Tail drp": {
+                "count": 0
+            },
+            "Vqi drp": {
+                "count": 0
+            },
+            "Header parsing drp": {
+                "count": 0
+            },
+            "pw to ni drp": {
+                "count": 0
+            },
+            "ni from pw drp": {
+                "count": 0
+            },
+            "sp0 crc err": {
+                "count": 12
+            },
+            "sp0 bad align": {
+                "count": 0
+            },
+            "sp0 bad code": {
+                "count": 6
+            },
+            "sp0 align fail": {
+                "count": 3
+            },
+            "sp0 prot err": {
+                "count": 1
+            },
+            "sp1 crc err": {
+                "count": 1
+            },
+            "sp1 bad align": {
+                "count": 0
+            },
+            "sp1 bad code": {
+                "count": 0
+            },
+            "sp1 align fail": {
+                "count": 3
+            },
+            "sp1 prot err": {
+                "count": 0
+            }
+        }
+    },
+    "FIA-3": {
+        "category": "in_drop-3",
+        "counters": {
+            "From Spaui Drop-0": {
+                "count": 0
+            },
+            "accpt tbl-0": {
+                "count": 0
+            },
+            "ctl len-0": {
+                "count": 0
+            },
+            "short pkt-0": {
+                "count": 0
+            },
+            "max pkt len-0": {
+                "count": 0
+            },
+            "min pkt len-0": {
+                "count": 0
+            },
+            "From Spaui Drop-1": {
+                "count": 0
+            },
+            "accpt tbl-1": {
+                "count": 0
+            },
+            "ctl len-1": {
+                "count": 0
+            },
+            "short pkt-1": {
+                "count": 0
+            },
+            "max pkt len-1": {
+                "count": 0
+            },
+            "min pkt len-1": {
+                "count": 0
+            },
+            "Tail drp": {
+                "count": 0
+            },
+            "Vqi drp": {
+                "count": 0
+            },
+            "Header parsing drp": {
+                "count": 0
+            },
+            "pw to ni drp": {
+                "count": 0
+            },
+            "ni from pw drp": {
+                "count": 0
+            },
+            "sp0 crc err": {
+                "count": 2
+            },
+            "sp0 bad align": {
+                "count": 0
+            },
+            "sp0 bad code": {
+                "count": 0
+            },
+            "sp0 align fail": {
+                "count": 3
+            },
+            "sp0 prot err": {
+                "count": 0
+            },
+            "sp1 crc err": {
+                "count": 3
+            },
+            "sp1 bad align": {
+                "count": 0
+            },
+            "sp1 bad code": {
+                "count": 0
+            },
+            "sp1 align fail": {
+                "count": 3
+            },
+            "sp1 prot err": {
+                "count": 0
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/001_basic/input.txt
@@ -1,0 +1,119 @@
+********** FIA-0 **********
+Category: in_drop-0
+                            From Spaui Drop-0                       11
+                                  accpt tbl-0                       22
+                                    ctl len-0                       33
+                                  short pkt-0                       44
+                                max pkt len-0                       55
+                                min pkt len-0                       66
+                            From Spaui Drop-1                       77
+                                  accpt tbl-1                       88
+                                    ctl len-1                       99
+                                  short pkt-1                        0
+                                max pkt len-1                       12
+                                min pkt len-1                       13
+                                     Tail drp                        4
+                                      Vqi drp                        1
+                           Header parsing drp                        2
+                                 pw to ni drp                        3
+                               ni from pw drp                        4
+                                  sp0 crc err                       12
+                                sp0 bad align                        5
+                                 sp0 bad code                        1
+                               sp0 align fail                        3
+                                 sp0 prot err                        1
+                                  sp1 crc err                        1
+                                sp1 bad align                        0
+                                 sp1 bad code                        0
+                               sp1 align fail                        3
+                                 sp1 prot err                        0
+
+ ********** FIA-1 **********
+Category: in_drop-1
+                            From Spaui Drop-0                        0
+                                  accpt tbl-0                        0
+                                    ctl len-0                        0
+                                  short pkt-0                        0
+                                max pkt len-0                        0
+                                min pkt len-0                        0
+                            From Spaui Drop-1                        0
+                                  accpt tbl-1                        0
+                                    ctl len-1                        0
+                                  short pkt-1                        0
+                                max pkt len-1                        0
+                                min pkt len-1                        0
+                                     Tail drp                        0
+                                      Vqi drp                        0
+                           Header parsing drp                        0
+                                 pw to ni drp                        0
+                               ni from pw drp                        0
+                                  sp0 crc err                        8
+                                sp0 bad align                        0
+                                 sp0 bad code                        5
+                               sp0 align fail                        3
+                                 sp0 prot err                        1
+                                  sp1 crc err                       12
+                                sp1 bad align                        0
+                                 sp1 bad code                        8
+                               sp1 align fail                        3
+                                 sp1 prot err                        0
+
+ ********** FIA-2 **********
+Category: in_drop-2
+                            From Spaui Drop-0                        0
+                                  accpt tbl-0                        0
+                                    ctl len-0                        0
+                                  short pkt-0                        0
+                                max pkt len-0                        0
+                                min pkt len-0                        0
+                            From Spaui Drop-1                        0
+                                  accpt tbl-1                        0
+                                    ctl len-1                        0
+                                  short pkt-1                        0
+                                max pkt len-1                        0
+                                min pkt len-1                        0
+                                     Tail drp                        0
+                                      Vqi drp                        0
+                           Header parsing drp                        0
+                                 pw to ni drp                        0
+                               ni from pw drp                        0
+                                  sp0 crc err                       12
+                                sp0 bad align                        0
+                                 sp0 bad code                        6
+                               sp0 align fail                        3
+                                 sp0 prot err                        1
+                                  sp1 crc err                        1
+                                sp1 bad align                        0
+                                 sp1 bad code                        0
+                               sp1 align fail                        3
+                                 sp1 prot err                        0
+
+ ********** FIA-3 **********
+Category: in_drop-3
+                            From Spaui Drop-0                        0
+                                  accpt tbl-0                        0
+                                    ctl len-0                        0
+                                  short pkt-0                        0
+                                max pkt len-0                        0
+                                min pkt len-0                        0
+                            From Spaui Drop-1                        0
+                                  accpt tbl-1                        0
+                                    ctl len-1                        0
+                                  short pkt-1                        0
+                                max pkt len-1                        0
+                                min pkt len-1                        0
+                                     Tail drp                        0
+                                      Vqi drp                        0
+                           Header parsing drp                        0
+                                 pw to ni drp                        0
+                               ni from pw drp                        0
+                                  sp0 crc err                        2
+                                sp0 bad align                        0
+                                 sp0 bad code                        0
+                               sp0 align fail                        3
+                                 sp0 prot err                        0
+                                  sp1 crc err                        3
+                                sp1 bad align                        0
+                                 sp1 bad code                        0
+                               sp1 align fail                        3
+                                 sp1 prot err                        0

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Four FIA instances with mixed zero and non-zero ingress drop counters"
+platform: "Unknown"
+software_version: "Unknown"

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/command.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_drops_ingress_location/command.txt
@@ -1,0 +1,1 @@
+show controllers fabric fia drops ingress location 0/0/CPU0


### PR DESCRIPTION
## Summary
- Add new parser for `show controllers fabric fia drops ingress location` on Cisco IOS-XR
- Parses per-FIA-instance ingress drop counters with category and counter name/value pairs
- Output structured as dict-of-dicts keyed by FIA instance name (e.g. FIA-0, FIA-1)

## Test plan
- [x] Test fixture with 4 FIA instances containing mixed zero and non-zero counters
- [x] All 6848 existing tests continue to pass
- [x] Lint (ruff), format, complexity (xenon), and security (bandit) checks pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)