### PR TITLE
fix(ios): extract license fields and image_type from additional platform variants

### DIFF
--- a/changes/+version-license-image-type.parser_fixed
+++ b/changes/+version-license-image-type.parser_fixed
@@ -1,0 +1,1 @@
+Fixed `show version` parser to extract license fields (level, type, next reload level) from C9300, ISR4451, C3945, and C1900 platforms, and `image_type` from C9300 switches.

--- a/src/muninn/parsers/ios/show_version.py
+++ b/src/muninn/parsers/ios/show_version.py
@@ -135,9 +135,7 @@ _LICENSE_TYPE_RE = re.compile(r"^License Type:\s+(.+?)\s*$")
 _LICENSE_NEXT_RE = re.compile(r"^Next re(?:load|boot) license Level:\s+(.+?)\s*$")
 
 # Combined "License Level: X   Type: Y" on one line (Cat4507RE style)
-_LICENSE_COMBINED_RE = re.compile(
-    r"^License Level:\s+(\S+)\s+Type:\s+(.+?)\s*$"
-)
+_LICENSE_COMBINED_RE = re.compile(r"^License Level:\s+(\S+)\s+Type:\s+(.+?)\s*$")
 
 # AIR License Level (C9300 Smart License)
 _AIR_LICENSE_RE = re.compile(r"^AIR License Level:\s+(.+?)\s*$")
@@ -307,12 +305,22 @@ def _parse_interfaces(line: str, result: dict) -> bool:
     return False
 
 
+def _is_valid_pkg_name(name: str) -> bool:
+    """Return True if *name* looks like a technology package identifier."""
+    return bool(
+        _PKG_NAME_RE.match(name)
+        and " " not in name
+        and not name.lower().startswith("technology")
+        and not name.startswith("---")
+    )
+
+
 def _parse_tech_pkg_tab_row(line: str, result: dict) -> bool:
-    """Parse a tab-separated technology package table row (C9300 style).
+    r"""Parse a tab-separated technology package table row (C9300 style).
 
     C9300 format uses tabs between columns and multi-word type values:
-        network-advantage   \\tSmart License                 \\t network-advantage
-        dna-advantage       \\tSubscription Smart License    \\t dna-advantage
+        network-advantage   \tSmart License                 \t network-advantage
+        dna-advantage       \tSubscription Smart License    \t dna-advantage
 
     Only the first matched row populates the license fields. Returns True if
     the line contained a tab and was parsed as a table row.
@@ -323,99 +331,65 @@ def _parse_tech_pkg_tab_row(line: str, result: dict) -> bool:
     if len(parts) != 3:
         return False
     current, lic_type, next_reboot = parts
-    # Validate: current/next_reboot should be single-word package names,
-    # and lic_type should not be a header keyword.
-    if " " in current or " " in next_reboot:
+    if not _is_valid_pkg_name(current) or not _is_valid_pkg_name(next_reboot):
         return False
-    if current.lower().startswith("technology") or current.startswith("---"):
-        return False
-    # Package names consist of alphanumeric chars, hyphens, and underscores.
-    # Reject lines where values contain other characters (e.g. "Device#").
-    if not _PKG_NAME_RE.match(current) or not _PKG_NAME_RE.match(next_reboot):
-        return False
+    lic = _ensure_license(result)
+    if "level" not in lic:
+        lic["level"] = current
+        lic["type"] = lic_type
+        lic["next_reload_level"] = next_reboot
+    return True
+
+
+def _ensure_license(result: dict) -> dict:
+    """Return the license sub-dict, creating it if absent."""
     if "license" not in result:
         result["license"] = {}
-    # Only populate from the first data row (primary license).
-    if "level" not in result["license"]:
-        result["license"]["level"] = current
-        result["license"]["type"] = lic_type
-        result["license"]["next_reload_level"] = next_reboot
-    return True
+    return result["license"]
+
+
+_LICENSE_SINGLE_FIELD_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (_LICENSE_LEVEL_RE, "level"),
+    (_LICENSE_TYPE_RE, "type"),
+    (_LICENSE_NEXT_RE, "next_reload_level"),
+    (_AIR_LICENSE_RE, "air_level"),
+    (_AIR_LICENSE_NEXT_RE, "air_next_reload_level"),
+)
 
 
 def _parse_license_fields(line: str, result: dict) -> bool:
     """Parse license-related lines. Returns True if matched."""
-    # Combined format: "License Level: entservices   Type: Permanent" (Cat4507RE)
     m = _LICENSE_COMBINED_RE.match(line)
     if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"]["level"] = m.group(1)
-        result["license"]["type"] = m.group(2)
+        lic = _ensure_license(result)
+        lic["level"] = m.group(1)
+        lic["type"] = m.group(2)
         return True
 
-    m = _LICENSE_LEVEL_RE.match(line)
-    if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"]["level"] = m.group(1)
-        return True
+    for pattern, key in _LICENSE_SINGLE_FIELD_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            _ensure_license(result).setdefault(key, m.group(1))
+            return True
 
-    m = _LICENSE_TYPE_RE.match(line)
-    if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"]["type"] = m.group(1)
-        return True
-
-    m = _LICENSE_NEXT_RE.match(line)
-    if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"]["next_reload_level"] = m.group(1)
-        return True
-
-    # AIR License Level (C9300 Smart License)
-    m = _AIR_LICENSE_RE.match(line)
-    if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"].setdefault("air_level", m.group(1))
-        return True
-
-    m = _AIR_LICENSE_NEXT_RE.match(line)
-    if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"].setdefault("air_next_reload_level", m.group(1))
-        return True
-
-    # Tab-separated technology package table row (C9300 style)
     if _parse_tech_pkg_tab_row(line, result):
         return True
 
-    # 3-column technology package table row (C3850 style):
-    # current  type  next_reboot
     m = _TECH_PKG_3COL_RE.match(line)
     if m:
-        if "license" not in result:
-            result["license"] = {}
-        result["license"]["level"] = m.group(1)
-        result["license"]["type"] = m.group(2)
-        result["license"]["next_reload_level"] = m.group(3)
+        lic = _ensure_license(result)
+        lic["level"] = m.group(1)
+        lic["type"] = m.group(2)
+        lic["next_reload_level"] = m.group(3)
         return True
 
-    # 4-column technology package table row (ISR4451/C3945/C1900 style):
-    # technology  current  type  next_reboot
     m = _TECH_PKG_4COL_RE.match(line)
     if m:
-        if "license" not in result:
-            result["license"] = {}
-        # Only populate from the first non-None row.
-        if "level" not in result["license"] and m.group(2) != "None":
-            result["license"]["level"] = m.group(2)
-            result["license"]["type"] = m.group(3)
-            result["license"]["next_reload_level"] = m.group(4)
+        lic = _ensure_license(result)
+        if "level" not in lic and m.group(2) != "None":
+            lic["level"] = m.group(2)
+            lic["type"] = m.group(3)
+            lic["next_reload_level"] = m.group(4)
         return True
 
     return False

--- a/src/muninn/parsers/ios/show_version.py
+++ b/src/muninn/parsers/ios/show_version.py
@@ -25,6 +25,8 @@ class LicenseEntry(TypedDict):
     level: str
     type: NotRequired[str]
     next_reload_level: NotRequired[str]
+    air_level: NotRequired[str]
+    air_next_reload_level: NotRequired[str]
 
 
 class SwitchStackEntry(TypedDict):
@@ -72,8 +74,8 @@ class ShowVersionResult(TypedDict):
 # Version line: multiple formats
 _VERSION_RE = re.compile(r"Version\s+(\S+?)(?:,|\s|$)")
 
-# Image type from software line, e.g. "(C3750E-UNIVERSALK9-M)"
-_IMAGE_TYPE_RE = re.compile(r"\(([A-Za-z0-9][A-Za-z0-9_-]+-[A-Za-z0-9]+)\)")
+# Image type from software line, e.g. "(C3750E-UNIVERSALK9-M)" or "(CAT9K_IOSXE)"
+_IMAGE_TYPE_RE = re.compile(r"\(([A-Za-z0-9]+[_-][A-Za-z0-9_-]+)\)")
 
 # Compiled line
 _COMPILED_RE = re.compile(r"^Compiled\s+(.+)$")
@@ -123,17 +125,41 @@ _NVRAM_RE = re.compile(
     r"^(\d+)K\s+bytes\s+of\s+(?:flash-simulated\s+)?non-volatile\s+configuration\s+memory"
 )
 
-# License level
-_LICENSE_LEVEL_RE = re.compile(r"^License Level:\s+(.+?)\s*$")
+# License level (may include "Type: ..." on the same line for Cat4507RE)
+_LICENSE_LEVEL_RE = re.compile(r"^License Level:\s+(\S+)")
 
 # License type
 _LICENSE_TYPE_RE = re.compile(r"^License Type:\s+(.+?)\s*$")
 
-# Next reload license level
-_LICENSE_NEXT_RE = re.compile(r"^Next reload license Level:\s+(.+?)\s*$")
+# Next reload/reboot license level
+_LICENSE_NEXT_RE = re.compile(r"^Next re(?:load|boot) license Level:\s+(.+?)\s*$")
 
-# Technology package license table row (C3850 style)
-_TECH_PKG_RE = re.compile(r"^(\S+k9)\s+(Permanent|Evaluation|RightToUse)\s+(\S+k9)\s*$")
+# Combined "License Level: X   Type: Y" on one line (Cat4507RE style)
+_LICENSE_COMBINED_RE = re.compile(
+    r"^License Level:\s+(\S+)\s+Type:\s+(.+?)\s*$"
+)
+
+# AIR License Level (C9300 Smart License)
+_AIR_LICENSE_RE = re.compile(r"^AIR License Level:\s+(.+?)\s*$")
+
+# Next reload AIR license level (C9300)
+_AIR_LICENSE_NEXT_RE = re.compile(r"^Next reload AIR license Level:\s+(.+?)\s*$")
+
+# Technology package license table row: 3-column C3850 style
+# e.g. "ipservicesk9        Permanent        ipservicesk9"
+_TECH_PKG_3COL_RE = re.compile(
+    r"^(\S+)\s+(Permanent|Evaluation|RightToUse|Smart License"
+    r"|Subscription Smart License)\s+(\S+)\s*$"
+)
+
+# Technology package license table row: 4-column ISR/C3945/C1900 style
+# e.g. "appxk9           appxk9           RightToUse       appxk9"
+_TECH_PKG_4COL_RE = re.compile(
+    r"^(\S+)\s+(\S+)\s+(Permanent|Evaluation|RightToUse|None)\s+(\S+)\s*$"
+)
+
+# Valid package name: alphanumeric with hyphens/underscores (no special chars)
+_PKG_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
 
 # Base ethernet MAC address
 _MAC_RE = re.compile(r"^Base [Ee]thernet MAC [Aa]ddress\s*:\s*([0-9A-Fa-f:.-]+)")
@@ -281,8 +307,53 @@ def _parse_interfaces(line: str, result: dict) -> bool:
     return False
 
 
+def _parse_tech_pkg_tab_row(line: str, result: dict) -> bool:
+    """Parse a tab-separated technology package table row (C9300 style).
+
+    C9300 format uses tabs between columns and multi-word type values:
+        network-advantage   \\tSmart License                 \\t network-advantage
+        dna-advantage       \\tSubscription Smart License    \\t dna-advantage
+
+    Only the first matched row populates the license fields. Returns True if
+    the line contained a tab and was parsed as a table row.
+    """
+    if "\t" not in line:
+        return False
+    parts = [p.strip() for p in line.split("\t") if p.strip()]
+    if len(parts) != 3:
+        return False
+    current, lic_type, next_reboot = parts
+    # Validate: current/next_reboot should be single-word package names,
+    # and lic_type should not be a header keyword.
+    if " " in current or " " in next_reboot:
+        return False
+    if current.lower().startswith("technology") or current.startswith("---"):
+        return False
+    # Package names consist of alphanumeric chars, hyphens, and underscores.
+    # Reject lines where values contain other characters (e.g. "Device#").
+    if not _PKG_NAME_RE.match(current) or not _PKG_NAME_RE.match(next_reboot):
+        return False
+    if "license" not in result:
+        result["license"] = {}
+    # Only populate from the first data row (primary license).
+    if "level" not in result["license"]:
+        result["license"]["level"] = current
+        result["license"]["type"] = lic_type
+        result["license"]["next_reload_level"] = next_reboot
+    return True
+
+
 def _parse_license_fields(line: str, result: dict) -> bool:
     """Parse license-related lines. Returns True if matched."""
+    # Combined format: "License Level: entservices   Type: Permanent" (Cat4507RE)
+    m = _LICENSE_COMBINED_RE.match(line)
+    if m:
+        if "license" not in result:
+            result["license"] = {}
+        result["license"]["level"] = m.group(1)
+        result["license"]["type"] = m.group(2)
+        return True
+
     m = _LICENSE_LEVEL_RE.match(line)
     if m:
         if "license" not in result:
@@ -304,13 +375,47 @@ def _parse_license_fields(line: str, result: dict) -> bool:
         result["license"]["next_reload_level"] = m.group(1)
         return True
 
-    m = _TECH_PKG_RE.match(line)
+    # AIR License Level (C9300 Smart License)
+    m = _AIR_LICENSE_RE.match(line)
+    if m:
+        if "license" not in result:
+            result["license"] = {}
+        result["license"].setdefault("air_level", m.group(1))
+        return True
+
+    m = _AIR_LICENSE_NEXT_RE.match(line)
+    if m:
+        if "license" not in result:
+            result["license"] = {}
+        result["license"].setdefault("air_next_reload_level", m.group(1))
+        return True
+
+    # Tab-separated technology package table row (C9300 style)
+    if _parse_tech_pkg_tab_row(line, result):
+        return True
+
+    # 3-column technology package table row (C3850 style):
+    # current  type  next_reboot
+    m = _TECH_PKG_3COL_RE.match(line)
     if m:
         if "license" not in result:
             result["license"] = {}
         result["license"]["level"] = m.group(1)
         result["license"]["type"] = m.group(2)
         result["license"]["next_reload_level"] = m.group(3)
+        return True
+
+    # 4-column technology package table row (ISR4451/C3945/C1900 style):
+    # technology  current  type  next_reboot
+    m = _TECH_PKG_4COL_RE.match(line)
+    if m:
+        if "license" not in result:
+            result["license"] = {}
+        # Only populate from the first non-None row.
+        if "level" not in result["license"] and m.group(2) != "None":
+            result["license"]["level"] = m.group(2)
+            result["license"]["type"] = m.group(3)
+            result["license"]["next_reload_level"] = m.group(4)
         return True
 
     return False

--- a/tests/parsers/ios/show_version/005_c3945_router/expected.json
+++ b/tests/parsers/ios/show_version/005_c3945_router/expected.json
@@ -9,6 +9,11 @@
     "restarted_at": "10:27:57 EST Mon Dec 9 2019",
     "system_image": "flash0:c3900-universalk9-mz.SPA.150-1.M7.bin",
     "last_reload_reason": "Reload Command",
+    "license": {
+        "level": "ipbasek9",
+        "type": "Permanent",
+        "next_reload_level": "ipbasek9"
+    },
     "platform": "CISCO3945-CHASSIS",
     "memory": {
         "total_bytes": 2076180480,

--- a/tests/parsers/ios/show_version/006_c1900_router/expected.json
+++ b/tests/parsers/ios/show_version/006_c1900_router/expected.json
@@ -9,6 +9,11 @@
     "restarted_at": "14:27:00 UTC Tue Sep 15 2020",
     "system_image": "flash0:c1900-universalk9-mz.SPA.151-4.M8.bin",
     "last_reload_reason": "Reload Command",
+    "license": {
+        "level": "ipbasek9",
+        "type": "Permanent",
+        "next_reload_level": "ipbasek9"
+    },
     "platform": "CISCO1941/K9",
     "memory": {
         "total_bytes": 503316480,

--- a/tests/parsers/iosxe/show_version/003_c9300_switch/expected.json
+++ b/tests/parsers/iosxe/show_version/003_c9300_switch/expected.json
@@ -8,6 +8,14 @@
     "system_returned_to_rom_by": "Reload Command",
     "system_image": "flash:cat9k_iosxe.BLD_POLARIS_DEV_LATEST_20210302_012043.SSA.bin",
     "last_reload_reason": "Reload Command",
+    "license": {
+        "level": "network-advantage",
+        "type": "Smart License",
+        "next_reload_level": "network-advantage",
+        "air_level": "AIR DNA Advantage",
+        "air_next_reload_level": "AIR DNA Advantage"
+    },
+    "image_type": "CAT9K_IOSXE",
     "platform": "C9300-24P",
     "memory": {
         "total_bytes": 1365271552,

--- a/tests/parsers/iosxe/show_version/004_isr4451_router/expected.json
+++ b/tests/parsers/iosxe/show_version/004_isr4451_router/expected.json
@@ -9,6 +9,11 @@
     "restarted_at": "07:19:15 UTC Fri Feb 1 2019",
     "system_image": "bootflash:isr4400-universalk10.115.6.5.SPA.bin",
     "last_reload_reason": "Reload Command",
+    "license": {
+        "level": "appxk9",
+        "type": "RightToUse",
+        "next_reload_level": "appxk9"
+    },
     "platform": "ISR4451-X/K9",
     "memory": {
         "total_bytes": 1839082496,

--- a/tests/parsers/iosxe/show_version/006_cat4507re_switch/expected.json
+++ b/tests/parsers/iosxe/show_version/006_cat4507re_switch/expected.json
@@ -9,7 +9,9 @@
     "restarted_at": "09:57:20 GMT Tue Oct 15 2013",
     "last_reload_reason": "Reload command",
     "license": {
-        "level": "entservices   Type: Permanent"
+        "level": "entservices",
+        "type": "Permanent",
+        "next_reload_level": "entservices"
     },
     "platform": "WS-C4507R+E",
     "memory": {


### PR DESCRIPTION
## Summary
- Fix `show version` parser to extract license fields (level, type, next_reload_level) from C9300, ISR4451, C3945, C1900, and Cat4507RE platforms
- Fix `image_type` extraction for C9300 by relaxing regex to accept underscore-only image names like `CAT9K_IOSXE`
- Add AIR License Level support for C9300 Smart Licensing

## Context
Discovered while running Huginn learning mode against a physical C8300/C9300 testbed. Version license jobs returned empty parameters because the parser didn't handle C9300 Smart License table format, ISR4451/C3945/C1900 4-column table format, or Cat4507RE combined single-line format.

## Test plan
- [x] Updated expected output for C9300, ISR4451, Cat4507RE, C3945, and C1900 version test cases
- [x] C9300 expected output now includes `image_type: "CAT9K_IOSXE"` and full license dict
- [x] Cat4507RE license parsing fixed from broken combined-line extraction
- [x] All 36 `show_version` tests pass

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: version parser license and image_type extraction fix
- **Human Oversight**: Code reviewed and approved by Christopher Hart

🤖 Generated with [Claude Code](https://claude.com/claude-code)