### PR TITLE
feat(cisco_iosxr): add parser for `admin show platform`

### DIFF
--- a/changes/+cisco-iosxr-admin-show-platform.parser_added
+++ b/changes/+cisco-iosxr-admin-show-platform.parser_added
@@ -1,0 +1,1 @@
+Added parser for `admin show platform` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/admin_show_platform.py
+++ b/src/muninn/parsers/cisco_iosxr/admin_show_platform.py
@@ -1,0 +1,95 @@
+"""Parser for 'admin show platform' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Sentinel values that mean "no value" and should be omitted from output.
+_NA_SENTINELS = frozenset({"N/A", "n/a", "NA"})
+
+
+class AdminShowPlatformEntry(TypedDict):
+    """Schema for a single node entry in 'admin show platform' output."""
+
+    type: str
+    hw_state: str
+    sw_state: NotRequired[str]
+    config_state: str
+
+
+AdminShowPlatformResult = dict[str, AdminShowPlatformEntry]
+
+
+@register(OS.CISCO_IOSXR, "admin show platform")
+class AdminShowPlatformParser(BaseParser[AdminShowPlatformResult]):
+    """Parser for 'admin show platform' on Cisco IOS-XR.
+
+    Returns a dict keyed by node location (e.g. '0/0', '0/RP0').
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    _SEPARATOR = re.compile(r"^-{3,}$")
+
+    _NODE_LINE = re.compile(
+        r"^(?P<location>\S+)\s+"
+        r"(?P<type>\S+)\s+"
+        r"(?P<hw_state>\S+)\s+"
+        r"(?P<sw_state>\S+)\s+"
+        r"(?P<config_state>\S+)\s*$"
+    )
+
+    @classmethod
+    def _build_entry(cls, match: re.Match[str]) -> AdminShowPlatformEntry:
+        """Build a platform entry from a regex match, omitting N/A sentinels."""
+        entry = AdminShowPlatformEntry(
+            type=match.group("type"),
+            hw_state=match.group("hw_state"),
+            config_state=match.group("config_state"),
+        )
+        sw_state = match.group("sw_state")
+        if sw_state not in _NA_SENTINELS:
+            entry["sw_state"] = sw_state
+        return entry
+
+    @classmethod
+    def parse(cls, output: str) -> AdminShowPlatformResult:
+        """Parse 'admin show platform' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by node location with card type, HW/SW/config state.
+
+        Raises:
+            ValueError: If no platform entries are found.
+        """
+        result: AdminShowPlatformResult = {}
+        past_header = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if cls._SEPARATOR.match(stripped):
+                past_header = True
+                continue
+
+            if not past_header:
+                continue
+
+            match = cls._NODE_LINE.match(stripped)
+            if match:
+                result[match.group("location")] = cls._build_entry(match)
+
+        if not result:
+            msg = "No platform entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_iosxr/admin_show_platform/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/admin_show_platform/001_basic/expected.json
@@ -1,0 +1,13 @@
+{
+    "0/0": {
+        "type": "R-IOSXRV9000-LC-C",
+        "hw_state": "OPERATIONAL",
+        "config_state": "NSHUT"
+    },
+    "0/RP0": {
+        "type": "R-IOSXRV9000-RP-C",
+        "hw_state": "OPERATIONAL",
+        "sw_state": "OPERATIONAL",
+        "config_state": "NSHUT"
+    }
+}

--- a/tests/parsers/cisco_iosxr/admin_show_platform/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/admin_show_platform/001_basic/input.txt
@@ -1,0 +1,5 @@
+Tue Nov 16 15:43:18.391 UTC
+Location  Card Type               HW State      SW State      Config State
+----------------------------------------------------------------------------
+0/0       R-IOSXRV9000-LC-C       OPERATIONAL   N/A           NSHUT
+0/RP0     R-IOSXRV9000-RP-C       OPERATIONAL   OPERATIONAL   NSHUT

--- a/tests/parsers/cisco_iosxr/admin_show_platform/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/admin_show_platform/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "Basic admin show platform with line card and route processor"
+platform: "IOS-XRv 9000"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `admin show platform` on Cisco IOS-XR, registered with `ParserTag.PLATFORM`
- Output is a dict-of-dicts keyed by node location (e.g. `0/0`, `0/RP0`) with card type, HW state, SW state, and config state
- SW state is omitted when the device reports `N/A` (sentinel value handling per project conventions)

## Test plan
- [x] Test fixture `001_basic` with real IOS-XRv 9000 output (line card + route processor)
- [x] All sentinel placeholder tests pass (no banned values in expected.json)
- [x] JSON convention tests pass (dict-of-dicts, no pipe keys)
- [x] Ruff lint + format clean
- [x] Bandit security scan clean
- [x] Xenon complexity under B absolute / A average
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)