### PR TITLE
feat(iosxe): cross-register ping parser from IOS

### DIFF
--- a/changes/+iosxe-ping-cross-register.parser_updated
+++ b/changes/+iosxe-ping-cross-register.parser_updated
@@ -1,0 +1,1 @@
+Cross-registered `ping` parser for IOS-XE (previously IOS-only).

--- a/src/muninn/parsers/ios/ping.py
+++ b/src/muninn/parsers/ios/ping.py
@@ -56,6 +56,7 @@ _PACKET_RESULT_MAP = {
 }
 
 
+@register(OS.CISCO_IOSXE, "ping")
 @register(OS.CISCO_IOS, "ping")
 class PingParser(BaseParser["PingResult"]):
     """Parser for 'ping' command.

--- a/tests/parsers/iosxe/ping/001_successful_ping/expected.json
+++ b/tests/parsers/iosxe/ping/001_successful_ping/expected.json
@@ -1,0 +1,15 @@
+{
+  "packets_sent": 5,
+  "packets_received": 5,
+  "success_rate_percent": 100,
+  "packet_data": {
+    "1": {"result": "successful"},
+    "2": {"result": "successful"},
+    "3": {"result": "successful"},
+    "4": {"result": "successful"},
+    "5": {"result": "successful"}
+  },
+  "rtt_min_ms": 1,
+  "rtt_avg_ms": 1,
+  "rtt_max_ms": 1
+}

--- a/tests/parsers/iosxe/ping/001_successful_ping/input.txt
+++ b/tests/parsers/iosxe/ping/001_successful_ping/input.txt
@@ -1,0 +1,4 @@
+Type escape sequence to abort.
+Sending 5, 100-byte ICMP Echos to 192.0.2.3, timeout is 2 seconds:
+!!!!!
+Success rate is 100 percent (5/5), round-trip min/avg/max = 1/1/1 ms

--- a/tests/parsers/iosxe/ping/001_successful_ping/metadata.yaml
+++ b/tests/parsers/iosxe/ping/001_successful_ping/metadata.yaml
@@ -1,0 +1,3 @@
+description: Successful ping to OSPF neighbor loopback (C8300 live device)
+platform: Cisco C8300-1N1S-6T
+software_version: IOS-XE 17.9


### PR DESCRIPTION
## Summary

- Cross-registers the existing IOS `ping` parser for IOS-XE
- The ping output format is identical between IOS and IOS-XE
- Adds test fixture from a live C8300-1N1S-6T running IOS-XE 17.9

## Test plan

- [x] `pytest tests/parsers/test_parsers.py -k "iosxe/ping"` passes
- [x] Existing IOS ping tests still pass (no regression)

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: cross-register ping for iosxe

🤖 Generated with [Claude Code](https://claude.com/claude-code)