### PR TITLE
feat(cisco_ios): add parser for `show spanning-tree inconsistentports`

### DIFF
--- a/changes/1058.parser_added
+++ b/changes/1058.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show spanning-tree inconsistentports` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_spanning_tree_inconsistentports.py
+++ b/src/muninn/parsers/ios/show_spanning_tree_inconsistentports.py
@@ -1,0 +1,97 @@
+"""Parser for 'show spanning-tree inconsistentports' command on IOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_SPACE_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+_HEADER_RE = re.compile(r"^\s*Name\s+Interface\s+Inconsistency\s*$", re.IGNORECASE)
+_ROW_RE = re.compile(
+    r"^VLAN(?P<vlan>\d+)\s+(?P<interface>\S+)\s+(?P<inconsistency>.+?)\s*$"
+)
+_COUNT_RE = re.compile(
+    r"^Number of inconsistent ports \(segments\) in the system\s*:\s*"
+    r"(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+
+class ShowSpanningTreeInconsistentPortsResult(TypedDict):
+    """Schema for 'show spanning-tree inconsistentports' parsed output."""
+
+    vlans: dict[str, dict[str, str]]
+    inconsistent_count: int
+
+
+def _try_row(line: str, vlans: dict[str, dict[str, str]]) -> bool:
+    """Attempt to parse one inconsistent-port row into the vlans map."""
+    match = _ROW_RE.match(line)
+    if match is None:
+        return False
+    vlan_id = str(int(match.group("vlan")))
+    interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_IOS)
+    vlans.setdefault(vlan_id, {})[interface] = match.group("inconsistency").strip()
+    return True
+
+
+@register(OS.CISCO_IOS, "show spanning-tree inconsistentports")
+class ShowSpanningTreeInconsistentPortsParser(
+    BaseParser[ShowSpanningTreeInconsistentPortsResult]
+):
+    """Parser for 'show spanning-tree inconsistentports' on IOS."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.STP,
+            ParserTag.SWITCHING,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowSpanningTreeInconsistentPortsResult:
+        """Parse 'show spanning-tree inconsistentports' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Mapping of VLAN ID to interface-to-inconsistency-state map, plus
+            the device-reported total inconsistent-port count.
+
+        Raises:
+            ValueError: If the footer count line is missing from the output.
+        """
+        vlans: dict[str, dict[str, str]] = {}
+        count: int | None = None
+
+        for line in output.splitlines():
+            if (
+                not line.strip()
+                or _HEADER_RE.match(line)
+                or SEPARATOR_DASH_SPACE_RE.match(line)
+            ):
+                continue
+
+            count_match = _COUNT_RE.match(line)
+            if count_match:
+                count = int(count_match.group("count"))
+                continue
+
+            _try_row(line, vlans)
+
+        if count is None:
+            msg = (
+                "Missing 'Number of inconsistent ports' footer in "
+                "'show spanning-tree inconsistentports' output"
+            )
+            raise ValueError(msg)
+
+        return cast(
+            ShowSpanningTreeInconsistentPortsResult,
+            {"vlans": vlans, "inconsistent_count": count},
+        )

--- a/tests/parsers/ios/show_spanning-tree_inconsistentports/001_basic/expected.json
+++ b/tests/parsers/ios/show_spanning-tree_inconsistentports/001_basic/expected.json
@@ -1,0 +1,4 @@
+{
+    "vlans": {},
+    "inconsistent_count": 0
+}

--- a/tests/parsers/ios/show_spanning-tree_inconsistentports/001_basic/input.txt
+++ b/tests/parsers/ios/show_spanning-tree_inconsistentports/001_basic/input.txt
@@ -1,0 +1,4 @@
+Name                 Interface                Inconsistency
+-------------------- ------------------------ ------------------
+
+Number of inconsistent ports (segments) in the system : 0

--- a/tests/parsers/ios/show_spanning-tree_inconsistentports/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_spanning-tree_inconsistentports/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: show spanning-tree inconsistentports output from a Catalyst 3750-X stack with no inconsistent ports
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds `show spanning-tree inconsistentports` parser for Cisco IOS.
- Schema: `vlans: dict[str, dict[str, str]]` keyed by VLAN id → canonical interface → inconsistency state (e.g. `Root Inconsistent`), plus the device-reported `inconsistent_count` footer.
- Fixture captured from a Catalyst 3750-X stack with no current inconsistent ports (per issue #1058). Row parsing logic exists but isn't exercised by this fixture — additional fixtures with active inconsistencies would strengthen coverage.

Closes #1058

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_spanning-tree_inconsistentports -v`
- [x] `uv run pytest` (full suite, 8379 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/ios/show_spanning_tree_inconsistentports.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)