### PR TITLE
feat(arista_eos): add parser for show mac security participants detail

### DIFF
--- a/changes/+arista-eos-show-mac-security-participants-detail.parser_added
+++ b/changes/+arista-eos-show-mac-security-participants-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show mac security participants detail` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_mac_security_participants_detail.py
+++ b/src/muninn/parsers/arista_eos/show_mac_security_participants_detail.py
@@ -7,17 +7,18 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class MacsecParticipantEntry(TypedDict):
     """Schema for a single MACsec participant (CKN) entry."""
 
-    message_id: str
+    message_id: NotRequired[str]
     elected_self: bool
     success: bool
     principal: bool
     default: bool
-    key_server_sci: str
+    key_server_sci: NotRequired[str]
     sak_transmit: bool
     llpn_exhaustion: int
     distributed_key_identifier: NotRequired[str]
@@ -160,7 +161,9 @@ class ShowMacSecurityParticipantsDetailParser(
                 continue
 
             if match := cls._INTERFACE.match(line):
-                current_interface = match.group("interface")
+                current_interface = canonical_interface_name(
+                    match.group("interface"), os=OS.ARISTA_EOS
+                )
                 interfaces[current_interface] = {}
                 current_ckn = None
                 continue

--- a/src/muninn/parsers/arista_eos/show_mac_security_participants_detail.py
+++ b/src/muninn/parsers/arista_eos/show_mac_security_participants_detail.py
@@ -1,0 +1,188 @@
+"""Parser for 'show mac security participants detail' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class MacsecParticipantEntry(TypedDict):
+    """Schema for a single MACsec participant (CKN) entry."""
+
+    message_id: str
+    elected_self: bool
+    success: bool
+    principal: bool
+    default: bool
+    key_server_sci: str
+    sak_transmit: bool
+    llpn_exhaustion: int
+    distributed_key_identifier: NotRequired[str]
+    live_peer_list: list[str]
+    potential_peer_list: list[str]
+
+
+class ShowMacSecurityParticipantsDetailResult(TypedDict):
+    """Schema for 'show mac security participants detail' parsed output.
+
+    Top-level keys are interface names, each containing a dict of CKN entries.
+    """
+
+    interfaces: dict[str, dict[str, MacsecParticipantEntry]]
+
+
+@register(OS.ARISTA_EOS, "show mac security participants detail")
+class ShowMacSecurityParticipantsDetailParser(
+    BaseParser[ShowMacSecurityParticipantsDetailResult],
+):
+    """Parser for 'show mac security participants detail' on Arista EOS.
+
+    Parses MACsec MKA participant details including key server information,
+    peer lists, and key distribution status per interface and CKN.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MACSEC})
+
+    _INTERFACE = re.compile(r"^Interface:\s+(?P<interface>\S+)")
+    _CKN = re.compile(r"^\s+CKN:\s+(?P<ckn>\S+)")
+    _MESSAGE_ID = re.compile(r"^\s+Message ID:\s+(?P<value>\S+)")
+    _ELECTED_SELF = re.compile(r"^\s+Elected self:\s+(?P<value>\S+)")
+    _SUCCESS = re.compile(r"^\s+Success:\s+(?P<value>\S+)")
+    _PRINCIPAL = re.compile(r"^\s+Principal:\s+(?P<value>\S+)")
+    _DEFAULT = re.compile(r"^\s+Default:\s+(?P<value>\S+)")
+    _KEY_SERVER_SCI = re.compile(r"^\s+KeyServer SCI:\s+(?P<value>\S+)")
+    _SAK_TRANSMIT = re.compile(r"^\s+SAK transmit:\s+(?P<value>\S+)")
+    _LLPN_EXHAUSTION = re.compile(r"^\s+LLPN exhaustion:\s+(?P<value>\d+)")
+    _DISTRIBUTED_KEY_ID = re.compile(
+        r"^\s+Distributed key identifier:\s+(?P<value>.+)$"
+    )
+    _LIVE_PEER_LIST = re.compile(r"^\s+Live peer list:\s+(?P<value>.+)$")
+    _POTENTIAL_PEER_LIST = re.compile(r"^\s+Potential peer list:\s+(?P<value>.+)$")
+
+    @classmethod
+    def _parse_bool(cls, value: str) -> bool:
+        """Convert a CLI boolean string to a Python bool."""
+        return value == "True"
+
+    @classmethod
+    def _parse_peer_list(cls, raw: str) -> list[str]:
+        """Parse a peer list string like "['abc', 'def']" into a list."""
+        raw = raw.strip()
+        if raw == "[]":
+            return []
+        # Strip surrounding brackets and split quoted entries
+        inner = raw.strip("[]")
+        return [item.strip().strip("'\"") for item in inner.split(",") if item.strip()]
+
+    @classmethod
+    def _parse_identity_fields(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse message ID and key server SCI fields."""
+        if match := cls._MESSAGE_ID.match(line):
+            entry["message_id"] = match.group("value")
+            return True
+        if match := cls._KEY_SERVER_SCI.match(line):
+            entry["key_server_sci"] = match.group("value")
+            return True
+        return False
+
+    @classmethod
+    def _parse_boolean_fields(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse boolean status fields."""
+        if match := cls._ELECTED_SELF.match(line):
+            entry["elected_self"] = cls._parse_bool(match.group("value"))
+            return True
+        if match := cls._SUCCESS.match(line):
+            entry["success"] = cls._parse_bool(match.group("value"))
+            return True
+        if match := cls._PRINCIPAL.match(line):
+            entry["principal"] = cls._parse_bool(match.group("value"))
+            return True
+        if match := cls._DEFAULT.match(line):
+            entry["default"] = cls._parse_bool(match.group("value"))
+            return True
+        if match := cls._SAK_TRANSMIT.match(line):
+            entry["sak_transmit"] = cls._parse_bool(match.group("value"))
+            return True
+        return False
+
+    @classmethod
+    def _parse_key_and_peer_fields(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse LLPN, distributed key identifier, and peer list fields."""
+        if match := cls._LLPN_EXHAUSTION.match(line):
+            entry["llpn_exhaustion"] = int(match.group("value"))
+            return True
+        if match := cls._DISTRIBUTED_KEY_ID.match(line):
+            value = match.group("value").strip()
+            # "None" means no key identifier; omit the key per project conventions
+            if value != "None":
+                entry["distributed_key_identifier"] = value
+            return True
+        if match := cls._LIVE_PEER_LIST.match(line):
+            entry["live_peer_list"] = cls._parse_peer_list(match.group("value"))
+            return True
+        if match := cls._POTENTIAL_PEER_LIST.match(line):
+            entry["potential_peer_list"] = cls._parse_peer_list(match.group("value"))
+            return True
+        return False
+
+    @classmethod
+    def _parse_entry_field(cls, line: str, entry: dict[str, object]) -> bool:
+        """Dispatch a single field line within a CKN block to sub-parsers."""
+        return (
+            cls._parse_identity_fields(line, entry)
+            or cls._parse_boolean_fields(line, entry)
+            or cls._parse_key_and_peer_fields(line, entry)
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMacSecurityParticipantsDetailResult:
+        """Parse 'show mac security participants detail' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed MACsec participant details keyed by interface and CKN.
+
+        Raises:
+            ValueError: If no interfaces found in output.
+        """
+        interfaces: dict[str, dict[str, MacsecParticipantEntry]] = {}
+        current_interface: str | None = None
+        current_ckn: str | None = None
+        current_entry: dict[str, object] = {}
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            if match := cls._INTERFACE.match(line):
+                current_interface = match.group("interface")
+                interfaces[current_interface] = {}
+                current_ckn = None
+                continue
+
+            if match := cls._CKN.match(line):
+                if current_interface is None:
+                    continue
+                current_ckn = match.group("ckn")
+                current_entry = {}
+                interfaces[current_interface][current_ckn] = cast(
+                    MacsecParticipantEntry, current_entry
+                )
+                continue
+
+            if current_ckn is not None:
+                cls._parse_entry_field(line, current_entry)
+
+        if not interfaces:
+            msg = "No MACsec participant interfaces found in output"
+            raise ValueError(msg)
+
+        return cast(
+            ShowMacSecurityParticipantsDetailResult,
+            {"interfaces": interfaces},
+        )

--- a/tests/parsers/arista_eos/show_mac_security_participants_detail/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_mac_security_participants_detail/001_basic/expected.json
@@ -1,0 +1,66 @@
+{
+    "interfaces": {
+        "Ethernet4/15/1": {
+            "cd1df125ffbd3027abe6068fcbfdchanged91af15c274998046ca547": {
+                "message_id": "changed0975adf202e94acf2",
+                "elected_self": true,
+                "success": true,
+                "principal": false,
+                "default": true,
+                "key_server_sci": "28:00:3a:69:06:cc::999",
+                "sak_transmit": false,
+                "llpn_exhaustion": 0,
+                "live_peer_list": [
+                    "changed0fd8d6b694b42be37f5"
+                ],
+                "potential_peer_list": []
+            },
+            "e9cae93c91ef6c62afbb9fffd2fa32380achangede0f6348a8a6e1bb205be4d": {
+                "message_id": "changed77f1f42e246ef05b",
+                "elected_self": true,
+                "success": true,
+                "principal": true,
+                "default": false,
+                "key_server_sci": "28:1b:22:69:36:cc::333",
+                "sak_transmit": true,
+                "llpn_exhaustion": 0,
+                "distributed_key_identifier": "changed2577f1f42e246ef05b:46",
+                "live_peer_list": [
+                    "changed4341200ff8e76821da"
+                ],
+                "potential_peer_list": []
+            }
+        },
+        "Ethernet5/13/1": {
+            "cd1df125ffbd3027abe6068fcbfd31f0changed58e91af15c274998046ca547": {
+                "message_id": "1860e9c0c1d2b4877fa78b77",
+                "elected_self": true,
+                "success": true,
+                "principal": false,
+                "default": true,
+                "key_server_sci": "28:22:1b:69:32:d4::111",
+                "sak_transmit": false,
+                "llpn_exhaustion": 0,
+                "live_peer_list": [
+                    "2071783e6e9b09640a2eee89"
+                ],
+                "potential_peer_list": []
+            },
+            "e9cae93c91ef6c62afbb9fffd2fa323changedd6e0f6348a8a6e1bb205be4d": {
+                "message_id": "changedf1e9662b5a94eac3",
+                "elected_self": true,
+                "success": true,
+                "principal": true,
+                "default": false,
+                "key_server_sci": "28:11:3a:69:32:d4::111",
+                "sak_transmit": true,
+                "llpn_exhaustion": 0,
+                "distributed_key_identifier": "dec1a8dchanged5a94eac3:46",
+                "live_peer_list": [
+                    "changedbe5869ab7cb6fa2c5cb1c"
+                ],
+                "potential_peer_list": []
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_mac_security_participants_detail/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_mac_security_participants_detail/001_basic/input.txt
@@ -1,0 +1,53 @@
+Interface: Ethernet4/15/1
+    CKN: cd1df125ffbd3027abe6068fcbfdchanged91af15c274998046ca547
+      Message ID: changed0975adf202e94acf2
+      Elected self: True
+      Success: True
+      Principal: False
+      Default: True
+      KeyServer SCI: 28:00:3a:69:06:cc::999
+      SAK transmit: False
+      LLPN exhaustion: 0
+      Distributed key identifier: None
+      Live peer list: ['changed0fd8d6b694b42be37f5']
+      Potential peer list: []
+
+    CKN: e9cae93c91ef6c62afbb9fffd2fa32380achangede0f6348a8a6e1bb205be4d
+      Message ID: changed77f1f42e246ef05b
+      Elected self: True
+      Success: True
+      Principal: True
+      Default: False
+      KeyServer SCI: 28:1b:22:69:36:cc::333
+      SAK transmit: True
+      LLPN exhaustion: 0
+      Distributed key identifier: changed2577f1f42e246ef05b:46
+      Live peer list: ['changed4341200ff8e76821da']
+      Potential peer list: []
+
+Interface: Ethernet5/13/1
+    CKN: cd1df125ffbd3027abe6068fcbfd31f0changed58e91af15c274998046ca547
+      Message ID: 1860e9c0c1d2b4877fa78b77
+      Elected self: True
+      Success: True
+      Principal: False
+      Default: True
+      KeyServer SCI: 28:22:1b:69:32:d4::111
+      SAK transmit: False
+      LLPN exhaustion: 0
+      Distributed key identifier: None
+      Live peer list: ['2071783e6e9b09640a2eee89']
+      Potential peer list: []
+
+    CKN: e9cae93c91ef6c62afbb9fffd2fa323changedd6e0f6348a8a6e1bb205be4d
+      Message ID: changedf1e9662b5a94eac3
+      Elected self: True
+      Success: True
+      Principal: True
+      Default: False
+      KeyServer SCI: 28:11:3a:69:32:d4::111
+      SAK transmit: True
+      LLPN exhaustion: 0
+      Distributed key identifier: dec1a8dchanged5a94eac3:46
+      Live peer list: ['changedbe5869ab7cb6fa2c5cb1c']
+      Potential peer list: []

--- a/tests/parsers/arista_eos/show_mac_security_participants_detail/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_mac_security_participants_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: MACsec participants detail across two interfaces with two CKNs each
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show mac security participants detail` on Arista EOS
- Parses MACsec MKA participant details per interface and CKN, including key server SCI, boolean status flags, LLPN exhaustion, distributed key identifier, and live/potential peer lists
- Uses dict-of-dicts structure keyed by interface name then CKN value

## Test plan
- [x] Parser test fixture with real device output (2 interfaces, 2 CKNs each)
- [x] All placeholder sentinel checks pass (None values omitted per convention)
- [x] ruff check/format, xenon complexity, bandit security scan all pass
- [x] pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)