### PR TITLE
feat(cisco_iosxr): add parser for `admin show vm`

### DIFF
--- a/changes/+cisco-iosxr-admin-show-vm.parser_added
+++ b/changes/+cisco-iosxr-admin-show-vm.parser_added
@@ -1,0 +1,1 @@
+Added parser for `admin show vm` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/admin_show_vm.py
+++ b/src/muninn/parsers/cisco_iosxr/admin_show_vm.py
@@ -1,0 +1,102 @@
+"""Parser for 'admin show vm' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class VMEntry(TypedDict):
+    """Schema for a single VM entry within a location."""
+
+    status: str
+    ip_address: str
+    heartbeat_sent: NotRequired[int]
+    heartbeat_recv: NotRequired[int]
+
+
+# Nested dict keyed by location, then by VM id.
+AdminShowVMResult = dict[str, dict[str, VMEntry]]
+
+
+@register(OS.CISCO_IOSXR, "admin show vm")
+class AdminShowVMParser(BaseParser[AdminShowVMResult]):
+    """Parser for 'admin show vm' command on Cisco IOS-XR.
+
+    Parses virtual machine status for each node location, including
+    VM id, status, IP address, and heartbeat counters.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.PLATFORM})
+
+    _LOCATION_PATTERN = re.compile(r"^Location:\s+(?P<location>\S+)")
+    _VM_ENTRY_PATTERN = re.compile(
+        r"^(?P<id>\S+)\s+"
+        r"(?P<status>\S+)\s+"
+        r"(?P<ip>\d+\.\d+\.\d+\.\d+)\s+"
+        r"(?P<hb>\S+)"
+    )
+    _SKIP_PREFIXES = ("---", "Id")
+    _HB_NOT_APPLICABLE = "NA/NA"
+
+    @classmethod
+    def _build_vm_entry(cls, vm_match: re.Match[str]) -> tuple[str, VMEntry]:
+        """Build a VM entry from a regex match.
+
+        Returns:
+            Tuple of (vm_id, entry dict).
+        """
+        entry: VMEntry = {
+            "status": vm_match.group("status"),
+            "ip_address": vm_match.group("ip"),
+        }
+        hb_value = vm_match.group("hb")
+        if hb_value != cls._HB_NOT_APPLICABLE:
+            sent, recv = hb_value.split("/")
+            entry["heartbeat_sent"] = int(sent)
+            entry["heartbeat_recv"] = int(recv)
+        return vm_match.group("id"), entry
+
+    @classmethod
+    def parse(cls, output: str) -> AdminShowVMResult:
+        """Parse 'admin show vm' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Nested dict keyed by location then VM id.
+
+        Raises:
+            ValueError: If no location entries are found.
+        """
+        result: AdminShowVMResult = {}
+        current_location: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith(cls._SKIP_PREFIXES):
+                continue
+
+            loc_match = cls._LOCATION_PATTERN.match(stripped)
+            if loc_match:
+                current_location = loc_match.group("location")
+                result[current_location] = {}
+                continue
+
+            if current_location is None:
+                continue
+
+            vm_match = cls._VM_ENTRY_PATTERN.match(stripped)
+            if vm_match:
+                vm_id, entry = cls._build_vm_entry(vm_match)
+                result[current_location][vm_id] = entry
+
+        if not result:
+            msg = "No VM location entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/cisco_iosxr/admin_show_vm.py
+++ b/src/muninn/parsers/cisco_iosxr/admin_show_vm.py
@@ -5,6 +5,7 @@ from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 
@@ -36,7 +37,7 @@ class AdminShowVMParser(BaseParser[AdminShowVMResult]):
     _VM_ENTRY_PATTERN = re.compile(
         r"^(?P<id>\S+)\s+"
         r"(?P<status>\S+)\s+"
-        r"(?P<ip>\d+\.\d+\.\d+\.\d+)\s+"
+        rf"(?P<ip>{IPV4_ADDRESS})\s+"
         r"(?P<hb>\S+)"
     )
     _SKIP_PREFIXES = ("---", "Id")

--- a/tests/parsers/cisco_iosxr/admin_show_vm/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/admin_show_vm/001_basic/expected.json
@@ -1,0 +1,122 @@
+{
+    "0/0": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.4.1"
+        },
+        "default-sdr": {
+            "status": "running",
+            "ip_address": "192.0.4.3",
+            "heartbeat_sent": 293478,
+            "heartbeat_recv": 293478
+        }
+    },
+    "0/1": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.8.1"
+        },
+        "default-sdr": {
+            "status": "running",
+            "ip_address": "192.0.8.3",
+            "heartbeat_sent": 293478,
+            "heartbeat_recv": 293478
+        }
+    },
+    "0/2": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.12.1"
+        },
+        "default-sdr": {
+            "status": "running",
+            "ip_address": "192.0.12.3",
+            "heartbeat_sent": 293478,
+            "heartbeat_recv": 293478
+        }
+    },
+    "0/3": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.16.1"
+        },
+        "default-sdr": {
+            "status": "running",
+            "ip_address": "192.0.16.3",
+            "heartbeat_sent": 293478,
+            "heartbeat_recv": 293478
+        }
+    },
+    "0/4": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.20.1"
+        },
+        "default-sdr": {
+            "status": "running",
+            "ip_address": "192.0.20.3",
+            "heartbeat_sent": 293478,
+            "heartbeat_recv": 293478
+        }
+    },
+    "0/FC0": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.84.1"
+        }
+    },
+    "0/FC1": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.88.1"
+        }
+    },
+    "0/FC2": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.92.1"
+        }
+    },
+    "0/FC3": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.96.1"
+        }
+    },
+    "0/FC4": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.100.1"
+        }
+    },
+    "0/FC5": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.104.1"
+        }
+    },
+    "0/RP0": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.108.1"
+        },
+        "default-sdr": {
+            "status": "running",
+            "ip_address": "192.0.108.4",
+            "heartbeat_sent": 5869560,
+            "heartbeat_recv": 5869560
+        }
+    },
+    "0/SC0": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.116.1"
+        }
+    },
+    "0/SC1": {
+        "sysadmin": {
+            "status": "running",
+            "ip_address": "192.0.120.1"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/admin_show_vm/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/admin_show_vm/001_basic/input.txt
@@ -1,0 +1,77 @@
+Wed Mar 14 10:04:35.018 UTC
+
+Location: 0/0
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.4.1        NA/NA
+default-sdr       running       192.0.4.3        293478/293478
+
+Location: 0/1
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.8.1        NA/NA
+default-sdr       running       192.0.8.3        293478/293478
+
+Location: 0/2
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.12.1       NA/NA
+default-sdr       running       192.0.12.3       293478/293478
+
+Location: 0/3
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.16.1       NA/NA
+default-sdr       running       192.0.16.3       293478/293478
+
+Location: 0/4
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.20.1       NA/NA
+default-sdr       running       192.0.20.3       293478/293478
+
+Location: 0/FC0
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.84.1       NA/NA
+
+Location: 0/FC1
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.88.1       NA/NA
+
+Location: 0/FC2
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.92.1       NA/NA
+
+Location: 0/FC3
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.96.1       NA/NA
+
+Location: 0/FC4
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.100.1      NA/NA
+
+Location: 0/FC5
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.104.1      NA/NA
+
+Location: 0/RP0
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.108.1      NA/NA
+default-sdr       running       192.0.108.4      5869560/5869560
+
+Location: 0/SC0
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.116.1      NA/NA
+
+Location: 0/SC1
+Id                Status        IP Address       HB Sent/Recv
+-------------------------------------------------------------
+sysadmin          running       192.0.120.1      NA/NA

--- a/tests/parsers/cisco_iosxr/admin_show_vm/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/admin_show_vm/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multi-slot chassis with line cards, fabric cards, route processor, and shelf controllers
+platform: ASR 9006
+software_version: IOS-XR 6.x


### PR DESCRIPTION
## Summary
- Add parser for `admin show vm` on Cisco IOS-XR
- Dict-of-dicts output keyed by node location, then VM id
- Parses VM status, IP address, and heartbeat sent/recv counters (omitted when NA)
- Tagged with `ParserTag.PLATFORM`

## Test plan
- [x] Fixture `001_basic` with real multi-slot ASR 9006 output (14 locations, line cards, fabric cards, RP, shelf controllers)
- [x] All placeholder sentinel tests pass (no NA, hyphen, empty string values)
- [x] ruff check/format, bandit, xenon complexity all pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)