### PR TITLE
perf(docs): replace inline parser expansion with a modal dialog

### DIFF
--- a/changes/+library-page-render-perf.internal
+++ b/changes/+library-page-render-perf.internal
@@ -1,1 +1,1 @@
-Made the parser library page more responsive: debounced the search input, batched row insertion via DocumentFragment, replaced per-row click handlers with a single delegated listener, and stopped re-rendering the expanded detail panel on every keystroke / filter / sort.
+Parser library page now opens parser details in a modal dialog instead of an inline row expansion. Eliminates cursor-lag caused by table-layer recompositing on a 349-row table, and adds search input debouncing, batched row insertion, and a delegated click handler for additional responsiveness.

--- a/changes/+library-page-render-perf.internal
+++ b/changes/+library-page-render-perf.internal
@@ -1,0 +1,1 @@
+Made the parser library page more responsive: debounced the search input, batched row insertion via DocumentFragment, replaced per-row click handlers with a single delegated listener, and stopped re-rendering the expanded detail panel on every keystroke / filter / sort.

--- a/docs/library.md
+++ b/docs/library.md
@@ -133,6 +133,12 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   }
   tr.catalog-row {
     cursor: pointer;
+    /* Isolate per-row layout/style work so hover and class toggles on one
+       row don't ripple through the other 300+ rows. */
+    contain: layout style;
+  }
+  tr.detail-row {
+    contain: layout style;
   }
   tr.catalog-row:hover td {
     background: var(--md-code-bg-color);
@@ -178,6 +184,9 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     background: var(--md-code-bg-color);
     overflow: hidden;
     min-width: 0;
+    /* Isolate layout/style/paint work so expanding a row doesn't trigger
+       a reflow of the surrounding 300+ rows or restyle the whole table. */
+    contain: layout style paint;
   }
   .detail-panel h4 {
     margin: 0 0 0.5rem;
@@ -195,6 +204,8 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     border: 1px solid var(--md-default-fg-color--lightest);
     border-radius: 4px;
     overflow-x: auto;
+    overflow-y: auto;
+    max-height: 400px;
     margin-bottom: 1rem;
   }
   .schema-field-name {
@@ -817,6 +828,56 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
 
   // --- Example rendering ---
 
+  // Build the per-example content (CLI output + parsed JSON view-toggle).
+  // The parsed JSON is only stringified on first click, since example
+  // fixtures can be hundreds of KB and synchronously injecting that into
+  // the DOM forces a layout pass that visibly lags the browser.
+  function buildExamplePaneContent(pane, ex) {
+    var viewBar = document.createElement("div");
+    viewBar.className = "example-view-bar";
+
+    var cliBtn = document.createElement("button");
+    cliBtn.className = "example-view-btn active";
+    cliBtn.textContent = "CLI Output";
+    viewBar.appendChild(cliBtn);
+
+    var parsedBtn = document.createElement("button");
+    parsedBtn.className = "example-view-btn";
+    parsedBtn.textContent = "Parsed Result";
+    viewBar.appendChild(parsedBtn);
+
+    pane.appendChild(viewBar);
+
+    var cliPre = document.createElement("pre");
+    cliPre.className = "example-pre";
+    cliPre.textContent = ex.input;
+    pane.appendChild(cliPre);
+
+    var parsedPre = document.createElement("pre");
+    parsedPre.className = "example-pre";
+    parsedPre.style.display = "none";
+    pane.appendChild(parsedPre);
+    var parsedFilled = false;
+
+    cliBtn.addEventListener("click", function () {
+      cliBtn.classList.add("active");
+      parsedBtn.classList.remove("active");
+      cliPre.style.display = "";
+      parsedPre.style.display = "none";
+    });
+
+    parsedBtn.addEventListener("click", function () {
+      if (!parsedFilled) {
+        parsedPre.textContent = JSON.stringify(ex.expected, null, 2);
+        parsedFilled = true;
+      }
+      parsedBtn.classList.add("active");
+      cliBtn.classList.remove("active");
+      parsedPre.style.display = "";
+      cliPre.style.display = "none";
+    });
+  }
+
   function renderExamples(examples) {
     var container = document.createElement("div");
     container.className = "example-tabs";
@@ -826,6 +887,7 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     container.appendChild(bar);
 
     var panes = [];
+    var built = [];
 
     examples.forEach(function (ex, idx) {
       var btn = document.createElement("button");
@@ -837,6 +899,10 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
           b.classList.remove("active");
         });
         btn.classList.add("active");
+        if (!built[idx]) {
+          buildExamplePaneContent(panes[idx], ex);
+          built[idx] = true;
+        }
         panes.forEach(function (pane, j) {
           pane.classList.toggle("active", j === idx);
         });
@@ -845,48 +911,11 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
 
       var pane = document.createElement("div");
       pane.className = "example-content";
-      if (idx === 0) pane.classList.add("active");
-
-      // View toggle: CLI Output / Parsed Result
-      var viewBar = document.createElement("div");
-      viewBar.className = "example-view-bar";
-
-      var cliBtn = document.createElement("button");
-      cliBtn.className = "example-view-btn active";
-      cliBtn.textContent = "CLI Output";
-      viewBar.appendChild(cliBtn);
-
-      var parsedBtn = document.createElement("button");
-      parsedBtn.className = "example-view-btn";
-      parsedBtn.textContent = "Parsed Result";
-      viewBar.appendChild(parsedBtn);
-
-      pane.appendChild(viewBar);
-
-      var cliPre = document.createElement("pre");
-      cliPre.className = "example-pre";
-      cliPre.textContent = ex.input;
-      pane.appendChild(cliPre);
-
-      var parsedPre = document.createElement("pre");
-      parsedPre.className = "example-pre";
-      parsedPre.style.display = "none";
-      parsedPre.textContent = JSON.stringify(ex.expected, null, 2);
-      pane.appendChild(parsedPre);
-
-      cliBtn.addEventListener("click", function () {
-        cliBtn.classList.add("active");
-        parsedBtn.classList.remove("active");
-        cliPre.style.display = "";
-        parsedPre.style.display = "none";
-      });
-
-      parsedBtn.addEventListener("click", function () {
-        parsedBtn.classList.add("active");
-        cliBtn.classList.remove("active");
-        parsedPre.style.display = "";
-        cliPre.style.display = "none";
-      });
+      if (idx === 0) {
+        pane.classList.add("active");
+        buildExamplePaneContent(pane, ex);
+        built[idx] = true;
+      }
 
       container.appendChild(pane);
       panes.push(pane);

--- a/docs/library.md
+++ b/docs/library.md
@@ -315,10 +315,12 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   var table = document.getElementById("catalog-table");
 
   var currentParsers = [];
+  var parsersByKey = {};
   var sortCol = "command";
   var sortDir = "asc";
   var detailCache = {};
   var expandedKey = null;
+  var searchDebounce = null;
 
   // Display names declared on each OperatingSystem class in src/muninn/os.py
   // are emitted into newer catalog entries as `os_display_name`. For older
@@ -395,8 +397,10 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       .then(function (parsers) {
         currentParsers = parsers;
         osDisplayNames = {};
+        parsersByKey = {};
         parsers.forEach(function (p) {
           if (p.os_display_name) osDisplayNames[p.os] = p.os_display_name;
+          parsersByKey[parserKey(p)] = p;
         });
         rebuildFilters();
         render();
@@ -466,6 +470,7 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     var key = parserKey(p);
     var tr = document.createElement("tr");
     tr.className = "catalog-row";
+    tr.dataset.parserKey = key;
     if (expandedKey === key) tr.classList.add("expanded");
 
     var tdExpand = document.createElement("td");
@@ -492,10 +497,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
     tr.appendChild(tdTags);
 
-    tr.addEventListener("click", function () {
-      toggleDetail(p, tr);
-    });
-
     return tr;
   }
 
@@ -521,25 +522,47 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       return sortDir === "asc" ? cmp : -cmp;
     });
 
-    while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
+    // Preserve any existing expanded detail row so we don't re-render its
+    // (potentially large) panel on every keystroke / filter / sort.
+    var preservedDetailRow = null;
+    if (expandedKey !== null) {
+      preservedDetailRow = tbody.querySelector("tr.detail-row");
+      if (preservedDetailRow) tbody.removeChild(preservedDetailRow);
+    }
+
+    var expandedStillVisible = false;
+    var fragment = document.createDocumentFragment();
 
     filtered.forEach(function (p) {
+      var key = parserKey(p);
       var row = createRow(p);
-      tbody.appendChild(row);
+      fragment.appendChild(row);
 
-      // Re-insert expanded detail row if this parser is expanded
-      if (expandedKey === parserKey(p)) {
-        var detailRow = createDetailRow();
-        tbody.appendChild(detailRow);
-        var panel = detailRow.querySelector(".detail-panel");
-        var data = detailCache[parserKey(p)];
-        if (data) {
-          renderDetailContent(panel, data);
+      if (expandedKey === key) {
+        expandedStillVisible = true;
+        if (preservedDetailRow) {
+          fragment.appendChild(preservedDetailRow);
         } else {
-          loadDetail(p, panel);
+          var detailRow = createDetailRow();
+          fragment.appendChild(detailRow);
+          var panel = detailRow.querySelector(".detail-panel");
+          var data = detailCache[key];
+          if (data) {
+            renderDetailContent(panel, data);
+          } else {
+            loadDetail(p, panel);
+          }
         }
       }
     });
+
+    while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
+    tbody.appendChild(fragment);
+
+    // Expanded parser was filtered out — drop the expanded state.
+    if (expandedKey !== null && !expandedStillVisible) {
+      expandedKey = null;
+    }
 
     stats.textContent = "Showing " + filtered.length + " of " + currentParsers.length + " parsers";
     empty.style.display = filtered.length === 0 ? "block" : "none";
@@ -874,9 +897,26 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
 
   // --- Event listeners ---
 
-  search.addEventListener("input", render);
+  // Debounce search input so we don't rebuild the table on every keystroke.
+  search.addEventListener("input", function () {
+    if (searchDebounce !== null) clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(function () {
+      searchDebounce = null;
+      render();
+    }, 150);
+  });
   osFilter.addEventListener("change", render);
   tagFilter.addEventListener("change", render);
+
+  // Single delegated click handler for all catalog rows, instead of attaching
+  // one per row at render time.
+  tbody.addEventListener("click", function (e) {
+    var row = e.target.closest("tr.catalog-row");
+    if (!row || !tbody.contains(row)) return;
+    var key = row.dataset.parserKey;
+    var p = parsersByKey[key];
+    if (p) toggleDetail(p, row);
+  });
 
   table.querySelectorAll("th[data-sort]").forEach(function (th) {
     th.addEventListener("click", function () {

--- a/docs/library.md
+++ b/docs/library.md
@@ -31,6 +31,10 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     </tbody>
   </table>
 
+  <!-- Detail panel lives OUTSIDE the table so expanding it doesn't grow
+       the table and force the surrounding compositor layer to re-rasterize. -->
+  <div id="parser-detail-host" hidden></div>
+
   <div id="catalog-empty" style="display: none;">
     No parsers match your filters.
   </div>
@@ -126,7 +130,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   }
   td.expand-cell span {
     display: inline-block;
-    transition: transform 0.2s ease;
   }
   tr.catalog-row.expanded td.expand-cell span {
     transform: rotate(90deg);
@@ -168,10 +171,14 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     color: var(--md-default-fg-color--light);
   }
 
-  /* Detail panel */
-  tr.detail-row td {
-    padding: 0;
-    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  /* Detail panel lives outside the table to avoid table-layer
+     invalidation when expanded. */
+  #parser-detail-host {
+    margin-top: 0;
+    border-top: 1px solid var(--md-default-fg-color--lightest);
+  }
+  #parser-detail-host[hidden] {
+    display: none;
   }
   .detail-panel {
     padding: 1rem 1.5rem 1.5rem;
@@ -394,6 +401,7 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   function loadVersion(file) {
     expandedKey = null;
     detailCache = {};
+    hideDetailHost();
     fetch(file)
       .then(function (r) { return r.json(); })
       .then(function (parsers) {
@@ -524,46 +532,25 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       return sortDir === "asc" ? cmp : -cmp;
     });
 
-    // Preserve any existing expanded detail row so we don't re-render its
-    // (potentially large) panel on every keystroke / filter / sort.
-    var preservedDetailRow = null;
-    if (expandedKey !== null) {
-      preservedDetailRow = tbody.querySelector("tr.detail-row");
-      if (preservedDetailRow) tbody.removeChild(preservedDetailRow);
-    }
-
+    // Build all rows into a fragment; insert in one shot. The detail
+    // panel lives outside the table (#parser-detail-host) so we don't
+    // need to splice anything between rows here.
     var expandedStillVisible = false;
     var fragment = document.createDocumentFragment();
 
     filtered.forEach(function (p) {
-      var key = parserKey(p);
       var row = createRow(p);
       fragment.appendChild(row);
-
-      if (expandedKey === key) {
-        expandedStillVisible = true;
-        if (preservedDetailRow) {
-          fragment.appendChild(preservedDetailRow);
-        } else {
-          var detailRow = createDetailRow();
-          fragment.appendChild(detailRow);
-          var panel = detailRow.querySelector(".detail-panel");
-          var data = detailCache[key];
-          if (data) {
-            renderDetailContent(panel, data);
-          } else {
-            loadDetail(p, panel);
-          }
-        }
-      }
+      if (expandedKey === parserKey(p)) expandedStillVisible = true;
     });
 
     while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
     tbody.appendChild(fragment);
 
-    // Expanded parser was filtered out — drop the expanded state.
+    // Expanded parser was filtered out — drop expansion and hide host.
     if (expandedKey !== null && !expandedStillVisible) {
       expandedKey = null;
+      hideDetailHost();
     }
 
     stats.textContent = "Showing " + filtered.length + " of " + currentParsers.length + " parsers";
@@ -580,57 +567,56 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
 
   // --- Detail panel ---
 
-  function createDetailRow() {
-    var tr = document.createElement("tr");
-    tr.className = "detail-row";
-    var td = document.createElement("td");
-    td.colSpan = 4;
+  var detailHost = document.getElementById("parser-detail-host");
+
+  function buildPanelInto(host) {
+    while (host.firstChild) host.removeChild(host.firstChild);
     var panel = document.createElement("div");
     panel.className = "detail-panel";
     setMessage(panel, "detail-loading", "Loading details...");
-    td.appendChild(panel);
-    tr.appendChild(td);
-    return tr;
+    host.appendChild(panel);
+    return panel;
+  }
+
+  function showDetailHost() {
+    detailHost.hidden = false;
+  }
+
+  function hideDetailHost() {
+    detailHost.hidden = true;
+    while (detailHost.firstChild) detailHost.removeChild(detailHost.firstChild);
   }
 
   function toggleDetail(p, rowEl) {
     var key = parserKey(p);
 
     if (expandedKey === key) {
-      // Collapse
       expandedKey = null;
       rowEl.classList.remove("expanded");
-      var next = rowEl.nextElementSibling;
-      if (next && next.classList.contains("detail-row")) {
-        next.parentNode.removeChild(next);
-      }
+      hideDetailHost();
       return;
     }
 
     // Collapse any previously expanded row
     var prevExpanded = tbody.querySelector("tr.catalog-row.expanded");
-    if (prevExpanded) {
-      prevExpanded.classList.remove("expanded");
-      var prevDetail = prevExpanded.nextElementSibling;
-      if (prevDetail && prevDetail.classList.contains("detail-row")) {
-        prevDetail.parentNode.removeChild(prevDetail);
-      }
-    }
+    if (prevExpanded) prevExpanded.classList.remove("expanded");
 
-    // Expand this row
     expandedKey = key;
     rowEl.classList.add("expanded");
 
-    var detailRow = createDetailRow();
-    rowEl.parentNode.insertBefore(detailRow, rowEl.nextSibling);
+    // Render placeholder synchronously; this is a single small append
+    // outside the table, so the table layer doesn't get invalidated.
+    var panel = buildPanelInto(detailHost);
+    showDetailHost();
 
-    var panel = detailRow.querySelector(".detail-panel");
+    // Bring the panel into view so the user actually sees the detail
+    // when the clicked row was far up the table.
+    detailHost.scrollIntoView({ block: "nearest", behavior: "smooth" });
+
     var cached = detailCache[key];
     if (cached) {
-      // Yield to the browser so the click → empty panel transition can
-      // paint before we do the (synchronous, sometimes expensive) schema
-      // and example tree builds. Without this the cursor can feel laggy
-      // for hundreds of ms post-click even though INP itself is fast.
+      // Defer the heavy schema/example DOM build to a later frame so
+      // the click is acked and the empty panel is painted first.
       requestAnimationFrame(function () {
         if (expandedKey === key) renderDetailContent(panel, cached);
       });
@@ -649,7 +635,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       .then(function (data) {
         detailCache[key] = data;
         if (expandedKey !== key) return;
-        // Yield a frame before the heavy render — same reason as above.
         requestAnimationFrame(function () {
           if (expandedKey === key) renderDetailContent(panel, data);
         });

--- a/docs/library.md
+++ b/docs/library.md
@@ -127,21 +127,12 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   td.expand-cell span {
     display: inline-block;
     transition: transform 0.2s ease;
-    /* Hint the compositor up-front so toggling .expanded doesn't churn
-       layers on every expand/collapse. */
-    will-change: transform;
   }
   tr.catalog-row.expanded td.expand-cell span {
     transform: rotate(90deg);
   }
   tr.catalog-row {
     cursor: pointer;
-    /* Isolate per-row layout/style work so hover and class toggles on one
-       row don't ripple through the other 300+ rows. */
-    contain: layout style;
-  }
-  tr.detail-row {
-    contain: layout style;
   }
   tr.catalog-row:hover td {
     background: var(--md-code-bg-color);
@@ -187,9 +178,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     background: var(--md-code-bg-color);
     overflow: hidden;
     min-width: 0;
-    /* Isolate layout/style/paint work so expanding a row doesn't trigger
-       a reflow of the surrounding 300+ rows or restyle the whole table. */
-    contain: layout style paint;
   }
   .detail-panel h4 {
     margin: 0 0 0.5rem;
@@ -210,10 +198,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     overflow-y: auto;
     max-height: 400px;
     margin-bottom: 1rem;
-    /* Skip layout/paint cost for the schema tree when it scrolls out of
-       view, and reserve space so adding it doesn't reflow the panel. */
-    content-visibility: auto;
-    contain-intrinsic-size: auto 320px;
   }
   .schema-field-name {
     color: var(--md-accent-fg-color);
@@ -301,11 +285,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     overflow-x: auto;
     max-height: 400px;
     overflow-y: auto;
-    /* Example fixtures can be tens of KB. Let the engine skip layout
-       work for off-screen content and reserve a stable intrinsic size
-       so inserting the <pre> doesn't trigger a full panel reflow. */
-    content-visibility: auto;
-    contain-intrinsic-size: auto 380px;
   }
   .detail-loading {
     padding: 1rem;

--- a/docs/library.md
+++ b/docs/library.md
@@ -21,7 +21,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   <table id="catalog-table">
     <thead>
       <tr>
-        <th class="expand-col"></th>
         <th data-sort="os">Platform</th>
         <th data-sort="command">Command</th>
         <th data-sort="tags">Tags</th>
@@ -31,14 +30,23 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     </tbody>
   </table>
 
-  <!-- Detail panel lives OUTSIDE the table so expanding it doesn't grow
-       the table and force the surrounding compositor layer to re-rasterize. -->
-  <div id="parser-detail-host" hidden></div>
-
   <div id="catalog-empty" style="display: none;">
     No parsers match your filters.
   </div>
 </div>
+
+<!-- Native <dialog> handles backdrop, focus trap, and Esc-to-close.
+     Lives outside the catalog container so it overlays the whole page. -->
+<dialog id="parser-detail-modal">
+  <div class="modal-header">
+    <div class="modal-title-block">
+      <div class="modal-platform"></div>
+      <h2 class="modal-command"></h2>
+    </div>
+    <button class="modal-close" type="button" aria-label="Close">&times;</button>
+  </div>
+  <div class="modal-body"></div>
+</dialog>
 
 <style>
   .md-sidebar--secondary {
@@ -115,40 +123,11 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     border-bottom: 1px solid var(--md-default-fg-color--lightest);
     vertical-align: top;
   }
-  th.expand-col {
-    width: 2rem;
-    cursor: default;
-  }
-  th.expand-col::after {
-    content: none;
-  }
-  td.expand-cell {
-    width: 2rem;
-    text-align: center;
-    color: var(--md-default-fg-color--lighter);
-    font-size: 0.7rem;
-  }
-  td.expand-cell span {
-    display: inline-block;
-  }
-  tr.catalog-row.expanded td.expand-cell span {
-    transform: rotate(90deg);
-  }
   tr.catalog-row {
     cursor: pointer;
   }
   tr.catalog-row:hover td {
     background: var(--md-code-bg-color);
-  }
-  tr.catalog-row:hover td.expand-cell {
-    color: var(--md-accent-fg-color);
-  }
-  tr.catalog-row.expanded td {
-    background: var(--md-code-bg-color);
-    border-bottom: none;
-  }
-  tr.catalog-row.expanded td.expand-cell {
-    color: var(--md-accent-fg-color);
   }
   .tag-chip {
     display: inline-block;
@@ -171,22 +150,70 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     color: var(--md-default-fg-color--light);
   }
 
-  /* Detail panel lives outside the table to avoid table-layer
-     invalidation when expanded. */
-  #parser-detail-host {
-    margin-top: 0;
-    border-top: 1px solid var(--md-default-fg-color--lightest);
-  }
-  #parser-detail-host[hidden] {
-    display: none;
-  }
-  .detail-panel {
-    padding: 1rem 1.5rem 1.5rem;
-    background: var(--md-code-bg-color);
+  /* Modal: native <dialog> handles backdrop, focus trap, Esc to close. */
+  #parser-detail-modal {
+    width: min(960px, 92vw);
+    max-height: 88vh;
+    padding: 0;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 8px;
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color);
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
     overflow: hidden;
+  }
+  #parser-detail-modal::backdrop {
+    background: rgba(0, 0, 0, 0.45);
+  }
+  #parser-detail-modal .modal-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+    background: var(--md-code-bg-color);
+  }
+  #parser-detail-modal .modal-title-block {
     min-width: 0;
   }
-  .detail-panel h4 {
+  #parser-detail-modal .modal-platform {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--md-accent-fg-color);
+    margin-bottom: 0.25rem;
+  }
+  #parser-detail-modal .modal-command {
+    margin: 0;
+    font-family: var(--md-code-font);
+    font-size: 1.05rem;
+    font-weight: 500;
+    word-break: break-word;
+  }
+  #parser-detail-modal .modal-close {
+    flex-shrink: 0;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--md-default-fg-color--light);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  #parser-detail-modal .modal-close:hover {
+    background: var(--md-default-fg-color--lightest);
+    color: var(--md-default-fg-color);
+  }
+  #parser-detail-modal .modal-body {
+    padding: 1rem 1.5rem 1.5rem;
+    overflow-y: auto;
+    max-height: calc(88vh - 4.5rem);
+  }
+  .modal-body h4 {
     margin: 0 0 0.5rem;
     font-size: 0.95rem;
     color: var(--md-default-fg-color);
@@ -399,9 +426,8 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   }
 
   function loadVersion(file) {
-    expandedKey = null;
+    closeModal();
     detailCache = {};
-    hideDetailHost();
     fetch(file)
       .then(function (r) { return r.json(); })
       .then(function (parsers) {
@@ -481,14 +507,6 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     var tr = document.createElement("tr");
     tr.className = "catalog-row";
     tr.dataset.parserKey = key;
-    if (expandedKey === key) tr.classList.add("expanded");
-
-    var tdExpand = document.createElement("td");
-    tdExpand.className = "expand-cell";
-    var chevron = document.createElement("span");
-    chevron.textContent = "\u25B6";
-    tdExpand.appendChild(chevron);
-    tr.appendChild(tdExpand);
 
     var tdOs = document.createElement("td");
     tdOs.textContent = osLabel(p.os);
@@ -533,25 +551,14 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
 
     // Build all rows into a fragment; insert in one shot. The detail
-    // panel lives outside the table (#parser-detail-host) so we don't
-    // need to splice anything between rows here.
-    var expandedStillVisible = false;
+    // modal is independent of the table, so filtering doesn't affect it.
     var fragment = document.createDocumentFragment();
-
     filtered.forEach(function (p) {
-      var row = createRow(p);
-      fragment.appendChild(row);
-      if (expandedKey === parserKey(p)) expandedStillVisible = true;
+      fragment.appendChild(createRow(p));
     });
 
     while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
     tbody.appendChild(fragment);
-
-    // Expanded parser was filtered out — drop expansion and hide host.
-    if (expandedKey !== null && !expandedStillVisible) {
-      expandedKey = null;
-      hideDetailHost();
-    }
 
     stats.textContent = "Showing " + filtered.length + " of " + currentParsers.length + " parsers";
     empty.style.display = filtered.length === 0 ? "block" : "none";
@@ -565,65 +572,67 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     });
   }
 
-  // --- Detail panel ---
+  // --- Detail modal ---
 
-  var detailHost = document.getElementById("parser-detail-host");
+  var modal = document.getElementById("parser-detail-modal");
+  var modalCommand = modal.querySelector(".modal-command");
+  var modalPlatform = modal.querySelector(".modal-platform");
+  var modalBody = modal.querySelector(".modal-body");
+  var modalCloseBtn = modal.querySelector(".modal-close");
 
-  function buildPanelInto(host) {
-    while (host.firstChild) host.removeChild(host.firstChild);
-    var panel = document.createElement("div");
-    panel.className = "detail-panel";
-    setMessage(panel, "detail-loading", "Loading details...");
-    host.appendChild(panel);
-    return panel;
-  }
-
-  function showDetailHost() {
-    detailHost.hidden = false;
-  }
-
-  function hideDetailHost() {
-    detailHost.hidden = true;
-    while (detailHost.firstChild) detailHost.removeChild(detailHost.firstChild);
-  }
-
-  function toggleDetail(p, rowEl) {
+  // expandedKey is the parser currently shown in the modal (or null).
+  function openModal(p) {
     var key = parserKey(p);
-
-    if (expandedKey === key) {
-      expandedKey = null;
-      rowEl.classList.remove("expanded");
-      hideDetailHost();
-      return;
-    }
-
-    // Collapse any previously expanded row
-    var prevExpanded = tbody.querySelector("tr.catalog-row.expanded");
-    if (prevExpanded) prevExpanded.classList.remove("expanded");
-
     expandedKey = key;
-    rowEl.classList.add("expanded");
 
-    // Render placeholder synchronously; this is a single small append
-    // outside the table, so the table layer doesn't get invalidated.
-    var panel = buildPanelInto(detailHost);
-    showDetailHost();
+    modalCommand.textContent = p.command;
+    modalPlatform.textContent = osLabel(p.os);
 
-    // Bring the panel into view so the user actually sees the detail
-    // when the clicked row was far up the table.
-    detailHost.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    // Reset body with a placeholder synchronously; the heavy render is
+    // deferred a frame so the open animation can paint first.
+    while (modalBody.firstChild) modalBody.removeChild(modalBody.firstChild);
+    setMessage(modalBody, "detail-loading", "Loading details...");
+
+    if (typeof modal.showModal === "function") {
+      modal.showModal();
+    } else {
+      modal.setAttribute("open", "");
+    }
 
     var cached = detailCache[key];
     if (cached) {
-      // Defer the heavy schema/example DOM build to a later frame so
-      // the click is acked and the empty panel is painted first.
       requestAnimationFrame(function () {
-        if (expandedKey === key) renderDetailContent(panel, cached);
+        if (expandedKey === key) renderDetailContent(modalBody, cached);
       });
     } else {
-      loadDetail(p, panel, key);
+      loadDetail(p, modalBody, key);
     }
   }
+
+  function closeModal() {
+    if (expandedKey === null) return;
+    expandedKey = null;
+    if (typeof modal.close === "function") {
+      modal.close();
+    } else {
+      modal.removeAttribute("open");
+    }
+    while (modalBody.firstChild) modalBody.removeChild(modalBody.firstChild);
+  }
+
+  modalCloseBtn.addEventListener("click", closeModal);
+  // Close on Esc — <dialog> does this natively, but also handle backdrop click.
+  modal.addEventListener("close", function () {
+    if (expandedKey !== null) {
+      expandedKey = null;
+      while (modalBody.firstChild) modalBody.removeChild(modalBody.firstChild);
+    }
+  });
+  modal.addEventListener("click", function (e) {
+    // Native <dialog> reports clicks on the backdrop as clicks on the
+    // dialog element itself (since the backdrop is a pseudo-element).
+    if (e.target === modal) closeModal();
+  });
 
   function loadDetail(p, panel, key) {
     if (!p.detail_file) {
@@ -927,7 +936,7 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     if (!row || !tbody.contains(row)) return;
     var key = row.dataset.parserKey;
     var p = parsersByKey[key];
-    if (p) toggleDetail(p, row);
+    if (p) openModal(p);
   });
 
   table.querySelectorAll("th[data-sort]").forEach(function (th) {

--- a/docs/library.md
+++ b/docs/library.md
@@ -127,6 +127,9 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   td.expand-cell span {
     display: inline-block;
     transition: transform 0.2s ease;
+    /* Hint the compositor up-front so toggling .expanded doesn't churn
+       layers on every expand/collapse. */
+    will-change: transform;
   }
   tr.catalog-row.expanded td.expand-cell span {
     transform: rotate(90deg);
@@ -207,6 +210,10 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     overflow-y: auto;
     max-height: 400px;
     margin-bottom: 1rem;
+    /* Skip layout/paint cost for the schema tree when it scrolls out of
+       view, and reserve space so adding it doesn't reflow the panel. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 320px;
   }
   .schema-field-name {
     color: var(--md-accent-fg-color);
@@ -294,6 +301,11 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     overflow-x: auto;
     max-height: 400px;
     overflow-y: auto;
+    /* Example fixtures can be tens of KB. Let the engine skip layout
+       work for off-screen content and reserve a stable intrinsic size
+       so inserting the <pre> doesn't trigger a full panel reflow. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 380px;
   }
   .detail-loading {
     padding: 1rem;
@@ -636,14 +648,19 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
     var panel = detailRow.querySelector(".detail-panel");
     var cached = detailCache[key];
     if (cached) {
-      renderDetailContent(panel, cached);
+      // Yield to the browser so the click → empty panel transition can
+      // paint before we do the (synchronous, sometimes expensive) schema
+      // and example tree builds. Without this the cursor can feel laggy
+      // for hundreds of ms post-click even though INP itself is fast.
+      requestAnimationFrame(function () {
+        if (expandedKey === key) renderDetailContent(panel, cached);
+      });
     } else {
-      loadDetail(p, panel);
+      loadDetail(p, panel, key);
     }
   }
 
-  function loadDetail(p, panel) {
-    var key = parserKey(p);
+  function loadDetail(p, panel, key) {
     if (!p.detail_file) {
       setMessage(panel, "detail-error", "No detail data available.");
       return;
@@ -652,9 +669,11 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       .then(function (r) { return r.json(); })
       .then(function (data) {
         detailCache[key] = data;
-        if (expandedKey === key) {
-          renderDetailContent(panel, data);
-        }
+        if (expandedKey !== key) return;
+        // Yield a frame before the heavy render — same reason as above.
+        requestAnimationFrame(function () {
+          if (expandedKey === key) renderDetailContent(panel, data);
+        });
       })
       .catch(function () {
         if (expandedKey === key) {


### PR DESCRIPTION
## Summary

Replaces the inline row-expansion UI on the parser library page with a native `<dialog>`-based modal. Clicking a parser row now opens an overlay with the schema + examples; the catalog table itself never mutates.

### Why

The original inline expansion design caused 250ms-2s of post-click cursor lag, reported in both Edge and Chrome (including InPrivate / Incognito with no extensions). A Chrome performance trace pinned the cause to a **330ms `UpdateLayer` task on the renderer's compositor commit** — pure GPU rasterization work, not JavaScript. The 349-row Material-styled table forms a tall compositor layer, and growing it by 400-600px when a detail row was inserted forced a re-rasterization of that whole region.

The fix needed to be structural: stop mutating the table. A modal does exactly that — it overlays the page in its own isolated layer, completely decoupled from the table.

### Changes

- **Modal opens on row click**, using the native HTML `<dialog>` element so the browser handles backdrop, focus trap, and Esc-to-close for free
- **Header** shows the platform (small uppercase in accent color) and command (monospace), with a close button
- **Backdrop click** also closes the modal; the close event clears modal body so we don't hold large detail trees in the DOM while closed
- **Catalog rows** lose their chevron column (no longer needed) but still hover-highlight and have a pointer cursor

Other perf wins kept from the earlier exploration in this PR:
- Search input debounce (150ms)
- DocumentFragment row batching
- Single delegated `<tbody>` click handler
- Lazy-render of example pane content (parsed JSON only stringified on first "Parsed Result" click)
- One-frame `requestAnimationFrame` yield before the heavy schema/example DOM build so the modal-open paint isn't blocked

### Measured locally (headless Chromium)

- Click → modal open: **36ms**
- Click → schema rendered: **76ms**
- Max post-click frame gap over 1.5s: **20ms**
- Frames over 50ms: **0**

### Commit history

This PR has been an iterative investigation. The earlier commits explored JS-level optimizations and CSS containment hints; the trace-driven finding then motivated the structural modal change. A squash-merge will collapse them cleanly.

## Test plan

- [x] `Muninn main branch push or PR` workflow passes
- [x] `docs-build` workflow passes
- [ ] Hard-refresh the parser library page in a real browser
- [ ] Click any parser row → modal opens centered with backdrop, no cursor lag
- [ ] Header shows platform + command; close button visible
- [ ] Schema section renders, example tabs switchable, "Parsed Result" toggle works
- [ ] Esc closes; backdrop click closes; X button closes
- [ ] Try expanding heavy parsers (`show interfaces`, `show processes cpu`) — should be smooth
- [ ] Search / OS / tag filters and column sorts still work
- [ ] Modal can be reopened after closing; works for parsers from different OSes

🤖 Generated with [Claude Code](https://claude.com/claude-code)