### PR TITLE
feat(ios,iosxe): add pattern registration for ping with destination

### DIFF
--- a/changes/+ping-pattern-registration.parser_updated
+++ b/changes/+ping-pattern-registration.parser_updated
@@ -1,0 +1,1 @@
+Added pattern registration `ping <destination>` for IOS and IOS-XE ping parser to support parameterized commands.

--- a/src/muninn/parsers/ios/ping.py
+++ b/src/muninn/parsers/ios/ping.py
@@ -56,7 +56,9 @@ _PACKET_RESULT_MAP = {
 }
 
 
+@register(OS.CISCO_IOSXE, r"ping (?P<destination>\S+)")
 @register(OS.CISCO_IOSXE, "ping")
+@register(OS.CISCO_IOS, r"ping (?P<destination>\S+)")
 @register(OS.CISCO_IOS, "ping")
 class PingParser(BaseParser["PingResult"]):
     """Parser for 'ping' command.


### PR DESCRIPTION
## Summary

- Adds `ping (?P<destination>\S+)` pattern registration for both IOS and IOS-XE
- Allows Muninn to resolve the ping parser when the command includes a target (e.g., `ping 192.0.2.3`, `ping router1.example.com`)
- Retains the bare `ping` registration for backward compatibility

## Context

Huginn gate jobs execute `ping <ip>` and then pass the full command string to `mn.parse()`. Without the pattern registration, Muninn raises `ParserNotFoundError` because it only matched the exact string `"ping"`.

## Test plan

- [x] All existing ping tests pass (`pytest -k ping` — 18 passed)
- [x] Programmatically verified: `mn.parse(os='iosxe', command='ping 192.0.2.3', output=...)` resolves correctly
- [x] Bare `ping` still works for backward compatibility

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~85%
- **AI Reason**: add pattern registration for ping

🤖 Generated with [Claude Code](https://claude.com/claude-code)