### PR TITLE
feat(cisco_ios): add parser for `show users wide`

### DIFF
--- a/changes/1060.parser_added
+++ b/changes/1060.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show users wide` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_users_wide.py
+++ b/src/muninn/parsers/ios/show_users_wide.py
@@ -1,0 +1,99 @@
+"""Parser for 'show users wide' command on IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_HEADER_RE = re.compile(r"^\s*Line\s+User\s+Host\(s\)\s+Idle\s+Location\s*$")
+_INTERFACE_HEADER_RE = re.compile(r"^\s*Interface\s+User\s+Mode\s+Idle\s+Peer Address")
+
+# Anchored on the idle HH:MM:SS field; everything before is line/user/host,
+# everything after is location. User+host appear together or not at all.
+_ROW_RE = re.compile(
+    r"^(?P<active>\*)?\s*"
+    r"(?:\d+\s+)?"
+    r"(?P<line_type>\S+)\s+(?P<line_id>\d+(?:/\d+)*)"
+    r"(?:\s+(?P<user>\S+)\s+(?P<host>\S+))?"
+    r"\s+(?P<idle>\d+:\d+:\d+)"
+    r"(?:\s+(?P<location>\S+))?\s*$"
+)
+
+
+class UserWideEntry(TypedDict):
+    """Schema for a single line entry from 'show users wide'."""
+
+    active: bool
+    user: NotRequired[str]
+    host: NotRequired[str]
+    idle: NotRequired[str]
+    location: NotRequired[str]
+
+
+class ShowUsersWideResult(TypedDict):
+    """Schema for 'show users wide' parsed output."""
+
+    lines: dict[str, dict[str, UserWideEntry]]
+
+
+_OPTIONAL_FIELDS = ("user", "host", "idle", "location")
+
+
+def _build_entry(match: re.Match[str]) -> tuple[str, str, UserWideEntry]:
+    """Assemble a (line_type, line_id, entry) tuple from a row match."""
+    entry: UserWideEntry = {"active": match.group("active") == "*"}
+    for field in _OPTIONAL_FIELDS:
+        value = match.group(field)
+        if value:
+            entry[field] = value
+    return match.group("line_type"), match.group("line_id"), entry
+
+
+@register(OS.CISCO_IOS, "show users wide")
+class ShowUsersWideParser(BaseParser[ShowUsersWideResult]):
+    """Parser for 'show users wide' on IOS.
+
+    Parses the user session table showing line, user, host, idle time,
+    and location for each terminal session. Lines without a logged-in
+    user (no user / no host columns) are handled correctly.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowUsersWideResult:
+        """Parse 'show users wide' output.
+
+        Args:
+            output: Raw CLI output from 'show users wide'.
+
+        Returns:
+            User entries keyed by line family (e.g. ``con``, ``vty``) and
+            line identifier.
+
+        Raises:
+            ValueError: If no user entries are found in the output.
+        """
+        result: dict[str, dict[str, UserWideEntry]] = {}
+
+        for raw_line in output.splitlines():
+            if _INTERFACE_HEADER_RE.match(raw_line):
+                break
+            if not raw_line.strip() or _HEADER_RE.match(raw_line):
+                continue
+
+            match = _ROW_RE.match(raw_line)
+            if match is None:
+                continue
+
+            line_type, line_id, entry = _build_entry(match)
+            result.setdefault(line_type, {})[line_id] = entry
+
+        if not result:
+            msg = "No user entries found in 'show users wide' output"
+            raise ValueError(msg)
+
+        return {"lines": result}

--- a/tests/parsers/ios/show_users_wide/001_basic/expected.json
+++ b/tests/parsers/ios/show_users_wide/001_basic/expected.json
@@ -1,0 +1,82 @@
+{
+    "lines": {
+        "con": {
+            "0": {
+                "active": false,
+                "idle": "00:00:00"
+            }
+        },
+        "vty": {
+            "0": {
+                "active": false,
+                "user": "superman",
+                "host": "idle",
+                "idle": "00:05:49",
+                "location": "192.0.2.50"
+            },
+            "1": {
+                "active": true,
+                "user": "admin",
+                "host": "idle",
+                "idle": "00:00:09",
+                "location": "192.0.2.50"
+            },
+            "2": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "3": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "4": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "5": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "6": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "7": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "8": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "9": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "10": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "11": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "12": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "13": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "14": {
+                "active": false,
+                "idle": "00:00:00"
+            },
+            "15": {
+                "active": false,
+                "idle": "00:00:00"
+            }
+        }
+    }
+}

--- a/tests/parsers/ios/show_users_wide/001_basic/input.txt
+++ b/tests/parsers/ios/show_users_wide/001_basic/input.txt
@@ -1,0 +1,20 @@
+Line       User       Host(s)              Idle       Location
+   0 con 0                                     00:00:00
+   1 vty 0     superman   idle                 00:05:49 192.0.2.50
+*  2 vty 1     admin      idle                 00:00:09 192.0.2.50
+   3 vty 2                                     00:00:00
+   4 vty 3                                     00:00:00
+   5 vty 4                                     00:00:00
+   6 vty 5                                     00:00:00
+   7 vty 6                                     00:00:00
+   8 vty 7                                     00:00:00
+   9 vty 8                                     00:00:00
+  10 vty 9                                     00:00:00
+  11 vty 10                                    00:00:00
+  12 vty 11                                    00:00:00
+  13 vty 12                                    00:00:00
+  14 vty 13                                    00:00:00
+  15 vty 14                                    00:00:00
+  16 vty 15                                    00:00:00
+
+  Interface    User               Mode         Idle     Peer Address

--- a/tests/parsers/ios/show_users_wide/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_users_wide/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: show users wide output from a Catalyst 3750-X stack with two active vty sessions
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds `show users wide` parser for Cisco IOS.
- Schema: `lines: dict[str, dict[str, UserWideEntry]]` keyed by line family (e.g. `con`, `vty`) then line id, matching the sibling `show users` shape. Per-row `active: bool` plus optional `user`, `host`, `idle`, `location`.
- Regex is anchored on the `HH:MM:SS` idle field so the common rows with empty user/host columns (e.g. `0 con 0  00:00:00`) parse correctly — column-position slicing doesn't work here because the wide format's data columns are not aligned with header columns.
- Ships fixture captured from a Catalyst 3750-X stack (per issue #1060).

Closes #1060

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_users_wide -v`
- [x] `uv run pytest` (full suite, 8361 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/ios/show_users_wide.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_users_wide.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)