### PR TITLE
feat(cisco_iosxr): add parser for `admin show environment power`

### DIFF
--- a/changes/+cisco-iosxr-admin-show-environment-power.parser_added
+++ b/changes/+cisco-iosxr-admin-show-environment-power.parser_added
@@ -1,0 +1,1 @@
+Added parser for `admin show environment power` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/admin_show_environment_power.py
+++ b/src/muninn/parsers/cisco_iosxr/admin_show_environment_power.py
@@ -1,0 +1,244 @@
+"""Parser for 'admin show environment power' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PowerSupplyEntry(TypedDict):
+    """Schema for a single power supply module."""
+
+    supply_type: str
+    input_voltage_a: float
+    input_voltage_b: float
+    input_current_a: float
+    input_current_b: float
+    output_voltage: float
+    output_current: float
+    status: str
+    power_group: int
+
+
+class PowerConsumerEntry(TypedDict):
+    """Schema for a single power consumer (line card, RP, fabric, fan, etc.)."""
+
+    card_type: NotRequired[str]
+    power_allocated_watts: int
+    power_used_watts: NotRequired[int]
+    status: str
+
+
+class ChassisPowerSummary(TypedDict):
+    """Schema for chassis-level power summary."""
+
+    total_capacity_watts: int
+    total_required_watts: int
+    total_input_watts: int
+    total_output_watts: int
+
+
+class AdminShowEnvironmentPowerResult(TypedDict):
+    """Schema for 'admin show environment power' parsed output."""
+
+    chassis_summary: ChassisPowerSummary
+    power_supplies: dict[str, PowerSupplyEntry]
+    power_consumers: dict[str, PowerConsumerEntry]
+
+
+@register(OS.CISCO_IOSXR, "admin show environment power")
+class AdminShowEnvironmentPowerParser(
+    BaseParser[AdminShowEnvironmentPowerResult],
+):
+    """Parser for 'admin show environment power' on Cisco IOS-XR.
+
+    Extracts chassis power summary, per-module power supply details,
+    and per-slot power consumer information.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ENVIRONMENT})
+
+    # Chassis summary patterns
+    _TOTAL_CAPACITY = re.compile(
+        r"Total output power capacity.*?:\s+(\d+)W\s*\+\s+(\d+)W",
+    )
+    _TOTAL_REQUIRED = re.compile(
+        r"Total output power required\s*:\s+(\d+)W",
+    )
+    _TOTAL_INPUT = re.compile(
+        r"Total power input\s*:\s+(\d+)W",
+    )
+    _TOTAL_OUTPUT = re.compile(
+        r"Total power output\s*:\s+(\d+)W",
+    )
+
+    # Power Group header
+    _POWER_GROUP = re.compile(r"^Power Group (\d+):")
+
+    # Power supply module line, e.g.:
+    #    0/PM0       3kW-DC      54.0/54.0   3.3/ 3.5    12.1     27.0    OK
+    _SUPPLY_LINE = re.compile(
+        r"^\s+(?P<location>\S+/PM\d+)\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<vin_a>[\d.]+)/(?P<vin_b>[\d.]+)\s+"
+        r"(?P<iin_a>[\d.]+)/\s*(?P<iin_b>[\d.]+)\s+"
+        r"(?P<vout>[\d.]+)\s+"
+        r"(?P<iout>[\d.]+)\s+"
+        r"(?P<status>\S+)",
+    )
+
+    # Power consumer line, e.g.:
+    #    0/0          NC55-36X100G           902         504       ON
+    #    0/1                 -                25           -       RESERVED
+    _CONSUMER_LINE = re.compile(
+        r"^\s+(?P<location>\S+)\s+"
+        r"(?P<card_type>\S+)\s+"
+        r"(?P<allocated>\d+)\s+"
+        r"(?P<used>\d+|-)\s+"
+        r"(?P<status>\S+)\s*$",
+    )
+
+    @classmethod
+    def _parse_chassis_summary(cls, output: str) -> ChassisPowerSummary:
+        """Extract chassis-level power totals."""
+        capacity = 0
+        if match := cls._TOTAL_CAPACITY.search(output):
+            capacity = int(match.group(1)) + int(match.group(2))
+
+        required = 0
+        if match := cls._TOTAL_REQUIRED.search(output):
+            required = int(match.group(1))
+
+        total_in = 0
+        if match := cls._TOTAL_INPUT.search(output):
+            total_in = int(match.group(1))
+
+        total_out = 0
+        if match := cls._TOTAL_OUTPUT.search(output):
+            total_out = int(match.group(1))
+
+        return ChassisPowerSummary(
+            total_capacity_watts=capacity,
+            total_required_watts=required,
+            total_input_watts=total_in,
+            total_output_watts=total_out,
+        )
+
+    @classmethod
+    def _parse_power_supplies(
+        cls,
+        output: str,
+    ) -> dict[str, PowerSupplyEntry]:
+        """Extract per-module power supply entries."""
+        supplies: dict[str, PowerSupplyEntry] = {}
+        current_group = 0
+
+        for line in output.splitlines():
+            group_match = cls._POWER_GROUP.match(line.strip())
+            if group_match:
+                current_group = int(group_match.group(1))
+                continue
+
+            match = cls._SUPPLY_LINE.match(line)
+            if match:
+                location = match.group("location")
+                supplies[location] = PowerSupplyEntry(
+                    supply_type=match.group("type"),
+                    input_voltage_a=float(match.group("vin_a")),
+                    input_voltage_b=float(match.group("vin_b")),
+                    input_current_a=float(match.group("iin_a")),
+                    input_current_b=float(match.group("iin_b")),
+                    output_voltage=float(match.group("vout")),
+                    output_current=float(match.group("iout")),
+                    status=match.group("status"),
+                    power_group=current_group,
+                )
+
+        return supplies
+
+    @classmethod
+    def _parse_power_consumers(
+        cls,
+        output: str,
+    ) -> dict[str, PowerConsumerEntry]:
+        """Extract per-slot power consumer entries."""
+        consumers: dict[str, PowerConsumerEntry] = {}
+
+        # Find the consumer table by locating its header
+        in_consumer_table = False
+        separator_seen = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            # Detect consumer table header (Location / Card Type / ...)
+            if "Location" in stripped and "Card Type" in stripped:
+                in_consumer_table = True
+                separator_seen = False
+                continue
+
+            if not in_consumer_table:
+                continue
+
+            # Wait for the separator line after the multi-line header
+            if not separator_seen:
+                if stripped.startswith("==="):
+                    separator_seen = True
+                continue
+
+            match = cls._CONSUMER_LINE.match(line)
+            if not match:
+                continue
+
+            location = match.group("location")
+            card_type = match.group("card_type")
+            used_str = match.group("used")
+
+            entry = PowerConsumerEntry(
+                power_allocated_watts=int(match.group("allocated")),
+                status=match.group("status"),
+            )
+
+            if card_type != "-":
+                entry["card_type"] = card_type
+
+            if used_str != "-":
+                entry["power_used_watts"] = int(used_str)
+
+            consumers[location] = entry
+
+        return consumers
+
+    @classmethod
+    def parse(cls, output: str) -> AdminShowEnvironmentPowerResult:
+        """Parse 'admin show environment power' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed power environment information including chassis summary,
+            power supply details, and power consumer data.
+
+        Raises:
+            ValueError: If no power supply or consumer data is found.
+        """
+        chassis_summary = cls._parse_chassis_summary(output)
+        power_supplies = cls._parse_power_supplies(output)
+        power_consumers = cls._parse_power_consumers(output)
+
+        if not power_supplies and not power_consumers:
+            msg = "No power supply or consumer data found in output"
+            raise ValueError(msg)
+
+        return cast(
+            AdminShowEnvironmentPowerResult,
+            {
+                "chassis_summary": chassis_summary,
+                "power_supplies": power_supplies,
+                "power_consumers": power_consumers,
+            },
+        )

--- a/src/muninn/parsers/cisco_iosxr/admin_show_environment_power.py
+++ b/src/muninn/parsers/cisco_iosxr/admin_show_environment_power.py
@@ -32,9 +32,20 @@ class PowerConsumerEntry(TypedDict):
     status: str
 
 
+class PowerGroupTotals(TypedDict):
+    """Schema for per-power-group input/output totals."""
+
+    input_watts: int
+    input_current_a: float
+    input_current_b: float
+    output_watts: int
+    output_current: float
+
+
 class ChassisPowerSummary(TypedDict):
     """Schema for chassis-level power summary."""
 
+    chassis_number: int
     total_capacity_watts: int
     total_required_watts: int
     total_input_watts: int
@@ -46,6 +57,7 @@ class AdminShowEnvironmentPowerResult(TypedDict):
 
     chassis_summary: ChassisPowerSummary
     power_supplies: dict[str, PowerSupplyEntry]
+    power_group_totals: dict[str, PowerGroupTotals]
     power_consumers: dict[str, PowerConsumerEntry]
 
 
@@ -62,6 +74,9 @@ class AdminShowEnvironmentPowerParser(
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ENVIRONMENT})
 
     # Chassis summary patterns
+    _CHASSIS_HEADER = re.compile(
+        r"CHASSIS LEVEL POWER INFO:\s*(\d+)",
+    )
     _TOTAL_CAPACITY = re.compile(
         r"Total output power capacity.*?:\s+(\d+)W\s*\+\s+(\d+)W",
     )
@@ -77,6 +92,14 @@ class AdminShowEnvironmentPowerParser(
 
     # Power Group header
     _POWER_GROUP = re.compile(r"^Power Group (\d+):")
+
+    # Per-group totals line, e.g.:
+    # Total of Power Group 0:       686W/  ( 6.3/ 6.4)A     639W/ 52.8A
+    _POWER_GROUP_TOTAL = re.compile(
+        r"^Total of Power Group (?P<group>\d+):\s+"
+        r"(?P<in_watts>\d+)W/\s*\(\s*(?P<in_amps_a>[\d.]+)/\s*(?P<in_amps_b>[\d.]+)\)A\s+"
+        r"(?P<out_watts>\d+)W/\s*(?P<out_amps>[\d.]+)A",
+    )
 
     # Power supply module line, e.g.:
     #    0/PM0       3kW-DC      54.0/54.0   3.3/ 3.5    12.1     27.0    OK
@@ -104,6 +127,10 @@ class AdminShowEnvironmentPowerParser(
     @classmethod
     def _parse_chassis_summary(cls, output: str) -> ChassisPowerSummary:
         """Extract chassis-level power totals."""
+        chassis_number = 0
+        if match := cls._CHASSIS_HEADER.search(output):
+            chassis_number = int(match.group(1))
+
         capacity = 0
         if match := cls._TOTAL_CAPACITY.search(output):
             capacity = int(match.group(1)) + int(match.group(2))
@@ -121,11 +148,35 @@ class AdminShowEnvironmentPowerParser(
             total_out = int(match.group(1))
 
         return ChassisPowerSummary(
+            chassis_number=chassis_number,
             total_capacity_watts=capacity,
             total_required_watts=required,
             total_input_watts=total_in,
             total_output_watts=total_out,
         )
+
+    @classmethod
+    def _parse_power_group_totals(
+        cls,
+        output: str,
+    ) -> dict[str, PowerGroupTotals]:
+        """Extract per-power-group input/output totals."""
+        totals: dict[str, PowerGroupTotals] = {}
+
+        for line in output.splitlines():
+            match = cls._POWER_GROUP_TOTAL.match(line.strip())
+            if not match:
+                continue
+            group = match.group("group")
+            totals[group] = PowerGroupTotals(
+                input_watts=int(match.group("in_watts")),
+                input_current_a=float(match.group("in_amps_a")),
+                input_current_b=float(match.group("in_amps_b")),
+                output_watts=int(match.group("out_watts")),
+                output_current=float(match.group("out_amps")),
+            )
+
+        return totals
 
     @classmethod
     def _parse_power_supplies(
@@ -228,6 +279,7 @@ class AdminShowEnvironmentPowerParser(
         """
         chassis_summary = cls._parse_chassis_summary(output)
         power_supplies = cls._parse_power_supplies(output)
+        power_group_totals = cls._parse_power_group_totals(output)
         power_consumers = cls._parse_power_consumers(output)
 
         if not power_supplies and not power_consumers:
@@ -239,6 +291,7 @@ class AdminShowEnvironmentPowerParser(
             {
                 "chassis_summary": chassis_summary,
                 "power_supplies": power_supplies,
+                "power_group_totals": power_group_totals,
                 "power_consumers": power_consumers,
             },
         )

--- a/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/expected.json
@@ -1,0 +1,152 @@
+{
+    "chassis_summary": {
+        "total_capacity_watts": 12000,
+        "total_required_watts": 2493,
+        "total_input_watts": 1334,
+        "total_output_watts": 1246
+    },
+    "power_supplies": {
+        "0/PM0": {
+            "supply_type": "3kW-DC",
+            "input_voltage_a": 54.0,
+            "input_voltage_b": 54.0,
+            "input_current_a": 3.3,
+            "input_current_b": 3.5,
+            "output_voltage": 12.1,
+            "output_current": 27.0,
+            "status": "Failed",
+            "power_group": 0
+        },
+        "0/PM1": {
+            "supply_type": "3kW-DC",
+            "input_voltage_a": 54.0,
+            "input_voltage_b": 54.0,
+            "input_current_a": 3.0,
+            "input_current_b": 2.9,
+            "output_voltage": 12.1,
+            "output_current": 25.8,
+            "status": "OK",
+            "power_group": 0
+        },
+        "0/PM2": {
+            "supply_type": "3kW-DC",
+            "input_voltage_a": 54.0,
+            "input_voltage_b": 54.0,
+            "input_current_a": 2.7,
+            "input_current_b": 2.9,
+            "output_voltage": 12.1,
+            "output_current": 23.8,
+            "status": "OK",
+            "power_group": 1
+        },
+        "0/PM3": {
+            "supply_type": "3kW-DC",
+            "input_voltage_a": 54.0,
+            "input_voltage_b": 54.0,
+            "input_current_a": 3.1,
+            "input_current_b": 3.3,
+            "output_voltage": 12.1,
+            "output_current": 26.4,
+            "status": "OK",
+            "power_group": 1
+        }
+    },
+    "power_consumers": {
+        "0/0": {
+            "card_type": "NC55-36X100G",
+            "power_allocated_watts": 902,
+            "power_used_watts": 504,
+            "status": "ON"
+        },
+        "0/1": {
+            "power_allocated_watts": 25,
+            "status": "RESERVED"
+        },
+        "0/2": {
+            "power_allocated_watts": 25,
+            "status": "RESERVED"
+        },
+        "0/3": {
+            "power_allocated_watts": 25,
+            "status": "RESERVED"
+        },
+        "0/RP0": {
+            "card_type": "NC55-RP",
+            "power_allocated_watts": 90,
+            "power_used_watts": 37,
+            "status": "ON"
+        },
+        "0/RP1": {
+            "card_type": "NC55-RP",
+            "power_allocated_watts": 90,
+            "power_used_watts": 28,
+            "status": "ON"
+        },
+        "0/FC0": {
+            "card_type": "NC55-5504-FC",
+            "power_allocated_watts": 124,
+            "power_used_watts": 89,
+            "status": "ON"
+        },
+        "0/FC1": {
+            "card_type": "NC55-5504-FC",
+            "power_allocated_watts": 124,
+            "power_used_watts": 90,
+            "status": "ON"
+        },
+        "0/FC2": {
+            "card_type": "NC55-5504-FC",
+            "power_allocated_watts": 124,
+            "power_used_watts": 88,
+            "status": "ON"
+        },
+        "0/FC3": {
+            "card_type": "NC55-5504-FC",
+            "power_allocated_watts": 124,
+            "power_used_watts": 88,
+            "status": "ON"
+        },
+        "0/FC4": {
+            "card_type": "NC55-5504-FC",
+            "power_allocated_watts": 124,
+            "power_used_watts": 87,
+            "status": "ON"
+        },
+        "0/FC5": {
+            "card_type": "NC55-5504-FC",
+            "power_allocated_watts": 124,
+            "power_used_watts": 88,
+            "status": "ON"
+        },
+        "0/FT0": {
+            "card_type": "NC55-5504-FAN",
+            "power_allocated_watts": 174,
+            "power_used_watts": 20,
+            "status": "ON"
+        },
+        "0/FT1": {
+            "card_type": "NC55-5504-FAN",
+            "power_allocated_watts": 174,
+            "power_used_watts": 19,
+            "status": "ON"
+        },
+        "0/FT2": {
+            "card_type": "NC55-5504-FAN",
+            "power_allocated_watts": 174,
+            "power_used_watts": 21,
+            "status": "ON"
+        },
+        "0/SC0": {
+            "card_type": "NC55-SC",
+            "power_allocated_watts": 35,
+            "power_used_watts": 17,
+            "status": "ON"
+        },
+        "0/SC1": {
+            "card_type": "NC55-SC",
+            "power_allocated_watts": 35,
+            "power_used_watts": 15,
+            "status": "ON"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/expected.json
@@ -1,5 +1,6 @@
 {
     "chassis_summary": {
+        "chassis_number": 0,
         "total_capacity_watts": 12000,
         "total_required_watts": 2493,
         "total_input_watts": 1334,
@@ -49,6 +50,22 @@
             "output_current": 26.4,
             "status": "OK",
             "power_group": 1
+        }
+    },
+    "power_group_totals": {
+        "0": {
+            "input_watts": 686,
+            "input_current_a": 6.3,
+            "input_current_b": 6.4,
+            "output_watts": 639,
+            "output_current": 52.8
+        },
+        "1": {
+            "input_watts": 648,
+            "input_current_a": 5.8,
+            "input_current_b": 6.2,
+            "output_watts": 607,
+            "output_current": 50.2
         }
     },
     "power_consumers": {

--- a/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/input.txt
@@ -1,0 +1,51 @@
+Fri Jan 17 14:45:54.414 EST
+================================================================================
+CHASSIS LEVEL POWER INFO: 0
+================================================================================
+   Total output power capacity (Group 0 + Group 1) :    6000W +    6000W
+   Total output power required                     :    2493W
+   Total power input                               :    1334W
+   Total power output                              :    1246W
+
+Power Group 0:
+================================================================================
+   Power       Supply      --------Input-------   ----Output----    Status
+   Module      Type        Volts A/B   Amps A/B   Volts     Amps
+================================================================================
+   0/PM0       3kW-DC      54.0/54.0   3.3/ 3.5    12.1     27.0    Failed
+   0/PM1       3kW-DC      54.0/54.0   3.0/ 2.9    12.1     25.8    OK
+
+Total of Power Group 0:       686W/  ( 6.3/ 6.4)A     639W/ 52.8A
+
+Power Group 1:
+================================================================================
+   Power       Supply      --------Input-------   ----Output----    Status
+   Module      Type        Volts A/B   Amps A/B   Volts     Amps
+================================================================================
+   0/PM2       3kW-DC      54.0/54.0   2.7/ 2.9    12.1     23.8    OK
+   0/PM3       3kW-DC      54.0/54.0   3.1/ 3.3    12.1     26.4    OK
+
+Total of Power Group 1:       648W/  ( 5.8/ 6.2)A     607W/ 50.2A
+
+================================================================================
+   Location     Card Type            Power       Power       Status
+                                     Allocated   Used
+                                     Watts       Watts
+================================================================================
+   0/0          NC55-36X100G           902         504       ON
+   0/1                 -                25           -       RESERVED
+   0/2                 -                25           -       RESERVED
+   0/3                 -                25           -       RESERVED
+   0/RP0        NC55-RP                 90          37       ON
+   0/RP1        NC55-RP                 90          28       ON
+   0/FC0        NC55-5504-FC           124          89       ON
+   0/FC1        NC55-5504-FC           124          90       ON
+   0/FC2        NC55-5504-FC           124          88       ON
+   0/FC3        NC55-5504-FC           124          88       ON
+   0/FC4        NC55-5504-FC           124          87       ON
+   0/FC5        NC55-5504-FC           124          88       ON
+   0/FT0        NC55-5504-FAN          174          20       ON
+   0/FT1        NC55-5504-FAN          174          19       ON
+   0/FT2        NC55-5504-FAN          174          21       ON
+   0/SC0        NC55-SC                 35          17       ON
+   0/SC1        NC55-SC                 35          15       ON

--- a/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/admin_show_environment_power/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "NCS 5504 chassis with 4 DC power supplies across 2 groups"
+platform: "NCS-5504"
+software_version: "IOS-XR"


### PR DESCRIPTION
## Summary
- Add new parser for `admin show environment power` on Cisco IOS-XR
- Parses chassis-level power summary (total capacity, required, input, output watts)
- Extracts per-module power supply details: supply type, input/output voltage and current, status, power group
- Extracts per-slot power consumer data: card type, allocated/used watts, status
- Omits keys for placeholder values (`-`) per project sentinel conventions

## Test plan
- [x] Fixture `001_basic` with real NCS-5504 output covering 4 DC supplies across 2 power groups, 17 consumer slots
- [x] All 6848 tests pass
- [x] Pre-commit hooks pass (ruff, xenon, json, yaml, etc.)
- [x] Placeholder sentinel tests pass (no `-`, `N/A`, empty strings in expected.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)