### PR TITLE
feat(cisco_iosxr): add parser for show controllers fabric fia errors egress location

### DIFF
--- a/changes/+cisco-iosxr-show-controllers-fabric-fia-errors-egress-location.parser_added
+++ b/changes/+cisco-iosxr-show-controllers-fabric-fia-errors-egress-location.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show controllers fabric fia errors egress location` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location.py
@@ -1,7 +1,7 @@
 """Parser for 'show controllers fabric fia errors egress location' on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, TypedDict
+from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -67,7 +67,7 @@ class ShowControllersFabricFiaErrorsEgressLocationParser(
         Raises:
             ValueError: If no FIA blocks are found in the output.
         """
-        result: ShowControllersFabricFiaErrorsEgressLocationResult = {}
+        result: dict[str, dict[str, object]] = {}
         current_fia: str | None = None
         current_entry: dict[str, object] = {}
 
@@ -78,7 +78,7 @@ class ShowControllersFabricFiaErrorsEgressLocationParser(
 
             if match := _FIA_HEADER.search(stripped):
                 if current_fia is not None:
-                    result[current_fia] = FiaErrorCounters(**current_entry)  # type: ignore[arg-type]
+                    result[current_fia] = current_entry
                 current_fia = match.group("fia")
                 current_entry = {}
                 continue
@@ -87,10 +87,10 @@ class ShowControllersFabricFiaErrorsEgressLocationParser(
 
         # Flush last FIA block
         if current_fia is not None:
-            result[current_fia] = FiaErrorCounters(**current_entry)  # type: ignore[arg-type]
+            result[current_fia] = current_entry
 
         if not result:
             msg = "No FIA blocks found in output"
             raise ValueError(msg)
 
-        return result
+        return cast(ShowControllersFabricFiaErrorsEgressLocationResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location.py
@@ -43,13 +43,19 @@ def _parse_counter_line(line: str, entry: dict[str, object]) -> None:
             return
 
 
-@register(OS.CISCO_IOSXR, "show controllers fabric fia errors egress location")
+@register(
+    OS.CISCO_IOSXR,
+    r"show controllers fabric fia errors egress location (?P<location>\S+)",
+)
 class ShowControllersFabricFiaErrorsEgressLocationParser(
     BaseParser[ShowControllersFabricFiaErrorsEgressLocationResult],
 ):
-    """Parser for 'show controllers fabric fia errors egress location'.
+    """Parser for 'show controllers fabric fia errors egress location <location>'.
 
     Parses per-FIA egress error counters from the fabric controller output.
+    The IOS-XR ``location`` keyword requires a node identifier
+    (e.g. ``0/RP0/CPU0`` or ``all``) to actually run on a device, so the
+    parser is registered as a regex pattern that captures the location.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location.py
@@ -1,0 +1,96 @@
+"""Parser for 'show controllers fabric fia errors egress location' on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FiaErrorCounters(TypedDict):
+    """Error counters for a single FIA instance."""
+
+    category: str
+    to_spaui_error_0: int
+    to_spaui_error_1: int
+    rl_over_under_flow_cnt: int
+
+
+# Top-level result keyed by FIA instance name (e.g. 'FIA-0').
+ShowControllersFabricFiaErrorsEgressLocationResult = dict[str, FiaErrorCounters]
+
+# Compiled patterns for matching FIA block structure and counter lines.
+_FIA_HEADER = re.compile(r"^\*+\s+(?P<fia>FIA-\d+)\s+\*+$")
+_COUNTER_PATTERNS: tuple[tuple[re.Pattern[str], str, bool], ...] = (
+    (re.compile(r"^Category:\s+(?P<value>\S+)"), "category", False),
+    (re.compile(r"To Spaui Error-0\s+(?P<value>\d+)"), "to_spaui_error_0", True),
+    (re.compile(r"To Spaui Error-1\s+(?P<value>\d+)"), "to_spaui_error_1", True),
+    (
+        re.compile(r"RL over/under flow cnt\s+(?P<value>\d+)"),
+        "rl_over_under_flow_cnt",
+        True,
+    ),
+)
+
+
+def _parse_counter_line(line: str, entry: dict[str, object]) -> None:
+    """Match a counter line and store its value in *entry*."""
+    for pattern, key, is_int in _COUNTER_PATTERNS:
+        if match := pattern.search(line):
+            entry[key] = int(match.group("value")) if is_int else match.group("value")
+            return
+
+
+@register(OS.CISCO_IOSXR, "show controllers fabric fia errors egress location")
+class ShowControllersFabricFiaErrorsEgressLocationParser(
+    BaseParser[ShowControllersFabricFiaErrorsEgressLocationResult],
+):
+    """Parser for 'show controllers fabric fia errors egress location'.
+
+    Parses per-FIA egress error counters from the fabric controller output.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControllersFabricFiaErrorsEgressLocationResult:
+        """Parse egress FIA error counters.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict keyed by FIA instance name with error counters.
+
+        Raises:
+            ValueError: If no FIA blocks are found in the output.
+        """
+        result: ShowControllersFabricFiaErrorsEgressLocationResult = {}
+        current_fia: str | None = None
+        current_entry: dict[str, object] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := _FIA_HEADER.search(stripped):
+                if current_fia is not None:
+                    result[current_fia] = FiaErrorCounters(**current_entry)  # type: ignore[arg-type]
+                current_fia = match.group("fia")
+                current_entry = {}
+                continue
+
+            _parse_counter_line(stripped, current_entry)
+
+        # Flush last FIA block
+        if current_fia is not None:
+            result[current_fia] = FiaErrorCounters(**current_entry)  # type: ignore[arg-type]
+
+        if not result:
+            msg = "No FIA blocks found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/001_basic/expected.json
@@ -1,0 +1,26 @@
+{
+    "FIA-0": {
+        "category": "eg_error-0",
+        "to_spaui_error_0": 1,
+        "to_spaui_error_1": 22,
+        "rl_over_under_flow_cnt": 33
+    },
+    "FIA-1": {
+        "category": "eg_error-1",
+        "to_spaui_error_0": 9999,
+        "to_spaui_error_1": 123333,
+        "rl_over_under_flow_cnt": 1
+    },
+    "FIA-2": {
+        "category": "eg_error-2",
+        "to_spaui_error_0": 0,
+        "to_spaui_error_1": 0,
+        "rl_over_under_flow_cnt": 0
+    },
+    "FIA-3": {
+        "category": "eg_error-3",
+        "to_spaui_error_0": 0,
+        "to_spaui_error_1": 0,
+        "rl_over_under_flow_cnt": 0
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/001_basic/input.txt
@@ -1,0 +1,23 @@
+********** FIA-0 **********
+Category: eg_error-0
+                             To Spaui Error-0                        1
+                             To Spaui Error-1                       22
+                       RL over/under flow cnt                       33
+
+ ********** FIA-1 **********
+Category: eg_error-1
+                             To Spaui Error-0                     9999
+                             To Spaui Error-1                   123333
+                       RL over/under flow cnt                        1
+
+ ********** FIA-2 **********
+Category: eg_error-2
+                             To Spaui Error-0                        0
+                             To Spaui Error-1                        0
+                       RL over/under flow cnt                        0
+
+ ********** FIA-3 **********
+Category: eg_error-3
+                             To Spaui Error-0                        0
+                             To Spaui Error-1                        0
+                       RL over/under flow cnt                        0

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Multiple FIA instances with egress error counters"
+platform: "Unknown"
+software_version: "Unknown"

--- a/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/command.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_fabric_fia_errors_egress_location/command.txt
@@ -1,0 +1,1 @@
+show controllers fabric fia errors egress location 0/RP0/CPU0


### PR DESCRIPTION
## Summary
- Add new parser for `show controllers fabric fia errors egress location` on Cisco IOS-XR
- Parses per-FIA egress error counters (category, spaui errors 0/1, RL over/under flow count) into a dict-of-dicts keyed by FIA instance name
- Tagged with `ParserTag.PLATFORM`

## Test plan
- [x] Test fixture `001_basic` with 4 FIA instances (mix of non-zero and zero counters)
- [x] All 7 parametrized tests pass (parser correctness, JSON conventions, placeholder sentinels)
- [x] Pre-commit hooks pass (ruff check, ruff format, xenon complexity, bandit security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)