### PR TITLE
feat(cisco_iosxr): add parser for `dir`

### DIFF
--- a/changes/+cisco-iosxr-dir.parser_added
+++ b/changes/+cisco-iosxr-dir.parser_added
@@ -1,0 +1,1 @@
+Added parser for `dir` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/dir.py
+++ b/src/muninn/parsers/cisco_iosxr/dir.py
@@ -8,18 +8,21 @@ from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
 
+_KBYTES_PER_BYTE = 1024
+
 
 class FileEntry(TypedDict):
     """Schema for a single file or directory entry."""
 
     permissions: str
     links: int
-    size: int
+    size_bytes: int
     date: str
     name: str
-    inode: NotRequired[int]
+    inode: int
     owner: NotRequired[str]
     group: NotRequired[str]
+    symlink_target: NotRequired[str]
 
 
 class DirResult(TypedDict):
@@ -27,8 +30,8 @@ class DirResult(TypedDict):
 
     directory: str
     files: dict[str, FileEntry]
-    total_kbytes: int
-    free_kbytes: int
+    total_bytes: int
+    free_bytes: int
 
 
 _DIRECTORY_HEADER = re.compile(r"^Directory\s+of\s+(?P<directory>\S+)\s*$")
@@ -47,9 +50,11 @@ _FILE_ENTRY = re.compile(
     r"(?:(?P<owner>\S+)\s+(?P<group>\S+)\s+)?"
     r"(?P<size>\d+)\s+"
     r"(?P<date>\w{3}\s+\d{1,2}\s+[\d:]+(?:\s+\d{4})?)\s+"
-    r"(?P<name>\S+(?:\s+->\s+\S+)?)\s*$"
+    r"(?P<name>\S+)(?:\s+->\s+(?P<symlink_target>\S+))?\s*$"
 )
 
+# IOS-XR reports filesystem totals in kbytes; we normalize to bytes for
+# parity with the IOS-XE sibling parser.
 _SUMMARY = re.compile(
     r"^(?P<total>\d+)\s+kbytes\s+total\s+"
     r"\((?P<free>\d+)\s+kbytes\s+free\)\s*$"
@@ -61,7 +66,7 @@ def _build_file_entry(match: re.Match[str]) -> FileEntry:
     entry = FileEntry(
         permissions=match.group("permissions"),
         links=int(match.group("links")),
-        size=int(match.group("size")),
+        size_bytes=int(match.group("size")),
         date=match.group("date"),
         name=match.group("name"),
         inode=int(match.group("inode")),
@@ -70,6 +75,8 @@ def _build_file_entry(match: re.Match[str]) -> FileEntry:
         entry["owner"] = match.group("owner")
     if match.group("group"):
         entry["group"] = match.group("group")
+    if match.group("symlink_target"):
+        entry["symlink_target"] = match.group("symlink_target")
     return entry
 
 
@@ -103,13 +110,13 @@ class DirParser(BaseParser[DirResult]):
         """
         directory = _extract_directory(output)
         files = _extract_files(output)
-        total_kbytes, free_kbytes = _extract_summary(output)
+        total_bytes, free_bytes = _extract_summary(output)
 
         return DirResult(
             directory=directory,
             files=files,
-            total_kbytes=total_kbytes,
-            free_kbytes=free_kbytes,
+            total_bytes=total_bytes,
+            free_bytes=free_bytes,
         )
 
 
@@ -135,10 +142,12 @@ def _extract_files(output: str) -> dict[str, FileEntry]:
 
 
 def _extract_summary(output: str) -> tuple[int, int]:
-    """Extract total and free kbytes from the summary line."""
+    """Extract total and free space, converting from kbytes to bytes."""
     for line in output.splitlines():
         match = _SUMMARY.match(line.strip())
         if match:
-            return int(match.group("total")), int(match.group("free"))
+            total_bytes = int(match.group("total")) * _KBYTES_PER_BYTE
+            free_bytes = int(match.group("free")) * _KBYTES_PER_BYTE
+            return total_bytes, free_bytes
     msg = "No summary line found in output"
     raise ValueError(msg)

--- a/src/muninn/parsers/cisco_iosxr/dir.py
+++ b/src/muninn/parsers/cisco_iosxr/dir.py
@@ -1,0 +1,144 @@
+"""Parser for 'dir' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FileEntry(TypedDict):
+    """Schema for a single file or directory entry."""
+
+    permissions: str
+    links: int
+    size: int
+    date: str
+    name: str
+    inode: NotRequired[int]
+    owner: NotRequired[str]
+    group: NotRequired[str]
+
+
+class DirResult(TypedDict):
+    """Schema for 'dir' parsed output."""
+
+    directory: str
+    files: dict[str, FileEntry]
+    total_kbytes: int
+    free_kbytes: int
+
+
+_DIRECTORY_HEADER = re.compile(r"^Directory\s+of\s+(?P<directory>\S+)\s*$")
+
+# IOS-XR dir entry format:
+#   74 drwxrwxrwx. 2  4096 Dec  6 19:39 resmon_debug
+#   38 -rw-------. 1   444 Nov 15  2023 .bash_history
+#   15 lrwxrwxrwx. 1    12 Nov 15 14:58 config -> /misc/config
+#
+# Fields: inode, permissions (may end with .), links, [owner group], size,
+#         month day time_or_year, name [-> target]
+_FILE_ENTRY = re.compile(
+    r"^\s*(?P<inode>\d+)\s+"
+    r"(?P<permissions>[dlrwxsStT-]+\.?)\s+"
+    r"(?P<links>\d+)\s+"
+    r"(?:(?P<owner>\S+)\s+(?P<group>\S+)\s+)?"
+    r"(?P<size>\d+)\s+"
+    r"(?P<date>\w{3}\s+\d{1,2}\s+[\d:]+(?:\s+\d{4})?)\s+"
+    r"(?P<name>\S+(?:\s+->\s+\S+)?)\s*$"
+)
+
+_SUMMARY = re.compile(
+    r"^(?P<total>\d+)\s+kbytes\s+total\s+"
+    r"\((?P<free>\d+)\s+kbytes\s+free\)\s*$"
+)
+
+
+def _build_file_entry(match: re.Match[str]) -> FileEntry:
+    """Build a FileEntry from a regex match."""
+    entry = FileEntry(
+        permissions=match.group("permissions"),
+        links=int(match.group("links")),
+        size=int(match.group("size")),
+        date=match.group("date"),
+        name=match.group("name"),
+        inode=int(match.group("inode")),
+    )
+    if match.group("owner"):
+        entry["owner"] = match.group("owner")
+    if match.group("group"):
+        entry["group"] = match.group("group")
+    return entry
+
+
+@register(OS.CISCO_IOSXR, "dir")
+@register(OS.CISCO_IOSXR, r"dir (?P<filesystem>\S+)")
+class DirParser(BaseParser[DirResult]):
+    """Parser for 'dir' command output on IOS-XR.
+
+    Example output:
+        Directory of /var/xr/scratch
+        74 drwxrwxrwx. 2  4096 Dec  6 19:39 resmon_debug
+        22 -rw-rw-rw-. 1  2464 Jan  7 19:34 status_file
+
+        3365348 kbytes total (3163632 kbytes free)
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> DirResult:
+        """Parse 'dir' output from IOS-XR.
+
+        Args:
+            output: Raw CLI output from 'dir' command.
+
+        Returns:
+            Parsed directory listing data.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        directory = _extract_directory(output)
+        files = _extract_files(output)
+        total_kbytes, free_kbytes = _extract_summary(output)
+
+        return DirResult(
+            directory=directory,
+            files=files,
+            total_kbytes=total_kbytes,
+            free_kbytes=free_kbytes,
+        )
+
+
+def _extract_directory(output: str) -> str:
+    """Extract the directory path from the header line."""
+    for line in output.splitlines():
+        match = _DIRECTORY_HEADER.match(line.strip())
+        if match:
+            return match.group("directory")
+    msg = "No directory header found in output"
+    raise ValueError(msg)
+
+
+def _extract_files(output: str) -> dict[str, FileEntry]:
+    """Extract all file entries from the output."""
+    files: dict[str, FileEntry] = {}
+    for line in output.splitlines():
+        match = _FILE_ENTRY.match(line)
+        if match:
+            entry = _build_file_entry(match)
+            files[entry["name"]] = entry
+    return files
+
+
+def _extract_summary(output: str) -> tuple[int, int]:
+    """Extract total and free kbytes from the summary line."""
+    for line in output.splitlines():
+        match = _SUMMARY.match(line.strip())
+        if match:
+            return int(match.group("total")), int(match.group("free"))
+    msg = "No summary line found in output"
+    raise ValueError(msg)

--- a/tests/parsers/cisco_iosxr/dir/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/dir/001_basic/expected.json
@@ -4,7 +4,7 @@
         "resmon_debug": {
             "permissions": "drwxrwxrwx.",
             "links": 2,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Dec  6 19:39",
             "name": "resmon_debug",
             "inode": 74
@@ -12,7 +12,7 @@
         "status_file": {
             "permissions": "-rw-rw-rw-.",
             "links": 1,
-            "size": 2464,
+            "size_bytes": 2464,
             "date": "Jan  7 19:34",
             "name": "status_file",
             "inode": 22
@@ -20,7 +20,7 @@
         "lost+found": {
             "permissions": "drwx------.",
             "links": 2,
-            "size": 16384,
+            "size_bytes": 16384,
             "date": "Nov 15 14:44",
             "name": "lost+found",
             "inode": 11
@@ -28,7 +28,7 @@
         "shutdown": {
             "permissions": "drwxr-xr-x.",
             "links": 3,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Jan  7 19:32",
             "name": "shutdown",
             "inode": 13
@@ -36,7 +36,7 @@
         "syslog-hm": {
             "permissions": "drwxrwxrwx.",
             "links": 3,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Nov 15 14:59",
             "name": "syslog-hm",
             "inode": 23
@@ -44,7 +44,7 @@
         "asic-err-logs-backup": {
             "permissions": "drwxrwxrwx.",
             "links": 3,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Dec  5 22:00",
             "name": "asic-err-logs-backup",
             "inode": 68
@@ -52,23 +52,24 @@
         "pam": {
             "permissions": "drwxr-xr-x.",
             "links": 3,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Nov 15 15:01",
             "name": "pam",
             "inode": 41
         },
-        "config -> /misc/config": {
+        "config": {
             "permissions": "lrwxrwxrwx.",
             "links": 1,
-            "size": 12,
+            "size_bytes": 12,
             "date": "Nov 15 14:58",
-            "name": "config -> /misc/config",
-            "inode": 15
+            "name": "config",
+            "inode": 15,
+            "symlink_target": "/misc/config"
         },
         "envoke_log": {
             "permissions": "-rw-r--r--.",
             "links": 1,
-            "size": 936,
+            "size_bytes": 936,
             "date": "Jan  7 19:32",
             "name": "envoke_log",
             "inode": 14
@@ -76,7 +77,7 @@
         "crypto": {
             "permissions": "drwxrwxrwx.",
             "links": 2,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Jan  7 19:33",
             "name": "crypto",
             "inode": 28
@@ -84,7 +85,7 @@
         "core": {
             "permissions": "drwxr-xr-x.",
             "links": 3,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Dec 11 00:53",
             "name": "core",
             "inode": 12
@@ -92,7 +93,7 @@
         "npu_drvr_cfg": {
             "permissions": "drwxrwxrwx.",
             "links": 2,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Nov 15 14:58",
             "name": "npu_drvr_cfg",
             "inode": 17
@@ -100,7 +101,7 @@
         "nvgen_traces": {
             "permissions": "drwxr-xr-x.",
             "links": 2,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Dec  5 22:46",
             "name": "nvgen_traces",
             "inode": 55
@@ -108,7 +109,7 @@
         ".bash_history": {
             "permissions": "-rw-------.",
             "links": 1,
-            "size": 444,
+            "size_bytes": 444,
             "date": "Nov 15  2023",
             "name": ".bash_history",
             "inode": 38
@@ -116,7 +117,7 @@
         "ztp": {
             "permissions": "drwxrwxrwx.",
             "links": 9,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Jan  7 19:34",
             "name": "ztp",
             "inode": 25
@@ -124,12 +125,12 @@
         "clihistory": {
             "permissions": "drwx---r-x.",
             "links": 2,
-            "size": 4096,
+            "size_bytes": 4096,
             "date": "Nov 15 14:58",
             "name": "clihistory",
             "inode": 19
         }
     },
-    "total_kbytes": 3365348,
-    "free_kbytes": 3163632
+    "total_bytes": 3446116352,
+    "free_bytes": 3239559168
 }

--- a/tests/parsers/cisco_iosxr/dir/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/dir/001_basic/expected.json
@@ -1,0 +1,135 @@
+{
+    "directory": "/var/xr/scratch",
+    "files": {
+        "resmon_debug": {
+            "permissions": "drwxrwxrwx.",
+            "links": 2,
+            "size": 4096,
+            "date": "Dec  6 19:39",
+            "name": "resmon_debug",
+            "inode": 74
+        },
+        "status_file": {
+            "permissions": "-rw-rw-rw-.",
+            "links": 1,
+            "size": 2464,
+            "date": "Jan  7 19:34",
+            "name": "status_file",
+            "inode": 22
+        },
+        "lost+found": {
+            "permissions": "drwx------.",
+            "links": 2,
+            "size": 16384,
+            "date": "Nov 15 14:44",
+            "name": "lost+found",
+            "inode": 11
+        },
+        "shutdown": {
+            "permissions": "drwxr-xr-x.",
+            "links": 3,
+            "size": 4096,
+            "date": "Jan  7 19:32",
+            "name": "shutdown",
+            "inode": 13
+        },
+        "syslog-hm": {
+            "permissions": "drwxrwxrwx.",
+            "links": 3,
+            "size": 4096,
+            "date": "Nov 15 14:59",
+            "name": "syslog-hm",
+            "inode": 23
+        },
+        "asic-err-logs-backup": {
+            "permissions": "drwxrwxrwx.",
+            "links": 3,
+            "size": 4096,
+            "date": "Dec  5 22:00",
+            "name": "asic-err-logs-backup",
+            "inode": 68
+        },
+        "pam": {
+            "permissions": "drwxr-xr-x.",
+            "links": 3,
+            "size": 4096,
+            "date": "Nov 15 15:01",
+            "name": "pam",
+            "inode": 41
+        },
+        "config -> /misc/config": {
+            "permissions": "lrwxrwxrwx.",
+            "links": 1,
+            "size": 12,
+            "date": "Nov 15 14:58",
+            "name": "config -> /misc/config",
+            "inode": 15
+        },
+        "envoke_log": {
+            "permissions": "-rw-r--r--.",
+            "links": 1,
+            "size": 936,
+            "date": "Jan  7 19:32",
+            "name": "envoke_log",
+            "inode": 14
+        },
+        "crypto": {
+            "permissions": "drwxrwxrwx.",
+            "links": 2,
+            "size": 4096,
+            "date": "Jan  7 19:33",
+            "name": "crypto",
+            "inode": 28
+        },
+        "core": {
+            "permissions": "drwxr-xr-x.",
+            "links": 3,
+            "size": 4096,
+            "date": "Dec 11 00:53",
+            "name": "core",
+            "inode": 12
+        },
+        "npu_drvr_cfg": {
+            "permissions": "drwxrwxrwx.",
+            "links": 2,
+            "size": 4096,
+            "date": "Nov 15 14:58",
+            "name": "npu_drvr_cfg",
+            "inode": 17
+        },
+        "nvgen_traces": {
+            "permissions": "drwxr-xr-x.",
+            "links": 2,
+            "size": 4096,
+            "date": "Dec  5 22:46",
+            "name": "nvgen_traces",
+            "inode": 55
+        },
+        ".bash_history": {
+            "permissions": "-rw-------.",
+            "links": 1,
+            "size": 444,
+            "date": "Nov 15  2023",
+            "name": ".bash_history",
+            "inode": 38
+        },
+        "ztp": {
+            "permissions": "drwxrwxrwx.",
+            "links": 9,
+            "size": 4096,
+            "date": "Jan  7 19:34",
+            "name": "ztp",
+            "inode": 25
+        },
+        "clihistory": {
+            "permissions": "drwx---r-x.",
+            "links": 2,
+            "size": 4096,
+            "date": "Nov 15 14:58",
+            "name": "clihistory",
+            "inode": 19
+        }
+    },
+    "total_kbytes": 3365348,
+    "free_kbytes": 3163632
+}

--- a/tests/parsers/cisco_iosxr/dir/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/dir/001_basic/input.txt
@@ -1,0 +1,21 @@
+Tue Jan 16 17:08:43.028 AEST
+
+Directory of /var/xr/scratch
+74 drwxrwxrwx. 2  4096 Dec  6 19:39 resmon_debug
+22 -rw-rw-rw-. 1  2464 Jan  7 19:34 status_file
+11 drwx------. 2 16384 Nov 15 14:44 lost+found
+13 drwxr-xr-x. 3  4096 Jan  7 19:32 shutdown
+23 drwxrwxrwx. 3  4096 Nov 15 14:59 syslog-hm
+68 drwxrwxrwx. 3  4096 Dec  5 22:00 asic-err-logs-backup
+41 drwxr-xr-x. 3  4096 Nov 15 15:01 pam
+15 lrwxrwxrwx. 1    12 Nov 15 14:58 config -> /misc/config
+14 -rw-r--r--. 1   936 Jan  7 19:32 envoke_log
+28 drwxrwxrwx. 2  4096 Jan  7 19:33 crypto
+12 drwxr-xr-x. 3  4096 Dec 11 00:53 core
+17 drwxrwxrwx. 2  4096 Nov 15 14:58 npu_drvr_cfg
+55 drwxr-xr-x. 2  4096 Dec  5 22:46 nvgen_traces
+38 -rw-------. 1   444 Nov 15  2023 .bash_history
+25 drwxrwxrwx. 9  4096 Jan  7 19:34 ztp
+19 drwx---r-x. 2  4096 Nov 15 14:58 clihistory
+
+3365348 kbytes total (3163632 kbytes free)

--- a/tests/parsers/cisco_iosxr/dir/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/dir/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Standard directory listing with files, directories, and a symlink
+platform: Unknown
+software_version: IOS-XR


### PR DESCRIPTION
## Summary
- Add new parser for the `dir` command on Cisco IOS-XR
- Parses directory path, file entries (permissions, link count, inode, size, date, name including symlink targets), and total/free kbytes summary
- Dict-of-dicts keyed by filename, tagged with `ParserTag.SYSTEM`
- Includes test fixture from real device output

## Test plan
- [x] Parser test passes (`test_parser[cisco_iosxr/dir/001_basic]`)
- [x] All fixture sentinel checks pass (no placeholder values)
- [x] JSON convention checks pass (no list-of-dicts, no pipe keys)
- [x] Empty output tests pass
- [x] ruff check and format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)