### PR TITLE
feat(cisco_ios): add parser for `show interfaces status`

### DIFF
--- a/changes/1045.parser_added
+++ b/changes/1045.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show interfaces status` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_interfaces_status.py
+++ b/src/muninn/parsers/ios/show_interfaces_status.py
@@ -31,8 +31,10 @@ _STATUS_ALTERNATION = "|".join(_STATUS_TOKENS)
 _HEADER_RE = re.compile(r"^\s*Port\s+Name\s+Status\b")
 
 # Interface line: a token starting with an uppercase letter followed by
-# digits/slashes (Gi1/0/1, Te1/1/2, Po1, Fa0, Lo0, Vlan10, ...).
-_PORT_TOKEN_RE = re.compile(r"^(?P<port>[A-Z][A-Za-z]*\d[\w/.:-]*)\s")
+# digits/slashes (Gi1/0/1, Te1/1/2, Po1, Fa0, Lo0, Vlan10, ...).  Used only
+# for boolean `.match()` checks during wrap detection, so the port token
+# itself is captured non-greedily without naming.
+_PORT_TOKEN_RE = re.compile(r"^[A-Z][A-Za-z]*\d[\w/.:-]*\s")
 
 # Full data line with all five required columns (Port + optional Name +
 # Status, Vlan, Duplex, Speed) and an optional Type that may be empty

--- a/src/muninn/parsers/ios/show_interfaces_status.py
+++ b/src/muninn/parsers/ios/show_interfaces_status.py
@@ -1,0 +1,196 @@
+"""Parser for 'show interfaces status' command on IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+# Recognized status tokens from Cisco IOS 'show interfaces status' output.
+_STATUS_TOKENS = (
+    "connected",
+    "notconnect",
+    "disabled",
+    "err-disabled",
+    "errdisabled",
+    "inactive",
+    "monitoring",
+    "suspended",
+    "sfpAbsent",
+    "faulty",
+    "dormant",
+    "down",
+    "up",
+)
+_STATUS_ALTERNATION = "|".join(_STATUS_TOKENS)
+
+# Header line: starts with 'Port' followed by 'Name', 'Status', etc.
+_HEADER_RE = re.compile(r"^\s*Port\s+Name\s+Status\b")
+
+# Interface line: a token starting with an uppercase letter followed by
+# digits/slashes (Gi1/0/1, Te1/1/2, Po1, Fa0, Lo0, Vlan10, ...).
+_PORT_TOKEN_RE = re.compile(r"^(?P<port>[A-Z][A-Za-z]*\d[\w/.:-]*)\s")
+
+# Full data line with all five required columns (Port + optional Name +
+# Status, Vlan, Duplex, Speed) and an optional Type that may be empty
+# (terminal-wrapped) or contain spaces (e.g. "Not Present").
+_DATA_LINE_RE = re.compile(
+    r"^(?P<port>[A-Z][A-Za-z]*\d[\w/.:-]*)"
+    r"(?:\s{2,}(?P<name>\S.*?))?"
+    r"\s+(?P<status>" + _STATUS_ALTERNATION + r")"
+    r"\s+(?P<vlan>\S+)"
+    r"\s+(?P<duplex>\S+)"
+    r"\s+(?P<speed>\S+)"
+    r"(?:\s+(?P<type>\S.*?))?\s*$"
+)
+
+
+class InterfaceStatusEntry(TypedDict):
+    """Schema for a single interface status entry."""
+
+    status: str
+    duplex: str
+    speed: str
+    name: NotRequired[str]
+    vlan: NotRequired[str]
+    type: NotRequired[str]
+
+
+class ShowInterfacesStatusResult(TypedDict):
+    """Schema for 'show interfaces status' parsed output on IOS."""
+
+    interfaces: dict[str, InterfaceStatusEntry]
+
+
+def _is_continuation_line(line: str) -> bool:
+    """Return True if a line looks like a wrapped Type-column continuation.
+
+    Cisco IOS 'show interfaces status' wraps the Type column onto the next
+    line when the terminal width is exceeded. Continuation lines do not
+    begin with a port token and do not contain any status keyword.
+
+    Pre-commit strips trailing whitespace, so wrap detection cannot rely
+    on a trailing space on the prior line. We instead detect continuations
+    by structure: the line is non-empty, doesn't begin with an interface
+    port prefix, and is not a header line.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if _HEADER_RE.match(stripped):
+        return False
+    if _PORT_TOKEN_RE.match(stripped):
+        return False
+    return True
+
+
+def _join_wrapped_lines(text: str) -> list[str]:
+    """Join terminal-wrapped Type-column continuations back into one line.
+
+    A line is treated as a continuation of the previous one when it does
+    not start with a port token (see :func:`_is_continuation_line`).
+    """
+    lines = text.splitlines()
+    joined: list[str] = []
+    for line in lines:
+        if (
+            joined
+            and joined[-1].strip()
+            and _PORT_TOKEN_RE.match(joined[-1])
+            and _is_continuation_line(line)
+        ):
+            joined[-1] = joined[-1].rstrip() + " " + line.strip()
+        else:
+            joined.append(line)
+    return joined
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    """Strip and discard empty/placeholder field values."""
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned or cleaned in {"-", "--", "N/A", "n/a"}:
+        return None
+    return cleaned
+
+
+def _parse_data_line(line: str) -> tuple[str, InterfaceStatusEntry] | None:
+    """Parse a single (already wrap-joined) interface status line.
+
+    Returns ``None`` if the line is not a data row.
+    """
+    match = _DATA_LINE_RE.match(line)
+    if match is None:
+        return None
+
+    port = canonical_interface_name(match.group("port"), os=OS.CISCO_IOS)
+    name = _normalize_optional(match.group("name"))
+    status = match.group("status")
+    vlan = _normalize_optional(match.group("vlan"))
+    duplex = match.group("duplex")
+    speed = match.group("speed")
+    intf_type = _normalize_optional(match.group("type"))
+
+    entry: InterfaceStatusEntry = {
+        "status": status,
+        "duplex": duplex,
+        "speed": speed,
+    }
+    if name:
+        entry["name"] = name
+    if vlan:
+        entry["vlan"] = vlan
+    if intf_type:
+        entry["type"] = intf_type
+    return port, entry
+
+
+@register(OS.CISCO_IOS, "show interfaces status")
+class ShowInterfacesStatusParser(BaseParser[ShowInterfacesStatusResult]):
+    """Parser for 'show interfaces status' on IOS.
+
+    Parses the columnar status table emitted by Cisco IOS, returning a
+    mapping keyed by canonical interface name. Handles terminal-wrapped
+    Type-column continuations (long media descriptors like
+    ``10/100/1000BaseTX`` or ``SFP-10GBase-LR`` are commonly pushed onto
+    the following line by 80-column wrapping).
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesStatusResult:
+        """Parse 'show interfaces status' output.
+
+        Args:
+            output: Raw CLI output from the ``show interfaces status``
+                command.
+
+        Returns:
+            Parsed interface status data keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interface rows are present in the output.
+        """
+        interfaces: dict[str, InterfaceStatusEntry] = {}
+
+        for line in _join_wrapped_lines(output):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if _HEADER_RE.match(stripped):
+                continue
+            parsed = _parse_data_line(stripped)
+            if parsed is not None:
+                port, entry = parsed
+                interfaces[port] = entry
+
+        if not interfaces:
+            msg = "No interfaces found in 'show interfaces status' output"
+            raise ValueError(msg)
+
+        return cast(ShowInterfacesStatusResult, {"interfaces": interfaces})

--- a/tests/parsers/ios/show_interfaces_status/001_basic/expected.json
+++ b/tests/parsers/ios/show_interfaces_status/001_basic/expected.json
@@ -1,0 +1,985 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/1": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "vlan": "trunk",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/2": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "vlan": "21",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/5": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/6": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/7": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/8": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/9": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/10": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/11": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/12": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/13": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/14": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/15": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/16": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/17": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/18": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/19": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/20": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/21": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/22": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/23": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/24": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/25": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/26": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/27": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/28": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/29": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/30": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/31": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/32": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/33": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/34": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/35": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/36": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/37": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/38": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/39": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/40": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/41": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/42": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/43": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/44": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/45": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/46": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/47": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/48": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/1/1": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet1/1/2": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet1/1/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet1/1/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "TenGigabitEthernet1/1/1": {
+            "status": "connected",
+            "duplex": "full",
+            "speed": "10G",
+            "vlan": "21",
+            "type": "SFP-10GBase-CX1"
+        },
+        "TenGigabitEthernet1/1/2": {
+            "status": "connected",
+            "duplex": "full",
+            "speed": "10G",
+            "name": "***Link to Grassho",
+            "vlan": "21",
+            "type": "SFP-10GBase-LR"
+        },
+        "GigabitEthernet2/0/1": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "vlan": "trunk",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/2": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "vlan": "21",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/5": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/6": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/7": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/8": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/9": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/10": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/11": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/12": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/13": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/14": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/15": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/16": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/17": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/18": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/19": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/20": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/21": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/22": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/23": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/24": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/25": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/26": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/27": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/28": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/29": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/30": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/31": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/32": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/33": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/34": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/35": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/36": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/37": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/38": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/39": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/40": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/41": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/42": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/43": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/44": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/45": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/46": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/47": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/0/48": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet2/1/1": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet2/1/2": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet2/1/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet2/1/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "TenGigabitEthernet2/1/1": {
+            "status": "connected",
+            "duplex": "full",
+            "speed": "10G",
+            "vlan": "21",
+            "type": "SFP-10GBase-CX1"
+        },
+        "TenGigabitEthernet2/1/2": {
+            "status": "connected",
+            "duplex": "full",
+            "speed": "10G",
+            "name": "***Link to Grassho",
+            "vlan": "21",
+            "type": "SFP-10GBase-LR"
+        },
+        "GigabitEthernet3/0/1": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/2": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/5": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/6": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/7": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/8": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/9": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/10": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/11": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/12": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/13": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/14": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/15": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/16": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/17": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/18": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/19": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/20": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/21": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/22": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/23": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/0/24": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet3/1/1": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet3/1/2": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet3/1/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "GigabitEthernet3/1/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "Not Present"
+        },
+        "Port-channel1": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "name": "**Link to Vlan21 i",
+            "vlan": "trunk"
+        },
+        "Port-channel10": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "vlan": "21"
+        },
+        "Port-channel17": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "10G",
+            "name": "***Link to Grassho",
+            "vlan": "21"
+        },
+        "FastEthernet0": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "routed",
+            "type": "10/100BaseTX"
+        }
+    }
+}

--- a/tests/parsers/ios/show_interfaces_status/001_basic/input.txt
+++ b/tests/parsers/ios/show_interfaces_status/001_basic/input.txt
@@ -1,0 +1,265 @@
+Port      Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/1                      connected    trunk      a-full a-1000
+10/100/1000BaseTX
+Gi1/0/2                      connected    21         a-full a-1000
+10/100/1000BaseTX
+Gi1/0/3                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/4                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/5                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/6                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/7                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/8                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/9                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/10                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/11                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/12                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/13                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/14                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/15                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/16                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/17                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/18                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/19                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/20                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/21                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/22                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/23                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/24                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/25                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/26                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/27                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/28                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/29                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/30                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/31                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/32                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/33                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/34                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/35                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/36                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/37                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/38                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/39                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/40                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/41                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/42                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/43                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/44                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/45                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/46                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/47                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/48                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/1/1                      notconnect   1            auto   auto Not Present
+Gi1/1/2                      notconnect   1            auto   auto Not Present
+Gi1/1/3                      notconnect   1            auto   auto Not Present
+Gi1/1/4                      notconnect   1            auto   auto Not Present
+Te1/1/1                      connected    21           full    10G
+SFP-10GBase-CX1
+Te1/1/2   ***Link to Grassho connected    21           full    10G
+SFP-10GBase-LR
+Gi2/0/1                      connected    trunk      a-full a-1000
+10/100/1000BaseTX
+Gi2/0/2                      connected    21         a-full a-1000
+10/100/1000BaseTX
+Gi2/0/3                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/4                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/5                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/6                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/7                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/8                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/9                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/10                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/11                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/12                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/13                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/14                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/15                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/16                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/17                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/18                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/19                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/20                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/21                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/22                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/23                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/24                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/25                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/26                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/27                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/28                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/29                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/30                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/31                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/32                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/33                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/34                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/35                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/36                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/37                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/38                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/39                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/40                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/41                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/42                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/43                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/44                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/45                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/46                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/47                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/0/48                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi2/1/1                      notconnect   1            auto   auto Not Present
+Gi2/1/2                      notconnect   1            auto   auto Not Present
+Gi2/1/3                      notconnect   1            auto   auto Not Present
+Gi2/1/4                      notconnect   1            auto   auto Not Present
+Te2/1/1                      connected    21           full    10G
+SFP-10GBase-CX1
+Te2/1/2   ***Link to Grassho connected    21           full    10G
+SFP-10GBase-LR
+Gi3/0/1                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/2                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/3                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/4                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/5                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/6                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/7                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/8                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/9                      notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/10                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/11                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/12                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/13                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/14                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/15                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/16                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/17                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/18                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/19                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/20                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/21                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/22                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/23                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/0/24                     notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi3/1/1                      notconnect   1            auto   auto Not Present
+Gi3/1/2                      notconnect   1            auto   auto Not Present
+Gi3/1/3                      notconnect   1            auto   auto Not Present
+Gi3/1/4                      notconnect   1            auto   auto Not Present
+Po1       **Link to Vlan21 i connected    trunk      a-full a-1000
+Po10                         connected    21         a-full a-1000
+Po17      ***Link to Grassho connected    21         a-full    10G
+Fa0                          notconnect   routed       auto   auto 10/100BaseTX

--- a/tests/parsers/ios/show_interfaces_status/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_interfaces_status/001_basic/metadata.yaml
@@ -1,0 +1,9 @@
+description: >-
+  Basic 'show interfaces status' output from a Catalyst 3750-X stack with
+  GigabitEthernet, TenGigabitEthernet, Port-channel, and FastEthernet
+  interfaces. Exercises connected/notconnect statuses, terminal-wrapped Type
+  values (10/100/1000BaseTX, SFP-10GBase-CX1, SFP-10GBase-LR), the special
+  'Not Present' Type value, the 'routed' vlan value, trunk vlan, truncated
+  description text, and port-channel rows without a Type column.
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- New parser for `show interfaces status` on Cisco IOS, returning `dict[str, InterfaceStatusEntry]` keyed by canonical interface name with `status`, `duplex`, `speed` (Required) and `name`, `vlan`, `type` (NotRequired). Schema mirrors the existing Arista EOS sibling.
- Handles the IOS-specific 80-column wrap of the Type column (long media descriptors like `10/100/1000BaseTX` and `SFP-10GBase-LR` are pushed onto the following line) by joining continuation lines structurally, since pre-commit strips the trailing-space wrap signal.
- Fixture captured from a Catalyst 3750-X stack (IOS 15.x) per the issue body — 140 interfaces covering connected/notconnect, trunk/access/routed vlans, terminal-wrapped Type values, the special `Not Present` Type, port-channels without a Type column, and a FastEthernet0 row.

Closes #1045

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_interfaces_status -v` (21 passed)
- [x] `uv run pytest` (8465 passed)
- [x] `uv run ruff check src/muninn/parsers/ios/show_interfaces_status.py`
- [x] `uv run ruff format src/muninn/parsers/ios/show_interfaces_status.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_interfaces_status.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_interfaces_status.py`
- [x] All pre-commit hooks pass

## Notes
- Self-review via `review-new-parser-pr` flagged one Concern (no fix required): the fixture's Name column contains device-truncated descriptions (`***Link to Grassho`, `**Link to Vlan21 i`). These are authentic IOS column-width truncations preserved verbatim from the issue sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)