### PR TITLE
feat(arista_eos): add parser for show ip mroute vrf all detail

### DIFF
--- a/changes/+arista-eos-show-ip-mroute-vrf-all-detail.parser_added
+++ b/changes/+arista-eos-show-ip-mroute-vrf-all-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ip mroute vrf all detail` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/show_ip_mroute_vrf_all_detail.py
+++ b/src/muninn/parsers/arista_eos/show_ip_mroute_vrf_all_detail.py
@@ -262,8 +262,9 @@ def _process_line(
 def _flush_source(state: dict[str, object]) -> None:
     """Flush the current source entry into the groups dict."""
     source_match = state["source_match"]
-    group = state["group"]
-    if source_match is not None and group is not None:
+    group_raw = state["group"]
+    if source_match is not None and group_raw is not None:
+        group = cast(str, group_raw)
         groups = cast(dict[str, GroupEntry], state["groups"])
         source_key = cast(re.Match[str], source_match).group("source")
         entry = _build_source_entry(

--- a/src/muninn/parsers/arista_eos/show_ip_mroute_vrf_all_detail.py
+++ b/src/muninn/parsers/arista_eos/show_ip_mroute_vrf_all_detail.py
@@ -1,0 +1,342 @@
+"""Parser for 'show ip mroute vrf all detail' command on Arista EOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# VRF header: "VRF:default" or "VRF:FOO"
+_VRF_RE = re.compile(r"^VRF:(?P<vrf>\S+)$")
+
+# Group line: bare IP at start of line (not indented)
+_GROUP_RE = re.compile(r"^(?P<group>\d+\.\d+\.\d+\.\d+)\s*$")
+
+# Source entry: indented source line with uptime, optional RP, and flags
+_SOURCE_RE = re.compile(
+    r"^\s+(?P<source>\d+\.\d+\.\d+\.\d+|\*),\s+"
+    r"(?P<uptime>\S+)"
+    r"(?:,\s+RP\s+(?P<rp>[\d.]+))?"
+    r",\s+flags:\s+(?P<flags>\S+)\s*$"
+)
+
+# Incoming interface: "Incoming interface: Ethernet32"
+_INCOMING_RE = re.compile(r"^\s+Incoming interface:\s+(?P<interface>\S+)\s*$")
+
+# RPF route line: "RPF route: [U] 192.168.98.0/27 [20/0] via 10.100.10.6"
+_RPF_ROUTE_RE = re.compile(
+    r"^\s+RPF route:\s+\[(?P<route_type>[UM])\]\s+"
+    r"(?P<prefix>\S+)\s+\[(?P<ad>\d+)/(?P<metric>\d+)\]\s+"
+    r"via\s+(?P<next_hop>[\d.]+)\s*$"
+)
+
+# Outgoing interface list header
+_OIF_HEADER_RE = re.compile(r"^\s+Outgoing interface list:\s*$")
+
+# Interfaces not in OIL header
+_NOT_IN_OIL_HEADER_RE = re.compile(r"^\s+Interfaces not in OIL:\s*$")
+
+# Interface line in OIL or not-in-OIL (indented, name only or name: reason)
+_OIF_ENTRY_RE = re.compile(r"^\s+(?P<interface>\S+)\s*$")
+_NOT_IN_OIL_ENTRY_RE = re.compile(r"^\s+(?P<interface>\S+):\s+(?P<reason>.+?)\s*$")
+
+# Upstream state lines
+_UPSTREAM_JOINED_RE = re.compile(r"^\s+Upstream joined state:\s+(?P<state>\S+)\s*$")
+_UPSTREAM_RPT_JOINED_RE = re.compile(
+    r"^\s+Upstream RPT joined state:\s+(?P<state>\S+)\s*$"
+)
+
+
+class RpfRouteInfo(TypedDict):
+    """Schema for RPF route information."""
+
+    route_type: str
+    prefix: str
+    ad: int
+    metric: int
+    next_hop: str
+
+
+class NotInOilEntry(TypedDict):
+    """Schema for an interface not in the outgoing interface list."""
+
+    reason: str
+
+
+class SourceEntry(TypedDict):
+    """Schema for a source entry within a multicast group."""
+
+    uptime: str
+    flags: str
+    incoming_interface: str
+    upstream_joined_state: str
+    upstream_rpt_joined_state: str
+    rp: NotRequired[str]
+    rpf_route: NotRequired[RpfRouteInfo]
+    outgoing_interfaces: NotRequired[list[str]]
+    interfaces_not_in_oil: NotRequired[dict[str, NotInOilEntry]]
+
+
+class GroupEntry(TypedDict):
+    """Schema for a multicast group."""
+
+    sources: dict[str, SourceEntry]
+
+
+class VrfEntry(TypedDict):
+    """Schema for a VRF's multicast routing table."""
+
+    groups: dict[str, GroupEntry]
+
+
+class ShowIpMrouteVrfAllDetailResult(TypedDict):
+    """Schema for 'show ip mroute vrf all detail' parsed output."""
+
+    vrfs: dict[str, VrfEntry]
+
+
+def _try_parse_scalar_field(line: str, result: dict[str, object]) -> bool:
+    """Try to match a single-value field line (incoming, RPF, upstream state).
+
+    Returns True if the line was consumed.
+    """
+    m = _INCOMING_RE.match(line)
+    if m:
+        result["incoming_interface"] = m.group("interface")
+        return True
+
+    m = _RPF_ROUTE_RE.match(line)
+    if m:
+        result["rpf_route"] = RpfRouteInfo(
+            route_type=m.group("route_type"),
+            prefix=m.group("prefix"),
+            ad=int(m.group("ad")),
+            metric=int(m.group("metric")),
+            next_hop=m.group("next_hop"),
+        )
+        return True
+
+    m = _UPSTREAM_JOINED_RE.match(line)
+    if m:
+        result["upstream_joined_state"] = m.group("state")
+        return True
+
+    m = _UPSTREAM_RPT_JOINED_RE.match(line)
+    if m:
+        result["upstream_rpt_joined_state"] = m.group("state")
+        return True
+
+    return False
+
+
+_LIST_NONE = 0
+_LIST_OIF = 1
+_LIST_NOT_OIL = 2
+
+
+def _try_accumulate_list_entry(
+    line: str,
+    list_mode: int,
+    oif_list: list[str],
+    not_in_oil: dict[str, NotInOilEntry],
+) -> tuple[bool, int]:
+    """Try to accumulate a list entry based on the current list mode.
+
+    Returns (consumed, new_list_mode).
+    """
+    if list_mode == _LIST_NOT_OIL:
+        m = _NOT_IN_OIL_ENTRY_RE.match(line)
+        if m:
+            not_in_oil[m.group("interface")] = NotInOilEntry(reason=m.group("reason"))
+            return True, list_mode
+        return False, _LIST_NONE
+
+    if list_mode == _LIST_OIF:
+        m = _OIF_ENTRY_RE.match(line)
+        if m:
+            oif_list.append(m.group("interface"))
+            return True, list_mode
+        return False, _LIST_NONE
+
+    return False, list_mode
+
+
+def _parse_source_body(lines: list[str]) -> dict[str, object]:
+    """Parse the body lines following a source header.
+
+    Args:
+        lines: Body lines for a single source entry.
+
+    Returns:
+        Dict of parsed fields to merge into the source entry.
+    """
+    result: dict[str, object] = {}
+    list_mode = _LIST_NONE
+    oif_list: list[str] = []
+    not_in_oil: dict[str, NotInOilEntry] = {}
+
+    for line in lines:
+        # Try scalar fields first; they also end any list context
+        if _try_parse_scalar_field(line, result):
+            list_mode = _LIST_NONE
+            continue
+
+        # Section headers toggle list-accumulation mode
+        if _OIF_HEADER_RE.match(line):
+            list_mode = _LIST_OIF
+            continue
+        if _NOT_IN_OIL_HEADER_RE.match(line):
+            list_mode = _LIST_NOT_OIL
+            continue
+
+        # Accumulate list entries
+        consumed, list_mode = _try_accumulate_list_entry(
+            line, list_mode, oif_list, not_in_oil
+        )
+        if consumed:
+            continue
+
+    if oif_list:
+        result["outgoing_interfaces"] = oif_list
+    if not_in_oil:
+        result["interfaces_not_in_oil"] = not_in_oil
+
+    return result
+
+
+def _build_source_entry(header: re.Match[str], body_lines: list[str]) -> SourceEntry:
+    """Build a SourceEntry from the header match and body lines."""
+    entry: dict[str, object] = {
+        "uptime": header.group("uptime"),
+        "flags": header.group("flags"),
+    }
+
+    rp = header.group("rp")
+    if rp:
+        entry["rp"] = rp
+
+    body = _parse_source_body(body_lines)
+    entry.update(body)
+
+    return cast(SourceEntry, entry)
+
+
+def _process_line(
+    line: str,
+    state: dict[str, object],
+) -> None:
+    """Process a single line, updating parser state.
+
+    State keys: vrf, group, source_match, body, groups, vrfs.
+    """
+    # VRF header
+    m = _VRF_RE.match(line)
+    if m:
+        _flush_vrf(state)
+        state["vrf"] = m.group("vrf")
+        state["group"] = None
+        return
+
+    # Group line
+    m = _GROUP_RE.match(line)
+    if m:
+        _flush_source(state)
+        state["group"] = m.group("group")
+        return
+
+    # Source header
+    m = _SOURCE_RE.match(line)
+    if m:
+        _flush_source(state)
+        state["source_match"] = m
+        state["body"] = []
+        return
+
+    # Accumulate body lines for current source
+    if state["source_match"] is not None:
+        cast(list[str], state["body"]).append(line)
+
+
+def _flush_source(state: dict[str, object]) -> None:
+    """Flush the current source entry into the groups dict."""
+    source_match = state["source_match"]
+    group = state["group"]
+    if source_match is not None and group is not None:
+        groups = cast(dict[str, GroupEntry], state["groups"])
+        source_key = cast(re.Match[str], source_match).group("source")
+        entry = _build_source_entry(
+            cast(re.Match[str], source_match),
+            cast(list[str], state["body"]),
+        )
+        if group not in groups:
+            groups[group] = GroupEntry(sources={})
+        groups[group]["sources"][source_key] = entry
+    state["source_match"] = None
+    state["body"] = []
+
+
+def _flush_vrf(state: dict[str, object]) -> None:
+    """Flush the current VRF's groups into the vrfs dict."""
+    _flush_source(state)
+    vrf = state["vrf"]
+    groups = cast(dict[str, GroupEntry], state["groups"])
+    if vrf is not None and groups:
+        cast(dict[str, VrfEntry], state["vrfs"])[cast(str, vrf)] = VrfEntry(
+            groups=groups
+        )
+    state["groups"] = {}
+
+
+@register(OS.ARISTA_EOS, "show ip mroute vrf all detail")
+class ShowIpMrouteVrfAllDetailParser(
+    BaseParser[ShowIpMrouteVrfAllDetailResult],
+):
+    """Parser for 'show ip mroute vrf all detail' on Arista EOS.
+
+    Parses PIM multicast routing table entries across all VRFs with
+    detailed source/group information including RPF routes, outgoing
+    interface lists, and upstream state.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.MULTICAST,
+            ParserTag.ROUTING,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpMrouteVrfAllDetailResult:
+        """Parse 'show ip mroute vrf all detail' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed multicast route entries nested by VRF, group, source.
+
+        Raises:
+            ValueError: If no VRF sections found in output.
+        """
+        state: dict[str, object] = {
+            "vrfs": {},
+            "groups": {},
+            "vrf": None,
+            "group": None,
+            "source_match": None,
+            "body": [],
+        }
+
+        for line in output.splitlines():
+            _process_line(line, state)
+
+        _flush_vrf(state)
+
+        vrfs = cast(dict[str, VrfEntry], state["vrfs"])
+        if not vrfs:
+            msg = "No VRF sections found in output"
+            raise ValueError(msg)
+
+        return ShowIpMrouteVrfAllDetailResult(vrfs=vrfs)

--- a/tests/parsers/arista_eos/show_ip_mroute_vrf_all_detail/001_basic/expected.json
+++ b/tests/parsers/arista_eos/show_ip_mroute_vrf_all_detail/001_basic/expected.json
@@ -1,0 +1,119 @@
+{
+    "vrfs": {
+        "default": {
+            "groups": {
+                "224.0.1.129": {
+                    "sources": {
+                        "169.254.132.172": {
+                            "uptime": "118d18h",
+                            "flags": "PE",
+                            "incoming_interface": "Null",
+                            "upstream_joined_state": "upNotJoined",
+                            "upstream_rpt_joined_state": "upRptNotJoined"
+                        }
+                    }
+                },
+                "224.0.23.192": {
+                    "sources": {
+                        "0.0.0.0": {
+                            "uptime": "38d14h",
+                            "flags": "W",
+                            "rp": "204.14.0.136",
+                            "incoming_interface": "Register",
+                            "upstream_joined_state": "upJoined",
+                            "upstream_rpt_joined_state": "upRptNotJoined",
+                            "outgoing_interfaces": [
+                                "Ethernet2/1",
+                                "Ethernet2/2"
+                            ]
+                        },
+                        "192.26.98.17": {
+                            "uptime": "8:57:21",
+                            "flags": "PE",
+                            "incoming_interface": "Register",
+                            "upstream_joined_state": "upNotJoined",
+                            "upstream_rpt_joined_state": "upRptNotPruned",
+                            "outgoing_interfaces": [
+                                "Ethernet2/1"
+                            ]
+                        },
+                        "192.168.98.17": {
+                            "uptime": "8:57:21",
+                            "flags": "SP",
+                            "incoming_interface": "Ethernet10",
+                            "rpf_route": {
+                                "route_type": "U",
+                                "prefix": "192.168.98.0/27",
+                                "ad": 20,
+                                "metric": 0,
+                                "next_hop": "10.100.10.6"
+                            },
+                            "upstream_joined_state": "upNotJoined",
+                            "upstream_rpt_joined_state": "upRptNotPruned",
+                            "outgoing_interfaces": [
+                                "Ethernet2/1"
+                            ]
+                        }
+                    }
+                },
+                "224.0.23.190": {
+                    "sources": {
+                        "0.0.0.0": {
+                            "uptime": "38d14h",
+                            "flags": "W",
+                            "rp": "204.14.0.136",
+                            "incoming_interface": "Register",
+                            "upstream_joined_state": "upJoined",
+                            "upstream_rpt_joined_state": "upRptNotJoined",
+                            "outgoing_interfaces": [
+                                "Ethernet0/1"
+                            ]
+                        },
+                        "10.205.227.165": {
+                            "uptime": "38d14h",
+                            "flags": "SBNP",
+                            "incoming_interface": "Ethernet32",
+                            "upstream_joined_state": "upJoined",
+                            "upstream_rpt_joined_state": "upRptNotPruned",
+                            "outgoing_interfaces": [
+                                "Ethernet2/1"
+                            ],
+                            "interfaces_not_in_oil": {
+                                "Ethernet0/1": {
+                                    "reason": "Not DR, RPT Pruned"
+                                }
+                            }
+                        },
+                        "10.205.227.166": {
+                            "uptime": "18d7h",
+                            "flags": "SBNP",
+                            "rp": "204.14.0.136",
+                            "incoming_interface": "Ethernet32",
+                            "upstream_joined_state": "upJoined",
+                            "upstream_rpt_joined_state": "upRptNotPruned",
+                            "outgoing_interfaces": [
+                                "Ethernet0/1",
+                                "Ethernet2/1"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "FOO": {
+            "groups": {
+                "224.0.1.130": {
+                    "sources": {
+                        "169.254.132.173": {
+                            "uptime": "1d18h",
+                            "flags": "PE",
+                            "incoming_interface": "Null",
+                            "upstream_joined_state": "upNotJoined",
+                            "upstream_rpt_joined_state": "upRptNotJoined"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/arista_eos/show_ip_mroute_vrf_all_detail/001_basic/input.txt
+++ b/tests/parsers/arista_eos/show_ip_mroute_vrf_all_detail/001_basic/input.txt
@@ -1,0 +1,144 @@
+VRF:default
+PIM Bidirectional Mode Multicast Routing Table
+RPF route: U - From unicast routing table
+           M - From multicast routing table
+PIM Sparse Mode Multicast Routing Table
+Flags: E - Entry forwarding on the RPT, J - Joining to the SPT
+    R - RPT bit is set, S - SPT bit is set, L - Source is attached
+    W - Wildcard entry, X - External component interest
+    I - SG Include Join alert rcvd, P - Programmed in hardware
+    H - Joining SPT due to policy, D - Joining SPT due to protocol
+    Z - Entry marked for deletion, C - Learned from a DR via a register
+    A - Learned via Anycast RP Router, M - Learned via MSDP
+    N - May notify MSDP, K - Keepalive timer not running
+    T - Switching Incoming Interface, B - Learned via Border Router
+    V - Source is reachable via Evpn Tenant Domain
+    F - Learned via MVPN
+RPF route: U - From unicast routing table
+           M - From multicast routing table
+* - Interface has EVPN information available in the 'detail' command output
+224.0.1.129
+  169.254.132.172, 118d18h, flags: PE
+    Incoming interface: Null
+    Upstream joined state: upNotJoined
+    Upstream RPT joined state: upRptNotJoined
+    State summarization macros:
+      Could register (S,G): False
+      Register stop (S,G): True
+      Join desired (S,G): False
+      Prune desired (S,G,Rpt): False
+      No interfaces in immediate olist (S,G): True
+      No interfaces in inherited olist (S,G): True
+224.0.23.192
+  0.0.0.0, 38d14h, RP 204.14.0.136, flags: W
+    Incoming interface: Register
+    Outgoing interface list:
+      Ethernet2/1
+      Ethernet2/2
+    Upstream joined state: upJoined
+    Upstream RPT joined state: upRptNotJoined
+    State summarization macros:
+      Join desired (*,G): True
+      Join desired (*,*,RP): False
+      RPT join desired (*,G): True
+      No interfaces in immediate olist (*,G): False
+      No interfaces in immediate olist (*,*,G): True
+  192.26.98.17, 8:57:21, flags: PE
+    Incoming interface: Register
+    Outgoing interface list:
+      Ethernet2/1
+    Upstream joined state: upNotJoined
+    Upstream RPT joined state: upRptNotPruned
+    State summarization macros:
+      Could register (S,G): False
+      Register stop (S,G): False
+      Join desired (S,G): False
+      Prune desired (S,G,Rpt): False
+      No interfaces in immediate olist (S,G): True
+      No interfaces in inherited olist (S,G): False
+  192.168.98.17, 8:57:21, flags: SP
+    Incoming interface: Ethernet10
+    RPF route: [U] 192.168.98.0/27 [20/0] via 10.100.10.6
+    Outgoing interface list:
+      Ethernet2/1
+    Upstream joined state: upNotJoined
+    Upstream RPT joined state: upRptNotPruned
+    State summarization macros:
+      Could register (S,G): False
+      Register stop (S,G): True
+      Join desired (S,G): True
+      Prune desired (S,G,Rpt): False
+      No interfaces in immediate olist (S,G): False
+      No interfaces in inherited olist (S,G): False
+224.0.23.190
+  0.0.0.0, 38d14h, RP 204.14.0.136, flags: W
+    Incoming interface: Register
+    Outgoing interface list:
+      Ethernet0/1
+    Upstream joined state: upJoined
+    Upstream RPT joined state: upRptNotJoined
+    State summarization macros:
+      Join desired (*,G): True
+      Join desired (*,*,RP): False
+      RPT join desired (*,G): True
+      No interfaces in immediate olist (*,G): False
+      No interfaces in immediate olist (*,*,G): True
+  10.205.227.165, 38d14h, flags: SBNP
+    Incoming interface: Ethernet32
+    Outgoing interface list:
+      Ethernet2/1
+    Interfaces not in OIL:
+      Ethernet0/1: Not DR, RPT Pruned
+    Upstream joined state: upJoined
+    Upstream RPT joined state: upRptNotPruned
+    State summarization macros:
+      Could register (S,G): True
+      Register stop (S,G): True
+      Join desired (S,G): True
+      Prune desired (S,G,Rpt): False
+      No interfaces in immediate olist (S,G): False
+      No interfaces in inherited olist (S,G): False
+  10.205.227.166, 18d7h, RP 204.14.0.136, flags: SBNP
+    Incoming interface: Ethernet32
+    Outgoing interface list:
+      Ethernet0/1
+      Ethernet2/1
+    Upstream joined state: upJoined
+    Upstream RPT joined state: upRptNotPruned
+    State summarization macros:
+      Could register (S,G): True
+      Register stop (S,G): True
+      Join desired (S,G): True
+      Prune desired (S,G,Rpt): False
+      No interfaces in immediate olist (S,G): False
+      No interfaces in inherited olist (S,G): False
+VRF:FOO
+PIM Bidirectional Mode Multicast Routing Table
+RPF route: U - From unicast routing table
+           M - From multicast routing table
+PIM Sparse Mode Multicast Routing Table
+Flags: E - Entry forwarding on the RPT, J - Joining to the SPT
+    R - RPT bit is set, S - SPT bit is set, L - Source is attached
+    W - Wildcard entry, X - External component interest
+    I - SG Include Join alert rcvd, P - Programmed in hardware
+    H - Joining SPT due to policy, D - Joining SPT due to protocol
+    Z - Entry marked for deletion, C - Learned from a DR via a register
+    A - Learned via Anycast RP Router, M - Learned via MSDP
+    N - May notify MSDP, K - Keepalive timer not running
+    T - Switching Incoming Interface, B - Learned via Border Router
+    V - Source is reachable via Evpn Tenant Domain
+    F - Learned via MVPN
+RPF route: U - From unicast routing table
+           M - From multicast routing table
+224.0.1.130
+  169.254.132.173, 1d18h, flags: PE
+    Incoming interface: Null
+    Upstream joined state: upNotJoined
+    Upstream RPT joined state: upRptNotJoined
+    State summarization macros:
+      Could register (S,G): False
+      Register stop (S,G): True
+      Join desired (S,G): False
+      Prune desired (S,G,Rpt): False
+      No interfaces in immediate olist (S,G): True
+      No interfaces in inherited olist (S,G): True

--- a/tests/parsers/arista_eos/show_ip_mroute_vrf_all_detail/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/show_ip_mroute_vrf_all_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple VRFs with PIM sparse-mode entries including RPF routes and OIL exclusions
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add parser for `show ip mroute vrf all detail` on Arista EOS
- Parses PIM sparse-mode multicast routing table entries across all VRFs with nested VRF/group/source hierarchy
- Handles RPF routes, outgoing interface lists, upstream joined state, and interfaces not in OIL
- Tagged with `MULTICAST` and `ROUTING`

## Test plan
- [x] Parser test with real device output (001_basic) covering multiple VRFs, groups, and sources
- [x] All fixture sentinel checks pass (no placeholder values)
- [x] All fixture JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity check passes (max-absolute B)
- [x] Full test suite passes (6848 tests)
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)