### PR TITLE
feat(cisco_ios): add parser for `show cdp interface`

### DIFF
--- a/changes/1037.parser_added
+++ b/changes/1037.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show cdp interface` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_cdp_interface.py
+++ b/src/muninn/parsers/ios/show_cdp_interface.py
@@ -1,0 +1,184 @@
+"""Parser for 'show cdp interface' command on IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+# Header line for each interface block, e.g.:
+#   GigabitEthernet1/0/1 is up, line protocol is up
+_INTERFACE_HEADER_RE = re.compile(
+    r"^(?P<interface>\S+)\s+is\s+(?P<status>[\w-]+(?:\s[\w-]+)*),\s+"
+    r"line\s+protocol\s+is\s+(?P<line_protocol>[\w-]+(?:\s[\w-]+)*)\s*$",
+)
+
+# Encapsulation line, e.g.:
+#   Encapsulation ARPA
+_ENCAPSULATION_RE = re.compile(r"^\s*Encapsulation\s+(?P<encapsulation>\S.*?)\s*$")
+
+# Send-interval line, e.g.:
+#   Sending CDP packets every 60 seconds
+_SEND_INTERVAL_RE = re.compile(
+    r"^\s*Sending\s+CDP\s+packets\s+every\s+(?P<interval>\d+)\s+seconds?\s*$",
+    re.IGNORECASE,
+)
+
+# Holdtime line, e.g.:
+#   Holdtime is 180 seconds
+_HOLDTIME_RE = re.compile(
+    r"^\s*Holdtime\s+is\s+(?P<holdtime>\d+)\s+seconds?\s*$",
+    re.IGNORECASE,
+)
+
+# Summary footer lines, e.g.:
+#   cdp enabled interfaces : 139
+#   interfaces up          : 8
+#   interfaces down        : 131
+_CDP_ENABLED_COUNT_RE = re.compile(
+    r"^\s*cdp\s+enabled\s+interfaces\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_INTERFACES_UP_RE = re.compile(
+    r"^\s*interfaces\s+up\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_INTERFACES_DOWN_RE = re.compile(
+    r"^\s*interfaces\s+down\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+
+class CdpInterfaceEntry(TypedDict):
+    """Schema for a single 'show cdp interface' per-interface entry."""
+
+    status: str
+    line_protocol: str
+    encapsulation: NotRequired[str]
+    send_interval_seconds: NotRequired[int]
+    holdtime_seconds: NotRequired[int]
+
+
+class ShowCdpInterfaceResult(TypedDict):
+    """Schema for 'show cdp interface' parsed output."""
+
+    interfaces: dict[str, CdpInterfaceEntry]
+    cdp_enabled_interfaces: NotRequired[int]
+    interfaces_up: NotRequired[int]
+    interfaces_down: NotRequired[int]
+
+
+def _try_match_summary(line: str, result: dict[str, object]) -> bool:
+    """Attempt to match a summary-footer line and record it.
+
+    Returns True if the line matched any summary pattern.
+    """
+    match = _CDP_ENABLED_COUNT_RE.match(line)
+    if match:
+        result["cdp_enabled_interfaces"] = int(match.group("count"))
+        return True
+
+    match = _INTERFACES_UP_RE.match(line)
+    if match:
+        result["interfaces_up"] = int(match.group("count"))
+        return True
+
+    match = _INTERFACES_DOWN_RE.match(line)
+    if match:
+        result["interfaces_down"] = int(match.group("count"))
+        return True
+
+    return False
+
+
+def _try_match_attribute(line: str, entry: CdpInterfaceEntry) -> bool:
+    """Attempt to match an attribute line of the current interface block.
+
+    Updates ``entry`` in place. Returns True if the line was consumed.
+    """
+    match = _ENCAPSULATION_RE.match(line)
+    if match:
+        entry["encapsulation"] = match.group("encapsulation")
+        return True
+
+    match = _SEND_INTERVAL_RE.match(line)
+    if match:
+        entry["send_interval_seconds"] = int(match.group("interval"))
+        return True
+
+    match = _HOLDTIME_RE.match(line)
+    if match:
+        entry["holdtime_seconds"] = int(match.group("holdtime"))
+        return True
+
+    return False
+
+
+@register(OS.CISCO_IOS, "show cdp interface")
+class ShowCdpInterfaceParser(BaseParser[ShowCdpInterfaceResult]):
+    """Parser for 'show cdp interface' on Cisco IOS.
+
+    Output consists of a block per CDP-enabled interface followed by a
+    footer with aggregate counts. Each interface block looks like::
+
+        GigabitEthernet1/0/1 is up, line protocol is up
+          Encapsulation ARPA
+          Sending CDP packets every 60 seconds
+          Holdtime is 180 seconds
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.CDP, ParserTag.INTERFACES}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCdpInterfaceResult:
+        """Parse 'show cdp interface' output on Cisco IOS.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed result with interfaces keyed by canonical name and an
+            optional summary footer.
+
+        Raises:
+            ValueError: If no interface blocks are found in the output.
+        """
+        result: dict[str, object] = {}
+        interfaces: dict[str, CdpInterfaceEntry] = {}
+        current_entry: CdpInterfaceEntry | None = None
+
+        for raw_line in output.splitlines():
+            line = raw_line.rstrip()
+            if not line.strip():
+                continue
+
+            header_match = _INTERFACE_HEADER_RE.match(line)
+            if header_match:
+                interface_name = canonical_interface_name(
+                    header_match.group("interface"), os=OS.CISCO_IOS
+                )
+                current_entry = {
+                    "status": header_match.group("status"),
+                    "line_protocol": header_match.group("line_protocol"),
+                }
+                interfaces[interface_name] = current_entry
+                continue
+
+            if current_entry is not None and _try_match_attribute(line, current_entry):
+                continue
+
+            if _try_match_summary(line, result):
+                current_entry = None
+                continue
+
+        if not interfaces:
+            msg = "No CDP interface blocks found in output"
+            raise ValueError(msg)
+
+        result["interfaces"] = interfaces
+        return cast(ShowCdpInterfaceResult, result)

--- a/tests/parsers/ios/show_cdp_interface/001_basic/expected.json
+++ b/tests/parsers/ios/show_cdp_interface/001_basic/expected.json
@@ -1,0 +1,980 @@
+{
+    "cdp_enabled_interfaces": 139,
+    "interfaces_up": 8,
+    "interfaces_down": 131,
+    "interfaces": {
+        "FastEthernet0": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/1": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/2": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/3": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/4": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/5": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/6": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/7": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/8": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/9": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/10": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/11": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/12": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/13": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/14": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/15": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/16": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/17": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/18": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/19": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/20": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/21": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/22": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/23": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/24": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/25": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/26": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/27": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/28": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/29": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/30": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/31": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/32": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/33": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/34": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/35": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/36": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/37": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/38": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/39": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/40": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/41": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/42": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/43": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/44": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/45": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/46": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/47": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/0/48": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/1/1": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/1/2": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/1/3": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet1/1/4": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "TenGigabitEthernet1/1/1": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "TenGigabitEthernet1/1/2": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/1": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/2": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/3": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/4": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/5": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/6": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/7": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/8": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/9": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/10": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/11": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/12": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/13": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/14": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/15": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/16": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/17": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/18": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/19": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/20": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/21": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/22": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/23": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/24": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/25": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/26": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/27": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/28": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/29": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/30": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/31": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/32": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/33": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/34": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/35": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/36": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/37": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/38": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/39": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/40": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/41": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/42": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/43": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/44": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/45": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/46": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/47": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/0/48": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/1/1": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/1/2": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/1/3": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet2/1/4": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "TenGigabitEthernet2/1/1": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "TenGigabitEthernet2/1/2": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/1": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/2": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/3": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/4": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/5": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/6": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/7": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/8": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/9": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/10": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/11": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/12": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/13": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/14": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/15": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/16": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/17": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/18": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/19": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/20": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/21": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/22": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/23": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/0/24": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/1/1": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/1/2": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/1/3": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "GigabitEthernet3/1/4": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "TenGigabitEthernet3/1/1": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        },
+        "TenGigabitEthernet3/1/2": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 180
+        }
+    }
+}

--- a/tests/parsers/ios/show_cdp_interface/001_basic/input.txt
+++ b/tests/parsers/ios/show_cdp_interface/001_basic/input.txt
@@ -1,0 +1,560 @@
+FastEthernet0 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/1 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/2 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/3 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/4 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/5 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/6 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/7 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/8 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/9 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/10 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/11 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/12 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/13 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/14 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/15 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/16 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/17 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/18 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/19 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/20 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/21 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/22 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/23 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/24 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/25 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/26 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/27 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/28 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/29 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/30 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/31 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/32 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/33 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/34 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/35 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/36 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/37 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/38 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/39 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/40 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/41 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/42 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/43 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/44 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/45 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/46 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/47 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/0/48 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/1/1 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/1/2 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/1/3 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet1/1/4 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+TenGigabitEthernet1/1/1 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+TenGigabitEthernet1/1/2 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/1 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/2 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/3 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/4 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/5 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/6 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/7 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/8 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/9 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/10 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/11 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/12 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/13 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/14 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/15 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/16 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/17 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/18 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/19 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/20 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/21 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/22 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/23 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/24 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/25 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/26 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/27 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/28 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/29 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/30 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/31 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/32 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/33 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/34 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/35 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/36 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/37 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/38 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/39 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/40 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/41 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/42 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/43 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/44 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/45 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/46 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/47 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/0/48 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/1/1 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/1/2 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/1/3 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet2/1/4 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+TenGigabitEthernet2/1/1 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+TenGigabitEthernet2/1/2 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/1 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/2 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/3 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/4 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/5 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/6 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/7 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/8 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/9 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/10 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/11 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/12 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/13 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/14 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/15 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/16 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/17 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/18 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/19 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/20 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/21 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/22 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/23 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/0/24 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/1/1 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/1/2 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/1/3 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+GigabitEthernet3/1/4 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+TenGigabitEthernet3/1/1 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+TenGigabitEthernet3/1/2 is down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 180 seconds
+
+ cdp enabled interfaces : 139
+ interfaces up          : 8
+ interfaces down        : 131

--- a/tests/parsers/ios/show_cdp_interface/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_cdp_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: CDP interface listing from a 3-member Catalyst 3750-X stack with per-interface CDP timers and an aggregate summary footer
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds a Cisco IOS parser for `show cdp interface`. Output is keyed by canonical interface name and carries `status`, `line_protocol`, plus the per-interface CDP `encapsulation`, `send_interval_seconds`, and `holdtime_seconds` timers. The aggregate footer is exposed as top-level `cdp_enabled_interfaces`, `interfaces_up`, and `interfaces_down` counts.
- Fixture `001_basic` is the verbatim sample from the issue (a 3-member Catalyst 3750-X stack, IOS 15.x — 139 CDP-enabled interfaces, 8 up / 131 down). Parsed counts match the footer exactly.

Closes #1037

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_cdp_interface -v` (7 passed)
- [x] `uv run pytest` (8465 passed)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/ios/show_cdp_interface.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_cdp_interface.py`
- [x] `uv run pre-commit run --files ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)