### PR TITLE
feat(cisco_iosxr): add parser for show controllers all phy

### DIFF
--- a/changes/+cisco-iosxr-show-controllers-all-phy.parser_added
+++ b/changes/+cisco-iosxr-show-controllers-all-phy.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show controllers all phy` on Cisco IOS-XR.

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_all_phy.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_all_phy.py
@@ -1,0 +1,264 @@
+"""Parser for 'show controllers all phy' command on Cisco IOS-XR."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class LaneDiagnostics(TypedDict):
+    """Schema for per-lane diagnostic measurements."""
+
+    bias_ma: NotRequired[float]
+    tx_power_mw: NotRequired[float]
+    tx_power_dbm: NotRequired[float]
+    rx_power_mw: NotRequired[float]
+    rx_power_dbm: NotRequired[float]
+
+
+class ModuleDiagnostics(TypedDict):
+    """Schema for module-level diagnostic measurements."""
+
+    temperature_c: NotRequired[float]
+    voltage_v: NotRequired[float]
+
+
+class ControllerPhyEntry(TypedDict):
+    """Schema for a single interface's PHY/EEPROM data."""
+
+    xcvr_type: NotRequired[str]
+    connector_type: NotRequired[str]
+    ethernet_compliance: NotRequired[str]
+    encoding: NotRequired[str]
+    nominal_bitrate_mbps: NotRequired[int]
+    length_smf_km: NotRequired[int]
+    length_om3_m: NotRequired[int]
+    length_om2_m: NotRequired[int]
+    length_om1_m: NotRequired[int]
+    length_copper_m: NotRequired[int]
+    vendor_name: NotRequired[str]
+    vendor_oui: NotRequired[str]
+    vendor_part_number: NotRequired[str]
+    vendor_revision: NotRequired[str]
+    vendor_serial_number: NotRequired[str]
+    wavelength_nm: NotRequired[float]
+    wavelength_tolerance_nm: NotRequired[float]
+    date_code: NotRequired[str]
+    clei_code: NotRequired[str]
+    cisco_part_number: NotRequired[str]
+    cisco_part_version: NotRequired[str]
+    product_id: NotRequired[str]
+    module_diagnostics: NotRequired[ModuleDiagnostics]
+    lanes: NotRequired[dict[str, LaneDiagnostics]]
+
+
+ShowControllersAllPhyResult = dict[str, ControllerPhyEntry]
+
+
+@register(OS.CISCO_IOSXR, "show controllers all phy")
+class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
+    """Parser for 'show controllers all phy' on Cisco IOS-XR.
+
+    Extracts transceiver EEPROM data and optical diagnostics per interface.
+    Hex dump sections (MSA Data) are skipped.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    _INTERFACE_HEADER = re.compile(r"^PHY data for interface:\s+(?P<interface>\S+)")
+
+    _XCVR_TYPE = re.compile(r"^\s+Xcvr Type:\s+(?P<value>.+?)\s*$")
+    _CONNECTOR = re.compile(r"^\s+Connector Type:\s+(?P<value>.+?)\s*$")
+    _ETH_COMPLIANCE = re.compile(
+        r"^\s+Ethernet Compliance Codes:\s+(?P<value>.+?),?\s*$"
+    )
+    _ENCODING = re.compile(r"^\s+Encoding:\s+(?P<value>.+?),?\s*$")
+    _NOMINAL_BR = re.compile(r"^\s+BR, nominal:\s+(?P<value>\d+)\s+Mbps")
+    _LENGTH = re.compile(
+        r"^\s+Length SMF:\s+(?P<smf>\d+)KM,\s+"
+        r"OM3:\s+(?P<om3>\d+)M,\s+"
+        r"OM2:\s+(?P<om2>\d+)M,\s+"
+        r"OM1:\s+(?P<om1>\d+)M,\s+"
+        r"Copper:\s+(?P<copper>\d+)M"
+    )
+    _VENDOR_NAME = re.compile(r"^\s+Vendor Name:\s+(?P<value>.+?)\s*$")
+    _VENDOR_OUI = re.compile(r"^\s+Vendor OUI:\s+(?P<value>\S+)")
+    _VENDOR_PN = re.compile(
+        r"^\s+Vendor Part Number:\s+(?P<pn>.+?)\s+"
+        r"\(rev\.:\s+(?P<rev>\S+)\)"
+    )
+    _VENDOR_PN_NO_REV = re.compile(r"^\s+Vendor Part Number:\s+(?P<pn>.+?)\s*$")
+    _WAVELENGTH = re.compile(r"^\s+Wavelength:\s+(?P<value>[\d.]+)\s+nm")
+    _WAVELENGTH_TOL = re.compile(r"^\s+Wavelength Tolerance:\s+(?P<value>[\d.]+)\s+nm")
+    _VENDOR_SN = re.compile(r"^\s+Vendor Serial Number:\s+(?P<value>.+?)\s*$")
+    _DATE_CODE = re.compile(r"^\s+Date Code \(yy/mm/dd\):\s+(?P<value>\S+)")
+    _CLEI = re.compile(r"^\s+CLEI Code:\s+(?P<value>\S+)")
+    _CISCO_PN = re.compile(
+        r"^\s+Part Number:\s+(?P<pn>\S+)\s+"
+        r"\(ver\.:\s+(?P<ver>.+?)\s*\)"
+    )
+    _PRODUCT_ID = re.compile(r"^\s+Product Id:\s+(?P<value>\S+)")
+
+    _MODULE_TEMP = re.compile(r"^\s+Temperature:\s+(?P<value>[+-]?[\d.]+)\s+C\s*$")
+    _MODULE_VOLTAGE = re.compile(r"^\s+Voltage:\s+(?P<value>[\d.]+)\s+Volt\s*$")
+
+    _LANE_DATA = re.compile(
+        r"^\s+(?P<lane>\d+)\s+"
+        r"(?P<temp>\S+)\s+"
+        r"(?P<bias>[\d.]+)\s+mAmps\s+"
+        r"(?P<tx_mw>[\d.]+)\s+mW\s+"
+        r"\((?P<tx_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<rx_mw>[\d.]+)\s+mW\s+"
+        r"\((?P<rx_dbm>[+-]?[\d.]+)\s+dBm\)"
+    )
+
+    # Lines to skip: hex dumps, thresholds headers, alarm/warning rows, etc.
+    _HEX_LINE = re.compile(r"^\s*0x[0-9a-fA-F]+:")
+    _MSA_HEADER = re.compile(r"^MSA Data\s")
+
+    @classmethod
+    def _parse_transceiver_basics(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse transceiver type, connector, encoding, and length fields."""
+        if match := cls._XCVR_TYPE.match(line):
+            entry["xcvr_type"] = match.group("value").strip()
+            return True
+        if match := cls._CONNECTOR.match(line):
+            entry["connector_type"] = match.group("value").strip()
+            return True
+        if match := cls._ETH_COMPLIANCE.match(line):
+            entry["ethernet_compliance"] = match.group("value").strip()
+            return True
+        if match := cls._ENCODING.match(line):
+            entry["encoding"] = match.group("value").strip()
+            return True
+        if match := cls._NOMINAL_BR.match(line):
+            entry["nominal_bitrate_mbps"] = int(match.group("value"))
+            return True
+        if match := cls._LENGTH.match(line):
+            entry["length_smf_km"] = int(match.group("smf"))
+            entry["length_om3_m"] = int(match.group("om3"))
+            entry["length_om2_m"] = int(match.group("om2"))
+            entry["length_om1_m"] = int(match.group("om1"))
+            entry["length_copper_m"] = int(match.group("copper"))
+            return True
+        return False
+
+    @classmethod
+    def _parse_vendor_info(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse vendor name, OUI, part number, serial, wavelength, and date."""
+        if match := cls._VENDOR_NAME.match(line):
+            entry["vendor_name"] = match.group("value").strip()
+            return True
+        if match := cls._VENDOR_OUI.match(line):
+            entry["vendor_oui"] = match.group("value").strip()
+            return True
+        if match := cls._VENDOR_PN.match(line):
+            entry["vendor_part_number"] = match.group("pn").strip()
+            entry["vendor_revision"] = match.group("rev").strip()
+            return True
+        if match := cls._VENDOR_PN_NO_REV.match(line):
+            entry["vendor_part_number"] = match.group("pn").strip()
+            return True
+        if match := cls._WAVELENGTH_TOL.match(line):
+            entry["wavelength_tolerance_nm"] = float(match.group("value"))
+            return True
+        if match := cls._WAVELENGTH.match(line):
+            entry["wavelength_nm"] = float(match.group("value"))
+            return True
+        if match := cls._VENDOR_SN.match(line):
+            entry["vendor_serial_number"] = match.group("value").strip()
+            return True
+        if match := cls._DATE_CODE.match(line):
+            entry["date_code"] = match.group("value").strip()
+            return True
+        return False
+
+    @classmethod
+    def _parse_cisco_fields(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse Cisco-specific CLEI, part number, and product ID fields."""
+        if match := cls._CLEI.match(line):
+            entry["clei_code"] = match.group("value").strip()
+            return True
+        if match := cls._CISCO_PN.match(line):
+            entry["cisco_part_number"] = match.group("pn").strip()
+            entry["cisco_part_version"] = match.group("ver").strip()
+            return True
+        if match := cls._PRODUCT_ID.match(line):
+            entry["product_id"] = match.group("value").strip()
+            return True
+        return False
+
+    @classmethod
+    def _parse_eeprom_fields(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse EEPROM key-value fields from a single line."""
+        return (
+            cls._parse_transceiver_basics(line, entry)
+            or cls._parse_vendor_info(line, entry)
+            or cls._parse_cisco_fields(line, entry)
+        )
+
+    @classmethod
+    def _parse_diagnostics(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse module-level and lane-level diagnostic lines."""
+        if match := cls._MODULE_TEMP.match(line):
+            diag = entry.setdefault("module_diagnostics", {})
+            diag["temperature_c"] = float(match.group("value"))
+            return True
+        if match := cls._MODULE_VOLTAGE.match(line):
+            diag = entry.setdefault("module_diagnostics", {})
+            diag["voltage_v"] = float(match.group("value"))
+            return True
+        if match := cls._LANE_DATA.match(line):
+            lanes = entry.setdefault("lanes", {})
+            lane_id = match.group("lane")
+            lane_entry: LaneDiagnostics = {
+                "bias_ma": float(match.group("bias")),
+                "tx_power_mw": float(match.group("tx_mw")),
+                "tx_power_dbm": float(match.group("tx_dbm")),
+                "rx_power_mw": float(match.group("rx_mw")),
+                "rx_power_dbm": float(match.group("rx_dbm")),
+            }
+            lanes[lane_id] = lane_entry
+            return True
+        return False
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControllersAllPhyResult:
+        """Parse 'show controllers all phy' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict keyed by interface name with transceiver/PHY details.
+
+        Raises:
+            ValueError: If no interface data is found in the output.
+        """
+        result: ShowControllersAllPhyResult = {}
+        current_entry: dict[str, object] | None = None
+
+        for line in output.splitlines():
+            # Skip hex dump and MSA header lines
+            if cls._HEX_LINE.match(line) or cls._MSA_HEADER.match(line):
+                continue
+
+            if match := cls._INTERFACE_HEADER.match(line):
+                current_entry = {}
+                result[match.group("interface")] = current_entry  # type: ignore[assignment]
+                continue
+
+            if current_entry is None:
+                continue
+
+            cls._parse_eeprom_fields(line, current_entry)
+            cls._parse_diagnostics(line, current_entry)
+
+        if not result:
+            msg = "No interface PHY data found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_all_phy.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_all_phy.py
@@ -1,7 +1,7 @@
 """Parser for 'show controllers all phy' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -204,15 +204,24 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
     def _parse_diagnostics(cls, line: str, entry: dict[str, object]) -> bool:
         """Parse module-level and lane-level diagnostic lines."""
         if match := cls._MODULE_TEMP.match(line):
-            diag = entry.setdefault("module_diagnostics", {})
+            diag = cast(
+                dict[str, float],
+                entry.setdefault("module_diagnostics", {}),
+            )
             diag["temperature_c"] = float(match.group("value"))
             return True
         if match := cls._MODULE_VOLTAGE.match(line):
-            diag = entry.setdefault("module_diagnostics", {})
+            diag = cast(
+                dict[str, float],
+                entry.setdefault("module_diagnostics", {}),
+            )
             diag["voltage_v"] = float(match.group("value"))
             return True
         if match := cls._LANE_DATA.match(line):
-            lanes = entry.setdefault("lanes", {})
+            lanes = cast(
+                dict[str, LaneDiagnostics],
+                entry.setdefault("lanes", {}),
+            )
             lane_id = match.group("lane")
             lane_entry: LaneDiagnostics = {
                 "bias_ma": float(match.group("bias")),
@@ -238,7 +247,7 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
         Raises:
             ValueError: If no interface data is found in the output.
         """
-        result: ShowControllersAllPhyResult = {}
+        result: dict[str, dict[str, object]] = {}
         current_entry: dict[str, object] | None = None
 
         for line in output.splitlines():
@@ -248,7 +257,9 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
 
             if match := cls._INTERFACE_HEADER.match(line):
                 current_entry = {}
-                result[match.group("interface")] = current_entry  # type: ignore[assignment]
+                interface_name = match.group("interface")
+                if interface_name is not None:
+                    result[interface_name] = current_entry
                 continue
 
             if current_entry is None:
@@ -261,4 +272,4 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
             msg = "No interface PHY data found in output"
             raise ValueError(msg)
 
-        return result
+        return cast(ShowControllersAllPhyResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_all_phy.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_all_phy.py
@@ -7,11 +7,39 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class ThresholdSet(TypedDict):
+    """Schema for alarm/warning threshold bounds for a single metric."""
+
+    alarm_high: NotRequired[float]
+    warning_high: NotRequired[float]
+    warning_low: NotRequired[float]
+    alarm_low: NotRequired[float]
+
+
+class ModuleThresholds(TypedDict):
+    """Schema for module-level alarm/warning thresholds."""
+
+    temperature_c: NotRequired[ThresholdSet]
+    voltage_v: NotRequired[ThresholdSet]
+
+
+class LaneThresholds(TypedDict):
+    """Schema for per-lane alarm/warning thresholds."""
+
+    bias_ma: NotRequired[ThresholdSet]
+    tx_power_mw: NotRequired[ThresholdSet]
+    tx_power_dbm: NotRequired[ThresholdSet]
+    rx_power_mw: NotRequired[ThresholdSet]
+    rx_power_dbm: NotRequired[ThresholdSet]
 
 
 class LaneDiagnostics(TypedDict):
     """Schema for per-lane diagnostic measurements."""
 
+    temperature_c: NotRequired[float]
     bias_ma: NotRequired[float]
     tx_power_mw: NotRequired[float]
     tx_power_dbm: NotRequired[float]
@@ -30,6 +58,7 @@ class ControllerPhyEntry(TypedDict):
     """Schema for a single interface's PHY/EEPROM data."""
 
     xcvr_type: NotRequired[str]
+    power_class: NotRequired[str]
     connector_type: NotRequired[str]
     ethernet_compliance: NotRequired[str]
     encoding: NotRequired[str]
@@ -39,6 +68,7 @@ class ControllerPhyEntry(TypedDict):
     length_om2_m: NotRequired[int]
     length_om1_m: NotRequired[int]
     length_copper_m: NotRequired[int]
+    device_tech: NotRequired[str]
     vendor_name: NotRequired[str]
     vendor_oui: NotRequired[str]
     vendor_part_number: NotRequired[str]
@@ -47,23 +77,41 @@ class ControllerPhyEntry(TypedDict):
     wavelength_nm: NotRequired[float]
     wavelength_tolerance_nm: NotRequired[float]
     date_code: NotRequired[str]
+    diagnostic_monitoring_type: NotRequired[str]
+    options: NotRequired[list[str]]
     clei_code: NotRequired[str]
     cisco_part_number: NotRequired[str]
     cisco_part_version: NotRequired[str]
     product_id: NotRequired[str]
     module_diagnostics: NotRequired[ModuleDiagnostics]
+    module_thresholds: NotRequired[ModuleThresholds]
     lanes: NotRequired[dict[str, LaneDiagnostics]]
+    lane_thresholds: NotRequired[LaneThresholds]
 
 
-ShowControllersAllPhyResult = dict[str, ControllerPhyEntry]
+class ShowControllersAllPhyResult(TypedDict):
+    """Schema for 'show controllers all phy' parsed output.
+
+    Dict-of-dicts keyed by canonical interface name.
+    """
+
+    interfaces: dict[str, ControllerPhyEntry]
+
+
+_LANE_TEMP_SKIP = frozenset({"N/A", "n/a", "--"})
+
+
+def _strip_trailing_comma(value: str) -> str:
+    """Return value with a single trailing comma removed."""
+    return value[:-1].rstrip() if value.endswith(",") else value
 
 
 @register(OS.CISCO_IOSXR, "show controllers all phy")
 class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
     """Parser for 'show controllers all phy' on Cisco IOS-XR.
 
-    Extracts transceiver EEPROM data and optical diagnostics per interface.
-    Hex dump sections (MSA Data) are skipped.
+    Extracts transceiver EEPROM data, alarm/warning thresholds, and
+    optical diagnostics per interface. Hex dump sections are skipped.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
@@ -71,6 +119,7 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
     _INTERFACE_HEADER = re.compile(r"^PHY data for interface:\s+(?P<interface>\S+)")
 
     _XCVR_TYPE = re.compile(r"^\s+Xcvr Type:\s+(?P<value>.+?)\s*$")
+    _EXT_TYPE = re.compile(r"^\s+Ext Type:\s+(?P<value>[^,]+?)\s*,")
     _CONNECTOR = re.compile(r"^\s+Connector Type:\s+(?P<value>.+?)\s*$")
     _ETH_COMPLIANCE = re.compile(
         r"^\s+Ethernet Compliance Codes:\s+(?P<value>.+?),?\s*$"
@@ -84,26 +133,63 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
         r"OM1:\s+(?P<om1>\d+)M,\s+"
         r"Copper:\s+(?P<copper>\d+)M"
     )
+    _DEVICE_TECH = re.compile(r"^\s+Device Tech:\s+(?P<value>.+?)\s*$")
     _VENDOR_NAME = re.compile(r"^\s+Vendor Name:\s+(?P<value>.+?)\s*$")
     _VENDOR_OUI = re.compile(r"^\s+Vendor OUI:\s+(?P<value>\S+)")
     _VENDOR_PN = re.compile(
-        r"^\s+Vendor Part Number:\s+(?P<pn>.+?)\s+"
-        r"\(rev\.:\s+(?P<rev>\S+)\)"
+        r"^\s+Vendor Part Number:\s+(?P<pn>.+?)"
+        r"(?:\s+\(rev\.:\s+(?P<rev>\S+)\))?\s*$"
     )
-    _VENDOR_PN_NO_REV = re.compile(r"^\s+Vendor Part Number:\s+(?P<pn>.+?)\s*$")
     _WAVELENGTH = re.compile(r"^\s+Wavelength:\s+(?P<value>[\d.]+)\s+nm")
     _WAVELENGTH_TOL = re.compile(r"^\s+Wavelength Tolerance:\s+(?P<value>[\d.]+)\s+nm")
     _VENDOR_SN = re.compile(r"^\s+Vendor Serial Number:\s+(?P<value>.+?)\s*$")
     _DATE_CODE = re.compile(r"^\s+Date Code \(yy/mm/dd\):\s+(?P<value>\S+)")
+    _DIAG_MON_TYPE = re.compile(r"^\s+Diagnostic Monitoring Type:\s+(?P<value>.+?)\s*$")
+    _OPTIONS = re.compile(r"^\s+Options:\s+(?P<value>.+?)\s*$")
     _CLEI = re.compile(r"^\s+CLEI Code:\s+(?P<value>\S+)")
     _CISCO_PN = re.compile(
-        r"^\s+Part Number:\s+(?P<pn>\S+)\s+"
-        r"\(ver\.:\s+(?P<ver>.+?)\s*\)"
+        r"^\s+Part Number:\s+(?P<pn>\S+)\s+\(ver\.:\s+(?P<ver>.+?)\s*\)"
     )
     _PRODUCT_ID = re.compile(r"^\s+Product Id:\s+(?P<value>\S+)")
 
     _MODULE_TEMP = re.compile(r"^\s+Temperature:\s+(?P<value>[+-]?[\d.]+)\s+C\s*$")
     _MODULE_VOLTAGE = re.compile(r"^\s+Voltage:\s+(?P<value>[\d.]+)\s+Volt\s*$")
+
+    _MODULE_TEMP_THRESHOLDS = re.compile(
+        r"^\s+Temperature:\s+"
+        r"(?P<alarm_high>[+-]?[\d.]+)\s+C\s+"
+        r"(?P<warning_high>[+-]?[\d.]+)\s+C\s+"
+        r"(?P<warning_low>[+-]?[\d.]+)\s+C\s+"
+        r"(?P<alarm_low>[+-]?[\d.]+)\s+C\s*$"
+    )
+    _MODULE_VOLT_THRESHOLDS = re.compile(
+        r"^\s+Voltage:\s+"
+        r"(?P<alarm_high>[\d.]+)\s+Volt\s+"
+        r"(?P<warning_high>[\d.]+)\s+Volt\s+"
+        r"(?P<warning_low>[\d.]+)\s+Volt\s+"
+        r"(?P<alarm_low>[\d.]+)\s+Volt\s*$"
+    )
+    _LANE_BIAS_THRESHOLDS = re.compile(
+        r"^\s+Bias:\s+"
+        r"(?P<alarm_high>[\d.]+)\s+mAmps\s+"
+        r"(?P<warning_high>[\d.]+)\s+mAmps\s+"
+        r"(?P<warning_low>[\d.]+)\s+mAmps\s+"
+        r"(?P<alarm_low>[\d.]+)\s+mAmps\s*$"
+    )
+    _LANE_TX_PWR_THRESHOLDS = re.compile(
+        r"^\s+Transmit Power:\s+"
+        r"(?P<ah_mw>[\d.]+)\s+mW\s+\((?P<ah_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<wh_mw>[\d.]+)\s+mW\s+\((?P<wh_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<wl_mw>[\d.]+)\s+mW\s+\((?P<wl_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<al_mw>[\d.]+)\s+mW\s+\((?P<al_dbm>[+-]?[\d.]+)\s+dBm\)"
+    )
+    _LANE_RX_PWR_THRESHOLDS = re.compile(
+        r"^\s+Receive Power:\s+"
+        r"(?P<ah_mw>[\d.]+)\s+mW\s+\((?P<ah_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<wh_mw>[\d.]+)\s+mW\s+\((?P<wh_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<wl_mw>[\d.]+)\s+mW\s+\((?P<wl_dbm>[+-]?[\d.]+)\s+dBm\)\s+"
+        r"(?P<al_mw>[\d.]+)\s+mW\s+\((?P<al_dbm>[+-]?[\d.]+)\s+dBm\)"
+    )
 
     _LANE_DATA = re.compile(
         r"^\s+(?P<lane>\d+)\s+"
@@ -115,7 +201,6 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
         r"\((?P<rx_dbm>[+-]?[\d.]+)\s+dBm\)"
     )
 
-    # Lines to skip: hex dumps, thresholds headers, alarm/warning rows, etc.
     _HEX_LINE = re.compile(r"^\s*0x[0-9a-fA-F]+:")
     _MSA_HEADER = re.compile(r"^MSA Data\s")
 
@@ -124,6 +209,9 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
         """Parse transceiver type, connector, encoding, and length fields."""
         if match := cls._XCVR_TYPE.match(line):
             entry["xcvr_type"] = match.group("value").strip()
+            return True
+        if match := cls._EXT_TYPE.match(line):
+            entry["power_class"] = match.group("value").strip()
             return True
         if match := cls._CONNECTOR.match(line):
             entry["connector_type"] = match.group("value").strip()
@@ -144,6 +232,9 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
             entry["length_om1_m"] = int(match.group("om1"))
             entry["length_copper_m"] = int(match.group("copper"))
             return True
+        if match := cls._DEVICE_TECH.match(line):
+            entry["device_tech"] = _strip_trailing_comma(match.group("value").strip())
+            return True
         return False
 
     @classmethod
@@ -157,10 +248,8 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
             return True
         if match := cls._VENDOR_PN.match(line):
             entry["vendor_part_number"] = match.group("pn").strip()
-            entry["vendor_revision"] = match.group("rev").strip()
-            return True
-        if match := cls._VENDOR_PN_NO_REV.match(line):
-            entry["vendor_part_number"] = match.group("pn").strip()
+            if rev := match.group("rev"):
+                entry["vendor_revision"] = rev.strip()
             return True
         if match := cls._WAVELENGTH_TOL.match(line):
             entry["wavelength_tolerance_nm"] = float(match.group("value"))
@@ -173,6 +262,20 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
             return True
         if match := cls._DATE_CODE.match(line):
             entry["date_code"] = match.group("value").strip()
+            return True
+        return False
+
+    @classmethod
+    def _parse_module_metadata(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse module-level descriptive fields (DDM type, options)."""
+        if match := cls._DIAG_MON_TYPE.match(line):
+            entry["diagnostic_monitoring_type"] = _strip_trailing_comma(
+                match.group("value").strip()
+            )
+            return True
+        if match := cls._OPTIONS.match(line):
+            raw = _strip_trailing_comma(match.group("value").strip())
+            entry["options"] = [item.strip() for item in raw.split(",") if item.strip()]
             return True
         return False
 
@@ -197,42 +300,116 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
         return (
             cls._parse_transceiver_basics(line, entry)
             or cls._parse_vendor_info(line, entry)
+            or cls._parse_module_metadata(line, entry)
             or cls._parse_cisco_fields(line, entry)
         )
 
+    @staticmethod
+    def _threshold_set(match: re.Match[str]) -> ThresholdSet:
+        """Build a ThresholdSet from a 4-value threshold regex match."""
+        return {
+            "alarm_high": float(match.group("alarm_high")),
+            "warning_high": float(match.group("warning_high")),
+            "warning_low": float(match.group("warning_low")),
+            "alarm_low": float(match.group("alarm_low")),
+        }
+
+    @staticmethod
+    def _threshold_pair(match: re.Match[str]) -> tuple[ThresholdSet, ThresholdSet]:
+        """Build mW and dBm ThresholdSets from a paired-value match."""
+        mw: ThresholdSet = {
+            "alarm_high": float(match.group("ah_mw")),
+            "warning_high": float(match.group("wh_mw")),
+            "warning_low": float(match.group("wl_mw")),
+            "alarm_low": float(match.group("al_mw")),
+        }
+        dbm: ThresholdSet = {
+            "alarm_high": float(match.group("ah_dbm")),
+            "warning_high": float(match.group("wh_dbm")),
+            "warning_low": float(match.group("wl_dbm")),
+            "alarm_low": float(match.group("al_dbm")),
+        }
+        return mw, dbm
+
     @classmethod
-    def _parse_diagnostics(cls, line: str, entry: dict[str, object]) -> bool:
-        """Parse module-level and lane-level diagnostic lines."""
+    def _parse_module_thresholds(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse module-level alarm/warning threshold rows."""
+        if match := cls._MODULE_TEMP_THRESHOLDS.match(line):
+            mt = cast(ModuleThresholds, entry.setdefault("module_thresholds", {}))
+            mt["temperature_c"] = cls._threshold_set(match)
+            return True
+        if match := cls._MODULE_VOLT_THRESHOLDS.match(line):
+            mt = cast(ModuleThresholds, entry.setdefault("module_thresholds", {}))
+            mt["voltage_v"] = cls._threshold_set(match)
+            return True
+        return False
+
+    @classmethod
+    def _parse_lane_thresholds(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse per-lane alarm/warning threshold rows."""
+        if match := cls._LANE_BIAS_THRESHOLDS.match(line):
+            lt = cast(LaneThresholds, entry.setdefault("lane_thresholds", {}))
+            lt["bias_ma"] = cls._threshold_set(match)
+            return True
+        if match := cls._LANE_TX_PWR_THRESHOLDS.match(line):
+            lt = cast(LaneThresholds, entry.setdefault("lane_thresholds", {}))
+            mw, dbm = cls._threshold_pair(match)
+            lt["tx_power_mw"] = mw
+            lt["tx_power_dbm"] = dbm
+            return True
+        if match := cls._LANE_RX_PWR_THRESHOLDS.match(line):
+            lt = cast(LaneThresholds, entry.setdefault("lane_thresholds", {}))
+            mw, dbm = cls._threshold_pair(match)
+            lt["rx_power_mw"] = mw
+            lt["rx_power_dbm"] = dbm
+            return True
+        return False
+
+    @classmethod
+    def _parse_module_diagnostics(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse single-value module temperature/voltage readings."""
         if match := cls._MODULE_TEMP.match(line):
-            diag = cast(
-                dict[str, float],
-                entry.setdefault("module_diagnostics", {}),
-            )
+            diag = cast(ModuleDiagnostics, entry.setdefault("module_diagnostics", {}))
             diag["temperature_c"] = float(match.group("value"))
             return True
         if match := cls._MODULE_VOLTAGE.match(line):
-            diag = cast(
-                dict[str, float],
-                entry.setdefault("module_diagnostics", {}),
-            )
+            diag = cast(ModuleDiagnostics, entry.setdefault("module_diagnostics", {}))
             diag["voltage_v"] = float(match.group("value"))
             return True
-        if match := cls._LANE_DATA.match(line):
-            lanes = cast(
-                dict[str, LaneDiagnostics],
-                entry.setdefault("lanes", {}),
-            )
-            lane_id = match.group("lane")
-            lane_entry: LaneDiagnostics = {
-                "bias_ma": float(match.group("bias")),
-                "tx_power_mw": float(match.group("tx_mw")),
-                "tx_power_dbm": float(match.group("tx_dbm")),
-                "rx_power_mw": float(match.group("rx_mw")),
-                "rx_power_dbm": float(match.group("rx_dbm")),
-            }
-            lanes[lane_id] = lane_entry
-            return True
         return False
+
+    @classmethod
+    def _parse_lane_data(cls, line: str, entry: dict[str, object]) -> bool:
+        """Parse per-lane bias / Tx / Rx data rows."""
+        match = cls._LANE_DATA.match(line)
+        if not match:
+            return False
+        lanes = cast(dict[str, LaneDiagnostics], entry.setdefault("lanes", {}))
+        lane_entry: LaneDiagnostics = {
+            "bias_ma": float(match.group("bias")),
+            "tx_power_mw": float(match.group("tx_mw")),
+            "tx_power_dbm": float(match.group("tx_dbm")),
+            "rx_power_mw": float(match.group("rx_mw")),
+            "rx_power_dbm": float(match.group("rx_dbm")),
+        }
+        temp_raw = match.group("temp")
+        if temp_raw not in _LANE_TEMP_SKIP:
+            try:
+                lane_entry["temperature_c"] = float(temp_raw)
+            except ValueError:
+                pass
+        lanes[match.group("lane")] = lane_entry
+        return True
+
+    @classmethod
+    def _parse_diagnostics(cls, line: str, entry: dict[str, object]) -> bool:
+        """Dispatch to module-level and lane-level diagnostic parsers."""
+        return (
+            cls._parse_module_thresholds(line, entry)
+            or cls._parse_lane_thresholds(line, entry)
+            or cls._parse_module_diagnostics(line, entry)
+            or cls._parse_lane_data(line, entry)
+        )
 
     @classmethod
     def parse(cls, output: str) -> ShowControllersAllPhyResult:
@@ -242,24 +419,24 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
             output: Raw CLI output from the command.
 
         Returns:
-            Dict keyed by interface name with transceiver/PHY details.
+            Parsed PHY/transceiver data keyed by canonical interface name.
 
         Raises:
             ValueError: If no interface data is found in the output.
         """
-        result: dict[str, dict[str, object]] = {}
+        interfaces: dict[str, ControllerPhyEntry] = {}
         current_entry: dict[str, object] | None = None
 
         for line in output.splitlines():
-            # Skip hex dump and MSA header lines
             if cls._HEX_LINE.match(line) or cls._MSA_HEADER.match(line):
                 continue
 
             if match := cls._INTERFACE_HEADER.match(line):
                 current_entry = {}
-                interface_name = match.group("interface")
-                if interface_name is not None:
-                    result[interface_name] = current_entry
+                interface_name = canonical_interface_name(
+                    match.group("interface"), os=OS.CISCO_IOSXR
+                )
+                interfaces[interface_name] = cast(ControllerPhyEntry, current_entry)
                 continue
 
             if current_entry is None:
@@ -268,8 +445,8 @@ class ShowControllersAllPhyParser(BaseParser[ShowControllersAllPhyResult]):
             cls._parse_eeprom_fields(line, current_entry)
             cls._parse_diagnostics(line, current_entry)
 
-        if not result:
+        if not interfaces:
             msg = "No interface PHY data found in output"
             raise ValueError(msg)
 
-        return cast(ShowControllersAllPhyResult, result)
+        return ShowControllersAllPhyResult(interfaces=interfaces)

--- a/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/expected.json
@@ -1,0 +1,60 @@
+{
+    "FortyGigE0/1/1/0": {
+        "xcvr_type": "QSFP+",
+        "connector_type": "MPO",
+        "ethernet_compliance": "40GBASE-SR4",
+        "encoding": "64B66B",
+        "nominal_bitrate_mbps": 10300,
+        "length_smf_km": 0,
+        "length_om3_m": 100,
+        "length_om2_m": 30,
+        "length_om1_m": 0,
+        "length_copper_m": 0,
+        "vendor_name": "CISCO",
+        "vendor_oui": "00.17.6a",
+        "vendor_part_number": "AFBR-79EIPZ-CS2",
+        "vendor_revision": "03",
+        "vendor_serial_number": "AVP1812S4QL",
+        "wavelength_nm": 850.03,
+        "wavelength_tolerance_nm": 10.03,
+        "date_code": "14/03/22",
+        "clei_code": "COUIA9JCAB",
+        "cisco_part_number": "10-2672-02",
+        "cisco_part_version": "V02",
+        "product_id": "QSFP-40G-SR4",
+        "module_diagnostics": {
+            "temperature_c": 26.535,
+            "voltage_v": 3.254
+        },
+        "lanes": {
+            "0": {
+                "bias_ma": 6.73,
+                "tx_power_mw": 0.6037,
+                "tx_power_dbm": -2.19179,
+                "rx_power_mw": 0.5845,
+                "rx_power_dbm": -2.33215
+            },
+            "1": {
+                "bias_ma": 6.452,
+                "tx_power_mw": 0.626,
+                "tx_power_dbm": -2.03426,
+                "rx_power_mw": 0.5164,
+                "rx_power_dbm": -2.87014
+            },
+            "2": {
+                "bias_ma": 6.164,
+                "tx_power_mw": 0.6256,
+                "tx_power_dbm": -2.03703,
+                "rx_power_mw": 0.6939,
+                "rx_power_dbm": -1.58703
+            },
+            "3": {
+                "bias_ma": 6.114,
+                "tx_power_mw": 0.649,
+                "tx_power_dbm": -1.87755,
+                "rx_power_mw": 0.5925,
+                "rx_power_dbm": -2.27312
+            }
+        }
+    }
+}

--- a/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/expected.json
+++ b/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/expected.json
@@ -1,59 +1,122 @@
 {
-    "FortyGigE0/1/1/0": {
-        "xcvr_type": "QSFP+",
-        "connector_type": "MPO",
-        "ethernet_compliance": "40GBASE-SR4",
-        "encoding": "64B66B",
-        "nominal_bitrate_mbps": 10300,
-        "length_smf_km": 0,
-        "length_om3_m": 100,
-        "length_om2_m": 30,
-        "length_om1_m": 0,
-        "length_copper_m": 0,
-        "vendor_name": "CISCO",
-        "vendor_oui": "00.17.6a",
-        "vendor_part_number": "AFBR-79EIPZ-CS2",
-        "vendor_revision": "03",
-        "vendor_serial_number": "AVP1812S4QL",
-        "wavelength_nm": 850.03,
-        "wavelength_tolerance_nm": 10.03,
-        "date_code": "14/03/22",
-        "clei_code": "COUIA9JCAB",
-        "cisco_part_number": "10-2672-02",
-        "cisco_part_version": "V02",
-        "product_id": "QSFP-40G-SR4",
-        "module_diagnostics": {
-            "temperature_c": 26.535,
-            "voltage_v": 3.254
-        },
-        "lanes": {
-            "0": {
-                "bias_ma": 6.73,
-                "tx_power_mw": 0.6037,
-                "tx_power_dbm": -2.19179,
-                "rx_power_mw": 0.5845,
-                "rx_power_dbm": -2.33215
+    "interfaces": {
+        "FortyGigabitEthernet0/1/1/0": {
+            "xcvr_type": "QSFP+",
+            "power_class": "1.5W",
+            "connector_type": "MPO",
+            "ethernet_compliance": "40GBASE-SR4",
+            "encoding": "64B66B",
+            "nominal_bitrate_mbps": 10300,
+            "length_smf_km": 0,
+            "length_om3_m": 100,
+            "length_om2_m": 30,
+            "length_om1_m": 0,
+            "length_copper_m": 0,
+            "device_tech": "850 nm VCSEL, No wavelength control, Uncooled transmitter device, Pin detector, Transmitter not tunable",
+            "vendor_name": "CISCO",
+            "vendor_oui": "00.17.6a",
+            "vendor_part_number": "AFBR-79EIPZ-CS2",
+            "vendor_revision": "03",
+            "wavelength_nm": 850.03,
+            "wavelength_tolerance_nm": 10.03,
+            "vendor_serial_number": "AVP1812S4QL",
+            "date_code": "14/03/22",
+            "diagnostic_monitoring_type": "Average Power",
+            "options": [
+                "Rx Squ Dis",
+                "Rx Op Dis cap",
+                "Tx Squ Dis",
+                "Tx Squelch",
+                "Page 02",
+                "Page 01",
+                "Tx_Disable",
+                "Tx_Fault",
+                "Pave",
+                "Tx LOS"
+            ],
+            "clei_code": "COUIA9JCAB",
+            "cisco_part_number": "10-2672-02",
+            "cisco_part_version": "V02",
+            "product_id": "QSFP-40G-SR4",
+            "module_thresholds": {
+                "temperature_c": {
+                    "alarm_high": 75.0,
+                    "warning_high": 70.0,
+                    "warning_low": 0.0,
+                    "alarm_low": -5.0
+                },
+                "voltage_v": {
+                    "alarm_high": 3.63,
+                    "warning_high": 3.465,
+                    "warning_low": 3.1,
+                    "alarm_low": 2.97
+                }
             },
-            "1": {
-                "bias_ma": 6.452,
-                "tx_power_mw": 0.626,
-                "tx_power_dbm": -2.03426,
-                "rx_power_mw": 0.5164,
-                "rx_power_dbm": -2.87014
+            "module_diagnostics": {
+                "temperature_c": 26.535,
+                "voltage_v": 3.254
             },
-            "2": {
-                "bias_ma": 6.164,
-                "tx_power_mw": 0.6256,
-                "tx_power_dbm": -2.03703,
-                "rx_power_mw": 0.6939,
-                "rx_power_dbm": -1.58703
+            "lane_thresholds": {
+                "bias_ma": {
+                    "alarm_high": 10.0,
+                    "warning_high": 9.5,
+                    "warning_low": 1.0,
+                    "alarm_low": 0.5
+                },
+                "tx_power_mw": {
+                    "alarm_high": 1.5848,
+                    "warning_high": 0.7943,
+                    "warning_low": 0.1737,
+                    "alarm_low": 0.0691
+                },
+                "tx_power_dbm": {
+                    "alarm_high": 1.99974,
+                    "warning_high": -1.00015,
+                    "warning_low": -7.602,
+                    "alarm_low": -11.60522
+                },
+                "rx_power_mw": {
+                    "alarm_high": 2.1877,
+                    "warning_high": 1.7378,
+                    "warning_low": 0.1122,
+                    "alarm_low": 0.0446
+                },
+                "rx_power_dbm": {
+                    "alarm_high": 3.39988,
+                    "warning_high": 2.4,
+                    "warning_low": -9.50007,
+                    "alarm_low": -13.50665
+                }
             },
-            "3": {
-                "bias_ma": 6.114,
-                "tx_power_mw": 0.649,
-                "tx_power_dbm": -1.87755,
-                "rx_power_mw": 0.5925,
-                "rx_power_dbm": -2.27312
+            "lanes": {
+                "0": {
+                    "bias_ma": 6.73,
+                    "tx_power_mw": 0.6037,
+                    "tx_power_dbm": -2.19179,
+                    "rx_power_mw": 0.5845,
+                    "rx_power_dbm": -2.33215
+                },
+                "1": {
+                    "bias_ma": 6.452,
+                    "tx_power_mw": 0.626,
+                    "tx_power_dbm": -2.03426,
+                    "rx_power_mw": 0.5164,
+                    "rx_power_dbm": -2.87014
+                },
+                "2": {
+                    "bias_ma": 6.164,
+                    "tx_power_mw": 0.6256,
+                    "tx_power_dbm": -2.03703,
+                    "rx_power_mw": 0.6939,
+                    "rx_power_dbm": -1.58703
+                },
+                "3": {
+                    "bias_ma": 6.114,
+                    "tx_power_mw": 0.649,
+                    "tx_power_dbm": -1.87755,
+                    "rx_power_mw": 0.5925,
+                    "rx_power_dbm": -2.27312
+                }
             }
         }
     }

--- a/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/input.txt
+++ b/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/input.txt
@@ -1,0 +1,88 @@
+Tue Mar  7 16:51:31.347 EST
+PHY data for interface: FortyGigE0/1/1/0
+
+QSFP EEPROM port: 0
+        Xcvr Type: QSFP+
+        Ext Type: 1.5W, CLEI,
+        Connector Type: MPO
+        Ethernet Compliance Codes: 40GBASE-SR4,
+        Encoding: 64B66B,
+        BR, nominal: 10300 Mbps
+        Length SMF: 0KM, OM3: 100M, OM2: 30M, OM1: 0M, Copper: 0M
+        Device Tech: 850 nm VCSEL, No wavelength control, Uncooled transmitter device, Pin detector, Transmitter not tunable,
+        Vendor Name: CISCO
+        Vendor OUI: 00.17.6a
+        Vendor Part Number: AFBR-79EIPZ-CS2   (rev.: 03)
+        Wavelength: 850.030 nm
+        Wavelength Tolerance: 10.030 nm
+        Vendor Serial Number: AVP1812S4QL
+        Date Code (yy/mm/dd): 14/03/22  lot code:
+        Diagnostic Monitoring Type: Average Power,
+        Enhanced Options: No Rate Selection, No Application Select,
+        Extended Module Codes:
+        Options: Rx Squ Dis, Rx Op Dis cap, Tx Squ Dis, Tx Squelch, Page 02, Page 01, Tx_Disable, Tx_Fault, Pave, Tx LOS,
+        L-Tx/Rx LOS:
+        L-Tx Fault:
+        Module DDM: Voltage, Temperature,
+MSA Data (Lower Memory)
+0x0000: 0d 00 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+0x0010: 00 00 00 00 00 00 1a 89 : 00 00 7f 19 00 00 00 00
+0x0020: 00 00 16 d5 14 2c 1b 1b : 17 25 0d 25 0c 9a 0c 0a
+0x0030: 0b f1 17 95 18 74 18 70 : 19 5a 00 00 00 00 00 00
+0x0040: 00 00 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+0x0050: 00 00 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+0x0060: 00 00 00 00 00 00 00 f0 : f0 00 18 00 00 00 00 00
+0x0070: 00 00 00 00 00 03 03 00 : 00 00 00 00 00 00 00 03
+
+
+MSA Data (Upper Memory Page 00)
+0x0080: 0d 10 0c 04 00 00 00 00 : 00 00 00 05 67 00 00 32
+0x0090: 1e 00 00 00 43 49 53 43 : 4f 20 20 20 20 20 20 20
+0x00a0: 20 20 20 20 00 00 17 6a : 41 46 42 52 2d 37 39 45
+0x00b0: 49 50 5a 2d 43 53 32 20 : 30 33 42 68 07 d0 46 6a
+0x00c0: 00 00 0f de 41 56 50 31 : 38 31 32 53 34 51 4c 20
+0x00d0: 20 20 20 20 31 34 30 33 : 32 32 20 20 0a 00 00 da
+0x00e0: 00 00 06 6a de 2e ae 68 : 0e ce 79 e7 a5 0f 93 fe
+0x00f0: 61 45 b8 00 00 00 00 00 : 00 00 00 00 7e 57 7d cc
+
+        CLEI Code: COUIA9JCAB
+        Part Number: 10-2672-02 (ver.: V02 )
+        Product Id: QSFP-40G-SR4
+MSA Data (Upper Memory Page 02)
+0x0100: 43 4f 55 49 41 39 4a 43 : 41 42 31 30 2d 32 36 37
+0x0110: 32 2d 30 32 56 30 32 20 : 01 00 00 00 00 00 00 00
+0x0120: 00 81 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+0x0130: 00 00 00 00 00 00 00 00 : 00 00 00 00 00 00 aa aa
+0x0140: 51 53 46 50 2d 34 30 47 : 2d 53 52 34 20 20 20 20
+0x0150: 20 20 20 20 00 00 00 00 : 00 00 00 00 00 00 00 18
+0x0160: 36 34 31 33 34 34 31 37 : 00 9e 00 00 00 00 00 00
+0x0170: 00 00 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+
+        Module
+        Thresholds:                   Alarm High          Warning High          Warning Low          Alarm Low
+              Temperature:            +75.000 C             +70.000 C              +0.000 C              -5.000 C
+                  Voltage:           3.630 Volt            3.465 Volt            3.100 Volt            2.970 Volt
+
+        Temperature: +26.535 C
+        Voltage: 3.254 Volt
+
+        Lanes
+        Thresholds:                   Alarm High          Warning High          Warning Low          Alarm Low
+                     Bias:         10.000 mAmps           9.500 mAmps           1.000 mAmps           0.500 mAmps
+           Transmit Power:  1.58480 mW (1.99974 dBm)   0.79430 mW (-1.00015 dBm)   0.17370 mW (-7.60200 dBm)   0.06910 mW (-11.60522 dBm)
+            Receive Power:  2.18770 mW (3.39988 dBm)   1.73780 mW (2.40000 dBm)   0.11220 mW (-9.50007 dBm)   0.04460 mW (-13.50665 dBm)
+
+                 Lane            Temp            Bias                   Tx Power                   Rx Power
+                    0             N/A     6.730 mAmps   0.60370 mW (-2.19179 dBm)   0.58450 mW (-2.33215 dBm)
+                    1             N/A     6.452 mAmps   0.62600 mW (-2.03426 dBm)   0.51640 mW (-2.87014 dBm)
+                    2             N/A     6.164 mAmps   0.62560 mW (-2.03703 dBm)   0.69390 mW (-1.58703 dBm)
+                    3             N/A     6.114 mAmps   0.64900 mW (-1.87755 dBm)   0.59250 mW (-2.27312 dBm)
+MSA Data (Upper Memory Page 03)
+0x0180: 4b 00 fb 00 46 00 00 00 : 00 00 00 00 00 00 00 00
+0x0190: 8d cc 74 04 87 5a 79 18 : 00 00 00 00 00 00 00 00
+0x01a0: 00 00 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+0x01b0: 55 75 01 be 43 e2 04 62 : 13 88 00 fa 12 8e 01 f4
+0x01c0: 3d e8 02 b3 1f 07 06 c9 : 00 00 00 00 00 00 00 00
+0x01d0: 00 00 00 00 00 00 00 00 : 00 00 00 00 00 00 00 00
+0x01e0: 00 00 00 00 00 00 00 00 : 00 00 00 00 33 33 77 77
+0x01f0: 00 00 ff ff ff ff ff ff : 00 00 00 00 00 00 00 00

--- a/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_iosxr/show_controllers_all_phy/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: "QSFP+ 40G-SR4 transceiver with per-lane optical diagnostics"
+platform: "Unknown"
+software_version: "Unknown"


### PR DESCRIPTION
## Summary
- Add new parser for `show controllers all phy` on Cisco IOS-XR
- Extracts transceiver EEPROM fields (type, vendor, part number, serial, wavelength, etc.) and per-lane optical diagnostics (bias, Tx/Rx power in mW and dBm)
- Output is dict-of-dicts keyed by interface name; hex dump sections are skipped

## Test plan
- [x] Test fixture uses real device output from ntc-templates
- [x] All 7 parametrized tests pass (parser correctness, JSON conventions, placeholder sentinels)
- [x] ruff check and ruff format pass
- [x] xenon complexity under B threshold
- [x] bandit security scan clean
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)