### PR TITLE
feat(cisco_ios): add parser for `show lldp`

### DIFF
--- a/changes/1051.parser_added
+++ b/changes/1051.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show lldp` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_lldp.py
+++ b/src/muninn/parsers/ios/show_lldp.py
@@ -1,0 +1,190 @@
+"""Parser for 'show lldp' command on Cisco IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowLldpResult(TypedDict):
+    """Schema for 'show lldp' parsed output.
+
+    Represents global LLDP configuration on the device. When LLDP is not
+    enabled, only ``lldp_enabled`` is populated (set to ``False``).
+    """
+
+    lldp_enabled: bool
+    status: NotRequired[str]
+    hello_timer_seconds: NotRequired[int]
+    hold_timer_seconds: NotRequired[int]
+    reinit_delay_seconds: NotRequired[int]
+
+
+# % LLDP is not enabled
+_LLDP_NOT_ENABLED_RE = re.compile(
+    r"^\s*%?\s*LLDP\s+is\s+not\s+enabled\s*$",
+    re.IGNORECASE,
+)
+
+# Global LLDP Information:
+_GLOBAL_HEADER_RE = re.compile(
+    r"^\s*Global\s+LLDP\s+Information:\s*$",
+    re.IGNORECASE,
+)
+
+# Status: ACTIVE
+_STATUS_RE = re.compile(
+    r"^\s*Status:\s+(?P<status>\S+)\s*$",
+    re.IGNORECASE,
+)
+
+# LLDP advertisements are sent every 30 seconds
+_HELLO_TIMER_RE = re.compile(
+    r"^\s*LLDP\s+advertisements\s+are\s+sent\s+every\s+"
+    r"(?P<value>\d+)\s+seconds?\s*$",
+    re.IGNORECASE,
+)
+
+# LLDP hold time advertised is 120 seconds
+_HOLD_TIMER_RE = re.compile(
+    r"^\s*LLDP\s+hold\s+time\s+advertised\s+is\s+"
+    r"(?P<value>\d+)\s+seconds?\s*$",
+    re.IGNORECASE,
+)
+
+# LLDP interface reinitialisation delay is 2 seconds
+_REINIT_DELAY_RE = re.compile(
+    r"^\s*LLDP\s+interface\s+reinitiali[sz]ation\s+delay\s+is\s+"
+    r"(?P<value>\d+)\s+seconds?\s*$",
+    re.IGNORECASE,
+)
+
+# Maps an integer field name to its compiled regex.
+_INT_FIELD_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("hello_timer_seconds", _HELLO_TIMER_RE),
+    ("hold_timer_seconds", _HOLD_TIMER_RE),
+    ("reinit_delay_seconds", _REINIT_DELAY_RE),
+)
+
+
+def _try_int_field(line: str, result: ShowLldpResult) -> bool:
+    """Try to match any integer ``_seconds`` field on the line.
+
+    Returns ``True`` when a match is found and the field is written to
+    ``result``.
+    """
+    for field, pattern in _INT_FIELD_PATTERNS:
+        match = pattern.match(line)
+        if match:
+            result["lldp_enabled"] = True
+            # field is one of three known NotRequired keys
+            if field == "hello_timer_seconds":
+                result["hello_timer_seconds"] = int(match.group("value"))
+            elif field == "hold_timer_seconds":
+                result["hold_timer_seconds"] = int(match.group("value"))
+            else:
+                result["reinit_delay_seconds"] = int(match.group("value"))
+            return True
+    return False
+
+
+def _try_status_field(line: str, result: ShowLldpResult) -> bool:
+    """Try to match the ``Status:`` line and write it to ``result``."""
+    match = _STATUS_RE.match(line)
+    if match:
+        result["lldp_enabled"] = True
+        result["status"] = match.group("status").upper()
+        return True
+    return False
+
+
+def _has_any_enabled_field(result: ShowLldpResult) -> bool:
+    """Return True if any enabled-state field has been written."""
+    return (
+        "status" in result
+        or "hello_timer_seconds" in result
+        or "hold_timer_seconds" in result
+        or "reinit_delay_seconds" in result
+    )
+
+
+class _ParseState:
+    """Mutable state tracked while walking ``show lldp`` output."""
+
+    def __init__(self) -> None:
+        self.saw_disabled = False
+        self.saw_global_header = False
+
+
+def _consume_line(line: str, result: ShowLldpResult, state: _ParseState) -> None:
+    """Dispatch a single non-blank line to the appropriate field handler."""
+    if _LLDP_NOT_ENABLED_RE.match(line):
+        state.saw_disabled = True
+        return
+    if _GLOBAL_HEADER_RE.match(line):
+        state.saw_global_header = True
+        result["lldp_enabled"] = True
+        return
+    if _try_status_field(line, result):
+        return
+    _try_int_field(line, result)
+
+
+@register(OS.CISCO_IOS, "show lldp")
+class ShowLldpParser(BaseParser[ShowLldpResult]):
+    """Parser for 'show lldp' command on Cisco IOS.
+
+    Parses global LLDP configuration. The command may report either that
+    LLDP is not enabled (a single status line) or, when enabled, a block
+    of global LLDP timer/status fields.
+
+    Example output when enabled::
+
+        Global LLDP Information:
+            Status: ACTIVE
+            LLDP advertisements are sent every 30 seconds
+            LLDP hold time advertised is 120 seconds
+            LLDP interface reinitialisation delay is 2 seconds
+
+    Example output when disabled::
+
+        % LLDP is not enabled
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.LLDP})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLldpResult:
+        """Parse 'show lldp' output.
+
+        Args:
+            output: Raw CLI output from 'show lldp' command.
+
+        Returns:
+            Parsed LLDP global configuration data.
+
+        Raises:
+            ValueError: If the output cannot be recognised as either an
+                enabled-state or disabled-state ``show lldp`` response.
+        """
+        result: ShowLldpResult = {"lldp_enabled": False}
+        state = _ParseState()
+
+        for raw_line in output.splitlines():
+            line = raw_line.rstrip()
+            if line.strip():
+                _consume_line(line, result, state)
+
+        recognised = (
+            state.saw_disabled
+            or state.saw_global_header
+            or _has_any_enabled_field(result)
+        )
+        if not recognised:
+            msg = "Output does not match 'show lldp' format"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/ios/show_lldp/001_disabled/expected.json
+++ b/tests/parsers/ios/show_lldp/001_disabled/expected.json
@@ -1,0 +1,3 @@
+{
+    "lldp_enabled": false
+}

--- a/tests/parsers/ios/show_lldp/001_disabled/input.txt
+++ b/tests/parsers/ios/show_lldp/001_disabled/input.txt
@@ -1,0 +1,1 @@
+% LLDP is not enabled

--- a/tests/parsers/ios/show_lldp/001_disabled/metadata.yaml
+++ b/tests/parsers/ios/show_lldp/001_disabled/metadata.yaml
@@ -1,0 +1,3 @@
+description: show lldp output when LLDP is not enabled globally
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x

--- a/tests/parsers/ios/show_lldp/002_enabled/expected.json
+++ b/tests/parsers/ios/show_lldp/002_enabled/expected.json
@@ -1,0 +1,7 @@
+{
+    "lldp_enabled": true,
+    "status": "ACTIVE",
+    "hello_timer_seconds": 30,
+    "hold_timer_seconds": 120,
+    "reinit_delay_seconds": 2
+}

--- a/tests/parsers/ios/show_lldp/002_enabled/input.txt
+++ b/tests/parsers/ios/show_lldp/002_enabled/input.txt
@@ -1,0 +1,5 @@
+Global LLDP Information:
+    Status: ACTIVE
+    LLDP advertisements are sent every 30 seconds
+    LLDP hold time advertised is 120 seconds
+    LLDP interface reinitialisation delay is 2 seconds

--- a/tests/parsers/ios/show_lldp/002_enabled/metadata.yaml
+++ b/tests/parsers/ios/show_lldp/002_enabled/metadata.yaml
@@ -1,0 +1,3 @@
+description: show lldp output with LLDP enabled showing global timer settings
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds a Cisco IOS parser for `show lldp`, exposing global LLDP configuration as a flat `TypedDict` with `lldp_enabled: bool` plus `NotRequired` fields for `status`, `hello_timer_seconds`, `hold_timer_seconds`, and `reinit_delay_seconds`.
- Schema mirrors the `iosxe/show_cdp` sibling (boolean enabled flag with optional per-field timers). Both the disabled-state (`% LLDP is not enabled`) and enabled-state samples from the issue are covered by dedicated fixtures (`001_disabled`, `002_enabled`) captured from a Catalyst 3750-X stack on IOS 15.x per the issue.

Closes #1051

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_lldp -v` (new fixtures pass)
- [x] `uv run pytest` (full suite: 8411 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/ios/show_lldp.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_lldp.py`
- [x] `uv run pre-commit run --files ...` (all hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)