### PR TITLE
feat(juniper_junos): add parser for show ppm transmissions protocol bfd detail

### DIFF
--- a/changes/+juniper-junos-show-ppm-transmissions-protocol-bfd-detail.parser_added
+++ b/changes/+juniper-junos-show-ppm-transmissions-protocol-bfd-detail.parser_added
@@ -1,0 +1,1 @@
+Added parser for `show ppm transmissions protocol bfd detail` on Juniper Junos.

--- a/src/muninn/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail.py
+++ b/src/muninn/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail.py
@@ -1,0 +1,114 @@
+"""Parser for 'show ppm transmissions protocol bfd detail' command on Juniper Junos."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PpmBfdTransmissionEntry(TypedDict):
+    """Schema for a single PPM BFD transmission entry."""
+
+    protocol: str
+    transmission_interval: int
+    distributed: bool
+    distribution_handle: int
+    distribution_address: str
+    ifl_index: int
+    replicated: bool
+
+
+@register(OS.JUNIPER_JUNOS, "show ppm transmissions protocol bfd detail")
+class ShowPpmTransmissionsProtocolBfdDetailParser(
+    BaseParser[dict[str, PpmBfdTransmissionEntry]],
+):
+    """Parser for 'show ppm transmissions protocol bfd detail' on Juniper Junos.
+
+    Returns a dict-of-dicts keyed by destination address. Each entry contains
+    protocol, transmission interval, distribution details, IFL index, and
+    replication status.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BFD})
+
+    _DESTINATION = re.compile(
+        r"^Destination:\s+(?P<destination>\S+),\s+"
+        r"Protocol:\s+(?P<protocol>\S+),\s+"
+        r"Transmission interval:\s+(?P<interval>\d+)"
+    )
+    _DISTRIBUTED = re.compile(
+        r"^Distributed:\s+(?P<distributed>\S+),\s+"
+        r"Distribution handle:\s+(?P<handle>\d+),\s+"
+        r"Distribution address:\s+(?P<address>\S+)"
+    )
+    _IFL_INDEX = re.compile(r"^IFL-index:\s+(?P<ifl_index>\d+)")
+    _REPLICATED = re.compile(r"^Replicated\s*$")
+    _NOT_REPLICATED = re.compile(r"^Not-Replicated\s*$")
+
+    @classmethod
+    def _parse_detail_line(cls, stripped: str, entry: dict[str, object]) -> None:
+        """Parse a detail line (non-destination) into the current entry."""
+        if match := cls._DISTRIBUTED.match(stripped):
+            entry["distributed"] = match.group("distributed").upper() == "TRUE"
+            entry["distribution_handle"] = int(match.group("handle"))
+            entry["distribution_address"] = match.group("address")
+        elif match := cls._IFL_INDEX.match(stripped):
+            entry["ifl_index"] = int(match.group("ifl_index"))
+        elif cls._REPLICATED.match(stripped):
+            entry["replicated"] = True
+        elif cls._NOT_REPLICATED.match(stripped):
+            entry["replicated"] = False
+
+    @classmethod
+    def _flush_entry(
+        cls,
+        dest: str | None,
+        entry: dict[str, object],
+        result: dict[str, PpmBfdTransmissionEntry],
+    ) -> None:
+        """Store a completed entry in the result dict."""
+        if dest is not None and entry:
+            result[dest] = PpmBfdTransmissionEntry(**entry)  # type: ignore[arg-type]
+
+    @classmethod
+    def parse(cls, output: str) -> dict[str, PpmBfdTransmissionEntry]:
+        """Parse 'show ppm transmissions protocol bfd detail' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict keyed by destination address with transmission details.
+
+        Raises:
+            ValueError: If no transmission entries are found.
+        """
+        result: dict[str, PpmBfdTransmissionEntry] = {}
+        current: dict[str, object] = {}
+        current_dest: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._DESTINATION.match(stripped):
+                cls._flush_entry(current_dest, current, result)
+                current_dest = match.group("destination")
+                current = {
+                    "protocol": match.group("protocol"),
+                    "transmission_interval": int(match.group("interval")),
+                }
+            else:
+                cls._parse_detail_line(stripped, current)
+
+        cls._flush_entry(current_dest, current, result)
+
+        if not result:
+            msg = "No PPM BFD transmission entries found in output"
+            raise ValueError(msg)
+
+        return result

--- a/src/muninn/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail.py
+++ b/src/muninn/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail.py
@@ -1,7 +1,7 @@
 """Parser for 'show ppm transmissions protocol bfd detail' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, TypedDict
+from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -71,7 +71,7 @@ class ShowPpmTransmissionsProtocolBfdDetailParser(
     ) -> None:
         """Store a completed entry in the result dict."""
         if dest is not None and entry:
-            result[dest] = PpmBfdTransmissionEntry(**entry)  # type: ignore[arg-type]
+            result[dest] = cast(PpmBfdTransmissionEntry, entry)
 
     @classmethod
     def parse(cls, output: str) -> dict[str, PpmBfdTransmissionEntry]:

--- a/tests/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail/001_basic/expected.json
+++ b/tests/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail/001_basic/expected.json
@@ -1,0 +1,11 @@
+{
+    "10.49.194.102": {
+        "protocol": "BFD",
+        "transmission_interval": 300,
+        "distributed": true,
+        "distribution_handle": 6918,
+        "distribution_address": "fpc9",
+        "ifl_index": 783,
+        "replicated": true
+    }
+}

--- a/tests/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail/001_basic/input.txt
+++ b/tests/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail/001_basic/input.txt
@@ -1,0 +1,5 @@
+show ppm transmissions protocol bfd detail
+Destination: 10.49.194.102, Protocol: BFD, Transmission interval: 300
+Distributed: TRUE, Distribution handle: 6918, Distribution address: fpc9
+IFL-index: 783
+Replicated

--- a/tests/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail/001_basic/metadata.yaml
+++ b/tests/parsers/juniper_junos/show_ppm_transmissions_protocol_bfd_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single BFD transmission entry with distributed and replicated status
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Add new parser for `show ppm transmissions protocol bfd detail` on Juniper Junos
- Returns dict-of-dicts keyed by destination address, with protocol, transmission interval, distributed status, distribution handle/address, IFL index, and replication status
- Tagged with `ParserTag.BFD`

## Test plan
- [x] Test fixture `001_basic` with real device output from Genie golden output
- [x] All 7 parametrized tests pass (parser, JSON conventions, placeholder sentinels)
- [x] ruff check and format pass
- [x] xenon complexity all A-rated
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)