### PR TITLE
feat(cisco_ios): add parser for `show errdisable flap-values`

### DIFF
--- a/changes/1042.parser_added
+++ b/changes/1042.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show errdisable flap-values` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_errdisable_flap_values.py
+++ b/src/muninn/parsers/ios/show_errdisable_flap_values.py
@@ -1,0 +1,77 @@
+"""Parser for 'show errdisable flap-values' command on IOS."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_SPACE_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_HEADER_RE = re.compile(
+    r"^\s*ErrDisable Reason\s+Flaps\s+Time\s*\(sec\)\s*$",
+    re.IGNORECASE,
+)
+_ROW_RE = re.compile(r"^(?P<reason>\S+)\s+(?P<flaps>\d+)\s+(?P<time_seconds>\d+)\s*$")
+
+
+class ErrdisableFlapValue(TypedDict):
+    """Per-reason flap detection parameters for err-disable."""
+
+    flaps: int
+    time_seconds: int
+
+
+class ShowErrdisableFlapValuesResult(TypedDict):
+    """Schema for 'show errdisable flap-values' parsed output."""
+
+    reasons: dict[str, ErrdisableFlapValue]
+
+
+@register(OS.CISCO_IOS, "show errdisable flap-values")
+class ShowErrdisableFlapValuesParser(BaseParser[ShowErrdisableFlapValuesResult]):
+    """Parser for 'show errdisable flap-values' on IOS."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.INTERFACES,
+            ParserTag.SWITCHING,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowErrdisableFlapValuesResult:
+        """Parse 'show errdisable flap-values' output.
+
+        The command lists the flap detection thresholds for each
+        err-disable reason. A reason becomes err-disabled when its
+        associated event occurs ``flaps`` times within ``time_seconds``.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Mapping of err-disable reason name to its flap-detection
+            parameters.
+        """
+        reasons: dict[str, ErrdisableFlapValue] = {}
+
+        for line in output.splitlines():
+            if (
+                not line.strip()
+                or _HEADER_RE.match(line)
+                or SEPARATOR_DASH_SPACE_RE.match(line)
+            ):
+                continue
+
+            match = _ROW_RE.match(line)
+            if match is None:
+                continue
+
+            reasons[match.group("reason")] = {
+                "flaps": int(match.group("flaps")),
+                "time_seconds": int(match.group("time_seconds")),
+            }
+
+        return cast(ShowErrdisableFlapValuesResult, {"reasons": reasons})

--- a/tests/parsers/ios/show_errdisable_flap-values/001_basic/expected.json
+++ b/tests/parsers/ios/show_errdisable_flap-values/001_basic/expected.json
@@ -1,0 +1,16 @@
+{
+    "reasons": {
+        "pagp-flap": {
+            "flaps": 3,
+            "time_seconds": 30
+        },
+        "dtp-flap": {
+            "flaps": 3,
+            "time_seconds": 30
+        },
+        "link-flap": {
+            "flaps": 5,
+            "time_seconds": 10
+        }
+    }
+}

--- a/tests/parsers/ios/show_errdisable_flap-values/001_basic/input.txt
+++ b/tests/parsers/ios/show_errdisable_flap-values/001_basic/input.txt
@@ -1,0 +1,5 @@
+ErrDisable Reason    Flaps    Time (sec)
+-----------------    ------   ----------
+pagp-flap              3       30
+dtp-flap               3       30
+link-flap              5       10

--- a/tests/parsers/ios/show_errdisable_flap-values/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_errdisable_flap-values/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic three-row err-disable flap-values output from a Catalyst stack.
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds an IOS parser for `show errdisable flap-values`, producing a `reasons: dict[str, {flaps, time_seconds}]` mapping keyed by err-disable reason name.
- Fixture sourced from a Catalyst 3750-X stack capture supplied in the issue; covers the three common flap reasons (`pagp-flap`, `dtp-flap`, `link-flap`).

Closes #1042

## Test plan
- [x] `uv run pytest tests/parsers/ -k "errdisable" -v` (16 passed)
- [x] `uv run pytest` (full suite, 8465 passed)
- [x] `uv run ruff check src/muninn/parsers/ios/show_errdisable_flap_values.py`
- [x] `uv run ruff format src/muninn/parsers/ios/show_errdisable_flap_values.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_errdisable_flap_values.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_errdisable_flap_values.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)