### PR TITLE
feat(os): centralize user-facing display names on OperatingSystem classes

### DIFF
--- a/changes/+os-display-names.internal
+++ b/changes/+os-display-names.internal
@@ -1,0 +1,1 @@
+Centralized user-facing OS display names on each `OperatingSystem` subclass via a new `display_name` ClassVar. The docs site catalog now sources display names from these declarations instead of a hardcoded JS map, ensuring new platforms render with proper names (e.g. "Palo Alto PAN-OS") rather than internal slugs.

--- a/docs/library.md
+++ b/docs/library.md
@@ -320,20 +320,21 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
   var detailCache = {};
   var expandedKey = null;
 
-  var osDisplayNames = {
+  // Display names declared on each OperatingSystem class in src/muninn/os.py
+  // are emitted into newer catalog entries as `os_display_name`. For older
+  // catalog files (v0.1.0, v0.2.0) that predate that, fall back to this map.
+  var osDisplayNamesFallback = {
     "cisco_ios": "Cisco IOS",
     "cisco_iosxe": "Cisco IOS-XE",
     "cisco_iosxr": "Cisco IOS-XR",
-    "cisco_nxos": "Cisco NX-OS",
-    "arista_eos": "Arista EOS",
-    "juniper_junos": "Juniper Junos",
-    "paloalto_panos": "Palo Alto PAN-OS",
-    "nokia_sros": "Nokia SR OS",
-    "linux": "Linux"
+    "cisco_nxos": "Cisco NX-OS"
   };
 
+  // Built per loaded catalog: os slug -> display name from catalog entries.
+  var osDisplayNames = {};
+
   function osLabel(os) {
-    return osDisplayNames[os] || os;
+    return osDisplayNames[os] || osDisplayNamesFallback[os] || os;
   }
 
   function parserKey(p) {
@@ -393,6 +394,10 @@ Browse all parsers available in Muninn. Use the search box and filters to find p
       .then(function (r) { return r.json(); })
       .then(function (parsers) {
         currentParsers = parsers;
+        osDisplayNames = {};
+        parsers.forEach(function (p) {
+          if (p.os_display_name) osDisplayNames[p.os] = p.os_display_name;
+        });
         rebuildFilters();
         render();
       })

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -285,13 +285,16 @@ def generate_catalog_from_source(
         details: dict[tuple[str, str], dict[str, object]] = {}
 
         for spec in specs:
-            os_name = spec.os.value.name
+            os_cls = spec.os.value
+            os_name = os_cls.name
+            os_display = getattr(os_cls, "display_name", os_name)
             command = spec.doc_template
 
             detail_file = f"details/{os_name}/{_command_to_filename(command)}.json"
             entries.append(
                 {
                     "os": os_name,
+                    "os_display_name": os_display,
                     "command": command,
                     "tags": sorted(str(tag) for tag in spec.tags),
                     "source": spec.source,

--- a/src/muninn/os.py
+++ b/src/muninn/os.py
@@ -7,15 +7,18 @@ from typing import ClassVar
 class OperatingSystem:
     """Base class for operating system definitions.
 
-    Each OS subclass defines a canonical name and a set of aliases
-    that can be used to look up the OS.
+    Each OS subclass defines a canonical name, a user-facing display
+    name, and a set of aliases that can be used to look up the OS.
 
     Attributes:
-        name: Canonical internal name for this OS.
+        name: Canonical internal name for this OS (used in slugs and paths).
+        display_name: Human-friendly name shown in user-facing surfaces
+            such as the docs site catalog and CLI tooling.
         aliases: Tuple of acceptable string identifiers for this OS.
     """
 
     name: ClassVar[str]
+    display_name: ClassVar[str]
     aliases: ClassVar[tuple[str, ...]]
 
 
@@ -23,6 +26,7 @@ class CiscoNXOS(OperatingSystem):
     """Cisco NX-OS (Nexus switches)."""
 
     name = "cisco_nxos"
+    display_name = "Cisco NX-OS"
     aliases = ("nxos", "cisco_nxos", "nexus", "nx-os", "nx_os")
 
 
@@ -30,6 +34,7 @@ class CiscoIOSXE(OperatingSystem):
     """Cisco IOS-XE (Catalyst switches, ISR/ASR routers)."""
 
     name = "cisco_iosxe"
+    display_name = "Cisco IOS-XE"
     aliases = ("iosxe", "cisco_iosxe", "ios-xe", "ios_xe", "cisco_ios_xe")
 
 
@@ -37,6 +42,7 @@ class CiscoIOSXR(OperatingSystem):
     """Cisco IOS-XR (ASR 9000, NCS, XRv)."""
 
     name = "cisco_iosxr"
+    display_name = "Cisco IOS-XR"
     aliases = ("iosxr", "cisco_iosxr", "ios-xr", "ios_xr", "cisco_ios_xr")
 
 
@@ -44,6 +50,7 @@ class CiscoIOS(OperatingSystem):
     """Cisco IOS Classic (legacy devices)."""
 
     name = "cisco_ios"
+    display_name = "Cisco IOS"
     aliases = ("ios", "cisco_ios")
 
 
@@ -51,6 +58,7 @@ class AristaEOS(OperatingSystem):
     """Arista EOS (data center and campus switches)."""
 
     name = "arista_eos"
+    display_name = "Arista EOS"
     aliases = ("arista_eos", "eos", "arista")
 
 
@@ -58,6 +66,7 @@ class JuniperJunos(OperatingSystem):
     """Juniper Junos (MX, QFX, EX, SRX, PTX)."""
 
     name = "juniper_junos"
+    display_name = "Juniper Junos"
     aliases = ("juniper_junos", "junos", "juniper")
 
 
@@ -65,6 +74,7 @@ class PaloAltoPanOS(OperatingSystem):
     """Palo Alto PAN-OS (next-generation firewalls)."""
 
     name = "paloalto_panos"
+    display_name = "Palo Alto PAN-OS"
     aliases = ("paloalto_panos", "panos", "paloalto", "pan-os", "pan_os")
 
 
@@ -72,6 +82,7 @@ class NokiaSROS(OperatingSystem):
     """Nokia SR OS (7750 SR, 7210 SAS, 7450 ESS)."""
 
     name = "nokia_sros"
+    display_name = "Nokia SR OS"
     aliases = ("nokia_sros", "sros", "nokia", "sr-os", "sr_os")
 
 
@@ -79,6 +90,7 @@ class Linux(OperatingSystem):
     """Linux (including SONiC, Cumulus, FRR-based platforms)."""
 
     name = "linux"
+    display_name = "Linux"
     aliases = ("linux",)
 
 

--- a/tests/test_os.py
+++ b/tests/test_os.py
@@ -35,6 +35,42 @@ class TestOperatingSystem:
         assert "cisco_iosxe" in CiscoIOSXE.aliases
 
 
+class TestDisplayName:
+    """Tests that every OS exposes a user-facing display name."""
+
+    @pytest.mark.parametrize(
+        ("os_member", "expected"),
+        [
+            (OS.CISCO_NXOS, "Cisco NX-OS"),
+            (OS.CISCO_IOSXE, "Cisco IOS-XE"),
+            (OS.CISCO_IOSXR, "Cisco IOS-XR"),
+            (OS.CISCO_IOS, "Cisco IOS"),
+            (OS.ARISTA_EOS, "Arista EOS"),
+            (OS.JUNIPER_JUNOS, "Juniper Junos"),
+            (OS.PALOALTO_PANOS, "Palo Alto PAN-OS"),
+            (OS.NOKIA_SROS, "Nokia SR OS"),
+            (OS.LINUX, "Linux"),
+        ],
+    )
+    def test_display_name(self, os_member: OS, expected: str) -> None:
+        """Each OS exposes the expected display name."""
+        assert os_member.value.display_name == expected
+
+    def test_every_os_has_a_display_name(self) -> None:
+        """Every registered OS declares a non-empty display_name."""
+        for member in OS:
+            assert getattr(member.value, "display_name", "")
+
+    def test_display_name_differs_from_slug(self) -> None:
+        """Display name is more human-readable than the canonical slug."""
+        for member in OS:
+            cls = member.value
+            # Linux is the one case where the slug == display name.
+            if cls.name == "linux":
+                continue
+            assert cls.display_name != cls.name
+
+
 class TestOSEnum:
     """Tests for OS enum."""
 


### PR DESCRIPTION
## Summary

Display names for the docs site parser library catalog were previously hardcoded in a JS map in `docs/library.md`. That worked for the four Cisco platforms in v0.2.0, but as v0.3.0 added Arista EOS, Juniper Junos, Palo Alto PAN-OS, Nokia SR OS, and Linux, the JS map became a duplicate, hand-maintained source of truth that's easy to forget when registering a new OS.

This PR makes `src/muninn/os.py` the single source of truth.

- Each `OperatingSystem` subclass now declares a `display_name` `ClassVar` alongside its canonical `name` and `aliases`. Examples: `Cisco NX-OS`, `Palo Alto PAN-OS`, `Nokia SR OS`, `Juniper Junos`.
- `scripts/generate_catalog.py` reads `display_name` off the OS class and emits it into each catalog entry as `os_display_name`.
- `docs/library.md` populates an `osDisplayNames` map per loaded catalog from the entries themselves, so new platforms render with the proper name automatically. A small fallback map keeps older catalog files (v0.1.0, v0.2.0) — which predate `os_display_name` — rendering correctly.

Adding a new OS now means setting `display_name` on the class. Nothing else to remember.

## Test plan

- [x] `tests/test_os.py` — added parametrized test covering all 9 OSes plus invariants (every OS has a non-empty `display_name`; display name differs from slug for everything except Linux).
- [x] `uv run pytest` — 8334 passed.
- [x] `uv run ruff check`, `ruff format --check`, `ty check src/` — all green.
- [ ] After merge, the next docs deploy should regenerate `docs/library/main.json` with `os_display_name` populated, and the parser library page should show the correct labels for all v0.3.0 platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)