### PR TITLE
feat(juniper_junos): add parser for show ted database extensive

### DIFF
--- a/changes/+juniper-junos-show-ted-database-extensive.parser_added
+++ b/changes/+juniper-junos-show-ted-database-extensive.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ted database extensive` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_ted_database_extensive.py
+++ b/src/muninn/parsers/juniper_junos/show_ted_database_extensive.py
@@ -1,7 +1,7 @@
 """Parser for 'show ted database extensive' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -186,11 +186,11 @@ def _collect_bw_values(
     if bw_target == "available":
         available = link.get("available_bw_bps")
         if isinstance(available, list):
-            available.extend(bw_vals)
+            cast(list[str], available).extend(bw_vals)
     elif bw_target == "max_lsp" and current_iscd is not None:
         max_lsp = current_iscd.get("maximum_lsp_bw_bps")
         if isinstance(max_lsp, list):
-            max_lsp.extend(bw_vals)
+            cast(list[str], max_lsp).extend(bw_vals)
 
 
 def _parse_link_attributes(
@@ -244,7 +244,7 @@ def _parse_link_section_header(
 
     if m := _ISCD_HEADER.match(stripped):
         new_iscd: dict[str, object] = {}
-        iscd_dict[m.group("index")] = new_iscd  # type: ignore[assignment]
+        iscd_dict[m.group("index")] = cast(ISCDEntry, new_iscd)
         return new_iscd, ""
 
     if stripped.startswith("Maximum LSP BW"):
@@ -348,7 +348,7 @@ def _parse_link_block(
         )
 
     _finalize_link(link, iscd_dict, adj_sids)
-    return to_addr, LinkEntry(**link), idx  # type: ignore[arg-type]
+    return to_addr, cast(LinkEntry, link), idx
 
 
 def _is_prefix_section_boundary(line: str, stripped: str) -> bool:
@@ -404,7 +404,7 @@ def _parse_prefixes(
 
         if m := _PREFIX_LINE.match(lines[idx]):
             current = {}
-            prefixes[m.group("prefix")] = current  # type: ignore[assignment]
+            prefixes[m.group("prefix")] = cast(PrefixEntry, current)
             in_prefix_sid = False
             idx += 1
             continue
@@ -602,7 +602,7 @@ class ShowTedDatabaseExtensiveParser(
             idx += 1
 
             idx = _parse_node_body(lines, idx, node)
-            result[node_id] = NodeEntry(**node)  # type: ignore[arg-type]
+            result[node_id] = cast(NodeEntry, node)
 
         if not result:
             msg = "No TED nodes found in output"

--- a/src/muninn/parsers/juniper_junos/show_ted_database_extensive.py
+++ b/src/muninn/parsers/juniper_junos/show_ted_database_extensive.py
@@ -5,6 +5,7 @@ from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_PREFIX
 from muninn.registry import register
 from muninn.tags import ParserTag
 
@@ -15,9 +16,9 @@ _UNKNOWN_TYPE = "---"
 class ISCDEntry(TypedDict):
     """Interface Switching Capability Descriptor."""
 
-    switching_type: str
-    encoding_type: str
-    maximum_lsp_bw_bps: list[str]
+    switching_type: NotRequired[str]
+    encoding_type: NotRequired[str]
+    maximum_lsp_bw_bps: NotRequired[list[int]]
 
 
 class AdjacencySID(TypedDict):
@@ -55,16 +56,23 @@ class LinkEntry(TypedDict):
 
     local_address: str
     remote_address: str
-    local_interface_index: int
-    remote_interface_index: int
+    local_interface_index: NotRequired[int]
+    remote_interface_index: NotRequired[int]
     color: NotRequired[int]
     color_name: NotRequired[str]
-    metric: int
-    static_bw: NotRequired[str]
-    reservable_bw: NotRequired[str]
-    available_bw_bps: NotRequired[list[str]]
+    metric: NotRequired[int]
+    static_bw_bps: NotRequired[int]
+    reservable_bw_bps: NotRequired[int]
+    available_bw_bps: NotRequired[list[int]]
     iscd: NotRequired[dict[str, ISCDEntry]]
     adjacency_sids: NotRequired[dict[str, AdjacencySID]]
+
+
+class TedSummary(TypedDict):
+    """Summary counts from the TED database header line."""
+
+    isis_nodes: int
+    inet_nodes: int
 
 
 class NodeEntry(TypedDict):
@@ -81,7 +89,11 @@ class NodeEntry(TypedDict):
     spring_algorithms: NotRequired[list[int]]
 
 
-ShowTedDatabaseExtensiveResult = dict[str, NodeEntry]
+class ShowTedDatabaseExtensiveResult(TypedDict):
+    """Top-level result for 'show ted database extensive'."""
+
+    summary: NotRequired[TedSummary]
+    nodes: dict[str, NodeEntry]
 
 
 # -- Compiled patterns --
@@ -113,7 +125,10 @@ _ADJ_SID = re.compile(
     r"^\s*(?P<af>IPV[46]),\s+SID:\s+(?P<sid>\d+),"
     r"\s+Flags:\s+(?P<flags>0x[0-9a-fA-F]+),\s+Weight:\s+(?P<weight>\d+)\s*$"
 )
-_PREFIX_LINE = re.compile(r"^\s+(?P<prefix>\d+\.\d+\.\d+\.\d+/\d+)\s*$")
+_PREFIX_LINE = re.compile(rf"^\s+(?P<prefix>{IPV4_PREFIX})\s*$")
+_TED_SUMMARY = re.compile(
+    r"^\s*TED database:\s+(?P<isis>\d+)\s+ISIS nodes\s+(?P<inet>\d+)\s+INET nodes\s*$"
+)
 _PREFIX_FLAGS = re.compile(r"^\s*Flags:\s+(?P<flags>0x[0-9a-fA-F]+)\s*$")
 _PREFIX_SID_LINE = re.compile(
     r"^\s*SID:\s+(?P<sid>\d+),\s+Flags:\s+(?P<flags>0x[0-9a-fA-F]+),"
@@ -126,11 +141,40 @@ _SRGB_BLOCK = re.compile(
 )
 _SPRING_ALGO = re.compile(r"^\s*Algo:\s+(?P<algo>\d+)\s*$")
 _BW_VALUES = re.compile(r"\[(\d+)\]\s+(\S+)")
+_BW_NUMERIC = re.compile(r"^(?P<num>\d+)(?P<unit>[a-zA-Z]+)?$")
+_BW_UNIT_MULTIPLIERS = {
+    "bps": 1,
+    "Kbps": 1_000,
+    "Mbps": 1_000_000,
+    "Gbps": 1_000_000_000,
+    "Tbps": 1_000_000_000_000,
+}
 
 
-def _parse_bw_line(line: str) -> list[str]:
-    """Extract bandwidth values from a priority-indexed line."""
-    return [m.group(2) for m in _BW_VALUES.finditer(line)]
+def _parse_bw_value_to_bps(value: str) -> int | None:
+    """Convert a bandwidth string like '10bps' or '2Mbps' to integer bits/sec.
+
+    Returns None if the value cannot be parsed.
+    """
+    m = _BW_NUMERIC.match(value)
+    if not m:
+        return None
+    num = int(m.group("num"))
+    unit = m.group("unit") or "bps"
+    multiplier = _BW_UNIT_MULTIPLIERS.get(unit)
+    if multiplier is None:
+        return None
+    return num * multiplier
+
+
+def _parse_bw_line(line: str) -> list[int]:
+    """Extract bandwidth values from a priority-indexed line, in bits/sec."""
+    out: list[int] = []
+    for m in _BW_VALUES.finditer(line):
+        bps = _parse_bw_value_to_bps(m.group(2))
+        if bps is not None:
+            out.append(bps)
+    return out
 
 
 def _is_link_block_boundary(line: str, stripped: str) -> bool:
@@ -177,7 +221,7 @@ def _process_link_value_line(
 
 
 def _collect_bw_values(
-    bw_vals: list[str],
+    bw_vals: list[int],
     bw_target: str,
     link: dict[str, object],
     current_iscd: dict[str, object] | None,
@@ -186,11 +230,11 @@ def _collect_bw_values(
     if bw_target == "available":
         available = link.get("available_bw_bps")
         if isinstance(available, list):
-            cast(list[str], available).extend(bw_vals)
+            cast(list[int], available).extend(bw_vals)
     elif bw_target == "max_lsp" and current_iscd is not None:
         max_lsp = current_iscd.get("maximum_lsp_bw_bps")
         if isinstance(max_lsp, list):
-            cast(list[str], max_lsp).extend(bw_vals)
+            cast(list[int], max_lsp).extend(bw_vals)
 
 
 def _parse_link_attributes(
@@ -218,11 +262,15 @@ def _parse_link_attributes(
         return True
 
     if m := _STATIC_BW.match(stripped):
-        link["static_bw"] = m.group("bw")
+        bps = _parse_bw_value_to_bps(m.group("bw"))
+        if bps is not None:
+            link["static_bw_bps"] = bps
         return True
 
     if m := _RESERVABLE_BW.match(stripped):
-        link["reservable_bw"] = m.group("bw")
+        bps = _parse_bw_value_to_bps(m.group("bw"))
+        if bps is not None:
+            link["reservable_bw_bps"] = bps
         return True
 
     return False
@@ -544,6 +592,36 @@ def _parse_node_body(
     return idx
 
 
+def _parse_node(
+    lines: list[str],
+    start: int,
+    node_id_match: re.Match[str],
+) -> tuple[str, NodeEntry, int] | None:
+    """Parse a single node block. Return (node_id, node, next_idx) or None."""
+    node_id = node_id_match.group("node_id")
+    idx = start + 1
+
+    if idx >= len(lines):
+        return None
+
+    type_match = _NODE_TYPE.match(lines[idx].strip())
+    if not type_match:
+        return node_id, cast(NodeEntry, {}), idx
+
+    node: dict[str, object] = {
+        "age_secs": int(type_match.group("age")),
+        "link_in": int(type_match.group("link_in")),
+        "link_out": int(type_match.group("link_out")),
+    }
+
+    node_type = type_match.group("type")
+    if node_type != _UNKNOWN_TYPE:
+        node["node_type"] = node_type
+
+    idx = _parse_node_body(lines, idx + 1, node)
+    return node_id, cast(NodeEntry, node), idx
+
+
 @register(OS.JUNIPER_JUNOS, "show ted database extensive")
 class ShowTedDatabaseExtensiveParser(
     BaseParser[ShowTedDatabaseExtensiveResult],
@@ -564,48 +642,45 @@ class ShowTedDatabaseExtensiveParser(
             output: Raw CLI output from command.
 
         Returns:
-            Dict keyed by node ID with node details.
+            Result dict with nodes keyed by node ID and an optional summary.
 
         Raises:
             ValueError: If no nodes found in output.
         """
         lines = output.splitlines()
-        result: ShowTedDatabaseExtensiveResult = {}
+        nodes: dict[str, NodeEntry] = {}
+        summary: TedSummary | None = None
         idx = 0
 
         while idx < len(lines):
-            m = _NODE_ID.match(lines[idx])
-            if not m:
+            line = lines[idx]
+
+            if summary is None and (sm := _TED_SUMMARY.match(line)):
+                summary = TedSummary(
+                    isis_nodes=int(sm.group("isis")),
+                    inet_nodes=int(sm.group("inet")),
+                )
                 idx += 1
                 continue
 
-            node_id = m.group("node_id")
-            idx += 1
-
-            if idx >= len(lines):
-                break
-
-            type_match = _NODE_TYPE.match(lines[idx].strip())
-            if not type_match:
+            node_id_match = _NODE_ID.match(line)
+            if not node_id_match:
+                idx += 1
                 continue
 
-            node: dict[str, object] = {
-                "age_secs": int(type_match.group("age")),
-                "link_in": int(type_match.group("link_in")),
-                "link_out": int(type_match.group("link_out")),
-            }
+            parsed = _parse_node(lines, idx, node_id_match)
+            if parsed is None:
+                break
+            node_id, node, idx = parsed
+            if node:
+                nodes[node_id] = node
 
-            node_type = type_match.group("type")
-            if node_type != _UNKNOWN_TYPE:
-                node["node_type"] = node_type
-
-            idx += 1
-
-            idx = _parse_node_body(lines, idx, node)
-            result[node_id] = cast(NodeEntry, node)
-
-        if not result:
+        if not nodes:
             msg = "No TED nodes found in output"
             raise ValueError(msg)
+
+        result: ShowTedDatabaseExtensiveResult = {"nodes": nodes}
+        if summary is not None:
+            result["summary"] = summary
 
         return result

--- a/src/muninn/parsers/juniper_junos/show_ted_database_extensive.py
+++ b/src/muninn/parsers/juniper_junos/show_ted_database_extensive.py
@@ -1,0 +1,611 @@
+"""Parser for 'show ted database extensive' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Sentinel for unknown node type (displayed as "---" by Junos)
+_UNKNOWN_TYPE = "---"
+
+
+class ISCDEntry(TypedDict):
+    """Interface Switching Capability Descriptor."""
+
+    switching_type: str
+    encoding_type: str
+    maximum_lsp_bw_bps: list[str]
+
+
+class AdjacencySID(TypedDict):
+    """P2P Adjacency-SID entry."""
+
+    address_family: str
+    flags: str
+    weight: int
+
+
+class PrefixSID(TypedDict):
+    """Prefix-SID entry."""
+
+    sid: int
+    flags: str
+    algorithm: int
+
+
+class PrefixEntry(TypedDict):
+    """A prefix with optional flags and Prefix-SID."""
+
+    flags: NotRequired[str]
+    prefix_sid: NotRequired[PrefixSID]
+
+
+class SRGBBlock(TypedDict):
+    """SPRING SRGB block."""
+
+    range: int
+    flags: str
+
+
+class LinkEntry(TypedDict):
+    """A single TE link to a neighbor."""
+
+    local_address: str
+    remote_address: str
+    local_interface_index: int
+    remote_interface_index: int
+    color: NotRequired[int]
+    color_name: NotRequired[str]
+    metric: int
+    static_bw: NotRequired[str]
+    reservable_bw: NotRequired[str]
+    available_bw_bps: NotRequired[list[str]]
+    iscd: NotRequired[dict[str, ISCDEntry]]
+    adjacency_sids: NotRequired[dict[str, AdjacencySID]]
+
+
+class NodeEntry(TypedDict):
+    """A single TED node."""
+
+    node_type: NotRequired[str]
+    age_secs: int
+    link_in: int
+    link_out: int
+    protocol: NotRequired[str]
+    links: NotRequired[dict[str, LinkEntry]]
+    prefixes: NotRequired[dict[str, PrefixEntry]]
+    srgb_blocks: NotRequired[dict[str, SRGBBlock]]
+    spring_algorithms: NotRequired[list[int]]
+
+
+ShowTedDatabaseExtensiveResult = dict[str, NodeEntry]
+
+
+# -- Compiled patterns --
+
+_NODE_ID = re.compile(r"^\s*NodeID:\s+(?P<node_id>\S+)\s*$")
+_NODE_TYPE = re.compile(
+    r"^\s*Type:\s+(?P<type>\S+),\s+Age:\s+(?P<age>\d+)\s+secs,"
+    r"\s+LinkIn:\s+(?P<link_in>\d+),\s+LinkOut:\s+(?P<link_out>\d+)\s*$"
+)
+_PROTOCOL = re.compile(r"^\s*Protocol:\s+(?P<protocol>.+?)\s*$")
+_TO = re.compile(
+    r"^\s*To:\s+(?P<to>\S+),\s+Local:\s+(?P<local>\S+),"
+    r"\s+Remote:\s+(?P<remote>\S+)\s*$"
+)
+_INTF_INDEX = re.compile(
+    r"^\s*Local interface index:\s+(?P<local>\d+),"
+    r"\s+Remote interface index:\s+(?P<remote>\d+)\s*$"
+)
+_COLOR = re.compile(r"^\s*Color:\s+(?P<color>\d+)\s*(?P<name>\S+)?\s*$")
+_METRIC = re.compile(r"^\s*Metric:\s+(?P<metric>\d+)\s*$")
+_STATIC_BW = re.compile(r"^\s*Static BW:\s+(?P<bw>\S+)\s*$")
+_RESERVABLE_BW = re.compile(r"^\s*Reservable BW:\s+(?P<bw>\S+)\s*$")
+_SWITCHING_TYPE = re.compile(r"^\s*Switching type:\s+(?P<val>.+?)\s*$")
+_ENCODING_TYPE = re.compile(r"^\s*Encoding type:\s+(?P<val>.+?)\s*$")
+_ISCD_HEADER = re.compile(
+    r"^\s*Interface Switching Capability Descriptor\((?P<index>\d+)\):\s*$"
+)
+_ADJ_SID = re.compile(
+    r"^\s*(?P<af>IPV[46]),\s+SID:\s+(?P<sid>\d+),"
+    r"\s+Flags:\s+(?P<flags>0x[0-9a-fA-F]+),\s+Weight:\s+(?P<weight>\d+)\s*$"
+)
+_PREFIX_LINE = re.compile(r"^\s+(?P<prefix>\d+\.\d+\.\d+\.\d+/\d+)\s*$")
+_PREFIX_FLAGS = re.compile(r"^\s*Flags:\s+(?P<flags>0x[0-9a-fA-F]+)\s*$")
+_PREFIX_SID_LINE = re.compile(
+    r"^\s*SID:\s+(?P<sid>\d+),\s+Flags:\s+(?P<flags>0x[0-9a-fA-F]+),"
+    r"\s+Algo:\s+(?P<algo>\d+)\s*$"
+)
+_SRGB_BLOCK = re.compile(
+    r"^\s*SRGB block \[Start:\s+(?P<start>\d+),"
+    r"\s+Range:\s+(?P<range>\d+),"
+    r"\s+Flags:\s+(?P<flags>0x[0-9a-fA-F]+)\]\s*$"
+)
+_SPRING_ALGO = re.compile(r"^\s*Algo:\s+(?P<algo>\d+)\s*$")
+_BW_VALUES = re.compile(r"\[(\d+)\]\s+(\S+)")
+
+
+def _parse_bw_line(line: str) -> list[str]:
+    """Extract bandwidth values from a priority-indexed line."""
+    return [m.group(2) for m in _BW_VALUES.finditer(line)]
+
+
+def _is_link_block_boundary(line: str, stripped: str) -> bool:
+    """Return True if this line marks the end of a link block."""
+    if _TO.match(line) or _NODE_ID.match(line):
+        return True
+    if stripped.startswith("Prefixes:") or stripped.startswith("SPRING-"):
+        return True
+    return False
+
+
+def _process_link_value_line(
+    stripped: str,
+    link: dict[str, object],
+    adj_sids: dict[str, AdjacencySID],
+    current_iscd: dict[str, object] | None,
+    bw_target: str,
+    idx: int,
+) -> tuple[int, dict[str, object] | None, str]:
+    """Process value lines (bandwidth arrays, ISCD fields, adj-SIDs)."""
+    if m := _ADJ_SID.match(stripped):
+        sid_key = str(m.group("sid"))
+        adj_sids[sid_key] = AdjacencySID(
+            address_family=m.group("af"),
+            flags=m.group("flags"),
+            weight=int(m.group("weight")),
+        )
+        return idx + 1, current_iscd, bw_target
+
+    if current_iscd is not None:
+        if m := _SWITCHING_TYPE.match(stripped):
+            current_iscd["switching_type"] = m.group("val")
+            return idx + 1, current_iscd, bw_target
+        if m := _ENCODING_TYPE.match(stripped):
+            current_iscd["encoding_type"] = m.group("val")
+            return idx + 1, current_iscd, bw_target
+
+    # Bandwidth priority lines like "[0] 10bps  [1] 10bps ..."
+    bw_vals = _parse_bw_line(stripped)
+    if bw_vals:
+        _collect_bw_values(bw_vals, bw_target, link, current_iscd)
+
+    return idx + 1, current_iscd, bw_target
+
+
+def _collect_bw_values(
+    bw_vals: list[str],
+    bw_target: str,
+    link: dict[str, object],
+    current_iscd: dict[str, object] | None,
+) -> None:
+    """Append bandwidth values to the correct target list."""
+    if bw_target == "available":
+        available = link.get("available_bw_bps")
+        if isinstance(available, list):
+            available.extend(bw_vals)
+    elif bw_target == "max_lsp" and current_iscd is not None:
+        max_lsp = current_iscd.get("maximum_lsp_bw_bps")
+        if isinstance(max_lsp, list):
+            max_lsp.extend(bw_vals)
+
+
+def _parse_link_attributes(
+    stripped: str,
+    link: dict[str, object],
+) -> bool:
+    """Try to parse a link attribute line (metric, color, BW, etc.).
+
+    Returns True if the line was consumed.
+    """
+    if m := _INTF_INDEX.match(stripped):
+        link["local_interface_index"] = int(m.group("local"))
+        link["remote_interface_index"] = int(m.group("remote"))
+        return True
+
+    if m := _COLOR.match(stripped):
+        link["color"] = int(m.group("color"))
+        name = m.group("name")
+        if name and name != "<none>":
+            link["color_name"] = name
+        return True
+
+    if m := _METRIC.match(stripped):
+        link["metric"] = int(m.group("metric"))
+        return True
+
+    if m := _STATIC_BW.match(stripped):
+        link["static_bw"] = m.group("bw")
+        return True
+
+    if m := _RESERVABLE_BW.match(stripped):
+        link["reservable_bw"] = m.group("bw")
+        return True
+
+    return False
+
+
+def _parse_link_section_header(
+    stripped: str,
+    link: dict[str, object],
+    iscd_dict: dict[str, ISCDEntry],
+    current_iscd: dict[str, object] | None,
+) -> tuple[dict[str, object] | None, str] | None:
+    """Try to parse a section header line inside a link block.
+
+    Returns (new_current_iscd, new_bw_target) if consumed, else None.
+    """
+    if stripped.startswith("Available BW"):
+        link["available_bw_bps"] = []
+        return current_iscd, "available"
+
+    if m := _ISCD_HEADER.match(stripped):
+        new_iscd: dict[str, object] = {}
+        iscd_dict[m.group("index")] = new_iscd  # type: ignore[assignment]
+        return new_iscd, ""
+
+    if stripped.startswith("Maximum LSP BW"):
+        if current_iscd is not None:
+            current_iscd["maximum_lsp_bw_bps"] = []
+        return current_iscd, "max_lsp"
+
+    if stripped.startswith("P2P Adjacency-SID"):
+        return current_iscd, ""
+
+    return None
+
+
+def _process_single_link_line(
+    stripped: str,
+    link: dict[str, object],
+    iscd_dict: dict[str, ISCDEntry],
+    adj_sids: dict[str, AdjacencySID],
+    current_iscd: dict[str, object] | None,
+    bw_target: str,
+    idx: int,
+) -> tuple[int, dict[str, object] | None, str]:
+    """Process one line inside a link block.
+
+    Returns (next_idx, current_iscd, bw_target).
+    """
+    if _parse_link_attributes(stripped, link):
+        return idx + 1, current_iscd, bw_target
+
+    result = _parse_link_section_header(
+        stripped,
+        link,
+        iscd_dict,
+        current_iscd,
+    )
+    if result is not None:
+        return idx + 1, result[0], result[1]
+
+    return _process_link_value_line(
+        stripped,
+        link,
+        adj_sids,
+        current_iscd,
+        bw_target,
+        idx,
+    )
+
+
+def _finalize_link(
+    link: dict[str, object],
+    iscd_dict: dict[str, ISCDEntry],
+    adj_sids: dict[str, AdjacencySID],
+) -> None:
+    """Attach optional sub-structures to the link dict if non-empty."""
+    if iscd_dict:
+        link["iscd"] = iscd_dict
+    if adj_sids:
+        link["adjacency_sids"] = adj_sids
+
+
+def _parse_link_block(
+    lines: list[str],
+    start: int,
+) -> tuple[str, LinkEntry, int]:
+    """Parse a link block starting at the 'To:' line.
+
+    Returns:
+        Tuple of (to_address, link_entry, next_line_index).
+    """
+    to_match = _TO.match(lines[start])
+    if not to_match:
+        msg = f"Expected 'To:' line at index {start}"
+        raise ValueError(msg)
+
+    to_addr = to_match.group("to")
+    link: dict[str, object] = {
+        "local_address": to_match.group("local"),
+        "remote_address": to_match.group("remote"),
+    }
+    idx = start + 1
+    iscd_dict: dict[str, ISCDEntry] = {}
+    adj_sids: dict[str, AdjacencySID] = {}
+    current_iscd: dict[str, object] | None = None
+    bw_target: str = ""
+
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+
+        if _is_link_block_boundary(line, stripped):
+            break
+
+        idx, current_iscd, bw_target = _process_single_link_line(
+            stripped,
+            link,
+            iscd_dict,
+            adj_sids,
+            current_iscd,
+            bw_target,
+            idx,
+        )
+
+    _finalize_link(link, iscd_dict, adj_sids)
+    return to_addr, LinkEntry(**link), idx  # type: ignore[arg-type]
+
+
+def _is_prefix_section_boundary(line: str, stripped: str) -> bool:
+    """Return True if the line ends the prefix section."""
+    if _NODE_ID.match(line):
+        return True
+    return stripped.startswith("SPRING-")
+
+
+def _parse_prefix_detail(
+    stripped: str,
+    current: dict[str, object],
+    in_prefix_sid: bool,
+) -> bool:
+    """Parse a detail line for the current prefix (flags or SID).
+
+    Returns True if the line was consumed.
+    """
+    if stripped.startswith("Prefix-SID:"):
+        return True  # caller sets in_prefix_sid
+
+    if in_prefix_sid:
+        if m := _PREFIX_SID_LINE.match(stripped):
+            current["prefix_sid"] = PrefixSID(
+                sid=int(m.group("sid")),
+                flags=m.group("flags"),
+                algorithm=int(m.group("algo")),
+            )
+            return True
+
+    if m := _PREFIX_FLAGS.match(stripped):
+        current["flags"] = m.group("flags")
+        return True
+
+    return False
+
+
+def _parse_prefixes(
+    lines: list[str],
+    start: int,
+) -> tuple[dict[str, PrefixEntry], int]:
+    """Parse the Prefixes: section. Return (prefix_dict, next_index)."""
+    idx = start
+    prefixes: dict[str, PrefixEntry] = {}
+    current: dict[str, object] | None = None
+    in_prefix_sid = False
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+
+        if _is_prefix_section_boundary(lines[idx], stripped):
+            break
+
+        if m := _PREFIX_LINE.match(lines[idx]):
+            current = {}
+            prefixes[m.group("prefix")] = current  # type: ignore[assignment]
+            in_prefix_sid = False
+            idx += 1
+            continue
+
+        if current is not None:
+            if stripped.startswith("Prefix-SID:"):
+                in_prefix_sid = True
+                idx += 1
+                continue
+            if _parse_prefix_detail(stripped, current, in_prefix_sid):
+                if in_prefix_sid and _PREFIX_SID_LINE.match(stripped):
+                    in_prefix_sid = False
+                idx += 1
+                continue
+
+        idx += 1
+
+    return prefixes, idx
+
+
+def _parse_spring_capabilities(
+    lines: list[str],
+    start: int,
+) -> tuple[dict[str, SRGBBlock], int]:
+    """Parse SPRING-Capabilities section. Return (srgb_blocks_dict, next_index)."""
+    idx = start
+    blocks: dict[str, SRGBBlock] = {}
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+
+        if _NODE_ID.match(lines[idx]):
+            break
+        if stripped.startswith("SPRING-Algorithms"):
+            break
+
+        if m := _SRGB_BLOCK.match(stripped):
+            start_key = m.group("start")
+            blocks[start_key] = SRGBBlock(
+                range=int(m.group("range")),
+                flags=m.group("flags"),
+            )
+
+        idx += 1
+
+    return blocks, idx
+
+
+def _parse_spring_algorithms(lines: list[str], start: int) -> tuple[list[int], int]:
+    """Parse SPRING-Algorithms section. Return (algo_list, next_index)."""
+    idx = start
+    algos: list[int] = []
+
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+
+        if _NODE_ID.match(lines[idx]):
+            break
+        if stripped.startswith("SPRING-Capabilities"):
+            break
+
+        if m := _SPRING_ALGO.match(stripped):
+            algos.append(int(m.group("algo")))
+
+        idx += 1
+
+    return algos, idx
+
+
+def _dispatch_node_section(
+    lines: list[str],
+    idx: int,
+    stripped: str,
+    node: dict[str, object],
+) -> int | None:
+    """Try to parse a named section (Prefixes, SPRING-*).
+
+    Returns new idx if a section was consumed, else None.
+    """
+    if stripped.startswith("Prefixes:"):
+        prefixes, new_idx = _parse_prefixes(lines, idx + 1)
+        if prefixes:
+            node["prefixes"] = prefixes
+        return new_idx
+
+    if stripped.startswith("SPRING-Capabilities:"):
+        blocks, new_idx = _parse_spring_capabilities(lines, idx + 1)
+        if blocks:
+            node["srgb_blocks"] = blocks
+        return new_idx
+
+    if stripped.startswith("SPRING-Algorithms:"):
+        algos, new_idx = _parse_spring_algorithms(lines, idx + 1)
+        if algos:
+            node["spring_algorithms"] = algos
+        return new_idx
+
+    return None
+
+
+def _parse_node_body(
+    lines: list[str],
+    start: int,
+    node: dict[str, object],
+) -> int:
+    """Parse the body of a node (links, prefixes, SPRING). Return next index."""
+    idx = start
+    links: dict[str, LinkEntry] = {}
+
+    while idx < len(lines):
+        line = lines[idx]
+        stripped = line.strip()
+
+        if _NODE_ID.match(line):
+            break
+
+        if m := _PROTOCOL.match(stripped):
+            node["protocol"] = m.group("protocol")
+            idx += 1
+            continue
+
+        if _TO.match(line):
+            to_addr, link, idx = _parse_link_block(lines, idx)
+            links[to_addr] = link
+            continue
+
+        new_idx = _dispatch_node_section(lines, idx, stripped, node)
+        if new_idx is not None:
+            idx = new_idx
+            continue
+
+        idx += 1
+
+    if links:
+        node["links"] = links
+
+    return idx
+
+
+@register(OS.JUNIPER_JUNOS, "show ted database extensive")
+class ShowTedDatabaseExtensiveParser(
+    BaseParser[ShowTedDatabaseExtensiveResult],
+):
+    """Parser for 'show ted database extensive' command on Juniper Junos.
+
+    Parses TED (Traffic Engineering Database) nodes including links,
+    prefixes, and SPRING/Segment Routing capabilities.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MPLS})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowTedDatabaseExtensiveResult:
+        """Parse 'show ted database extensive' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by node ID with node details.
+
+        Raises:
+            ValueError: If no nodes found in output.
+        """
+        lines = output.splitlines()
+        result: ShowTedDatabaseExtensiveResult = {}
+        idx = 0
+
+        while idx < len(lines):
+            m = _NODE_ID.match(lines[idx])
+            if not m:
+                idx += 1
+                continue
+
+            node_id = m.group("node_id")
+            idx += 1
+
+            if idx >= len(lines):
+                break
+
+            type_match = _NODE_TYPE.match(lines[idx].strip())
+            if not type_match:
+                continue
+
+            node: dict[str, object] = {
+                "age_secs": int(type_match.group("age")),
+                "link_in": int(type_match.group("link_in")),
+                "link_out": int(type_match.group("link_out")),
+            }
+
+            node_type = type_match.group("type")
+            if node_type != _UNKNOWN_TYPE:
+                node["node_type"] = node_type
+
+            idx += 1
+
+            idx = _parse_node_body(lines, idx, node)
+            result[node_id] = NodeEntry(**node)  # type: ignore[arg-type]
+
+        if not result:
+            msg = "No TED nodes found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/expected.json
@@ -1,0 +1,194 @@
+{
+    "10.4.1.1": {
+        "age_secs": 1024,
+        "link_in": 0,
+        "link_out": 1,
+        "node_type": "Rtr",
+        "protocol": "OSPF(0.0.0.4)",
+        "prefixes": {
+            "10.4.1.1/32": {
+                "flags": "0x60",
+                "prefix_sid": {
+                    "sid": 1234,
+                    "flags": "0x00",
+                    "algorithm": 0
+                }
+            }
+        },
+        "srgb_blocks": {
+            "12000": {
+                "range": 3000,
+                "flags": "0x00"
+            }
+        },
+        "spring_algorithms": [
+            0,
+            1
+        ],
+        "links": {
+            "172.16.1.1": {
+                "local_address": "10.4.0.2",
+                "remote_address": "10.4.0.1",
+                "local_interface_index": 0,
+                "remote_interface_index": 0,
+                "color": 0,
+                "metric": 1,
+                "static_bw": "2000Mbps",
+                "reservable_bw": "0bps",
+                "available_bw_bps": [
+                    "10bps",
+                    "10bps",
+                    "0bps",
+                    "0bps",
+                    "10bps",
+                    "0bps",
+                    "0bps",
+                    "0bps"
+                ],
+                "iscd": {
+                    "1": {
+                        "switching_type": "Packet",
+                        "encoding_type": "Packet",
+                        "maximum_lsp_bw_bps": [
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps"
+                        ]
+                    }
+                },
+                "adjacency_sids": {
+                    "12345": {
+                        "address_family": "IPV4",
+                        "flags": "0x24",
+                        "weight": 0
+                    }
+                }
+            }
+        }
+    },
+    "10.16.2.2-1": {
+        "age_secs": 1024,
+        "link_in": 0,
+        "link_out": 2,
+        "node_type": "Net",
+        "protocol": "OSPF(0.0.0.4)",
+        "links": {
+            "10.16.2.34": {
+                "local_address": "0.0.0.0",
+                "remote_address": "0.0.0.0",
+                "local_interface_index": 0,
+                "remote_interface_index": 0,
+                "metric": 0,
+                "iscd": {
+                    "1": {
+                        "switching_type": "Packet",
+                        "encoding_type": "Packet",
+                        "maximum_lsp_bw_bps": [
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "1000bps",
+                            "0bps"
+                        ]
+                    }
+                }
+            },
+            "10.16.2.42": {
+                "local_address": "0.0.0.0",
+                "remote_address": "0.0.0.0",
+                "local_interface_index": 0,
+                "remote_interface_index": 0,
+                "metric": 0,
+                "iscd": {
+                    "1": {
+                        "switching_type": "Packet",
+                        "encoding_type": "Packet",
+                        "maximum_lsp_bw_bps": [
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "172.16.1.4-1": {
+        "age_secs": 2048,
+        "link_in": 0,
+        "link_out": 2,
+        "node_type": "Net",
+        "protocol": "OSPF(0.0.0.4)",
+        "links": {
+            "172.16.85.48": {
+                "local_address": "0.0.0.0",
+                "remote_address": "0.0.0.0",
+                "local_interface_index": 0,
+                "remote_interface_index": 0,
+                "metric": 0,
+                "iscd": {
+                    "1": {
+                        "switching_type": "Packet",
+                        "encoding_type": "Packet",
+                        "maximum_lsp_bw_bps": [
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps"
+                        ]
+                    }
+                }
+            },
+            "172.16.85.52": {
+                "local_address": "0.0.0.0",
+                "remote_address": "0.0.0.0",
+                "local_interface_index": 0,
+                "remote_interface_index": 0,
+                "metric": 0,
+                "iscd": {
+                    "1": {
+                        "switching_type": "Packet",
+                        "encoding_type": "Packet",
+                        "maximum_lsp_bw_bps": [
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps",
+                            "0bps"
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "10.36.3.3": {
+        "age_secs": 3440,
+        "link_in": 1,
+        "link_out": 0
+    },
+    "10.64.4.4": {
+        "age_secs": 2560,
+        "link_in": 1,
+        "link_out": 0
+    }
+}

--- a/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/expected.json
@@ -1,194 +1,200 @@
 {
-    "10.4.1.1": {
-        "age_secs": 1024,
-        "link_in": 0,
-        "link_out": 1,
-        "node_type": "Rtr",
-        "protocol": "OSPF(0.0.0.4)",
-        "prefixes": {
-            "10.4.1.1/32": {
-                "flags": "0x60",
-                "prefix_sid": {
-                    "sid": 1234,
-                    "flags": "0x00",
-                    "algorithm": 0
+    "summary": {
+        "isis_nodes": 0,
+        "inet_nodes": 6
+    },
+    "nodes": {
+        "10.4.1.1": {
+            "age_secs": 1024,
+            "link_in": 0,
+            "link_out": 1,
+            "node_type": "Rtr",
+            "protocol": "OSPF(0.0.0.4)",
+            "prefixes": {
+                "10.4.1.1/32": {
+                    "flags": "0x60",
+                    "prefix_sid": {
+                        "sid": 1234,
+                        "flags": "0x00",
+                        "algorithm": 0
+                    }
+                }
+            },
+            "srgb_blocks": {
+                "12000": {
+                    "range": 3000,
+                    "flags": "0x00"
+                }
+            },
+            "spring_algorithms": [
+                0,
+                1
+            ],
+            "links": {
+                "172.16.1.1": {
+                    "local_address": "10.4.0.2",
+                    "remote_address": "10.4.0.1",
+                    "local_interface_index": 0,
+                    "remote_interface_index": 0,
+                    "color": 0,
+                    "metric": 1,
+                    "static_bw_bps": 2000000000,
+                    "reservable_bw_bps": 0,
+                    "available_bw_bps": [
+                        10,
+                        10,
+                        0,
+                        0,
+                        10,
+                        0,
+                        0,
+                        0
+                    ],
+                    "iscd": {
+                        "1": {
+                            "switching_type": "Packet",
+                            "encoding_type": "Packet",
+                            "maximum_lsp_bw_bps": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ]
+                        }
+                    },
+                    "adjacency_sids": {
+                        "12345": {
+                            "address_family": "IPV4",
+                            "flags": "0x24",
+                            "weight": 0
+                        }
+                    }
                 }
             }
         },
-        "srgb_blocks": {
-            "12000": {
-                "range": 3000,
-                "flags": "0x00"
-            }
-        },
-        "spring_algorithms": [
-            0,
-            1
-        ],
-        "links": {
-            "172.16.1.1": {
-                "local_address": "10.4.0.2",
-                "remote_address": "10.4.0.1",
-                "local_interface_index": 0,
-                "remote_interface_index": 0,
-                "color": 0,
-                "metric": 1,
-                "static_bw": "2000Mbps",
-                "reservable_bw": "0bps",
-                "available_bw_bps": [
-                    "10bps",
-                    "10bps",
-                    "0bps",
-                    "0bps",
-                    "10bps",
-                    "0bps",
-                    "0bps",
-                    "0bps"
-                ],
-                "iscd": {
-                    "1": {
-                        "switching_type": "Packet",
-                        "encoding_type": "Packet",
-                        "maximum_lsp_bw_bps": [
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps"
-                        ]
+        "10.16.2.2-1": {
+            "age_secs": 1024,
+            "link_in": 0,
+            "link_out": 2,
+            "node_type": "Net",
+            "protocol": "OSPF(0.0.0.4)",
+            "links": {
+                "10.16.2.34": {
+                    "local_address": "0.0.0.0",
+                    "remote_address": "0.0.0.0",
+                    "local_interface_index": 0,
+                    "remote_interface_index": 0,
+                    "metric": 0,
+                    "iscd": {
+                        "1": {
+                            "switching_type": "Packet",
+                            "encoding_type": "Packet",
+                            "maximum_lsp_bw_bps": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                1000,
+                                0
+                            ]
+                        }
                     }
                 },
-                "adjacency_sids": {
-                    "12345": {
-                        "address_family": "IPV4",
-                        "flags": "0x24",
-                        "weight": 0
+                "10.16.2.42": {
+                    "local_address": "0.0.0.0",
+                    "remote_address": "0.0.0.0",
+                    "local_interface_index": 0,
+                    "remote_interface_index": 0,
+                    "metric": 0,
+                    "iscd": {
+                        "1": {
+                            "switching_type": "Packet",
+                            "encoding_type": "Packet",
+                            "maximum_lsp_bw_bps": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
                 }
             }
-        }
-    },
-    "10.16.2.2-1": {
-        "age_secs": 1024,
-        "link_in": 0,
-        "link_out": 2,
-        "node_type": "Net",
-        "protocol": "OSPF(0.0.0.4)",
-        "links": {
-            "10.16.2.34": {
-                "local_address": "0.0.0.0",
-                "remote_address": "0.0.0.0",
-                "local_interface_index": 0,
-                "remote_interface_index": 0,
-                "metric": 0,
-                "iscd": {
-                    "1": {
-                        "switching_type": "Packet",
-                        "encoding_type": "Packet",
-                        "maximum_lsp_bw_bps": [
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "1000bps",
-                            "0bps"
-                        ]
+        },
+        "172.16.1.4-1": {
+            "age_secs": 2048,
+            "link_in": 0,
+            "link_out": 2,
+            "node_type": "Net",
+            "protocol": "OSPF(0.0.0.4)",
+            "links": {
+                "172.16.85.48": {
+                    "local_address": "0.0.0.0",
+                    "remote_address": "0.0.0.0",
+                    "local_interface_index": 0,
+                    "remote_interface_index": 0,
+                    "metric": 0,
+                    "iscd": {
+                        "1": {
+                            "switching_type": "Packet",
+                            "encoding_type": "Packet",
+                            "maximum_lsp_bw_bps": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
-                }
-            },
-            "10.16.2.42": {
-                "local_address": "0.0.0.0",
-                "remote_address": "0.0.0.0",
-                "local_interface_index": 0,
-                "remote_interface_index": 0,
-                "metric": 0,
-                "iscd": {
-                    "1": {
-                        "switching_type": "Packet",
-                        "encoding_type": "Packet",
-                        "maximum_lsp_bw_bps": [
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps"
-                        ]
-                    }
-                }
-            }
-        }
-    },
-    "172.16.1.4-1": {
-        "age_secs": 2048,
-        "link_in": 0,
-        "link_out": 2,
-        "node_type": "Net",
-        "protocol": "OSPF(0.0.0.4)",
-        "links": {
-            "172.16.85.48": {
-                "local_address": "0.0.0.0",
-                "remote_address": "0.0.0.0",
-                "local_interface_index": 0,
-                "remote_interface_index": 0,
-                "metric": 0,
-                "iscd": {
-                    "1": {
-                        "switching_type": "Packet",
-                        "encoding_type": "Packet",
-                        "maximum_lsp_bw_bps": [
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps"
-                        ]
-                    }
-                }
-            },
-            "172.16.85.52": {
-                "local_address": "0.0.0.0",
-                "remote_address": "0.0.0.0",
-                "local_interface_index": 0,
-                "remote_interface_index": 0,
-                "metric": 0,
-                "iscd": {
-                    "1": {
-                        "switching_type": "Packet",
-                        "encoding_type": "Packet",
-                        "maximum_lsp_bw_bps": [
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps",
-                            "0bps"
-                        ]
+                },
+                "172.16.85.52": {
+                    "local_address": "0.0.0.0",
+                    "remote_address": "0.0.0.0",
+                    "local_interface_index": 0,
+                    "remote_interface_index": 0,
+                    "metric": 0,
+                    "iscd": {
+                        "1": {
+                            "switching_type": "Packet",
+                            "encoding_type": "Packet",
+                            "maximum_lsp_bw_bps": [
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
                 }
             }
+        },
+        "10.36.3.3": {
+            "age_secs": 3440,
+            "link_in": 1,
+            "link_out": 0
+        },
+        "10.64.4.4": {
+            "age_secs": 2560,
+            "link_in": 1,
+            "link_out": 0
         }
-    },
-    "10.36.3.3": {
-        "age_secs": 3440,
-        "link_in": 1,
-        "link_out": 0
-    },
-    "10.64.4.4": {
-        "age_secs": 2560,
-        "link_in": 1,
-        "link_out": 0
     }
 }

--- a/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/input.txt
@@ -1,0 +1,79 @@
+
+        show ted database extensive
+        TED database: 0 ISIS nodes 6 INET nodes
+        NodeID: 10.4.1.1
+          Type: Rtr, Age: 1024 secs, LinkIn: 0, LinkOut: 1
+          Protocol: OSPF(0.0.0.4)
+            To: 172.16.1.1, Local: 10.4.0.2, Remote: 10.4.0.1
+              Local interface index: 0, Remote interface index: 0
+              Color: 0 <none>
+              Metric: 1
+              Static BW: 2000Mbps
+              Reservable BW: 0bps
+              Available BW [priority] bps:
+                  [0] 10bps         [1] 10bps        [2] 0bps        [3] 0bps
+                  [4] 10bps         [5] 0bps        [6] 0bps        [7] 0bps
+              Interface Switching Capability Descriptor(1):
+                Switching type: Packet
+                Encoding type: Packet
+                Maximum LSP BW [priority] bps:
+                  [0] 0bps         [1] 0bps        [2] 0bps        [3] 0bps
+                  [4] 0bps         [5] 0bps        [6] 0bps        [7] 0bps
+              P2P Adjacency-SID:
+                IPV4, SID: 12345, Flags: 0x24, Weight: 0
+           Prefixes:
+             10.4.1.1/32
+              Flags: 0x60
+              Prefix-SID:
+                SID: 1234, Flags: 0x00, Algo: 0
+           SPRING-Capabilities:
+             SRGB block [Start: 12000, Range: 3000, Flags: 0x00]
+           SPRING-Algorithms:
+             Algo: 0
+             Algo: 1
+        NodeID: 10.16.2.2-1
+          Type: Net, Age: 1024 secs, LinkIn: 0, LinkOut: 2
+          Protocol: OSPF(0.0.0.4)
+            To: 10.16.2.34, Local: 0.0.0.0, Remote: 0.0.0.0
+              Local interface index: 0, Remote interface index: 0
+              Metric: 0
+              Interface Switching Capability Descriptor(1):
+                Switching type: Packet
+                Encoding type: Packet
+                Maximum LSP BW [priority] bps:
+                  [0] 0bps         [1] 0bps        [2] 0bps        [3] 0bps
+                  [4] 0bps         [5] 0bps        [6] 1000bps        [7] 0bps
+            To: 10.16.2.42, Local: 0.0.0.0, Remote: 0.0.0.0
+              Local interface index: 0, Remote interface index: 0
+              Metric: 0
+              Interface Switching Capability Descriptor(1):
+                Switching type: Packet
+                Encoding type: Packet
+                Maximum LSP BW [priority] bps:
+                  [0] 0bps         [1] 0bps        [2] 0bps        [3] 0bps
+                  [4] 0bps         [5] 0bps        [6] 0bps        [7] 0bps
+        NodeID: 172.16.1.4-1
+          Type: Net, Age: 2048 secs, LinkIn: 0, LinkOut: 2
+          Protocol: OSPF(0.0.0.4)
+            To: 172.16.85.48, Local: 0.0.0.0, Remote: 0.0.0.0
+              Local interface index: 0, Remote interface index: 0
+              Metric: 0
+              Interface Switching Capability Descriptor(1):
+                Switching type: Packet
+                Encoding type: Packet
+                Maximum LSP BW [priority] bps:
+                  [0] 0bps         [1] 0bps        [2] 0bps        [3] 0bps
+                  [4] 0bps         [5] 0bps        [6] 0bps        [7] 0bps
+            To: 172.16.85.52, Local: 0.0.0.0, Remote: 0.0.0.0
+              Local interface index: 0, Remote interface index: 0
+              Metric: 0
+              Interface Switching Capability Descriptor(1):
+                Switching type: Packet
+                Encoding type: Packet
+                Maximum LSP BW [priority] bps:
+                  [0] 0bps         [1] 0bps        [2] 0bps        [3] 0bps
+                  [4] 0bps         [5] 0bps        [6] 0bps        [7] 0bps
+        NodeID: 10.36.3.3
+          Type: ---, Age: 3440 secs, LinkIn: 1, LinkOut: 0
+        NodeID: 10.64.4.4
+          Type: ---, Age: 2560 secs, LinkIn: 1, LinkOut: 0

--- a/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_ted_database_extensive/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: TED database with router and network nodes, SPRING capabilities, and adjacency SIDs
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add parser for `show ted database extensive` on Juniper Junos (`juniper_junos`)
- Parses TED (Traffic Engineering Database) nodes with links, prefixes, SPRING/SR capabilities, adjacency SIDs, and ISCD entries
- Output uses dict-of-dicts keyed by node ID, with nested dicts for links (keyed by destination), prefixes (keyed by prefix), ISCD (keyed by index), adjacency SIDs (keyed by SID), and SRGB blocks (keyed by start value)
- Nodes with unknown type (`---`) omit the `node_type` field to comply with placeholder sentinel guardrails
- Tagged with `ParserTag.MPLS`

## Test plan

- [x] Parser test fixture `001_basic` with 5 nodes (router, network, and stub types) passes
- [x] All 7 fixture convention/sentinel tests pass
- [x] Full test suite (6848 tests) passes
- [x] ruff check, ruff format, xenon complexity (B/B/A), bandit security scan all pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)