### PR TITLE
feat(cisco_ios): add parser for `show cdp`

### DIFF
--- a/changes/1036.parser_added
+++ b/changes/1036.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show cdp` on Cisco IOS.

--- a/src/muninn/parsers/iosxe/show_cdp.py
+++ b/src/muninn/parsers/iosxe/show_cdp.py
@@ -1,4 +1,4 @@
-"""Parser for 'show cdp' command on IOS-XE."""
+"""Parser for 'show cdp' command on IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict
@@ -135,6 +135,7 @@ def _build_result(fields: _CdpFields) -> ShowCdpResult:
     return result
 
 
+@register(OS.CISCO_IOS, "show cdp")
 @register(OS.CISCO_IOSXE, "show cdp")
 class ShowCdpParser(BaseParser[ShowCdpResult]):
     """Parser for 'show cdp' command.

--- a/tests/parsers/ios/show_cdp/001_basic/expected.json
+++ b/tests/parsers/ios/show_cdp/001_basic/expected.json
@@ -1,0 +1,6 @@
+{
+    "cdp_enabled": true,
+    "send_interval": 60,
+    "holdtime": 180,
+    "cdp_version": 2
+}

--- a/tests/parsers/ios/show_cdp/001_basic/input.txt
+++ b/tests/parsers/ios/show_cdp/001_basic/input.txt
@@ -1,0 +1,4 @@
+Global CDP information:
+        Sending CDP packets every 60 seconds
+        Sending a holdtime value of 180 seconds
+        Sending CDPv2 advertisements is  enabled

--- a/tests/parsers/ios/show_cdp/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_cdp/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show cdp output from a Catalyst 3750-X stack running IOS 15.x
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds `cisco_ios` support for `show cdp` by stacking `@register(OS.CISCO_IOS, "show cdp")` on the existing IOSXE `ShowCdpParser`. The IOS sample output in #1036 is structurally identical to the IOSXE fixture (same fields, same line format), so a separate parser module would just duplicate code.
- New test fixture `tests/parsers/ios/show_cdp/001_basic/` copied verbatim from the Catalyst 3750-X (IOS 15.x) sample in the issue.

Closes #1036

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_cdp -v` (210 passed)
- [x] `uv run pytest` (8517 passed)
- [x] `uv run ruff check src/muninn/parsers/iosxe/show_cdp.py`
- [x] `uv run ruff format --check src/muninn/parsers/iosxe/show_cdp.py`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_cdp.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_cdp.py`
- [x] Self-review via `review-new-parser-pr` skill: 0 blockers, 0 concerns, 0 nits.

Generated with [Claude Code](https://claude.com/claude-code)