### PR TITLE
docs: list all supported platforms in the documentation

### DIFF
--- a/changes/+supported-platforms-docs.internal
+++ b/changes/+supported-platforms-docs.internal
@@ -1,0 +1,1 @@
+Updated Supported Platforms table and parser library OS labels to include Arista EOS, Juniper Junos, Palo Alto PAN-OS, Nokia SR OS, and Linux.

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,11 @@ result: ShowIpOspfNeighborResult = ShowIpOspfNeighborParser.parse(raw_output)
 | Cisco IOS-XE | `iosxe`, `cisco_iosxe`, `ios-xe` |
 | Cisco IOS | `ios`, `cisco_ios` |
 | Cisco IOS-XR | `iosxr`, `cisco_iosxr`, `ios-xr` |
+| Arista EOS | `arista_eos`, `eos`, `arista` |
+| Juniper Junos | `juniper_junos`, `junos`, `juniper` |
+| Palo Alto PAN-OS | `paloalto_panos`, `panos`, `paloalto`, `pan-os` |
+| Nokia SR OS | `nokia_sros`, `sros`, `nokia`, `sr-os` |
+| Linux | `linux` |
 
 Browse all available parsers in the [Parser Library](library.md).
 

--- a/docs/library.md
+++ b/docs/library.md
@@ -324,7 +324,12 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     "cisco_ios": "Cisco IOS",
     "cisco_iosxe": "Cisco IOS-XE",
     "cisco_iosxr": "Cisco IOS-XR",
-    "cisco_nxos": "Cisco NX-OS"
+    "cisco_nxos": "Cisco NX-OS",
+    "arista_eos": "Arista EOS",
+    "juniper_junos": "Juniper Junos",
+    "paloalto_panos": "Palo Alto PAN-OS",
+    "nokia_sros": "Nokia SR OS",
+    "linux": "Linux"
   };
 
   function osLabel(os) {


### PR DESCRIPTION
## Summary

- Add Arista EOS, Juniper Junos, Palo Alto PAN-OS, Nokia SR OS, and Linux to the Supported Platforms table in `docs/index.md` (previously only listed the Cisco platforms).
- Extend the `osDisplayNames` map in `docs/library.md` so the parser library filter dropdown shows proper display names for the new vendors instead of the raw OS slug.

Aliases shown in the table were sourced from `src/muninn/os.py` and follow the existing convention of omitting underscore variants of hyphenated aliases (e.g. `nx-os` is shown but `nx_os` is not).

## Test plan

- [ ] `Muninn main branch push or PR` workflow passes
- [ ] `Deploy documentation` workflow renders the new table on the docs site
- [ ] Verify the parser library filter dropdown labels the new OSes correctly on the rendered docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)