### PR TITLE
feat(juniper_junos): add parser for show security policies hit-count

### DIFF
--- a/changes/+juniper-junos-show-security-policies-hit-count.parser_added
+++ b/changes/+juniper-junos-show-security-policies-hit-count.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show security policies hit-count` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_security_policies_hit_count.py
+++ b/src/muninn/parsers/juniper_junos/show_security_policies_hit_count.py
@@ -1,0 +1,114 @@
+"""Parser for 'show security policies hit-count' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PolicyHitCount(TypedDict):
+    """Schema for a single security policy hit-count entry."""
+
+    index: int
+    hit_count: int
+
+
+class LogicalSystemPolicies(TypedDict):
+    """Schema for policies within a logical system.
+
+    Nested as from_zone -> to_zone -> policy_name -> PolicyHitCount.
+    """
+
+    policies: dict[str, dict[str, dict[str, PolicyHitCount]]]
+    policy_count: int
+
+
+class ShowSecurityPoliciesHitCountResult(TypedDict):
+    """Schema for 'show security policies hit-count' parsed output.
+
+    Top-level keys are logical system names. Each contains nested dicts:
+    from_zone -> to_zone -> policy_name -> {index, hit_count}.
+    """
+
+    logical_systems: dict[str, LogicalSystemPolicies]
+
+
+@register(OS.JUNIPER_JUNOS, "show security policies hit-count")
+class ShowSecurityPoliciesHitCountParser(
+    BaseParser[ShowSecurityPoliciesHitCountResult],
+):
+    """Parser for 'show security policies hit-count' on Juniper Junos.
+
+    Parses per-policy hit counts organized by logical system, from-zone,
+    and to-zone.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    _LOGICAL_SYSTEM = re.compile(r"^Logical system:\s+(?P<name>\S+)")
+    _POLICY_LINE = re.compile(
+        r"^\s+(?P<index>\d+)"
+        r"\s+(?P<from_zone>\S+)"
+        r"\s+(?P<to_zone>\S+)"
+        r"\s+(?P<name>\S+)"
+        r"\s+(?P<hit_count>\d+)\s*$",
+    )
+    _POLICY_COUNT = re.compile(r"^Number of policy:\s+(?P<count>\d+)")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSecurityPoliciesHitCountResult:
+        """Parse 'show security policies hit-count' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed hit-count data nested by logical system, zones, and policy.
+
+        Raises:
+            ValueError: If no logical systems are found in the output.
+        """
+        logical_systems: dict[str, LogicalSystemPolicies] = {}
+        current_ls: str | None = None
+        current_policies: dict[str, dict[str, dict[str, PolicyHitCount]]] = {}
+
+        for line in output.splitlines():
+            if match := cls._LOGICAL_SYSTEM.match(line):
+                current_ls = match.group("name")
+                current_policies = {}
+                continue
+
+            if current_ls is None:
+                continue
+
+            if match := cls._POLICY_LINE.match(line):
+                from_zone = match.group("from_zone")
+                to_zone = match.group("to_zone")
+                policy_name = match.group("name")
+
+                from_dict = current_policies.setdefault(from_zone, {})
+                to_dict = from_dict.setdefault(to_zone, {})
+                to_dict[policy_name] = PolicyHitCount(
+                    index=int(match.group("index")),
+                    hit_count=int(match.group("hit_count")),
+                )
+                continue
+
+            if match := cls._POLICY_COUNT.match(line):
+                logical_systems[current_ls] = LogicalSystemPolicies(
+                    policies=current_policies,
+                    policy_count=int(match.group("count")),
+                )
+                current_ls = None
+                current_policies = {}
+
+        if not logical_systems:
+            msg = "No logical systems found in output"
+            raise ValueError(msg)
+
+        return ShowSecurityPoliciesHitCountResult(
+            logical_systems=logical_systems,
+        )

--- a/tests/parsers/juniper_junos/show_security_policies_hit_count/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_security_policies_hit_count/001_basic/expected.json
@@ -1,0 +1,366 @@
+{
+    "logical_systems": {
+        "root-logical-system": {
+            "policies": {
+                "junos-global": {
+                    "junos-global": {
+                        "GLOBAL-PERMIT-TRACE-IN": {
+                            "index": 1,
+                            "hit_count": 78
+                        },
+                        "GLOBAL-PERMIT-RADIUS-IN": {
+                            "index": 2,
+                            "hit_count": 0
+                        },
+                        "GLOBAL-PERMIT-NTP-IN": {
+                            "index": 3,
+                            "hit_count": 0
+                        },
+                        "GLOBAL-PERMIT-ICMP-IN": {
+                            "index": 4,
+                            "hit_count": 3504
+                        },
+                        "GLOBAL-PERMIT-SNMP-IN": {
+                            "index": 5,
+                            "hit_count": 1
+                        },
+                        "DEFAULT-DENY": {
+                            "index": 6,
+                            "hit_count": 4567302
+                        },
+                        "GLOBAL-PERMIT-DNS-IN": {
+                            "index": 7,
+                            "hit_count": 0
+                        },
+                        "GLOBAL-PERMIT-TELEMETRY-IN": {
+                            "index": 8,
+                            "hit_count": 0
+                        },
+                        "GLOBAL-PERMIT-SSH-IN": {
+                            "index": 9,
+                            "hit_count": 0
+                        },
+                        "GLOBAL-PERMIT-KNOWN-WIDE": {
+                            "index": 10,
+                            "hit_count": 337917
+                        }
+                    }
+                },
+                "untrust": {
+                    "TEST-STRICT": {
+                        "STRICT-PERMIT-OPENGEAR-IN": {
+                            "index": 11,
+                            "hit_count": 0
+                        },
+                        "STRICT-PERMIT-SSH-IN": {
+                            "index": 12,
+                            "hit_count": 445265
+                        },
+                        "STRICT-PERMIT-SNMP-IN": {
+                            "index": 13,
+                            "hit_count": 287972350
+                        },
+                        "STRICT-PERMIT-TELEMETRY-IN": {
+                            "index": 14,
+                            "hit_count": 0
+                        },
+                        "STRICT-PERMIT-NETCONF-IN": {
+                            "index": 15,
+                            "hit_count": 523
+                        },
+                        "STRICT-PERMIT-SSH-CORE-IN": {
+                            "index": 16,
+                            "hit_count": 782267
+                        },
+                        "STRICT-PERMIT-SSH-PDUs-IN": {
+                            "index": 17,
+                            "hit_count": 333
+                        },
+                        "STRICT-PERMIT-SSH-TEST-FW-IN": {
+                            "index": 18,
+                            "hit_count": 91441
+                        },
+                        "STRICT-PERMIT-ICMP-IN": {
+                            "index": 19,
+                            "hit_count": 24426998
+                        },
+                        "STRICT-PERMIT-TRACE-IN": {
+                            "index": 20,
+                            "hit_count": 1196
+                        },
+                        "STRICT-PERMIT-RADIUS-IN": {
+                            "index": 21,
+                            "hit_count": 0
+                        },
+                        "STRICT-PERMIT-NTP-IN": {
+                            "index": 22,
+                            "hit_count": 117709
+                        },
+                        "STRICT-PERMIT-TEST-IPSEC-GRE-IN": {
+                            "index": 23,
+                            "hit_count": 0
+                        },
+                        "STRICT-PERMIT-SSH-NSO-CORE-IN": {
+                            "index": 24,
+                            "hit_count": 223809
+                        },
+                        "STRICT-PERMIT-DNS-IN": {
+                            "index": 25,
+                            "hit_count": 0
+                        }
+                    },
+                    "TEST-DCN": {
+                        "DCN-PERMIT-MONITORING-IN": {
+                            "index": 26,
+                            "hit_count": 475804
+                        },
+                        "DCN-PERMIT-SNMP-IN": {
+                            "index": 27,
+                            "hit_count": 32808
+                        },
+                        "DCN-PERMIT-DNS-IN": {
+                            "index": 28,
+                            "hit_count": 0
+                        },
+                        "DCN-PERMIT-NTP-IN": {
+                            "index": 29,
+                            "hit_count": 0
+                        },
+                        "DCN-PERMIT-ICMP-IN": {
+                            "index": 30,
+                            "hit_count": 1129854
+                        },
+                        "DCN-PERMIT-ONE-CONTROL-IN": {
+                            "index": 31,
+                            "hit_count": 0
+                        },
+                        "DCN-PERMIT-MCP-IN": {
+                            "index": 32,
+                            "hit_count": 5305845
+                        },
+                        "DCN-PERMIT-RADIUS-IN": {
+                            "index": 33,
+                            "hit_count": 0
+                        },
+                        "DCN-PERMIT-PNC-IN": {
+                            "index": 34,
+                            "hit_count": 0
+                        },
+                        "DCN-PERMIT-TRACE-IN": {
+                            "index": 35,
+                            "hit_count": 592
+                        },
+                        "DCN-PERMIT-SSH-IN": {
+                            "index": 36,
+                            "hit_count": 77474
+                        }
+                    },
+                    "TEST-OPTICAL": {
+                        "OPTICAL-PERMIT-KNOWN-RDP-IN": {
+                            "index": 37,
+                            "hit_count": 0
+                        },
+                        "OPTICAL-BLOCK-RDP-IN": {
+                            "index": 38,
+                            "hit_count": 7636
+                        },
+                        "OPTICAL-BLOCK-TELNET-IN": {
+                            "index": 39,
+                            "hit_count": 51210
+                        },
+                        "OPTICAL-PERMIT-KNOWN-TELNET-IN": {
+                            "index": 40,
+                            "hit_count": 1
+                        },
+                        "OPTICAL-BLOCK-IDRAC-IN": {
+                            "index": 41,
+                            "hit_count": 2167
+                        },
+                        "OPTICAL-PERMIT-IDRAC-IN": {
+                            "index": 42,
+                            "hit_count": 6528
+                        },
+                        "OPTICAL-BLOCK-SSH-IN": {
+                            "index": 43,
+                            "hit_count": 10886
+                        },
+                        "OPTICAL-PERMIT-SSH-IN": {
+                            "index": 44,
+                            "hit_count": 36221
+                        },
+                        "OPTICAL-BLOCK-OTHER-NTP-IN": {
+                            "index": 45,
+                            "hit_count": 253
+                        },
+                        "OPTICAL-PERMIT-KNOWN-NTP-IN": {
+                            "index": 46,
+                            "hit_count": 0
+                        },
+                        "OPTICAL-BLOCK-OTHER-DNS-IN": {
+                            "index": 47,
+                            "hit_count": 10292
+                        },
+                        "OPTICAL-PERMIT-DNS-IN": {
+                            "index": 48,
+                            "hit_count": 0
+                        }
+                    }
+                },
+                "TEST-STRICT": {
+                    "untrust": {
+                        "STRICT-PERMIT-NTP-OUT": {
+                            "index": 49,
+                            "hit_count": 4468672
+                        },
+                        "All_TEST-STRICT_COMMODITY-INTERNET": {
+                            "index": 50,
+                            "hit_count": 14599527
+                        },
+                        "STRICT-PERMIT-SNMP-OUT": {
+                            "index": 51,
+                            "hit_count": 0
+                        },
+                        "STRICT-BLOCK-SNMP-OUT": {
+                            "index": 52,
+                            "hit_count": 0
+                        },
+                        "STRICT-PERMIT-TELEMETRY-OUT": {
+                            "index": 53,
+                            "hit_count": 4038240
+                        },
+                        "STRICT-PERMIT-SYSLOG-OUT": {
+                            "index": 54,
+                            "hit_count": 125964123
+                        },
+                        "STRICT-BLOCK-SYSLOG-OUT": {
+                            "index": 55,
+                            "hit_count": 205620273
+                        },
+                        "STRICT-PERMIT-DNS-OUT": {
+                            "index": 56,
+                            "hit_count": 27
+                        },
+                        "STRICT-BLOCK-DNS-OUT": {
+                            "index": 57,
+                            "hit_count": 160995
+                        },
+                        "STRICT-BLOCK-NTP-OUT": {
+                            "index": 58,
+                            "hit_count": 38040
+                        },
+                        "STRICT-PERMIT-RADIUS-OUT": {
+                            "index": 59,
+                            "hit_count": 1699379
+                        },
+                        "STRICT-BLOCK-RADIUS-OUT": {
+                            "index": 60,
+                            "hit_count": 0
+                        }
+                    },
+                    "TEST-STRICT": {
+                        "STRICT-INTRA-ZONE-PERMIT": {
+                            "index": 61,
+                            "hit_count": 118930
+                        }
+                    },
+                    "TEST-OPTICAL": {
+                        "STRICT-TO-OPTICAL-PERMIT-TELEMETRY": {
+                            "index": 62,
+                            "hit_count": 0
+                        },
+                        "STRICT-TO-OPTICAL-PERMIT-ICMP": {
+                            "index": 63,
+                            "hit_count": 0
+                        }
+                    }
+                },
+                "TEST-DCN": {
+                    "untrust": {
+                        "DCN-PERMIT-MCP-OUT": {
+                            "index": 64,
+                            "hit_count": 81375
+                        },
+                        "DCN-PERMIT-WAVESERVERS-TEST-TRAPS-OUT": {
+                            "index": 65,
+                            "hit_count": 0
+                        },
+                        "DCN-PERMIT-RADIUS-OUT": {
+                            "index": 66,
+                            "hit_count": 158601
+                        },
+                        "DCN-DEFAULT-DENY-OUT": {
+                            "index": 67,
+                            "hit_count": 43959
+                        },
+                        "DCN-PERMIT-SYSLOG-OUT": {
+                            "index": 68,
+                            "hit_count": 13650
+                        },
+                        "DCN-PERMIT-NTP-OUT": {
+                            "index": 69,
+                            "hit_count": 204
+                        }
+                    },
+                    "TEST-DCN": {
+                        "DCN-INTRA-ZONE-PERMIT": {
+                            "index": 70,
+                            "hit_count": 0
+                        }
+                    }
+                },
+                "TEST-OPTICAL": {
+                    "untrust": {
+                        "OPTICAL-DEFAULT-DENY-OUT": {
+                            "index": 71,
+                            "hit_count": 0
+                        },
+                        "OPTICAL-PERMIT-DNS-OUT": {
+                            "index": 72,
+                            "hit_count": 7552861
+                        },
+                        "OPTICAL-BLOCK-OTHER-NTP-OUT": {
+                            "index": 73,
+                            "hit_count": 0
+                        },
+                        "OPTICAL-PERMIT-NTP-OUT": {
+                            "index": 74,
+                            "hit_count": 1222475
+                        },
+                        "OPTICAL-BLOCK-OTHER-DNS-OUT": {
+                            "index": 75,
+                            "hit_count": 2256
+                        }
+                    },
+                    "TEST-OPTICAL": {
+                        "OPTICAL-INTRA-ZONE-PERMIT": {
+                            "index": 76,
+                            "hit_count": 0
+                        }
+                    }
+                }
+            },
+            "policy_count": 76
+        },
+        "root-logical-system2": {
+            "policies": {
+                "junos-global": {
+                    "junos-global": {
+                        "GLOBAL-PERMIT-TRACE-IN": {
+                            "index": 1,
+                            "hit_count": 78
+                        },
+                        "GLOBAL-PERMIT-RADIUS-IN": {
+                            "index": 2,
+                            "hit_count": 0
+                        },
+                        "GLOBAL-PERMIT-NTP-IN": {
+                            "index": 3,
+                            "hit_count": 0
+                        }
+                    }
+                }
+            },
+            "policy_count": 3
+        }
+    }
+}

--- a/tests/parsers/juniper_junos/show_security_policies_hit_count/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_security_policies_hit_count/001_basic/input.txt
@@ -1,0 +1,88 @@
+Logical system: root-logical-system
+ Index   From zone        To zone           Name           Policy count
+ 1       junos-global     junos-global      GLOBAL-PERMIT-TRACE-IN 78
+ 2       junos-global     junos-global      GLOBAL-PERMIT-RADIUS-IN 0
+ 3       junos-global     junos-global      GLOBAL-PERMIT-NTP-IN 0
+ 4       junos-global     junos-global      GLOBAL-PERMIT-ICMP-IN 3504
+ 5       junos-global     junos-global      GLOBAL-PERMIT-SNMP-IN 1
+ 6       junos-global     junos-global      DEFAULT-DENY   4567302
+ 7       junos-global     junos-global      GLOBAL-PERMIT-DNS-IN 0
+ 8       junos-global     junos-global      GLOBAL-PERMIT-TELEMETRY-IN 0
+ 9       junos-global     junos-global      GLOBAL-PERMIT-SSH-IN 0
+ 10      junos-global     junos-global      GLOBAL-PERMIT-KNOWN-WIDE 337917
+ 11      untrust          TEST-STRICT        STRICT-PERMIT-OPENGEAR-IN 0
+ 12      untrust          TEST-STRICT        STRICT-PERMIT-SSH-IN 445265
+ 13      untrust          TEST-STRICT        STRICT-PERMIT-SNMP-IN 287972350
+ 14      untrust          TEST-STRICT        STRICT-PERMIT-TELEMETRY-IN 0
+ 15      untrust          TEST-STRICT        STRICT-PERMIT-NETCONF-IN 523
+ 16      untrust          TEST-STRICT        STRICT-PERMIT-SSH-CORE-IN 782267
+ 17      untrust          TEST-STRICT        STRICT-PERMIT-SSH-PDUs-IN 333
+ 18      untrust          TEST-STRICT        STRICT-PERMIT-SSH-TEST-FW-IN 91441
+ 19      untrust          TEST-STRICT        STRICT-PERMIT-ICMP-IN 24426998
+ 20      untrust          TEST-STRICT        STRICT-PERMIT-TRACE-IN 1196
+ 21      untrust          TEST-STRICT        STRICT-PERMIT-RADIUS-IN 0
+ 22      untrust          TEST-STRICT        STRICT-PERMIT-NTP-IN 117709
+ 23      untrust          TEST-STRICT        STRICT-PERMIT-TEST-IPSEC-GRE-IN 0
+ 24      untrust          TEST-STRICT        STRICT-PERMIT-SSH-NSO-CORE-IN 223809
+ 25      untrust          TEST-STRICT        STRICT-PERMIT-DNS-IN 0
+ 26      untrust          TEST-DCN           DCN-PERMIT-MONITORING-IN 475804
+ 27      untrust          TEST-DCN           DCN-PERMIT-SNMP-IN 32808
+ 28      untrust          TEST-DCN           DCN-PERMIT-DNS-IN 0
+ 29      untrust          TEST-DCN           DCN-PERMIT-NTP-IN 0
+ 30      untrust          TEST-DCN           DCN-PERMIT-ICMP-IN 1129854
+ 31      untrust          TEST-DCN           DCN-PERMIT-ONE-CONTROL-IN 0
+ 32      untrust          TEST-DCN           DCN-PERMIT-MCP-IN 5305845
+ 33      untrust          TEST-DCN           DCN-PERMIT-RADIUS-IN 0
+ 34      untrust          TEST-DCN           DCN-PERMIT-PNC-IN 0
+ 35      untrust          TEST-DCN           DCN-PERMIT-TRACE-IN 592
+ 36      untrust          TEST-DCN           DCN-PERMIT-SSH-IN 77474
+ 37      untrust          TEST-OPTICAL       OPTICAL-PERMIT-KNOWN-RDP-IN 0
+ 38      untrust          TEST-OPTICAL       OPTICAL-BLOCK-RDP-IN 7636
+ 39      untrust          TEST-OPTICAL       OPTICAL-BLOCK-TELNET-IN 51210
+ 40      untrust          TEST-OPTICAL       OPTICAL-PERMIT-KNOWN-TELNET-IN 1
+ 41      untrust          TEST-OPTICAL       OPTICAL-BLOCK-IDRAC-IN 2167
+ 42      untrust          TEST-OPTICAL       OPTICAL-PERMIT-IDRAC-IN 6528
+ 43      untrust          TEST-OPTICAL       OPTICAL-BLOCK-SSH-IN 10886
+ 44      untrust          TEST-OPTICAL       OPTICAL-PERMIT-SSH-IN 36221
+ 45      untrust          TEST-OPTICAL       OPTICAL-BLOCK-OTHER-NTP-IN 253
+ 46      untrust          TEST-OPTICAL       OPTICAL-PERMIT-KNOWN-NTP-IN 0
+ 47      untrust          TEST-OPTICAL       OPTICAL-BLOCK-OTHER-DNS-IN 10292
+ 48      untrust          TEST-OPTICAL       OPTICAL-PERMIT-DNS-IN 0
+ 49      TEST-STRICT       untrust           STRICT-PERMIT-NTP-OUT 4468672
+ 50      TEST-STRICT       untrust           All_TEST-STRICT_COMMODITY-INTERNET 14599527
+ 51      TEST-STRICT       untrust           STRICT-PERMIT-SNMP-OUT 0
+ 52      TEST-STRICT       untrust           STRICT-BLOCK-SNMP-OUT 0
+ 53      TEST-STRICT       untrust           STRICT-PERMIT-TELEMETRY-OUT 4038240
+ 54      TEST-STRICT       untrust           STRICT-PERMIT-SYSLOG-OUT 125964123
+ 55      TEST-STRICT       untrust           STRICT-BLOCK-SYSLOG-OUT 205620273
+ 56      TEST-STRICT       untrust           STRICT-PERMIT-DNS-OUT 27
+ 57      TEST-STRICT       untrust           STRICT-BLOCK-DNS-OUT 160995
+ 58      TEST-STRICT       untrust           STRICT-BLOCK-NTP-OUT 38040
+ 59      TEST-STRICT       untrust           STRICT-PERMIT-RADIUS-OUT 1699379
+ 60      TEST-STRICT       untrust           STRICT-BLOCK-RADIUS-OUT 0
+ 61      TEST-STRICT       TEST-STRICT        STRICT-INTRA-ZONE-PERMIT 118930
+ 62      TEST-STRICT       TEST-OPTICAL       STRICT-TO-OPTICAL-PERMIT-TELEMETRY 0
+ 63      TEST-STRICT       TEST-OPTICAL       STRICT-TO-OPTICAL-PERMIT-ICMP 0
+ 64      TEST-DCN          untrust           DCN-PERMIT-MCP-OUT 81375
+ 65      TEST-DCN          untrust           DCN-PERMIT-WAVESERVERS-TEST-TRAPS-OUT 0
+ 66      TEST-DCN          untrust           DCN-PERMIT-RADIUS-OUT 158601
+ 67      TEST-DCN          untrust           DCN-DEFAULT-DENY-OUT 43959
+ 68      TEST-DCN          untrust           DCN-PERMIT-SYSLOG-OUT 13650
+ 69      TEST-DCN          untrust           DCN-PERMIT-NTP-OUT 204
+ 70      TEST-DCN          TEST-DCN           DCN-INTRA-ZONE-PERMIT 0
+ 71      TEST-OPTICAL      untrust           OPTICAL-DEFAULT-DENY-OUT 0
+ 72      TEST-OPTICAL      untrust           OPTICAL-PERMIT-DNS-OUT 7552861
+ 73      TEST-OPTICAL      untrust           OPTICAL-BLOCK-OTHER-NTP-OUT 0
+ 74      TEST-OPTICAL      untrust           OPTICAL-PERMIT-NTP-OUT 1222475
+ 75      TEST-OPTICAL      untrust           OPTICAL-BLOCK-OTHER-DNS-OUT 2256
+ 76      TEST-OPTICAL      TEST-OPTICAL       OPTICAL-INTRA-ZONE-PERMIT 0
+
+Number of policy: 76
+
+Logical system: root-logical-system2
+ Index   From zone        To zone           Name           Policy count
+ 1       junos-global     junos-global      GLOBAL-PERMIT-TRACE-IN 78
+ 2       junos-global     junos-global      GLOBAL-PERMIT-RADIUS-IN 0
+ 3       junos-global     junos-global      GLOBAL-PERMIT-NTP-IN 0
+
+Number of policy: 3

--- a/tests/parsers/juniper_junos/show_security_policies_hit_count/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_security_policies_hit_count/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple logical systems with policies across various zones
+platform: SRX
+software_version: Unknown

--- a/tests/parsers/juniper_junos/show_security_policies_hit_count/command.txt
+++ b/tests/parsers/juniper_junos/show_security_policies_hit_count/command.txt
@@ -1,0 +1,1 @@
+show security policies hit-count


### PR DESCRIPTION
## Summary
- Add parser for `show security policies hit-count` on Juniper Junos
- Nested dict-of-dicts output: logical_system -> from_zone -> to_zone -> policy_name -> {index, hit_count}
- Tagged with `ParserTag.SECURITY`

## Test plan
- [x] Parser test with multi-logical-system fixture passes
- [x] Placeholder sentinel tests pass (no banned values in expected.json)
- [x] Ruff lint and format checks pass
- [x] Xenon complexity under B threshold
- [x] Bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)