### PR TITLE
feat(cisco_ios): add parser for `show mac address-table count`

### DIFF
--- a/changes/1053.parser_added
+++ b/changes/1053.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show mac address-table count` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_mac_address_table_count.py
+++ b/src/muninn/parsers/ios/show_mac_address_table_count.py
@@ -1,0 +1,124 @@
+"""Parser for 'show mac address-table count' command on IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_VLAN_HEADER_RE = re.compile(
+    r"^\s*Mac\s+Entries\s+for\s+Vlan\s+(?P<vlan>\d+)\s*:\s*$",
+    re.IGNORECASE,
+)
+_DYNAMIC_COUNT_RE = re.compile(
+    r"^\s*Dynamic\s+Address\s+Count\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_STATIC_COUNT_RE = re.compile(
+    r"^\s*Static\s+Address\s+Count\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_TOTAL_MAC_RE = re.compile(
+    r"^\s*Total\s+Mac\s+Addresses\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_TOTAL_SPACE_RE = re.compile(
+    r"^\s*Total\s+Mac\s+Address\s+Space\s+Available\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+_COUNT_FIELD_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("dynamic_address_count", _DYNAMIC_COUNT_RE),
+    ("static_address_count", _STATIC_COUNT_RE),
+    ("total_mac_addresses", _TOTAL_MAC_RE),
+)
+
+
+class VlanMacCount(TypedDict):
+    """Per-VLAN MAC address counts."""
+
+    dynamic_address_count: int
+    static_address_count: int
+    total_mac_addresses: int
+
+
+class ShowMacAddressTableCountResult(TypedDict):
+    """Schema for 'show mac address-table count' parsed output."""
+
+    vlans: dict[str, VlanMacCount]
+    total_mac_address_space_available: NotRequired[int]
+
+
+def _try_count_line(line: str, current_entry: dict[str, int]) -> bool:
+    """Populate ``current_entry`` if ``line`` is a recognised count field."""
+    for key, pattern in _COUNT_FIELD_PATTERNS:
+        match = pattern.match(line)
+        if match:
+            current_entry[key] = int(match.group("count"))
+            return True
+    return False
+
+
+@register(OS.CISCO_IOS, "show mac address-table count")
+class ShowMacAddressTableCountParser(BaseParser[ShowMacAddressTableCountResult]):
+    """Parser for 'show mac address-table count' command on IOS."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.MAC, ParserTag.SWITCHING, ParserTag.VLAN}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMacAddressTableCountResult:
+        """Parse 'show mac address-table count' output into structured data.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed per-VLAN MAC counts plus total available MAC address space.
+
+        Raises:
+            ValueError: If no per-VLAN entries are parsed from the output.
+        """
+        result: dict = {}
+        vlans: dict[str, VlanMacCount] = {}
+        current_vlan: str | None = None
+        current_entry: dict[str, int] = {}
+
+        def _flush() -> None:
+            if current_vlan is not None and current_entry:
+                vlans[current_vlan] = cast(VlanMacCount, dict(current_entry))
+
+        for line in output.splitlines():
+            vlan_match = _VLAN_HEADER_RE.match(line)
+            if vlan_match:
+                _flush()
+                current_vlan = vlan_match.group("vlan")
+                current_entry = {}
+                continue
+
+            space_match = _TOTAL_SPACE_RE.match(line)
+            if space_match:
+                _flush()
+                current_vlan = None
+                current_entry = {}
+                result["total_mac_address_space_available"] = int(
+                    space_match.group("count")
+                )
+                continue
+
+            if current_vlan is None:
+                continue
+
+            _try_count_line(line, current_entry)
+
+        _flush()
+
+        if not vlans:
+            msg = "No VLAN MAC address-table count entries found"
+            raise ValueError(msg)
+
+        result["vlans"] = vlans
+        return cast(ShowMacAddressTableCountResult, result)

--- a/src/muninn/parsers/ios/show_mac_address_table_count.py
+++ b/src/muninn/parsers/ios/show_mac_address_table_count.py
@@ -35,6 +35,10 @@ _COUNT_FIELD_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("total_mac_addresses", _TOTAL_MAC_RE),
 )
 
+_REQUIRED_COUNT_FIELDS: frozenset[str] = frozenset(
+    key for key, _ in _COUNT_FIELD_PATTERNS
+)
+
 
 class VlanMacCount(TypedDict):
     """Per-VLAN MAC address counts."""
@@ -62,8 +66,9 @@ def _try_count_line(line: str, current_entry: dict[str, int]) -> bool:
 
 
 @register(OS.CISCO_IOS, "show mac address-table count")
+@register(OS.CISCO_IOSXE, "show mac address-table count")
 class ShowMacAddressTableCountParser(BaseParser[ShowMacAddressTableCountResult]):
-    """Parser for 'show mac address-table count' command on IOS."""
+    """Parser for 'show mac address-table count' command on IOS/IOS-XE."""
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset(
         {ParserTag.MAC, ParserTag.SWITCHING, ParserTag.VLAN}
@@ -88,8 +93,11 @@ class ShowMacAddressTableCountParser(BaseParser[ShowMacAddressTableCountResult])
         current_entry: dict[str, int] = {}
 
         def _flush() -> None:
-            if current_vlan is not None and current_entry:
-                vlans[current_vlan] = cast(VlanMacCount, dict(current_entry))
+            if current_vlan is None:
+                return
+            if not _REQUIRED_COUNT_FIELDS.issubset(current_entry):
+                return
+            vlans[current_vlan] = cast(VlanMacCount, dict(current_entry))
 
         for line in output.splitlines():
             vlan_match = _VLAN_HEADER_RE.match(line)

--- a/tests/parsers/ios/show_mac_address-table_count/001_basic/expected.json
+++ b/tests/parsers/ios/show_mac_address-table_count/001_basic/expected.json
@@ -1,0 +1,20 @@
+{
+    "total_mac_address_space_available": 6113,
+    "vlans": {
+        "1": {
+            "dynamic_address_count": 0,
+            "static_address_count": 0,
+            "total_mac_addresses": 0
+        },
+        "21": {
+            "dynamic_address_count": 8,
+            "static_address_count": 0,
+            "total_mac_addresses": 8
+        },
+        "1000": {
+            "dynamic_address_count": 0,
+            "static_address_count": 0,
+            "total_mac_addresses": 0
+        }
+    }
+}

--- a/tests/parsers/ios/show_mac_address-table_count/001_basic/input.txt
+++ b/tests/parsers/ios/show_mac_address-table_count/001_basic/input.txt
@@ -1,0 +1,19 @@
+Mac Entries for Vlan 1:
+---------------------------
+Dynamic Address Count  : 0
+Static  Address Count  : 0
+Total Mac Addresses    : 0
+
+Mac Entries for Vlan 21:
+---------------------------
+Dynamic Address Count  : 8
+Static  Address Count  : 0
+Total Mac Addresses    : 8
+
+Mac Entries for Vlan 1000:
+---------------------------
+Dynamic Address Count  : 0
+Static  Address Count  : 0
+Total Mac Addresses    : 0
+
+Total Mac Address Space Available: 6113

--- a/tests/parsers/ios/show_mac_address-table_count/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_mac_address-table_count/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic per-VLAN MAC address-table count summary with total available MAC address space footer
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds a parser for `show mac address-table count` on Cisco IOS. Output is keyed as `vlans: dict[str, VlanMacCount]` (per-VLAN dynamic/static/total counts) with an optional `total_mac_address_space_available` integer footer.
- Fixture sourced verbatim from issue #1053 sample output (Catalyst 3750-X stack, IOS 15.x).

Closes #1053

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_mac_address-table_count -v` (7 passed)
- [x] `uv run pytest` (8404 passed)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/ios/show_mac_address_table_count.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_mac_address_table_count.py`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)