### PR TITLE
fix(ios): add FiveGigabitEthernet support to LLDP parser and canonical_interface_name

### DIFF
--- a/changes/928.parser_fixed
+++ b/changes/928.parser_fixed
@@ -1,0 +1,1 @@
+Fixed `show lldp neighbors` parser and `canonical_interface_name` to correctly handle FiveGigabitEthernet (`Fi`) interfaces on Catalyst 9000 series switches.

--- a/src/muninn/parsers/ios/show_lldp_neighbors.py
+++ b/src/muninn/parsers/ios/show_lldp_neighbors.py
@@ -43,7 +43,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
     # Capability codes are single uppercase letters separated by commas (R, B, T, etc.)
     _NEIGHBOR_PATTERN = re.compile(
         r"^(?P<device_id>.+?)\s+"
-        r"(?P<local_intf>(?:Gi|Fa|Te|Fo|Hu|Et|Po|Vl|Lo|Tu|Se|Mg)\S+)\s+"
+        r"(?P<local_intf>(?:Gi|Fa|Te|Fo|Fi|Hu|Et|Po|Vl|Lo|Tu|Se|Mg)\S+)\s+"
         r"(?P<hold_time>\d+)\s+"
         r"(?:(?P<capability>[A-Z,]+)\s+)?"
         r"(?P<port_id>\S+)$"
@@ -52,7 +52,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
     # Pattern for wrapped long device names (no space between device_id and local_intf)
     # long_name_swt.josh-vGi0/2          120        R               Gi0/0
     _WRAPPED_NEIGHBOR_PATTERN = re.compile(
-        r"^(?P<device_id>.+?)(?P<local_intf>(?:Gi|Fa|Te|Fo|Hu|Et|Po|Vl|Lo|Tu|Se|Mg)\S+)\s+"
+        r"^(?P<device_id>.+?)(?P<local_intf>(?:Gi|Fa|Te|Fo|Fi|Hu|Et|Po|Vl|Lo|Tu|Se|Mg)\S+)\s+"
         r"(?P<hold_time>\d+)\s+"
         r"(?:(?P<capability>[A-Z,]+)\s+)?"
         r"(?P<port_id>\S+)$"
@@ -64,7 +64,7 @@ class ShowLldpNeighborsParser(BaseParser[ShowLldpNeighborsResult]):
     # Pattern to detect if port_id looks like an interface
     _INTERFACE_PATTERN = re.compile(
         r"^(?:Gi(?:g(?:abit)?)?|Fa(?:s(?:t)?)?|Eth?|Te(?:n)?|Fo(?:r(?:ty)?)?|"
-        r"Hu(?:n(?:dred)?)?|mgmt|Lo|Vlan|Po|Tu|Se|nve)(?:Ethernet)?\d",
+        r"Fi(?:ve)?|Hu(?:n(?:dred)?)?|mgmt|Lo|Vlan|Po|Tu|Se|nve)(?:Ethernet)?\d",
         re.IGNORECASE,
     )
 

--- a/src/muninn/utils.py
+++ b/src/muninn/utils.py
@@ -13,6 +13,9 @@ _IOS_FOUR_HUNDRED_GIGE_PATTERN = re.compile(
     r"^(?P<prefix>Fou)(?P<suffix>\d.*)$",
     re.IGNORECASE,
 )
+_IOS_FIVE_GIGE_PATTERN = re.compile(
+    r"^Fi(?P<suffix>\d.*)$",
+)
 
 # IOS-XR abbreviated prefixes that netutils does not expand.
 _IOSXR_PREFIX_MAP: dict[str, str] = {
@@ -60,6 +63,10 @@ def canonical_interface_name(name: str, *, os: OS | None = None) -> str:
         match = _IOS_FOUR_HUNDRED_GIGE_PATTERN.match(name)
         if match:
             name = f"FourHundredGigabitEthernet{match.group('suffix')}"
+        else:
+            match = _IOS_FIVE_GIGE_PATTERN.match(name)
+            if match:
+                name = f"FiveGigabitEthernet{match.group('suffix')}"
 
     if os is OS.CISCO_IOSXR:
         match = _IOSXR_PREFIX_PATTERN.match(name)

--- a/tests/parsers/ios/show_power_inline/005_fivegig_tenGig_multimodule/expected.json
+++ b/tests/parsers/ios/show_power_inline/005_fivegig_tenGig_multimodule/expected.json
@@ -1,13 +1,13 @@
 {
     "interfaces": {
-        "FiftyGigabitEthernet1/0/1": {
+        "FiveGigabitEthernet1/0/1": {
             "admin": "auto",
             "oper": "off",
             "power": 0.0,
             "max": 90.0,
             "module": 1
         },
-        "FiftyGigabitEthernet1/0/2": {
+        "FiveGigabitEthernet1/0/2": {
             "admin": "auto",
             "oper": "on",
             "power": 6.3,
@@ -16,7 +16,7 @@
             "max": 90.0,
             "module": 1
         },
-        "FiftyGigabitEthernet1/0/32": {
+        "FiveGigabitEthernet1/0/32": {
             "admin": "auto",
             "oper": "on",
             "power": 6.3,
@@ -24,14 +24,14 @@
             "max": 90.0,
             "module": 1
         },
-        "FiftyGigabitEthernet1/0/33": {
+        "FiveGigabitEthernet1/0/33": {
             "admin": "auto",
             "oper": "off",
             "power": 0.0,
             "max": 90.0,
             "module": 1
         },
-        "FiftyGigabitEthernet1/0/34": {
+        "FiveGigabitEthernet1/0/34": {
             "admin": "auto",
             "oper": "on",
             "power": 30.0,
@@ -40,7 +40,7 @@
             "max": 90.0,
             "module": 1
         },
-        "FiftyGigabitEthernet1/0/35": {
+        "FiveGigabitEthernet1/0/35": {
             "admin": "auto",
             "oper": "on",
             "power": 15.4,
@@ -58,7 +58,7 @@
             "max": 90.0,
             "module": 1
         },
-        "FiftyGigabitEthernet2/0/1": {
+        "FiveGigabitEthernet2/0/1": {
             "admin": "auto",
             "oper": "off",
             "power": 0.0,
@@ -74,7 +74,7 @@
             "max": 90.0,
             "module": 2
         },
-        "FiftyGigabitEthernet3/0/1": {
+        "FiveGigabitEthernet3/0/1": {
             "admin": "auto",
             "oper": "off",
             "power": 0.0,
@@ -90,7 +90,7 @@
             "max": 90.0,
             "module": 3
         },
-        "FiftyGigabitEthernet4/0/1": {
+        "FiveGigabitEthernet4/0/1": {
             "admin": "auto",
             "oper": "on",
             "power": 6.3,
@@ -108,7 +108,7 @@
             "max": 90.0,
             "module": 4
         },
-        "FiftyGigabitEthernet5/0/1": {
+        "FiveGigabitEthernet5/0/1": {
             "admin": "auto",
             "oper": "on",
             "power": 15.4,


### PR DESCRIPTION
## Summary
- Add `Fi` (FiveGigabitEthernet) prefix to the LLDP neighbors parser regex patterns, fixing parse failures on Catalyst 9000 series switches
- Add a case-sensitive shim in `canonical_interface_name` that expands `Fi` + digit to `FiveGigabitEthernet`, correcting netutils which incorrectly maps `Fi` to `FiftyGigabitEthernet`
- Update `show power inline` test expectations to reflect the corrected canonicalization

## Context
Discovered while running Huginn learning mode against a physical testbed with C9300 switches. The `show lldp neighbors` output uses `Fi1/0/x` as the abbreviated local interface for FiveGigabitEthernet ports. The parser's regex only recognized `Gi|Fa|Te|Fo|Hu|Et|Po|Vl|Lo|Tu|Se|Mg` prefixes, so lines with `Fi` were silently skipped, ultimately causing a `ValueError: No LLDP neighbors found in output` on devices where all neighbors were on FiveGigabitEthernet interfaces.

The `canonical_interface_name` shim uses a case-sensitive match (`Fi` + digit) to avoid colliding with `FiftyGigE` (which starts with `Fi` but is followed by letters, not digits).

## Test plan
- [x] All 7268 existing Muninn tests pass
- [x] Verified parser correctly handles sanitized `show lldp neighbors` output from C9300 switches with `Fi1/0/x` local interfaces
- [x] Verified `FiftyGigE` canonicalization is unaffected (two existing test cases with `FiftyGigabitEthernet` expectations still pass)
- [x] Verified `canonical_interface_name('Fi1/0/2', os=OS.CISCO_IOSXE)` → `FiveGigabitEthernet1/0/2`
- [x] Verified `canonical_interface_name('FiftyGigE1/6/0/33', os=OS.CISCO_IOSXE)` → `FiftyGigabitEthernet1/6/0/33` (unchanged)

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: parser fix for FiveGigabitEthernet support
- **Human Oversight**: Code reviewed and approved by Christopher Hart

🤖 Generated with [Claude Code](https://claude.com/claude-code)