### PR TITLE
feat(cisco_ios): add parser for `show class-map`

### DIFF
--- a/changes/1038.parser_added
+++ b/changes/1038.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show class-map` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_class-map.py
+++ b/src/muninn/parsers/ios/show_class-map.py
@@ -1,7 +1,7 @@
 """Parser for 'show class-map' command on IOS."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -92,4 +92,4 @@ class ShowClassMapParser(BaseParser["ShowClassMapResult"]):
             msg = "No class-map entries found in output"
             raise ValueError(msg)
 
-        return cast("ShowClassMapResult", {"class_maps": class_maps})
+        return {"class_maps": class_maps}

--- a/src/muninn/parsers/ios/show_class-map.py
+++ b/src/muninn/parsers/ios/show_class-map.py
@@ -1,0 +1,95 @@
+"""Parser for 'show class-map' command on IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ClassMapEntry(TypedDict):
+    """Schema for a single class-map entry."""
+
+    match_type: str
+    id: int
+    matches: NotRequired[list[str]]
+    description: NotRequired[str]
+
+
+class ShowClassMapResult(TypedDict):
+    """Schema for 'show class-map' parsed output."""
+
+    class_maps: dict[str, ClassMapEntry]
+
+
+_CLASS_MAP_HEADER_RE = re.compile(
+    r"^Class\s+Map\s+(?P<match_type>match-any|match-all)\s+"
+    r"(?P<name>\S+)\s+\(id\s+(?P<id>\d+)\)\s*$"
+)
+_MATCH_LINE_RE = re.compile(r"^\s+Match\s+(?P<criteria>.+?)\s*$")
+_DESCRIPTION_LINE_RE = re.compile(r"^\s+Description:\s+(?P<description>.+?)\s*$")
+
+
+@register(OS.CISCO_IOS, "show class-map")
+class ShowClassMapParser(BaseParser["ShowClassMapResult"]):
+    """Parser for 'show class-map' on IOS.
+
+    Example output::
+
+        Class Map match-any class-default (id 0)
+           Match any
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.QOS})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowClassMapResult:
+        """Parse 'show class-map' output.
+
+        Args:
+            output: Raw CLI output from 'show class-map' command.
+
+        Returns:
+            Parsed data keyed by class-map name.
+
+        Raises:
+            ValueError: If no class-map entries are found in the output.
+        """
+        class_maps: dict[str, ClassMapEntry] = {}
+        current_name: str | None = None
+
+        for line in output.splitlines():
+            header_match = _CLASS_MAP_HEADER_RE.match(line)
+            if header_match:
+                current_name = header_match.group("name")
+                class_maps[current_name] = {
+                    "match_type": header_match.group("match_type"),
+                    "id": int(header_match.group("id")),
+                }
+                continue
+
+            if current_name is None:
+                continue
+
+            desc_match = _DESCRIPTION_LINE_RE.match(line)
+            if desc_match:
+                class_maps[current_name]["description"] = desc_match.group(
+                    "description"
+                )
+                continue
+
+            match_match = _MATCH_LINE_RE.match(line)
+            if match_match:
+                criteria = match_match.group("criteria")
+                entry = class_maps[current_name]
+                if "matches" not in entry:
+                    entry["matches"] = []
+                entry["matches"].append(criteria)
+
+        if not class_maps:
+            msg = "No class-map entries found in output"
+            raise ValueError(msg)
+
+        return cast("ShowClassMapResult", {"class_maps": class_maps})

--- a/tests/parsers/ios/show_class-map/001_basic/expected.json
+++ b/tests/parsers/ios/show_class-map/001_basic/expected.json
@@ -1,0 +1,11 @@
+{
+    "class_maps": {
+        "class-default": {
+            "match_type": "match-any",
+            "id": 0,
+            "matches": [
+                "any"
+            ]
+        }
+    }
+}

--- a/tests/parsers/ios/show_class-map/001_basic/input.txt
+++ b/tests/parsers/ios/show_class-map/001_basic/input.txt
@@ -1,0 +1,2 @@
+Class Map match-any class-default (id 0)
+   Match any

--- a/tests/parsers/ios/show_class-map/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_class-map/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Default class-map with match-any criteria
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds a `show class-map` parser for Cisco IOS that returns `class_maps` keyed by class-map name, each entry carrying `match_type` (match-any/match-all), numeric `id`, and (when present) `description` and a `matches` list of criteria strings.
- Fixture is the verbatim sample from the issue (Catalyst 3750-X stack, IOS 15.x), showing the default class-map with `Match any` — coverage is intentionally narrow to the device output supplied; user-defined class-maps with multiple match criteria or descriptions will be picked up by the same regexes but are not exercised by this fixture.

Closes #1038

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_class-map -v` (7 passed)
- [x] `uv run pytest` (8465 passed)
- [x] `uv run ruff check src/muninn/parsers/ios/show_class-map.py`
- [x] `uv run ruff format src/muninn/parsers/ios/show_class-map.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_class-map.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_class-map.py`
- [x] Pre-commit hooks (full suite via commit hook)

Generated with [Claude Code](https://claude.com/claude-code)