### PR TITLE
feat(cisco_iosxr): add parser for show controllers fabric fia errors ingress location

### DIFF
--- a/changes/+cisco-iosxr-show-controllers-fabric-fia-errors-ingress-location.parser_added
+++ b/changes/+cisco-iosxr-show-controllers-fabric-fia-errors-ingress-location.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show controllers fabric fia errors ingress location` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location.py
@@ -1,0 +1,106 @@
+"""Parser for 'show controllers fabric fia errors ingress location' on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FiaErrorCounter(TypedDict):
+    """Schema for a single FIA error counter."""
+
+    category: str
+    counters: dict[str, int]
+
+
+class ShowControllersFabricFiaErrorsIngressLocationResult(TypedDict):
+    """Schema for 'show controllers fabric fia errors ingress location' parsed output.
+
+    Keyed by FIA instance identifier (e.g. "0", "1").
+    Each FIA instance contains a category string and a dict of counter name to value.
+    """
+
+    fia_instances: dict[str, FiaErrorCounter]
+
+
+@register(OS.CISCO_IOSXR, "show controllers fabric fia errors ingress location")
+class ShowControllersFabricFiaErrorsIngressLocationParser(
+    BaseParser[ShowControllersFabricFiaErrorsIngressLocationResult],
+):
+    """Parser for 'show controllers fabric fia errors ingress location' on IOS-XR.
+
+    Parses FIA instance error counters from fabric ingress diagnostics.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    _FIA_HEADER = re.compile(r"^\s*\*{10}\s+FIA-(?P<instance>\d+)\s+\*{10}")
+    _CATEGORY = re.compile(r"^Category:\s+(?P<category>\S+)")
+    _COUNTER = re.compile(r"^(?P<name>.+?)\s{2,}(?P<value>\d+)\s*$")
+
+    @classmethod
+    def _save_instance(
+        cls,
+        fia_instances: dict[str, FiaErrorCounter],
+        instance: str | None,
+        category: str | None,
+        counters: dict[str, int],
+    ) -> None:
+        """Store a completed FIA instance into the results dict."""
+        if instance is not None and category is not None:
+            fia_instances[instance] = FiaErrorCounter(
+                category=category,
+                counters=counters,
+            )
+
+    @classmethod
+    def _parse_counter_line(cls, line: str, counters: dict[str, int]) -> None:
+        """Parse a counter line and add it to the counters dict if it matches."""
+        if match := cls._COUNTER.match(line):
+            counters[match.group("name").strip()] = int(match.group("value"))
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControllersFabricFiaErrorsIngressLocationResult:
+        """Parse FIA ingress error counters.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed FIA error counter data keyed by instance number.
+
+        Raises:
+            ValueError: If no FIA instances are found in the output.
+        """
+        fia_instances: dict[str, FiaErrorCounter] = {}
+        current_instance: str | None = None
+        current_category: str | None = None
+        current_counters: dict[str, int] = {}
+
+        for line in output.splitlines():
+            if match := cls._FIA_HEADER.match(line):
+                cls._save_instance(
+                    fia_instances, current_instance, current_category, current_counters
+                )
+                current_instance = match.group("instance")
+                current_category = None
+                current_counters = {}
+            elif current_instance is not None and (cat := cls._CATEGORY.match(line)):
+                current_category = cat.group("category")
+            elif current_instance is not None:
+                cls._parse_counter_line(line, current_counters)
+
+        cls._save_instance(
+            fia_instances, current_instance, current_category, current_counters
+        )
+
+        if not fia_instances:
+            msg = "No FIA instances found in output"
+            raise ValueError(msg)
+
+        return ShowControllersFabricFiaErrorsIngressLocationResult(
+            fia_instances=fia_instances,
+        )

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location.py
@@ -26,7 +26,10 @@ class ShowControllersFabricFiaErrorsIngressLocationResult(TypedDict):
     fia_instances: dict[str, FiaErrorCounter]
 
 
-@register(OS.CISCO_IOSXR, "show controllers fabric fia errors ingress location")
+@register(
+    OS.CISCO_IOSXR,
+    r"show controllers fabric fia errors ingress location (?P<location>\S+)",
+)
 class ShowControllersFabricFiaErrorsIngressLocationParser(
     BaseParser[ShowControllersFabricFiaErrorsIngressLocationResult],
 ):

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/001_basic/expected.json
@@ -1,0 +1,88 @@
+{
+    "fia_instances": {
+        "0": {
+            "category": "in_error-0",
+            "counters": {
+                "To Xbar Uc Crc-0": 11,
+                "To Xbar Uc Crc-1": 22,
+                "To Xbar Uc Crc-2": 33,
+                "To Xbar Uc Crc-3": 44,
+                "To Xbar Mc Crc-0": 55,
+                "To Xbar Mc Crc-1": 66,
+                "To Xbar Mc Crc-2": 77,
+                "To Xbar Mc Crc-3": 0,
+                "nb pa read data err": 12334,
+                "pa header err": 0,
+                "pa crc16 err": 0,
+                "pa crc32 err": 0,
+                "pa to tf err": 99999,
+                "ab overflow req lost": 0,
+                "ni bad crc32": 0,
+                "ni crc32 corrupt": 0
+            }
+        },
+        "1": {
+            "category": "in_error-1",
+            "counters": {
+                "To Xbar Uc Crc-0": 0,
+                "To Xbar Uc Crc-1": 0,
+                "To Xbar Uc Crc-2": 0,
+                "To Xbar Uc Crc-3": 0,
+                "To Xbar Mc Crc-0": 0,
+                "To Xbar Mc Crc-1": 0,
+                "To Xbar Mc Crc-2": 0,
+                "To Xbar Mc Crc-3": 0,
+                "nb pa read data err": 0,
+                "pa header err": 0,
+                "pa crc16 err": 0,
+                "pa crc32 err": 0,
+                "pa to tf err": 0,
+                "ab overflow req lost": 0,
+                "ni bad crc32": 0,
+                "ni crc32 corrupt": 11111111
+            }
+        },
+        "2": {
+            "category": "in_error-2",
+            "counters": {
+                "To Xbar Uc Crc-0": 0,
+                "To Xbar Uc Crc-1": 0,
+                "To Xbar Uc Crc-2": 0,
+                "To Xbar Uc Crc-3": 0,
+                "To Xbar Mc Crc-0": 0,
+                "To Xbar Mc Crc-1": 0,
+                "To Xbar Mc Crc-2": 0,
+                "To Xbar Mc Crc-3": 0,
+                "nb pa read data err": 0,
+                "pa header err": 0,
+                "pa crc16 err": 0,
+                "pa crc32 err": 0,
+                "pa to tf err": 0,
+                "ab overflow req lost": 0,
+                "ni bad crc32": 0,
+                "ni crc32 corrupt": 0
+            }
+        },
+        "3": {
+            "category": "in_error-3",
+            "counters": {
+                "To Xbar Uc Crc-0": 0,
+                "To Xbar Uc Crc-1": 0,
+                "To Xbar Uc Crc-2": 0,
+                "To Xbar Uc Crc-3": 0,
+                "To Xbar Mc Crc-0": 0,
+                "To Xbar Mc Crc-1": 0,
+                "To Xbar Mc Crc-2": 0,
+                "To Xbar Mc Crc-3": 0,
+                "nb pa read data err": 0,
+                "pa header err": 0,
+                "pa crc16 err": 0,
+                "pa crc32 err": 0,
+                "pa to tf err": 0,
+                "ab overflow req lost": 0,
+                "ni bad crc32": 0,
+                "ni crc32 corrupt": 0
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/001_basic/input.txt
@@ -1,0 +1,75 @@
+********** FIA-0 **********
+Category: in_error-0
+                             To Xbar Uc Crc-0                       11
+                             To Xbar Uc Crc-1                       22
+                             To Xbar Uc Crc-2                       33
+                             To Xbar Uc Crc-3                       44
+                             To Xbar Mc Crc-0                       55
+                             To Xbar Mc Crc-1                       66
+                             To Xbar Mc Crc-2                       77
+                             To Xbar Mc Crc-3                        0
+                          nb pa read data err                    12334
+                                pa header err                        0
+                                 pa crc16 err                        0
+                                 pa crc32 err                        0
+                                 pa to tf err                    99999
+                         ab overflow req lost                        0
+                                 ni bad crc32                        0
+                             ni crc32 corrupt                        0
+
+ ********** FIA-1 **********
+Category: in_error-1
+                             To Xbar Uc Crc-0                        0
+                             To Xbar Uc Crc-1                        0
+                             To Xbar Uc Crc-2                        0
+                             To Xbar Uc Crc-3                        0
+                             To Xbar Mc Crc-0                        0
+                             To Xbar Mc Crc-1                        0
+                             To Xbar Mc Crc-2                        0
+                             To Xbar Mc Crc-3                        0
+                          nb pa read data err                        0
+                                pa header err                        0
+                                 pa crc16 err                        0
+                                 pa crc32 err                        0
+                                 pa to tf err                        0
+                         ab overflow req lost                        0
+                                 ni bad crc32                        0
+                             ni crc32 corrupt                 11111111
+
+ ********** FIA-2 **********
+Category: in_error-2
+                             To Xbar Uc Crc-0                        0
+                             To Xbar Uc Crc-1                        0
+                             To Xbar Uc Crc-2                        0
+                             To Xbar Uc Crc-3                        0
+                             To Xbar Mc Crc-0                        0
+                             To Xbar Mc Crc-1                        0
+                             To Xbar Mc Crc-2                        0
+                             To Xbar Mc Crc-3                        0
+                          nb pa read data err                        0
+                                pa header err                        0
+                                 pa crc16 err                        0
+                                 pa crc32 err                        0
+                                 pa to tf err                        0
+                         ab overflow req lost                        0
+                                 ni bad crc32                        0
+                             ni crc32 corrupt                        0
+
+ ********** FIA-3 **********
+Category: in_error-3
+                             To Xbar Uc Crc-0                        0
+                             To Xbar Uc Crc-1                        0
+                             To Xbar Uc Crc-2                        0
+                             To Xbar Uc Crc-3                        0
+                             To Xbar Mc Crc-0                        0
+                             To Xbar Mc Crc-1                        0
+                             To Xbar Mc Crc-2                        0
+                             To Xbar Mc Crc-3                        0
+                          nb pa read data err                        0
+                                pa header err                        0
+                                 pa crc16 err                        0
+                                 pa crc32 err                        0
+                                 pa to tf err                        0
+                         ab overflow req lost                        0
+                                 ni bad crc32                        0
+                             ni crc32 corrupt                        0

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "FIA ingress errors with non-zero counters across multiple instances"
+platform: "Unknown"
+software_version: "Unknown"

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/command.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_ingress_location/command.txt
@@ -1,0 +1,1 @@
+show controllers fabric fia errors ingress location 0/RP0/CPU0


### PR DESCRIPTION
## Summary
- Add parser for `show controllers fabric fia errors ingress location` on Cisco IOS-XR
- Parses FIA instance error counters from fabric ingress diagnostics into a dict-of-dicts keyed by FIA instance number
- Each instance contains the error category and a counters dict mapping counter names to integer values
- Tagged with `ParserTag.PLATFORM`

## Test plan
- [x] Test fixture `001_basic` with 4 FIA instances, including non-zero error counters
- [x] All 6848 tests pass (including sentinel, JSON convention, and parser tests)
- [x] Pre-commit hooks pass (ruff, format, xenon complexity B)
- [x] Bandit security scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)