### PR TITLE
feat(cisco_ios): add parser for `show boot`

### DIFF
--- a/changes/1035.parser_added
+++ b/changes/1035.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show boot` on Cisco IOS.

--- a/src/muninn/parsers/iosxe/show_boot.py
+++ b/src/muninn/parsers/iosxe/show_boot.py
@@ -357,6 +357,7 @@ def _process_line(
     return current_key, is_path_list
 
 
+@register(OS.CISCO_IOS, "show boot")
 @register(OS.CISCO_IOSXE, "show boot")
 class ShowBootParser(BaseParser[ShowBootResult]):
     """Parser for 'show boot' command.

--- a/tests/parsers/ios/show_boot/001_basic/expected.json
+++ b/tests/parsers/ios/show_boot/001_basic/expected.json
@@ -1,0 +1,34 @@
+{
+    "switches": {
+        "active": {
+            "boot_path_list": "flash:c3750e-universalk9-mz.152-4.E7.bin",
+            "config_file": "flash:/config.text",
+            "private_config_file": "flash:/private-config.text",
+            "enable_break": true,
+            "manual_boot": false,
+            "allow_dev_key": true,
+            "auto_upgrade": true,
+            "nvram_buffer_size": 524288,
+            "config_download_timeout": 0,
+            "config_download_via_dhcp": "disabled (next boot: disabled)"
+        },
+        "1": {
+            "boot_path_list": "flash:c3750e-universalk9-mz.152-4.E7.bin",
+            "config_file": "flash:/config.text",
+            "private_config_file": "flash:/private-config.text",
+            "enable_break": true,
+            "manual_boot": false,
+            "allow_dev_key": true,
+            "auto_upgrade": false
+        },
+        "3": {
+            "boot_path_list": "flash:c3750e-universalk9-mz.152-4.E7.bin",
+            "config_file": "flash:/config.text",
+            "private_config_file": "flash:/private-config.text",
+            "enable_break": true,
+            "manual_boot": false,
+            "allow_dev_key": true,
+            "auto_upgrade": false
+        }
+    }
+}

--- a/tests/parsers/ios/show_boot/001_basic/input.txt
+++ b/tests/parsers/ios/show_boot/001_basic/input.txt
@@ -1,0 +1,39 @@
+BOOT path-list      : flash:c3750e-universalk9-mz.152-4.E7.bin
+Config file         : flash:/config.text
+Private Config file : flash:/private-config.text
+Enable Break        : yes
+Manual Boot         : no
+Allow Dev Key         : yes
+HELPER path-list    :
+Auto upgrade        : yes
+Auto upgrade path   :
+NVRAM/Config file
+      buffer size:   524288
+Timeout for Config
+          Download:    0 seconds
+Config Download
+       via DHCP:       disabled (next boot: disabled)
+-------------------
+Switch 1
+-------------------
+BOOT path-list      : flash:c3750e-universalk9-mz.152-4.E7.bin
+Config file         : flash:/config.text
+Private Config file : flash:/private-config.text
+Enable Break        : yes
+Manual Boot         : no
+Allow Dev Key         : yes
+HELPER path-list    :
+Auto upgrade        : no
+Auto upgrade path   :
+-------------------
+Switch 3
+-------------------
+BOOT path-list      : flash:c3750e-universalk9-mz.152-4.E7.bin
+Config file         : flash:/config.text
+Private Config file : flash:/private-config.text
+Enable Break        : yes
+Manual Boot         : no
+Allow Dev Key         : yes
+HELPER path-list    :
+Auto upgrade        : no
+Auto upgrade path   :

--- a/tests/parsers/ios/show_boot/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_boot/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Path-list format on Catalyst 3750-X stack with two member switch sections
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x


### PR DESCRIPTION
## Summary
- Adds Cisco IOS support for `show boot` by stacking `@register(OS.CISCO_IOS, "show boot")` onto the existing IOS-XE `ShowBootParser`. The IOS path-list format (Catalyst 3750-X stack with per-switch sections) is structurally identical to the IOS-XE path-list format already handled, so the same parser, schema, and helpers cover both platforms.
- Includes one fixture (`tests/parsers/ios/show_boot/001_basic/`) captured verbatim from the issue sample (Catalyst 3750-X stack, IOS 15.x). Output is keyed by switch identifier: `"active"` for the standalone/global section and `"1"`, `"3"` for the stack member sections.

Closes #1035

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_boot" -v` (63 passing)
- [x] `uv run pytest -q` (8621 passing)
- [x] `uv run ruff check src/muninn/parsers/iosxe/show_boot.py`
- [x] `uv run ruff format src/muninn/parsers/iosxe/show_boot.py`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_boot.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_boot.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)