### PR TITLE
feat(cisco_iosxr): add parser for admin show inventory

### DIFF
--- a/changes/+cisco-iosxr-admin-show-inventory.parser_added
+++ b/changes/+cisco-iosxr-admin-show-inventory.parser_added
@@ -1,0 +1,1 @@
+Added parser for `admin show inventory` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/admin_show_inventory.py
+++ b/src/muninn/parsers/cisco_iosxr/admin_show_inventory.py
@@ -1,0 +1,134 @@
+"""Parser for 'admin show inventory' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class InventoryItem(TypedDict):
+    """Schema for a single inventory item."""
+
+    name: str
+    description: NotRequired[str]
+    pid: NotRequired[str]
+    vid: NotRequired[str]
+    serial_number: NotRequired[str]
+
+
+class AdminShowInventoryResult(TypedDict):
+    """Schema for 'admin show inventory' parsed output."""
+
+    inventory: dict[str, InventoryItem]
+
+
+@register(OS.CISCO_IOSXR, "admin show inventory")
+class AdminShowInventoryParser(BaseParser[AdminShowInventoryResult]):
+    """Parser for 'admin show inventory' command on Cisco IOS-XR.
+
+    Parses hardware inventory information including chassis, modules,
+    power supplies, fans, and transceivers from the admin context.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INVENTORY})
+
+    # Pattern for NAME/DESCR line: NAME: "...", DESCR: "..."
+    _NAME_DESCR_PATTERN = re.compile(
+        r'^NAME:\s*"(?P<name>[^"]+)"\s*,\s*DESCR:\s*"(?P<descr>[^"]*)"',
+        re.IGNORECASE,
+    )
+
+    # Pattern for PID/VID/SN line: PID: ..., VID: ..., SN: ...
+    _PID_VID_SN_PATTERN = re.compile(
+        r"^PID:\s*(?P<pid>[^,]*?)\s*,\s*VID:\s*(?P<vid>[^,]*?)\s*,\s*SN:\s*(?P<sn>.*?)\s*$",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _normalize_value(cls, value: str) -> str | None:
+        """Normalize a field value, converting empty or N/A to None.
+
+        Args:
+            value: Raw field value from CLI output.
+
+        Returns:
+            Normalized value or None if empty/N/A.
+        """
+        value = value.strip()
+        if not value or value.upper() == "N/A":
+            return None
+        return value
+
+    @classmethod
+    def _build_item(
+        cls, name: str, descr: str, pid_match: re.Match[str]
+    ) -> InventoryItem:
+        """Build an InventoryItem from parsed NAME/DESCR and PID/VID/SN match.
+
+        Args:
+            name: Component name from NAME field.
+            descr: Component description from DESCR field.
+            pid_match: Regex match for the PID/VID/SN line.
+
+        Returns:
+            Populated inventory item with only non-empty fields.
+        """
+        pid = cls._normalize_value(pid_match.group("pid"))
+        vid = cls._normalize_value(pid_match.group("vid"))
+        sn = cls._normalize_value(pid_match.group("sn"))
+
+        item: InventoryItem = {"name": name}
+        if descr:
+            item["description"] = descr
+        if pid:
+            item["pid"] = pid
+        if vid:
+            item["vid"] = vid
+        if sn:
+            item["serial_number"] = sn
+        return item
+
+    @classmethod
+    def parse(cls, output: str) -> AdminShowInventoryResult:
+        """Parse 'admin show inventory' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed inventory data keyed by component name.
+
+        Raises:
+            ValueError: If no inventory items found.
+        """
+        inventory: dict[str, InventoryItem] = {}
+        current_name: str | None = None
+        current_descr: str | None = None
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            name_match = cls._NAME_DESCR_PATTERN.match(line)
+            if name_match:
+                current_name = name_match.group("name")
+                current_descr = name_match.group("descr")
+                continue
+
+            pid_match = cls._PID_VID_SN_PATTERN.match(line)
+            if pid_match and current_name is not None:
+                inventory[current_name] = cls._build_item(
+                    current_name, current_descr or "", pid_match
+                )
+                current_name = None
+                current_descr = None
+
+        if not inventory:
+            msg = "No inventory items found in output"
+            raise ValueError(msg)
+
+        return AdminShowInventoryResult(inventory=inventory)

--- a/tests/parsers/cisco_iosxr/admin_show_inventory/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/admin_show_inventory/001_basic/expected.json
@@ -1,0 +1,64 @@
+{
+    "inventory": {
+        "module 0/RSP0/CPU0": {
+            "name": "module 0/RSP0/CPU0",
+            "description": "ASR9K Route Switch Processor with 440G/slot Fabric and 6GB",
+            "pid": "A9K-RSP440-TR",
+            "vid": "V06",
+            "serial_number": "M9YXCZV9QF"
+        },
+        "fantray 0/FT0/SP": {
+            "name": "fantray 0/FT0/SP",
+            "description": "ASR-9006 Fan Tray V2",
+            "pid": "ASR-9006-FAN-V2",
+            "vid": "V09",
+            "serial_number": "PDANV9GYV8H"
+        },
+        "fan0 0/FT0/SP": {
+            "name": "fan0 0/FT0/SP",
+            "description": "ASR9K Generic Fan"
+        },
+        "module 0/1/CPU0": {
+            "name": "module 0/1/CPU0",
+            "description": "160G Modular Linecard, Packet Transport Optimized",
+            "pid": "A9K-MOD160-TR",
+            "vid": "V05",
+            "serial_number": "94TU4CACM47Y"
+        },
+        "module 0/1/0": {
+            "name": "module 0/1/0",
+            "description": "ASR 9000 8-port 10GE Modular Port Adapter",
+            "pid": "A9K-MPA-8X10GE",
+            "vid": "V02",
+            "serial_number": "2ZZQVPHZCJ5"
+        },
+        "module mau 0/1/0/0": {
+            "name": "module mau 0/1/0/0",
+            "description": "10GBASE-LR SFP+ Module for SMF",
+            "pid": "SFP-10G-LR",
+            "vid": "V01",
+            "serial_number": "QMXQLS9GKS"
+        },
+        "module mau TenGigE0/2/CPU0/0": {
+            "name": "module mau TenGigE0/2/CPU0/0",
+            "description": "10GBASE-LR SFP+ Module for SMF",
+            "pid": "SFP-10G-LR",
+            "vid": "V01",
+            "serial_number": "CB7HHMVC"
+        },
+        "power-module 0/PS0/M0/SP": {
+            "name": "power-module 0/PS0/M0/SP",
+            "description": "3kW AC V2 Power Module",
+            "pid": "PWR-3KW-AC-V2",
+            "vid": "V03",
+            "serial_number": "ZP7K5XBV9KE"
+        },
+        "chassis ASR-9006": {
+            "name": "chassis ASR-9006",
+            "description": "ASR 9006 4 Line Card Slot Chassis with V2 AC PEM",
+            "pid": "ASR-9006",
+            "vid": "V01",
+            "serial_number": "JCY98XR393D"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/admin_show_inventory/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/admin_show_inventory/001_basic/input.txt
@@ -1,0 +1,27 @@
+Fri Aug  9 09:08:06.986 CDT
+NAME: "module 0/RSP0/CPU0", DESCR: "ASR9K Route Switch Processor with 440G/slot Fabric and 6GB"
+PID: A9K-RSP440-TR, VID: V06, SN: M9YXCZV9QF
+
+NAME: "fantray 0/FT0/SP", DESCR: "ASR-9006 Fan Tray V2"
+PID: ASR-9006-FAN-V2, VID: V09, SN: PDANV9GYV8H
+
+NAME: "fan0 0/FT0/SP", DESCR: "ASR9K Generic Fan"
+PID: N/A, VID: N/A, SN:
+
+NAME: "module 0/1/CPU0", DESCR: "160G Modular Linecard, Packet Transport Optimized"
+PID: A9K-MOD160-TR, VID: V05, SN: 94TU4CACM47Y
+
+NAME: "module 0/1/0", DESCR: "ASR 9000 8-port 10GE Modular Port Adapter"
+PID: A9K-MPA-8X10GE, VID: V02, SN: 2ZZQVPHZCJ5
+
+NAME: "module mau 0/1/0/0", DESCR: "10GBASE-LR SFP+ Module for SMF"
+PID: SFP-10G-LR          , VID: V01 , SN: QMXQLS9GKS
+
+NAME: "module mau TenGigE0/2/CPU0/0", DESCR: "10GBASE-LR SFP+ Module for SMF"
+PID: SFP-10G-LR         , VID: V01 , SN: CB7HHMVC
+
+NAME: "power-module 0/PS0/M0/SP", DESCR: "3kW AC V2 Power Module"
+PID: PWR-3KW-AC-V2, VID: V03, SN: ZP7K5XBV9KE
+
+NAME: "chassis ASR-9006", DESCR: "ASR 9006 4 Line Card Slot Chassis with V2 AC PEM"
+PID: ASR-9006, VID: V01, SN: JCY98XR393D

--- a/tests/parsers/cisco_iosxr/admin_show_inventory/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/admin_show_inventory/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic admin show inventory output from ASR-9006 with modules, fans, optics, and chassis
+platform: ASR-9006
+software_version: IOS-XR


### PR DESCRIPTION
## Summary
- Add `admin show inventory` parser for Cisco IOS-XR (same format as `show inventory` but from admin context)
- Dict-of-dicts output keyed by component NAME, with N/A and empty values omitted per project conventions
- Includes test fixture from real ASR-9006 device output covering modules, fans, optics, power supplies, and chassis

## Test plan
- [x] Parser test passes against real device fixture (`001_basic`)
- [x] Sentinel guardrail tests pass (no N/A, empty strings, or hyphen placeholders in expected.json)
- [x] JSON convention tests pass (no list-of-dicts, no pipe keys)
- [x] ruff check and format clean
- [x] xenon complexity under B threshold
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)