### PR TITLE
feat(arista_eos): add parser for show pim ipv4 interface

### DIFF
--- a/changes/+arista-eos-show-pim-ipv4-interface.parser_added
+++ b/changes/+arista-eos-show-pim-ipv4-interface.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show pim ipv4 interface` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_pim_ipv4_interface.py
+++ b/src/muninn/parsers/arista_eos/show_pim_ipv4_interface.py
@@ -1,0 +1,94 @@
+"""Parser for 'show pim ipv4 interface' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class PimInterfaceEntry(TypedDict):
+    """Schema for a single PIM interface entry."""
+
+    address: str
+    mode: str
+    neighbor_count: int
+    hello_interval: int
+    dr_priority: int
+    dr_address: str
+    packets_queued: int
+    packets_dropped: int
+
+
+ShowPimIpv4InterfaceResult = dict[str, PimInterfaceEntry]
+
+
+@register(OS.ARISTA_EOS, "show pim ipv4 interface")
+class ShowPimIpv4InterfaceParser(BaseParser[ShowPimIpv4InterfaceResult]):
+    """Parser for 'show pim ipv4 interface' command on Arista EOS.
+
+    Parses PIM IPv4 interface information including neighbor counts,
+    hello intervals, and designated router details.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MULTICAST})
+
+    # Data line: address, interface, mode, neighbor_count, hello_intvl,
+    #            dr_pri, dr_address, pkts_queued, pkts_dropped
+    _ENTRY_PATTERN = re.compile(
+        r"^(?P<address>\d+\.\d+\.\d+\.\d+)\s+"
+        r"(?P<interface>\S+)\s+"
+        r"(?P<mode>\S+)\s+"
+        r"(?P<neighbor_count>\d+)\s+"
+        r"(?P<hello_interval>\d+)\s+"
+        r"(?P<dr_priority>\d+)\s+"
+        r"(?P<dr_address>\d+\.\d+\.\d+\.\d+)\s+"
+        r"(?P<packets_queued>\d+)\s+"
+        r"(?P<packets_dropped>\d+)\s*$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPimIpv4InterfaceResult:
+        """Parse 'show pim ipv4 interface' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict of PIM interface entries keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no PIM interface entries found.
+        """
+        result: ShowPimIpv4InterfaceResult = {}
+
+        for line in output.splitlines():
+            match = cls._ENTRY_PATTERN.match(line.strip())
+            if not match:
+                continue
+
+            interface = canonical_interface_name(
+                match.group("interface"), os=OS.ARISTA_EOS
+            )
+
+            entry = PimInterfaceEntry(
+                address=match.group("address"),
+                mode=match.group("mode"),
+                neighbor_count=int(match.group("neighbor_count")),
+                hello_interval=int(match.group("hello_interval")),
+                dr_priority=int(match.group("dr_priority")),
+                dr_address=match.group("dr_address"),
+                packets_queued=int(match.group("packets_queued")),
+                packets_dropped=int(match.group("packets_dropped")),
+            )
+
+            result[interface] = entry
+
+        if not result:
+            msg = "No PIM interface entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowPimIpv4InterfaceResult, result)

--- a/tests/parsers/arista_eos/show_pim_ipv4_interface/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_pim_ipv4_interface/001_basic/expected.json
@@ -1,0 +1,42 @@
+{
+    "Ethernet20/1": {
+        "address": "192.0.2.1",
+        "mode": "sparse",
+        "neighbor_count": 1,
+        "hello_interval": 5,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.2",
+        "packets_queued": 0,
+        "packets_dropped": 0
+    },
+    "Port-channel1.10": {
+        "address": "192.0.2.3",
+        "mode": "sparse",
+        "neighbor_count": 1,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.4",
+        "packets_queued": 28,
+        "packets_dropped": 0
+    },
+    "Vlan100": {
+        "address": "192.0.2.5",
+        "mode": "sparse",
+        "neighbor_count": 1,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.6",
+        "packets_queued": 0,
+        "packets_dropped": 0
+    },
+    "Vlan200": {
+        "address": "192.0.2.7",
+        "mode": "sparse",
+        "neighbor_count": 1,
+        "hello_interval": 30,
+        "dr_priority": 1,
+        "dr_address": "192.0.2.8",
+        "packets_queued": 0,
+        "packets_dropped": 0
+    }
+}

--- a/tests/parsers/arista_eos/show_pim_ipv4_interface/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_pim_ipv4_interface/001_basic/input.txt
@@ -1,0 +1,6 @@
+Address       Interface             Mode    Neighbor  Hello  DR   DR Address    PktsQed  PktsDropped
+                                            Count     Intvl  Pri
+192.0.2.1     Ethernet20/1          sparse  1         5      1    192.0.2.2     0        0
+192.0.2.3     Port-Channel1.10      sparse  1         30     1    192.0.2.4     28       0
+192.0.2.5     Vlan100               sparse  1         30     1    192.0.2.6     0        0
+192.0.2.7     Vlan200               sparse  1         30     1    192.0.2.8     0        0

--- a/tests/parsers/arista_eos/show_pim_ipv4_interface/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_pim_ipv4_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: PIM IPv4 interfaces with Ethernet, Port-channel, and Vlan types
+platform: Unknown
+software_version: EOS


### PR DESCRIPTION
## Summary
- Add new parser for `show pim ipv4 interface` on Arista EOS
- Returns dict-of-dicts keyed by canonical interface name with address, mode, neighbor count, hello interval, DR priority/address, and packet counters
- Tagged with `ParserTag.MULTICAST`

## Test plan
- [x] Fixture `001_basic` with Ethernet, Port-channel, and Vlan interface types
- [x] All pre-commit hooks pass (ruff, xenon, json formatting, placeholder sentinels)
- [x] `uv run pytest tests/parsers/ -k show_pim_ipv4_interface` -- 7/7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)