### PR TITLE
feat(cisco_ios): add parser for `show crypto key mypubkey rsa`

### DIFF
--- a/changes/1039.parser_added
+++ b/changes/1039.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto key mypubkey rsa` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_crypto_key_mypubkey_rsa.py
+++ b/src/muninn/parsers/ios/show_crypto_key_mypubkey_rsa.py
@@ -1,0 +1,203 @@
+"""Parser for 'show crypto key mypubkey rsa' command on IOS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class RsaKeyEntry(TypedDict):
+    """Schema for a single public RSA key entry."""
+
+    key_name: str
+    key_type: str
+    generated_at: str
+    usage: str
+    exportable: bool
+    key_data: str
+    storage_device: NotRequired[str]
+    temporary: NotRequired[bool]
+    redundancy_enabled: NotRequired[bool]
+
+
+class ShowCryptoKeyMypubkeyRsaResult(TypedDict):
+    """Schema for 'show crypto key mypubkey rsa' parsed output.
+
+    Keyed by key name (e.g. ``TP-self-signed-2189069696``).
+    """
+
+    keys: dict[str, RsaKeyEntry]
+
+
+# --- Regex patterns ---
+
+# Start of a new key block:
+# "% Key pair was generated at: 01:29:31 UTC Mar 30 2011"
+_GENERATED_AT_RE = re.compile(
+    r"^%\s+Key pair was generated at:\s+(?P<generated_at>.+?)\s*$"
+)
+
+# Key name line: "Key name: TP-self-signed-2189069696"
+_KEY_NAME_RE = re.compile(r"^Key name:\s+(?P<key_name>.+?)\s*$")
+
+# Key type line: "Key type: RSA KEYS"
+_KEY_TYPE_RE = re.compile(r"^Key type:\s+(?P<key_type>.+?)\s*$")
+
+# Temporary marker: "Temporary key"
+_TEMPORARY_RE = re.compile(r"^Temporary key\s*$")
+
+# Storage device: " Storage Device: private-config"
+_STORAGE_RE = re.compile(r"^\s+Storage Device:\s+(?P<storage>.+?)\s*$")
+
+# Usage: " Usage: General Purpose Key"
+_USAGE_RE = re.compile(r"^\s+Usage:\s+(?P<usage>.+?)\s*$")
+
+# Exportable / redundancy combined line:
+# " Key is not exportable. Redundancy enabled."
+# " Key is exportable."
+_EXPORTABLE_RE = re.compile(
+    r"^\s+Key is (?P<negation>not )?exportable\."
+    r"(?:\s+Redundancy (?P<redundancy>enabled|disabled)\.)?\s*$"
+)
+
+# Key Data section header: " Key Data:"
+_KEY_DATA_HEADER_RE = re.compile(r"^\s+Key Data:\s*$")
+
+
+def _finalize_entry(entry: dict, key_data_lines: list[str]) -> RsaKeyEntry:
+    """Attach collected key data to an entry and cast to RsaKeyEntry."""
+    entry["key_data"] = "\n".join(key_data_lines).strip()
+    return cast(RsaKeyEntry, entry)
+
+
+def _is_block_start(line: str) -> bool:
+    """Return True if the line starts a new key block."""
+    return bool(_GENERATED_AT_RE.match(line))
+
+
+def _parse_block_line(line: str, entry: dict) -> bool:
+    """Apply a header/metadata regex to a non-key-data line.
+
+    Returns True if the line was consumed by a metadata regex (so the caller
+    should not append it to the key-data buffer).
+    """
+    if match := _GENERATED_AT_RE.match(line):
+        entry["generated_at"] = match.group("generated_at")
+        return True
+    if match := _KEY_NAME_RE.match(line):
+        entry["key_name"] = match.group("key_name")
+        return True
+    if match := _KEY_TYPE_RE.match(line):
+        entry["key_type"] = match.group("key_type")
+        return True
+    if _TEMPORARY_RE.match(line):
+        entry["temporary"] = True
+        return True
+    if match := _STORAGE_RE.match(line):
+        entry["storage_device"] = match.group("storage")
+        return True
+    if match := _USAGE_RE.match(line):
+        entry["usage"] = match.group("usage")
+        return True
+    if match := _EXPORTABLE_RE.match(line):
+        entry["exportable"] = match.group("negation") is None
+        redundancy = match.group("redundancy")
+        if redundancy is not None:
+            entry["redundancy_enabled"] = redundancy == "enabled"
+        return True
+    return False
+
+
+def _split_key_blocks(output: str) -> list[list[str]]:
+    """Split raw output into per-key blocks delimited by ``% Key pair`` lines."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for raw_line in output.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            continue
+        if _is_block_start(line):
+            if current:
+                blocks.append(current)
+            current = [line]
+        elif current:
+            current.append(line)
+    if current:
+        blocks.append(current)
+    return blocks
+
+
+_REQUIRED_FIELDS: tuple[str, ...] = (
+    "key_name",
+    "key_type",
+    "generated_at",
+    "usage",
+    "exportable",
+)
+
+
+def _parse_key_block(block_lines: list[str]) -> RsaKeyEntry | None:
+    """Parse a single key block into an :class:`RsaKeyEntry`.
+
+    Returns ``None`` if the block lacks the required ``Key name`` line (a
+    safety net for partial buffers; a block without a name cannot be keyed).
+
+    Raises:
+        ValueError: If a named key block is missing any other required field.
+    """
+    entry: dict = {}
+    in_key_data = False
+    key_data_lines: list[str] = []
+    for line in block_lines:
+        if _KEY_DATA_HEADER_RE.match(line):
+            in_key_data = True
+            continue
+        if in_key_data:
+            key_data_lines.append(line.strip())
+            continue
+        _parse_block_line(line, entry)
+    if "key_name" not in entry:
+        return None
+    missing = [field for field in _REQUIRED_FIELDS if field not in entry]
+    if missing:
+        msg = (
+            f"Key block for {entry['key_name']!r} is missing required fields: {missing}"
+        )
+        raise ValueError(msg)
+    return _finalize_entry(entry, key_data_lines)
+
+
+@register(OS.CISCO_IOS, "show crypto key mypubkey rsa")
+class ShowCryptoKeyMypubkeyRsaParser(BaseParser[ShowCryptoKeyMypubkeyRsaResult]):
+    """Parser for 'show crypto key mypubkey rsa' on IOS."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoKeyMypubkeyRsaResult:
+        """Parse 'show crypto key mypubkey rsa' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed public RSA key entries keyed by key name.
+
+        Raises:
+            ValueError: If no public RSA key entries are found in the output.
+        """
+        keys: dict[str, RsaKeyEntry] = {}
+        for block_lines in _split_key_blocks(output):
+            entry = _parse_key_block(block_lines)
+            if entry is None:
+                continue
+            keys[entry["key_name"]] = entry
+
+        if not keys:
+            msg = "No public RSA key entries found in output."
+            raise ValueError(msg)
+
+        return cast(ShowCryptoKeyMypubkeyRsaResult, {"keys": keys})

--- a/src/muninn/parsers/ios/show_crypto_key_mypubkey_rsa.py
+++ b/src/muninn/parsers/ios/show_crypto_key_mypubkey_rsa.py
@@ -17,7 +17,7 @@ class RsaKeyEntry(TypedDict):
     generated_at: str
     usage: str
     exportable: bool
-    key_data: str
+    key_data: NotRequired[str]
     storage_device: NotRequired[str]
     temporary: NotRequired[bool]
     redundancy_enabled: NotRequired[bool]
@@ -68,8 +68,15 @@ _KEY_DATA_HEADER_RE = re.compile(r"^\s+Key Data:\s*$")
 
 
 def _finalize_entry(entry: dict, key_data_lines: list[str]) -> RsaKeyEntry:
-    """Attach collected key data to an entry and cast to RsaKeyEntry."""
-    entry["key_data"] = "\n".join(key_data_lines).strip()
+    """Attach collected key data to an entry and cast to RsaKeyEntry.
+
+    ``key_data`` is only written when the device actually emitted key bytes;
+    omitting the field keeps the output free of empty-string placeholders
+    when a ``Key Data:`` section is absent or empty.
+    """
+    key_data = "\n".join(key_data_lines).strip()
+    if key_data:
+        entry["key_data"] = key_data
     return cast(RsaKeyEntry, entry)
 
 

--- a/tests/parsers/ios/show_crypto_key_mypubkey_rsa/001_basic/expected.json
+++ b/tests/parsers/ios/show_crypto_key_mypubkey_rsa/001_basic/expected.json
@@ -1,0 +1,43 @@
+{
+    "keys": {
+        "TP-self-signed-2189069696": {
+            "generated_at": "01:29:31 UTC Mar 30 2011",
+            "key_name": "TP-self-signed-2189069696",
+            "key_type": "RSA KEYS",
+            "storage_device": "private-config",
+            "usage": "General Purpose Key",
+            "exportable": false,
+            "redundancy_enabled": true,
+            "key_data": "<KEY DATA REDACTED>"
+        },
+        "TP-self-signed-2188743936": {
+            "generated_at": "01:31:53 UTC Mar 30 2011",
+            "key_name": "TP-self-signed-2188743936",
+            "key_type": "RSA KEYS",
+            "storage_device": "private-config",
+            "usage": "General Purpose Key",
+            "exportable": false,
+            "redundancy_enabled": true,
+            "key_data": "<KEY DATA REDACTED>"
+        },
+        "IOS-SW1.example.com": {
+            "generated_at": "02:26:28 UTC Jan 2 2006",
+            "key_name": "IOS-SW1.example.com",
+            "key_type": "RSA KEYS",
+            "storage_device": "private-config",
+            "usage": "General Purpose Key",
+            "exportable": false,
+            "redundancy_enabled": true,
+            "key_data": "<KEY DATA REDACTED>"
+        },
+        "TP-self-signed-2189069696.server": {
+            "generated_at": "00:03:32 UTC Jan 2 2006",
+            "key_name": "TP-self-signed-2189069696.server",
+            "key_type": "RSA KEYS",
+            "temporary": true,
+            "usage": "Encryption Key",
+            "exportable": false,
+            "key_data": "<KEY DATA REDACTED>"
+        }
+    }
+}

--- a/tests/parsers/ios/show_crypto_key_mypubkey_rsa/001_basic/input.txt
+++ b/tests/parsers/ios/show_crypto_key_mypubkey_rsa/001_basic/input.txt
@@ -1,0 +1,32 @@
+% Key pair was generated at: 01:29:31 UTC Mar 30 2011
+Key name: TP-self-signed-2189069696
+Key type: RSA KEYS
+ Storage Device: private-config
+ Usage: General Purpose Key
+ Key is not exportable. Redundancy enabled.
+ Key Data:
+  <KEY DATA REDACTED>
+% Key pair was generated at: 01:31:53 UTC Mar 30 2011
+Key name: TP-self-signed-2188743936
+Key type: RSA KEYS
+ Storage Device: private-config
+ Usage: General Purpose Key
+ Key is not exportable. Redundancy enabled.
+ Key Data:
+  <KEY DATA REDACTED>
+% Key pair was generated at: 02:26:28 UTC Jan 2 2006
+Key name: IOS-SW1.example.com
+Key type: RSA KEYS
+ Storage Device: private-config
+ Usage: General Purpose Key
+ Key is not exportable. Redundancy enabled.
+ Key Data:
+  <KEY DATA REDACTED>
+% Key pair was generated at: 00:03:32 UTC Jan 2 2006
+Key name: TP-self-signed-2189069696.server
+Key type: RSA KEYS
+Temporary key
+ Usage: Encryption Key
+ Key is not exportable.
+ Key Data:
+  <KEY DATA REDACTED>

--- a/tests/parsers/ios/show_crypto_key_mypubkey_rsa/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_crypto_key_mypubkey_rsa/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Public RSA keys including self-signed and temporary keys
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto key mypubkey rsa` on Cisco IOS, exposing each public RSA key as a `dict[str, RsaKeyEntry]` keyed by key name with `generated_at`, `key_type`, `usage`, `exportable`, `storage_device`, `temporary`, `redundancy_enabled`, and the raw `key_data` blob.
- Fixture sourced verbatim from the issue's IOS-SW1 capture (Catalyst 3750-X, IOS 15.x) covering self-signed keys, an identity key, and a temporary/server key block; key material itself is redacted in the source.

Closes #1039

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_key_mypubkey_rsa -v` (7 passed)
- [x] `uv run pytest` (8517 passed)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/ios/show_crypto_key_mypubkey_rsa.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_crypto_key_mypubkey_rsa.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)