### PR TITLE
feat(cisco_iosxr): add parser for `show version brief`

### DIFF
--- a/changes/+cisco-iosxr-show-version-brief.parser_added
+++ b/changes/+cisco-iosxr-show-version-brief.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show version brief` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_version_brief.py
+++ b/src/muninn/parsers/cisco_iosxr/show_version_brief.py
@@ -11,6 +11,13 @@ from muninn.tags import ParserTag
 from .show_version import UptimeInfo
 
 
+class StorageDevice(TypedDict):
+    """Schema for a storage device entry."""
+
+    size: str
+    sector_size: NotRequired[int]
+
+
 class ShowVersionBriefResult(TypedDict):
     """Schema for 'show version brief' parsed output on IOS-XR."""
 
@@ -20,8 +27,13 @@ class ShowVersionBriefResult(TypedDict):
     uptime: NotRequired[UptimeInfo]
     image_file: NotRequired[str]
     chassis: str
+    chassis_detail: NotRequired[str]
     processor: NotRequired[str]
+    processor_speed: NotRequired[str]
     memory: NotRequired[str]
+    nvram: NotRequired[str]
+    interfaces: NotRequired[dict[str, int]]
+    storage: NotRequired[dict[str, StorageDevice]]
 
 
 @register(OS.CISCO_IOSXR, "show version brief")
@@ -64,6 +76,32 @@ class ShowVersionBriefParser(BaseParser[ShowVersionBriefResult]):
     _CHASSIS_WITH_MEMORY = re.compile(
         r"^cisco\s+(?P<chassis>.+?)\s+\((?P<processor>[^)]+)\)\s+processor"
         r"\s+with\s+(?P<memory>\S+\s+\S+)\s+of\s+memory",
+        re.I,
+    )
+
+    _PROCESSOR_SPEED = re.compile(
+        r"^(?P<processor>.+?)\s+(?:at|@)\s+(?P<speed>\d+\S*Hz)",
+        re.I,
+    )
+
+    _CHASSIS_DETAIL = re.compile(
+        r"^(?P<detail>(?:ASR|CRS|NCS|IOS XRv|Cisco)\s+.*(?:Chassis|Slot).*)$",
+        re.I,
+    )
+
+    _INTERFACE_COUNT = re.compile(
+        r"^(?P<count>\d+)\s+(?P<type>.+?)(?:\s+interface\(s\))?\s*$",
+        re.I,
+    )
+
+    _NVRAM = re.compile(
+        r"^(?P<size>\S+)\s+bytes of non-volatile configuration memory",
+        re.I,
+    )
+
+    _STORAGE = re.compile(
+        r"^(?P<size>\S+)\s+bytes of\s+(?P<device>.+?)"
+        r"(?:\s+\(Sector size\s+(?P<sector>\d+)\s+bytes\))?\s*\.\s*$",
         re.I,
     )
 
@@ -124,7 +162,7 @@ class ShowVersionBriefParser(BaseParser[ShowVersionBriefResult]):
 
     @classmethod
     def _parse_hardware(cls, line: str, result: dict[str, object]) -> bool:
-        """Parse image file and chassis lines."""
+        """Parse image file, chassis, interfaces, and storage lines."""
         if match := cls._IMAGE_FILE.match(line):
             result["image_file"] = match.group("file")
             return True
@@ -135,6 +173,31 @@ class ShowVersionBriefParser(BaseParser[ShowVersionBriefResult]):
             if processor:
                 result["processor"] = processor
             result["memory"] = match.group("memory")
+            return True
+
+        if match := cls._PROCESSOR_SPEED.match(line):
+            result["processor_speed"] = match.group("speed")
+            return True
+
+        if match := cls._CHASSIS_DETAIL.match(line):
+            result["chassis_detail"] = match.group("detail").strip()
+            return True
+
+        if match := cls._NVRAM.match(line):
+            result["nvram"] = match.group("size") + " bytes"
+            return True
+
+        if match := cls._STORAGE.match(line):
+            storage = cast(dict[str, StorageDevice], result.setdefault("storage", {}))
+            device: StorageDevice = {"size": match.group("size") + " bytes"}
+            if match.group("sector"):
+                device["sector_size"] = int(match.group("sector"))
+            storage[match.group("device")] = device
+            return True
+
+        if match := cls._INTERFACE_COUNT.match(line):
+            interfaces = cast(dict[str, int], result.setdefault("interfaces", {}))
+            interfaces[match.group("type").strip()] = int(match.group("count"))
             return True
 
         return False

--- a/src/muninn/parsers/cisco_iosxr/show_version_brief.py
+++ b/src/muninn/parsers/cisco_iosxr/show_version_brief.py
@@ -1,0 +1,172 @@
+"""Parser for 'show version brief' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+from .show_version import UptimeInfo
+
+
+class ShowVersionBriefResult(TypedDict):
+    """Schema for 'show version brief' parsed output on IOS-XR."""
+
+    software_version: str
+    rom: NotRequired[str]
+    device_name: NotRequired[str]
+    uptime: NotRequired[UptimeInfo]
+    image_file: NotRequired[str]
+    chassis: str
+    processor: NotRequired[str]
+    memory: NotRequired[str]
+
+
+@register(OS.CISCO_IOSXR, "show version brief")
+class ShowVersionBriefParser(BaseParser[ShowVersionBriefResult]):
+    """Parser for 'show version brief' command on Cisco IOS-XR.
+
+    Parses the abbreviated version output containing software version,
+    ROM, device name, uptime, image file, and chassis information.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _SOFTWARE_VERSION = re.compile(
+        r"^Cisco IOS XR Software,\s+Version\s+"
+        r"(?P<version>[^\s\[]+)(?:\[Default\])?"
+        r"(?:\s+(?P<extra>\S+))?$",
+        re.I,
+    )
+
+    _ROM = re.compile(
+        r"^ROM:\s+(?P<rom>.+?),?\s*$",
+        re.I,
+    )
+
+    _DEVICE_UPTIME = re.compile(
+        r"^(?P<hostname>\S+)\s+uptime\s+is\s+(?P<uptime>.+)$",
+        re.I,
+    )
+
+    _SYSTEM_UPTIME = re.compile(
+        r"^System uptime is\s+(?P<uptime>.+)$",
+        re.I,
+    )
+
+    _IMAGE_FILE = re.compile(
+        r'^System image file is\s+"(?P<file>[^"]+)"',
+        re.I,
+    )
+
+    _CHASSIS_WITH_MEMORY = re.compile(
+        r"^cisco\s+(?P<chassis>.+?)\s+\((?P<processor>[^)]+)\)\s+processor"
+        r"\s+with\s+(?P<memory>\S+\s+\S+)\s+of\s+memory",
+        re.I,
+    )
+
+    _UPTIME_YEARS = re.compile(r"(\d+)\s+year", re.I)
+    _UPTIME_WEEKS = re.compile(r"(\d+)\s+week", re.I)
+    _UPTIME_DAYS = re.compile(r"(\d+)\s+day", re.I)
+    _UPTIME_HOURS = re.compile(r"(\d+)\s+hour", re.I)
+    _UPTIME_MINUTES = re.compile(r"(\d+)\s+minute", re.I)
+
+    @classmethod
+    def _parse_uptime_string(cls, uptime_str: str) -> UptimeInfo:
+        """Parse an uptime string into an UptimeInfo dict."""
+        info: UptimeInfo = {}
+
+        if match := cls._UPTIME_YEARS.search(uptime_str):
+            info["years"] = int(match.group(1))
+        if match := cls._UPTIME_WEEKS.search(uptime_str):
+            info["weeks"] = int(match.group(1))
+        if match := cls._UPTIME_DAYS.search(uptime_str):
+            info["days"] = int(match.group(1))
+        if match := cls._UPTIME_HOURS.search(uptime_str):
+            info["hours"] = int(match.group(1))
+        if match := cls._UPTIME_MINUTES.search(uptime_str):
+            info["minutes"] = int(match.group(1))
+
+        return info
+
+    @classmethod
+    def _parse_software(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse software version and ROM lines."""
+        if match := cls._SOFTWARE_VERSION.match(line):
+            version = match.group("version")
+            extra = match.group("extra")
+            if extra:
+                version = f"{version} {extra}"
+            result["software_version"] = version
+            return True
+
+        if match := cls._ROM.match(line):
+            result["rom"] = match.group("rom").rstrip(",").strip()
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_uptime(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse uptime lines (system uptime or device-name uptime)."""
+        if match := cls._SYSTEM_UPTIME.match(line):
+            result["uptime"] = cls._parse_uptime_string(match.group("uptime"))
+            return True
+
+        if match := cls._DEVICE_UPTIME.match(line):
+            result["device_name"] = match.group("hostname")
+            result["uptime"] = cls._parse_uptime_string(match.group("uptime"))
+            return True
+
+        return False
+
+    @classmethod
+    def _parse_hardware(cls, line: str, result: dict[str, object]) -> bool:
+        """Parse image file and chassis lines."""
+        if match := cls._IMAGE_FILE.match(line):
+            result["image_file"] = match.group("file")
+            return True
+
+        if match := cls._CHASSIS_WITH_MEMORY.match(line):
+            result["chassis"] = f"cisco {match.group('chassis')}"
+            processor = match.group("processor").strip()
+            if processor:
+                result["processor"] = processor
+            result["memory"] = match.group("memory")
+            return True
+
+        return False
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVersionBriefResult:
+        """Parse 'show version brief' output on Cisco IOS-XR.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed version brief information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result: dict[str, object] = {}
+
+        for line in output.splitlines():
+            stripped = line.rstrip()
+            if stripped:
+                (
+                    cls._parse_software(stripped, result)
+                    or cls._parse_uptime(stripped, result)
+                    or cls._parse_hardware(stripped, result)
+                )
+
+        required = ["software_version", "chassis"]
+        missing = [f for f in required if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return cast(ShowVersionBriefResult, result)

--- a/tests/parsers/cisco_iosxr/show_version_brief/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_version_brief/001_basic/expected.json
@@ -11,6 +11,29 @@
     },
     "image_file": "disk0:asr9k-os-mbi-5.3.2.sp1-1.0.0/0x100305/mbiasr9k-rsp3.vm",
     "chassis": "cisco ASR9K Series",
+    "chassis_detail": "ASR 9912 10 Line Card Slot Chassis with V2 AC PEM",
     "processor": "Intel 686 F6M14S4",
-    "memory": "12582912K bytes"
+    "processor_speed": "2130MHz",
+    "memory": "12582912K bytes",
+    "nvram": "503k bytes",
+    "interfaces": {
+        "Management Ethernet": 4,
+        "GigabitEthernet/IEEE 802.3": 132,
+        "TenGigE": 72,
+        "DWDM controller(s)": 72,
+        "WANPHY controller(s)": 72
+    },
+    "storage": {
+        "hard disk": {
+            "size": "6111M bytes"
+        },
+        "disk0:": {
+            "size": "12510192k bytes",
+            "sector_size": 512
+        },
+        "disk1:": {
+            "size": "12510192k bytes",
+            "sector_size": 512
+        }
+    }
 }

--- a/tests/parsers/cisco_iosxr/show_version_brief/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_version_brief/001_basic/expected.json
@@ -1,0 +1,16 @@
+{
+    "software_version": "5.3.2",
+    "rom": "System Bootstrap, Version 5.15(c) 1994-2012 by Cisco Systems,  Inc.",
+    "device_name": "rtr-01",
+    "uptime": {
+        "years": 2,
+        "weeks": 51,
+        "days": 5,
+        "hours": 11,
+        "minutes": 1
+    },
+    "image_file": "disk0:asr9k-os-mbi-5.3.2.sp1-1.0.0/0x100305/mbiasr9k-rsp3.vm",
+    "chassis": "cisco ASR9K Series",
+    "processor": "Intel 686 F6M14S4",
+    "memory": "12582912K bytes"
+}

--- a/tests/parsers/cisco_iosxr/show_version_brief/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_version_brief/001_basic/input.txt
@@ -1,0 +1,24 @@
+
+Wed Jul 27 17:17:42.915 CST
+
+Cisco IOS XR Software, Version 5.3.2[Default]
+Copyright (c) 2015 by Cisco Systems, Inc.
+
+ROM: System Bootstrap, Version 5.15(c) 1994-2012 by Cisco Systems,  Inc.
+
+rtr-01 uptime is 2 years, 51 weeks, 5 days, 11 hours, 1 minute
+System image file is "disk0:asr9k-os-mbi-5.3.2.sp1-1.0.0/0x100305/mbiasr9k-rsp3.vm"
+
+cisco ASR9K Series (Intel 686 F6M14S4) processor with 12582912K bytes of memory.
+Intel 686 F6M14S4 processor at 2130MHz, Revision 2.174
+ASR 9912 10 Line Card Slot Chassis with V2 AC PEM
+
+4 Management Ethernet
+132 GigabitEthernet/IEEE 802.3 interface(s)
+72 TenGigE
+72 DWDM controller(s)
+72 WANPHY controller(s)
+503k bytes of non-volatile configuration memory.
+6111M bytes of hard disk.
+12510192k bytes of disk0: (Sector size 512 bytes).
+12510192k bytes of disk1: (Sector size 512 bytes).

--- a/tests/parsers/cisco_iosxr/show_version_brief/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_version_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "ASR9K with ROM, image file, uptime, and chassis info"
+platform: "ASR 9912"
+software_version: "IOS-XR 5.3.2"


### PR DESCRIPTION
## Summary
- Add new parser for `show version brief` on Cisco IOS-XR
- Extracts software version, ROM, device name, uptime, image file, chassis, processor, and memory
- Reuses `UptimeInfo` TypedDict from the existing `show version` parser
- Tagged with `ParserTag.SYSTEM`

## Test plan
- [x] Test fixture `001_basic` uses real ASR9K device output (IOS-XR 5.3.2)
- [x] All 7 fixture tests pass (parser output, JSON conventions, placeholder sentinels)
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)