### PR TITLE
feat(cisco_iosxr): add parser for ping

### DIFF
--- a/changes/+cisco-iosxr-ping.parser_added
+++ b/changes/+cisco-iosxr-ping.parser_added
@@ -1,0 +1,1 @@
+Added parser for `ping` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/ping.py
+++ b/src/muninn/parsers/cisco_iosxr/ping.py
@@ -1,0 +1,111 @@
+"""Parser for 'ping' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PingPacketData(TypedDict):
+    """Per-packet ping result."""
+
+    result: str
+
+
+class PingResult(TypedDict):
+    """Schema for 'ping' parsed output.
+
+    RTT fields are only present when at least one reply was received.
+    """
+
+    packets_sent: int
+    packets_received: int
+    success_rate_percent: int
+    packet_data: dict[str, PingPacketData]
+    rtt_min_ms: NotRequired[int]
+    rtt_avg_ms: NotRequired[int]
+    rtt_max_ms: NotRequired[int]
+
+
+_SUCCESS_RATE_RE = re.compile(
+    r"Success rate is (?P<success_rate>\d+) percent"
+    r" \((?P<received>\d+)/(?P<sent>\d+)\)"
+    r"(?:,\s*round-trip min/avg/max\s*=\s*"
+    r"(?P<rtt_min>\d+)/(?P<rtt_avg>\d+)/(?P<rtt_max>\d+)\s*ms)?"
+)
+
+_PACKET_LINE_RE = re.compile(r"^[!.UQM&?]+$")
+
+_PACKET_RESULT_MAP: dict[str, str] = {
+    "!": "successful",
+    ".": "failed",
+    "U": "unreachable",
+    "Q": "source_quench",
+    "M": "cannot_fragment",
+    "&": "time_exceeded",
+    "?": "unknown",
+}
+
+
+@register(OS.CISCO_IOSXR, "ping")
+class PingParser(BaseParser["PingResult"]):
+    """Parser for 'ping' command on Cisco IOS-XR.
+
+    Example output::
+
+        Fri Dec 22 17:30:39.512 BRA
+        Type escape sequence to abort.
+        Sending 5, 100-byte ICMP Echos to 10.191.129.114, timeout is 2 seconds:
+        !!!!!
+        Success rate is 100 percent (5/5), round-trip min/avg/max = 1/1/1 ms
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.CONNECTIVITY})
+
+    @classmethod
+    def parse(cls, output: str) -> PingResult:
+        """Parse 'ping' output into structured data.
+
+        Args:
+            output: Raw CLI output from 'ping' command.
+
+        Returns:
+            Parsed ping result with success rate, packet counts,
+            and optional RTT statistics.
+
+        Raises:
+            ValueError: If no success rate line is found in the output.
+        """
+        packet_symbols: list[str] = []
+
+        for line in output.splitlines():
+            match = _SUCCESS_RATE_RE.search(line)
+            if match:
+                result: PingResult = {
+                    "success_rate_percent": int(match.group("success_rate")),
+                    "packets_received": int(match.group("received")),
+                    "packets_sent": int(match.group("sent")),
+                    "packet_data": {
+                        str(index): PingPacketData(
+                            result=_PACKET_RESULT_MAP.get(symbol, "unknown"),
+                        )
+                        for index, symbol in enumerate(packet_symbols, start=1)
+                    },
+                }
+
+                if match.group("rtt_min") is not None:
+                    result["rtt_min_ms"] = int(match.group("rtt_min"))
+                    result["rtt_avg_ms"] = int(match.group("rtt_avg"))
+                    result["rtt_max_ms"] = int(match.group("rtt_max"))
+
+                return result
+
+            stripped = line.strip()
+            if _PACKET_LINE_RE.fullmatch(stripped):
+                packet_symbols.extend(stripped)
+
+        msg = "No success rate line found in ping output"
+        raise ValueError(msg)

--- a/tests/parsers/cisco_iosxr/ping/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/ping/001_basic/expected.json
@@ -1,0 +1,25 @@
+{
+    "success_rate_percent": 100,
+    "packets_received": 5,
+    "packets_sent": 5,
+    "packet_data": {
+        "1": {
+            "result": "successful"
+        },
+        "2": {
+            "result": "successful"
+        },
+        "3": {
+            "result": "successful"
+        },
+        "4": {
+            "result": "successful"
+        },
+        "5": {
+            "result": "successful"
+        }
+    },
+    "rtt_min_ms": 1,
+    "rtt_avg_ms": 1,
+    "rtt_max_ms": 1
+}

--- a/tests/parsers/cisco_iosxr/ping/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/ping/001_basic/input.txt
@@ -1,0 +1,5 @@
+Fri Dec 22 17:30:39.512 BRA
+Type escape sequence to abort.
+Sending 5, 100-byte ICMP Echos to 10.191.129.114, timeout is 2 seconds:
+!!!!!
+Success rate is 100 percent (5/5), round-trip min/avg/max = 1/1/1 ms

--- a/tests/parsers/cisco_iosxr/ping/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/ping/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic successful ping with 100% success rate and RTT statistics
+platform: Unknown
+software_version: IOS-XR

--- a/tests/parsers/cisco_iosxr/ping/002_all_failed/expected.json
+++ b/tests/parsers/cisco_iosxr/ping/002_all_failed/expected.json
@@ -1,0 +1,22 @@
+{
+    "success_rate_percent": 0,
+    "packets_received": 0,
+    "packets_sent": 5,
+    "packet_data": {
+        "1": {
+            "result": "failed"
+        },
+        "2": {
+            "result": "failed"
+        },
+        "3": {
+            "result": "failed"
+        },
+        "4": {
+            "result": "failed"
+        },
+        "5": {
+            "result": "failed"
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/ping/002_all_failed/input.txt
+++ b/tests/parsers/cisco_iosxr/ping/002_all_failed/input.txt
@@ -1,0 +1,5 @@
+Fri Nov 17 16:29:18.710 BRA
+Type escape sequence to abort.
+Sending 5, 100-byte ICMP Echos to 10.27.18.2, timeout is 2 seconds:
+.....
+Success rate is 0 percent (0/5)

--- a/tests/parsers/cisco_iosxr/ping/002_all_failed/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/ping/002_all_failed/metadata.yaml
@@ -1,0 +1,3 @@
+description: Ping with 0% success rate and no RTT statistics
+platform: Unknown
+software_version: IOS-XR


### PR DESCRIPTION
## Summary
- Add parser for `ping` command on Cisco IOS-XR
- Parses success rate, packets sent/received, per-packet results, and optional RTT min/avg/max
- Includes two test fixtures: successful ping (100%) and failed ping (0%)

## Test plan
- [x] Parser tests pass for both `001_basic` (100% success) and `002_all_failed` (0% success)
- [x] Full test suite passes (6855 tests)
- [x] Pre-commit hooks pass (ruff, xenon, json formatting, etc.)
- [x] No placeholder sentinel violations in expected.json files

🤖 Generated with [Claude Code](https://claude.com/claude-code)