### PR TITLE
feat(arista_eos): add parser for `dir`

### DIFF
--- a/changes/+arista-eos-dir.parser_added
+++ b/changes/+arista-eos-dir.parser_added
@@ -1,0 +1,1 @@
+Added parser for `dir` on Arista EOS.

--- a/src/muninn/parsers/arista_eos/dir.py
+++ b/src/muninn/parsers/arista_eos/dir.py
@@ -1,0 +1,137 @@
+"""Parser for 'dir' command on Arista EOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FileEntry(TypedDict):
+    """Schema for a single file or directory entry."""
+
+    permissions: str
+    size: int
+    date: str
+    type: str
+
+
+class DirResult(TypedDict):
+    """Schema for 'dir' parsed output on Arista EOS."""
+
+    directory: str
+    files: dict[str, FileEntry]
+    total_bytes: int
+    free_bytes: int
+
+
+@register(OS.ARISTA_EOS, "dir")
+class DirParser(BaseParser[DirResult]):
+    """Parser for 'dir' command on Arista EOS.
+
+    Parses directory listing including file entries with permissions,
+    size, date, and name. Extracts total and free space from the
+    summary line. Only the first directory section is parsed.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _DIRECTORY_HEADER = re.compile(r"^Directory of (?P<directory>\S+)")
+    _FILE_ENTRY = re.compile(
+        r"^\s+(?P<perms>[drwx-]+)\s+(?P<size>\d+)\s+"
+        r"(?P<date>\S+\s+\S+\s+\S+)\s+(?P<name>\S+)$"
+    )
+    _SPACE_SUMMARY = re.compile(
+        r"^(?P<total>\d+)\s+bytes total\s+\((?P<free>\d+)\s+bytes free\)"
+    )
+
+    @classmethod
+    def _parse_file_entry(cls, line: str) -> tuple[str, FileEntry] | None:
+        """Parse a single file entry line into a (name, entry) pair."""
+        match = cls._FILE_ENTRY.match(line)
+        if not match:
+            return None
+        perms = match.group("perms")
+        file_type = "directory" if perms.startswith("d") else "file"
+        return (
+            match.group("name"),
+            FileEntry(
+                permissions=perms,
+                size=int(match.group("size")),
+                date=match.group("date"),
+                type=file_type,
+            ),
+        )
+
+    @classmethod
+    def _parse_space_summary(cls, line: str) -> tuple[int, int] | None:
+        """Parse the bytes total / bytes free summary line."""
+        match = cls._SPACE_SUMMARY.match(line)
+        if not match:
+            return None
+        return int(match.group("total")), int(match.group("free"))
+
+    @classmethod
+    def _validate(
+        cls,
+        directory: str | None,
+        total_bytes: int | None,
+        free_bytes: int | None,
+    ) -> None:
+        """Raise if required fields are missing."""
+        if directory is None:
+            msg = "No directory header found in output"
+            raise ValueError(msg)
+        if total_bytes is None or free_bytes is None:
+            msg = "No space summary found in output"
+            raise ValueError(msg)
+
+    @classmethod
+    def parse(cls, output: str) -> DirResult:
+        """Parse 'dir' output on Arista EOS.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed directory listing.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        directory: str | None = None
+        files: dict[str, FileEntry] = {}
+        total_bytes: int | None = None
+        free_bytes: int | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._DIRECTORY_HEADER.match(stripped):
+                if directory is not None:
+                    break  # Stop at second directory header (recursive output)
+                directory = match.group("directory")
+                continue
+
+            if entry := cls._parse_file_entry(line):
+                files[entry[0]] = entry[1]
+                continue
+
+            if space := cls._parse_space_summary(stripped):
+                total_bytes, free_bytes = space
+
+        cls._validate(directory, total_bytes, free_bytes)
+
+        return cast(
+            DirResult,
+            {
+                "directory": directory,
+                "files": files,
+                "total_bytes": total_bytes,
+                "free_bytes": free_bytes,
+            },
+        )

--- a/tests/parsers/arista_eos/dir/001_basic/expected.json
+++ b/tests/parsers/arista_eos/dir/001_basic/expected.json
@@ -1,0 +1,73 @@
+{
+    "directory": "flash:/",
+    "files": {
+        "EOS-4.18.3.1F.swi": {
+            "permissions": "-rwx",
+            "size": 591941836,
+            "date": "Aug 2  2017",
+            "type": "file"
+        },
+        "EOS-4.19.5M.swi": {
+            "permissions": "-rwx",
+            "size": 609823300,
+            "date": "Feb 14 02:03",
+            "type": "file"
+        },
+        "boot-config": {
+            "permissions": "-rwx",
+            "size": 29,
+            "date": "Aug 23  2017",
+            "type": "file"
+        },
+        "debug": {
+            "permissions": "drwx",
+            "size": 4096,
+            "date": "Aug 23  2017",
+            "type": "directory"
+        },
+        "enable3px": {
+            "permissions": "-rwx",
+            "size": 0,
+            "date": "Apr 15  2017",
+            "type": "file"
+        },
+        "enable3px.key": {
+            "permissions": "-rwx",
+            "size": 19,
+            "date": "Apr 15  2017",
+            "type": "file"
+        },
+        "kickstart-config": {
+            "permissions": "-rwx",
+            "size": 31,
+            "date": "Apr 15  2017",
+            "type": "file"
+        },
+        "persist": {
+            "permissions": "drwx",
+            "size": 4096,
+            "date": "Apr 3 10:29",
+            "type": "directory"
+        },
+        "schedule": {
+            "permissions": "drwx",
+            "size": 4096,
+            "date": "Apr 15  2017",
+            "type": "directory"
+        },
+        "startup-config": {
+            "permissions": "-rwx",
+            "size": 20530,
+            "date": "Jan 18 22:46",
+            "type": "file"
+        },
+        "zerotouch-config": {
+            "permissions": "-rwx",
+            "size": 13,
+            "date": "Aug 23  2017",
+            "type": "file"
+        }
+    },
+    "total_bytes": 3519041536,
+    "free_bytes": 1725112320
+}

--- a/tests/parsers/arista_eos/dir/001_basic/input.txt
+++ b/tests/parsers/arista_eos/dir/001_basic/input.txt
@@ -1,0 +1,15 @@
+Directory of flash:/
+
+       -rwx   591941836            Aug 2  2017  EOS-4.18.3.1F.swi
+       -rwx   609823300           Feb 14 02:03  EOS-4.19.5M.swi
+       -rwx          29           Aug 23  2017  boot-config
+       drwx        4096           Aug 23  2017  debug
+       -rwx           0           Apr 15  2017  enable3px
+       -rwx          19           Apr 15  2017  enable3px.key
+       -rwx          31           Apr 15  2017  kickstart-config
+       drwx        4096            Apr 3 10:29  persist
+       drwx        4096           Apr 15  2017  schedule
+       -rwx       20530           Jan 18 22:46  startup-config
+       -rwx          13           Aug 23  2017  zerotouch-config
+
+3519041536 bytes total (1725112320 bytes free)

--- a/tests/parsers/arista_eos/dir/001_basic/metadata.yaml
+++ b/tests/parsers/arista_eos/dir/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic flash directory listing with files and directories
+platform: Unknown
+software_version: EOS 4.19.5M


### PR DESCRIPTION
## Summary
- Add new parser for the `dir` command on Arista EOS
- Parses directory path, file entries (permissions, size, date, name, type), and total/free space
- Dict-of-dicts keyed by filename; only parses the first directory section (handles recursive output gracefully)

## Test plan
- [x] Test fixture `001_basic` with real device output from flash directory listing
- [x] All 9 parametrized tests pass (parser, empty output, JSON conventions, placeholder sentinels)
- [x] Xenon complexity under B threshold
- [x] Ruff lint/format clean
- [x] Bandit security scan clean
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)