### PR TITLE
feat(cisco_iosxe): add parser for `show controllers ethernet-controller`

### DIFF
--- a/changes/1028.parser_added
+++ b/changes/1028.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show controllers ethernet-controller` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_controllers_ethernet_controller.py
+++ b/src/muninn/parsers/iosxe/show_controllers_ethernet_controller.py
@@ -1,0 +1,169 @@
+"""Parser for 'show controllers ethernet-controller' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class ControllerEthernetCounterEntry(TypedDict):
+    """Numeric counter under a label key."""
+
+    value: str
+
+
+class ControllerEthernetStatistics(TypedDict):
+    """Per-column counters keyed by CLI label.
+
+    Labels are unique keys; if the device repeats a label in the same column,
+    later keys are suffixed `` (2)``, `` (3)``, ...
+    """
+
+    transmit: dict[str, ControllerEthernetCounterEntry]
+    receive: dict[str, ControllerEthernetCounterEntry]
+
+
+class ControllerEthernetInterfaceEntry(TypedDict):
+    """Per-interface entry from 'show controllers ethernet-controller'."""
+
+    statistics: ControllerEthernetStatistics
+    last_update: NotRequired[str]
+
+
+# Top-level schema is a mapping of canonical interface name to entry.
+ShowControllersEthernetControllerResult = dict[str, ControllerEthernetInterfaceEntry]
+
+
+# Header line identifying each interface block:
+#   Transmit                  GigabitEthernet1/0/1          Receive
+_IF_RE = re.compile(r"^Transmit\s+(?P<interface>\S+)\s+Receive\s*$", re.IGNORECASE)
+
+# Footer line for each interface block:
+#   LAST UPDATE 5392 msecs AGO
+_LAST_RE = re.compile(r"^LAST UPDATE\s+(?P<value>.+)$", re.IGNORECASE)
+
+# Two-column counter row: "<num> <label>  <num> <label>". Labels may contain
+# single spaces (e.g. "Total bytes", "65 to 127 byte frames"). The two
+# columns are separated by two or more spaces.
+_STAT_ROW_FULL_RE = re.compile(
+    r"^\s*(?P<tx_value>\d+)\s+(?P<tx_label>.+?)"
+    r"\s{2,}(?P<rx_value>\d+)\s+(?P<rx_label>.+)$"
+)
+
+# Transmit-only continuation row (e.g. per-collision-count counters).
+_STAT_ROW_TX_ONLY_RE = re.compile(r"^\s*(?P<tx_value>\d+)\s+(?P<tx_label>.+)$")
+
+
+def _unique_label_key(d: dict[str, ControllerEthernetCounterEntry], label: str) -> str:
+    """Return a key not already present in ``d`` (suffix duplicate labels)."""
+    if label not in d:
+        return label
+    n = 2
+    while f"{label} ({n})" in d:
+        n += 1
+    return f"{label} ({n})"
+
+
+def _new_block() -> ControllerEthernetInterfaceEntry:
+    """Return a fresh per-interface entry with empty statistics."""
+    return ControllerEthernetInterfaceEntry(
+        statistics=ControllerEthernetStatistics(transmit={}, receive={}),
+    )
+
+
+def _handle_full_row(
+    match: re.Match[str], entry: ControllerEthernetInterfaceEntry
+) -> None:
+    """Apply a two-column counter row to ``entry``."""
+    tx_label = match.group("tx_label").strip()
+    rx_label = match.group("rx_label").strip()
+    transmit = entry["statistics"]["transmit"]
+    receive = entry["statistics"]["receive"]
+    tx_key = _unique_label_key(transmit, tx_label)
+    rx_key = _unique_label_key(receive, rx_label)
+    transmit[tx_key] = ControllerEthernetCounterEntry(value=match.group("tx_value"))
+    receive[rx_key] = ControllerEthernetCounterEntry(value=match.group("rx_value"))
+
+
+def _handle_tx_only_row(
+    match: re.Match[str], entry: ControllerEthernetInterfaceEntry
+) -> None:
+    """Apply a transmit-only continuation row to ``entry``."""
+    tx_label = match.group("tx_label").strip()
+    transmit = entry["statistics"]["transmit"]
+    tx_key = _unique_label_key(transmit, tx_label)
+    transmit[tx_key] = ControllerEthernetCounterEntry(value=match.group("tx_value"))
+
+
+@register(OS.CISCO_IOSXE, "show controllers ethernet-controller")
+class ShowControllersEthernetControllerParser(
+    BaseParser[ShowControllersEthernetControllerResult]
+):
+    """Parser for 'show controllers ethernet-controller' on IOS-XE.
+
+    The command emits one block per physical Ethernet interface. Each block
+    starts with a header line identifying the interface (e.g.
+    ``Transmit  GigabitEthernet1/0/1  Receive``) and ends with an optional
+    ``LAST UPDATE`` footer.
+
+    The parsed output is keyed by canonical interface name. Each entry
+    contains a ``statistics`` sub-dict with ``transmit`` and ``receive``
+    columns, where counter labels (as printed by the device) are dict keys
+    and values are stringified integers.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowControllersEthernetControllerResult:
+        """Parse 'show controllers ethernet-controller' output."""
+        result: dict[str, ControllerEthernetInterfaceEntry] = {}
+        current_key: str | None = None
+
+        for raw_line in output.splitlines():
+            line = raw_line.rstrip()
+            if not line.strip():
+                continue
+
+            if_match = _IF_RE.match(line.strip())
+            if if_match:
+                interface = canonical_interface_name(
+                    if_match.group("interface"), os=OS.CISCO_IOSXE
+                )
+                result[interface] = _new_block()
+                current_key = interface
+                continue
+
+            if current_key is None:
+                # Skip any preamble before the first interface header.
+                continue
+
+            entry = result[current_key]
+
+            last_match = _LAST_RE.match(line.strip())
+            if last_match:
+                entry["last_update"] = last_match.group("value").strip()
+                continue
+
+            full_match = _STAT_ROW_FULL_RE.match(line)
+            if full_match:
+                _handle_full_row(full_match, entry)
+                continue
+
+            tx_only_match = _STAT_ROW_TX_ONLY_RE.match(line)
+            if tx_only_match:
+                _handle_tx_only_row(tx_only_match, entry)
+                continue
+
+        if not result:
+            msg = (
+                "No interface blocks found in 'show controllers "
+                "ethernet-controller' output"
+            )
+            raise ValueError(msg)
+
+        return cast(ShowControllersEthernetControllerResult, result)

--- a/tests/parsers/iosxe/show_controllers_ethernet-controller/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_controllers_ethernet-controller/001_basic/expected.json
@@ -1,0 +1,688 @@
+{
+    "GigabitEthernet1/0/1": {
+        "statistics": {
+            "transmit": {
+                "Total bytes": {
+                    "value": "97618691"
+                },
+                "Unicast frames": {
+                    "value": "363747"
+                },
+                "Unicast bytes": {
+                    "value": "26187775"
+                },
+                "Multicast frames": {
+                    "value": "453372"
+                },
+                "Multicast bytes": {
+                    "value": "70982682"
+                },
+                "Broadcast frames": {
+                    "value": "4173"
+                },
+                "Broadcast bytes": {
+                    "value": "448234"
+                },
+                "System FCS error frames": {
+                    "value": "0"
+                },
+                "MacUnderrun frames": {
+                    "value": "0"
+                },
+                "Pause frames": {
+                    "value": "0"
+                },
+                "Cos 0 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 1 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 2 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 3 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 4 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 5 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 6 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 7 Pause frames": {
+                    "value": "0"
+                },
+                "Oam frames": {
+                    "value": "0"
+                },
+                "Oam frames (2)": {
+                    "value": "0"
+                },
+                "Minimum size frames": {
+                    "value": "1806"
+                },
+                "65 to 127 byte frames": {
+                    "value": "756164"
+                },
+                "128 to 255 byte frames": {
+                    "value": "112"
+                },
+                "256 to 511 byte frames": {
+                    "value": "63210"
+                },
+                "512 to 1023 byte frames": {
+                    "value": "0"
+                },
+                "1024 to 1518 byte frames": {
+                    "value": "0"
+                },
+                "1519 to 2047 byte frames": {
+                    "value": "0"
+                },
+                "2048 to 4095 byte frames": {
+                    "value": "0"
+                },
+                "4096 to 8191 byte frames": {
+                    "value": "0"
+                },
+                "8192 to 16383 byte frames": {
+                    "value": "0"
+                },
+                "16384 to 32767 byte frame": {
+                    "value": "0"
+                },
+                "> 32768 byte frames": {
+                    "value": "0"
+                },
+                "Late collision frames": {
+                    "value": "0"
+                },
+                "Excess Defer frames": {
+                    "value": "0"
+                },
+                "Good (1 coll) frames": {
+                    "value": "0"
+                },
+                "Good (>1 coll) frames": {
+                    "value": "0"
+                },
+                "Deferred frames": {
+                    "value": "0"
+                },
+                "Gold frames dropped": {
+                    "value": "0"
+                },
+                "Gold frames truncated": {
+                    "value": "0"
+                },
+                "Gold frames successful": {
+                    "value": "0"
+                },
+                "1 collision frames": {
+                    "value": "0"
+                },
+                "2 collision frames": {
+                    "value": "0"
+                },
+                "3 collision frames": {
+                    "value": "0"
+                },
+                "4 collision frames": {
+                    "value": "0"
+                },
+                "5 collision frames": {
+                    "value": "0"
+                },
+                "6 collision frames": {
+                    "value": "0"
+                },
+                "7 collision frames": {
+                    "value": "0"
+                },
+                "8 collision frames": {
+                    "value": "0"
+                },
+                "9 collision frames": {
+                    "value": "0"
+                },
+                "10 collision frames": {
+                    "value": "0"
+                },
+                "11 collision frames": {
+                    "value": "0"
+                },
+                "12 collision frames": {
+                    "value": "0"
+                },
+                "13 collision frames": {
+                    "value": "0"
+                },
+                "14 collision frames": {
+                    "value": "0"
+                },
+                "15 collision frames": {
+                    "value": "0"
+                },
+                "Excess collision frames": {
+                    "value": "0"
+                }
+            },
+            "receive": {
+                "Total bytes": {
+                    "value": "97559269"
+                },
+                "Unicast frames": {
+                    "value": "363756"
+                },
+                "Unicast bytes": {
+                    "value": "25970978"
+                },
+                "Multicast frames": {
+                    "value": "452232"
+                },
+                "Multicast bytes": {
+                    "value": "71141479"
+                },
+                "Broadcast frames": {
+                    "value": "4159"
+                },
+                "Broadcast bytes": {
+                    "value": "446812"
+                },
+                "IpgViolation frames": {
+                    "value": "0"
+                },
+                "MacOverrun frames": {
+                    "value": "0"
+                },
+                "Pause frames": {
+                    "value": "0"
+                },
+                "Cos 0 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 1 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 2 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 3 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 4 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 5 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 6 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 7 Pause frames": {
+                    "value": "0"
+                },
+                "OamProcessed frames": {
+                    "value": "0"
+                },
+                "OamDropped frames": {
+                    "value": "0"
+                },
+                "Minimum size frames": {
+                    "value": "54700"
+                },
+                "65 to 127 byte frames": {
+                    "value": "700624"
+                },
+                "128 to 255 byte frames": {
+                    "value": "1596"
+                },
+                "256 to 511 byte frames": {
+                    "value": "63227"
+                },
+                "512 to 1023 byte frames": {
+                    "value": "0"
+                },
+                "1024 to 1518 byte frames": {
+                    "value": "0"
+                },
+                "1519 to 2047 byte frames": {
+                    "value": "0"
+                },
+                "2048 to 4095 byte frames": {
+                    "value": "0"
+                },
+                "4096 to 8191 byte frames": {
+                    "value": "0"
+                },
+                "8192 to 16383 byte frames": {
+                    "value": "0"
+                },
+                "16384 to 32767 byte frame": {
+                    "value": "0"
+                },
+                "> 32768 byte frames": {
+                    "value": "0"
+                },
+                "SymbolErr frames": {
+                    "value": "0"
+                },
+                "Collision fragments": {
+                    "value": "0"
+                },
+                "ValidUnderSize frames": {
+                    "value": "0"
+                },
+                "InvalidOverSize frames": {
+                    "value": "0"
+                },
+                "ValidOverSize frames": {
+                    "value": "0"
+                },
+                "FcsErr frames": {
+                    "value": "0"
+                }
+            }
+        },
+        "last_update": "5392 msecs AGO"
+    },
+    "GigabitEthernet1/0/2": {
+        "statistics": {
+            "transmit": {
+                "Total bytes": {
+                    "value": "4240316"
+                },
+                "Unicast frames": {
+                    "value": "6695"
+                },
+                "Unicast bytes": {
+                    "value": "453852"
+                },
+                "Multicast frames": {
+                    "value": "25236"
+                },
+                "Multicast bytes": {
+                    "value": "3758084"
+                },
+                "Broadcast frames": {
+                    "value": "292"
+                },
+                "Broadcast bytes": {
+                    "value": "28380"
+                },
+                "System FCS error frames": {
+                    "value": "0"
+                },
+                "MacUnderrun frames": {
+                    "value": "0"
+                },
+                "Pause frames": {
+                    "value": "0"
+                },
+                "Cos 0 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 1 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 2 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 3 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 4 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 5 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 6 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 7 Pause frames": {
+                    "value": "0"
+                },
+                "Oam frames": {
+                    "value": "0"
+                },
+                "Oam frames (2)": {
+                    "value": "0"
+                },
+                "Minimum size frames": {
+                    "value": "2072"
+                },
+                "65 to 127 byte frames": {
+                    "value": "26743"
+                },
+                "128 to 255 byte frames": {
+                    "value": "0"
+                },
+                "256 to 511 byte frames": {
+                    "value": "3408"
+                },
+                "512 to 1023 byte frames": {
+                    "value": "0"
+                },
+                "1024 to 1518 byte frames": {
+                    "value": "0"
+                },
+                "1519 to 2047 byte frames": {
+                    "value": "0"
+                },
+                "2048 to 4095 byte frames": {
+                    "value": "0"
+                },
+                "4096 to 8191 byte frames": {
+                    "value": "0"
+                },
+                "8192 to 16383 byte frames": {
+                    "value": "0"
+                },
+                "16384 to 32767 byte frame": {
+                    "value": "0"
+                },
+                "> 32768 byte frames": {
+                    "value": "0"
+                },
+                "Late collision frames": {
+                    "value": "0"
+                },
+                "Excess Defer frames": {
+                    "value": "0"
+                },
+                "Good (1 coll) frames": {
+                    "value": "0"
+                },
+                "Good (>1 coll) frames": {
+                    "value": "0"
+                },
+                "Deferred frames": {
+                    "value": "0"
+                },
+                "Gold frames dropped": {
+                    "value": "0"
+                },
+                "Gold frames truncated": {
+                    "value": "0"
+                },
+                "Gold frames successful": {
+                    "value": "0"
+                },
+                "1 collision frames": {
+                    "value": "0"
+                },
+                "2 collision frames": {
+                    "value": "0"
+                },
+                "3 collision frames": {
+                    "value": "0"
+                },
+                "4 collision frames": {
+                    "value": "0"
+                },
+                "5 collision frames": {
+                    "value": "0"
+                },
+                "6 collision frames": {
+                    "value": "0"
+                },
+                "7 collision frames": {
+                    "value": "0"
+                },
+                "8 collision frames": {
+                    "value": "0"
+                },
+                "9 collision frames": {
+                    "value": "0"
+                },
+                "10 collision frames": {
+                    "value": "0"
+                },
+                "11 collision frames": {
+                    "value": "0"
+                },
+                "12 collision frames": {
+                    "value": "0"
+                },
+                "13 collision frames": {
+                    "value": "0"
+                },
+                "14 collision frames": {
+                    "value": "0"
+                },
+                "15 collision frames": {
+                    "value": "0"
+                },
+                "Excess collision frames": {
+                    "value": "0"
+                }
+            },
+            "receive": {
+                "Total bytes": {
+                    "value": "547171"
+                },
+                "Unicast frames": {
+                    "value": "0"
+                },
+                "Unicast bytes": {
+                    "value": "0"
+                },
+                "Multicast frames": {
+                    "value": "1269"
+                },
+                "Multicast bytes": {
+                    "value": "546792"
+                },
+                "Broadcast frames": {
+                    "value": "1"
+                },
+                "Broadcast bytes": {
+                    "value": "379"
+                },
+                "IpgViolation frames": {
+                    "value": "0"
+                },
+                "MacOverrun frames": {
+                    "value": "0"
+                },
+                "Pause frames": {
+                    "value": "0"
+                },
+                "Cos 0 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 1 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 2 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 3 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 4 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 5 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 6 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 7 Pause frames": {
+                    "value": "0"
+                },
+                "OamProcessed frames": {
+                    "value": "0"
+                },
+                "OamDropped frames": {
+                    "value": "0"
+                },
+                "Minimum size frames": {
+                    "value": "0"
+                },
+                "65 to 127 byte frames": {
+                    "value": "11"
+                },
+                "128 to 255 byte frames": {
+                    "value": "0"
+                },
+                "256 to 511 byte frames": {
+                    "value": "1259"
+                },
+                "512 to 1023 byte frames": {
+                    "value": "0"
+                },
+                "1024 to 1518 byte frames": {
+                    "value": "0"
+                },
+                "1519 to 2047 byte frames": {
+                    "value": "0"
+                },
+                "2048 to 4095 byte frames": {
+                    "value": "0"
+                },
+                "4096 to 8191 byte frames": {
+                    "value": "0"
+                },
+                "8192 to 16383 byte frames": {
+                    "value": "0"
+                },
+                "16384 to 32767 byte frame": {
+                    "value": "0"
+                },
+                "> 32768 byte frames": {
+                    "value": "0"
+                },
+                "SymbolErr frames": {
+                    "value": "0"
+                },
+                "Collision fragments": {
+                    "value": "0"
+                },
+                "ValidUnderSize frames": {
+                    "value": "0"
+                },
+                "InvalidOverSize frames": {
+                    "value": "0"
+                },
+                "ValidOverSize frames": {
+                    "value": "0"
+                },
+                "FcsErr frames": {
+                    "value": "0"
+                }
+            }
+        },
+        "last_update": "1149106114 msecs AGO"
+    },
+    "GigabitEthernet1/0/3": {
+        "statistics": {
+            "transmit": {
+                "Total bytes": {
+                    "value": "0"
+                },
+                "Unicast frames": {
+                    "value": "0"
+                },
+                "Unicast bytes": {
+                    "value": "0"
+                },
+                "Multicast frames": {
+                    "value": "0"
+                },
+                "Multicast bytes": {
+                    "value": "0"
+                },
+                "Broadcast frames": {
+                    "value": "0"
+                },
+                "Broadcast bytes": {
+                    "value": "0"
+                },
+                "System FCS error frames": {
+                    "value": "0"
+                },
+                "MacUnderrun frames": {
+                    "value": "0"
+                },
+                "Pause frames": {
+                    "value": "0"
+                },
+                "Cos 0 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 1 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 2 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 3 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 4 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 5 Pause frames": {
+                    "value": "0"
+                }
+            },
+            "receive": {
+                "Total bytes": {
+                    "value": "0"
+                },
+                "Unicast frames": {
+                    "value": "0"
+                },
+                "Unicast bytes": {
+                    "value": "0"
+                },
+                "Multicast frames": {
+                    "value": "0"
+                },
+                "Multicast bytes": {
+                    "value": "0"
+                },
+                "Broadcast frames": {
+                    "value": "0"
+                },
+                "Broadcast bytes": {
+                    "value": "0"
+                },
+                "IpgViolation frames": {
+                    "value": "0"
+                },
+                "MacOverrun frames": {
+                    "value": "0"
+                },
+                "Pause frames": {
+                    "value": "0"
+                },
+                "Cos 0 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 1 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 2 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 3 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 4 Pause frames": {
+                    "value": "0"
+                },
+                "Cos 5 Pause frames": {
+                    "value": "0"
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_controllers_ethernet-controller/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_controllers_ethernet-controller/001_basic/input.txt
@@ -1,0 +1,137 @@
+Transmit                  GigabitEthernet1/0/1          Receive
+     97618691 Total bytes                    97559269 Total bytes
+       363747 Unicast frames                   363756 Unicast frames
+     26187775 Unicast bytes                  25970978 Unicast bytes
+       453372 Multicast frames                 452232 Multicast frames
+     70982682 Multicast bytes                71141479 Multicast bytes
+         4173 Broadcast frames                   4159 Broadcast frames
+       448234 Broadcast bytes                  446812 Broadcast bytes
+            0 System FCS error frames               0 IpgViolation frames
+            0 MacUnderrun frames                    0 MacOverrun frames
+            0 Pause frames                          0 Pause frames
+            0 Cos 0 Pause frames                    0 Cos 0 Pause frames
+            0 Cos 1 Pause frames                    0 Cos 1 Pause frames
+            0 Cos 2 Pause frames                    0 Cos 2 Pause frames
+            0 Cos 3 Pause frames                    0 Cos 3 Pause frames
+            0 Cos 4 Pause frames                    0 Cos 4 Pause frames
+            0 Cos 5 Pause frames                    0 Cos 5 Pause frames
+            0 Cos 6 Pause frames                    0 Cos 6 Pause frames
+            0 Cos 7 Pause frames                    0 Cos 7 Pause frames
+            0 Oam frames                            0 OamProcessed frames
+            0 Oam frames                            0 OamDropped frames
+         1806 Minimum size frames               54700 Minimum size frames
+       756164 65 to 127 byte frames            700624 65 to 127 byte frames
+          112 128 to 255 byte frames             1596 128 to 255 byte frames
+        63210 256 to 511 byte frames            63227 256 to 511 byte frames
+            0 512 to 1023 byte frames               0 512 to 1023 byte frames
+            0 1024 to 1518 byte frames              0 1024 to 1518 byte frames
+            0 1519 to 2047 byte frames              0 1519 to 2047 byte frames
+            0 2048 to 4095 byte frames              0 2048 to 4095 byte frames
+            0 4096 to 8191 byte frames              0 4096 to 8191 byte frames
+            0 8192 to 16383 byte frames             0 8192 to 16383 byte frames
+            0 16384 to 32767 byte frame             0 16384 to 32767 byte frame
+            0 > 32768 byte frames                   0 > 32768 byte frames
+            0 Late collision frames                 0 SymbolErr frames
+            0 Excess Defer frames                   0 Collision fragments
+            0 Good (1 coll) frames                  0 ValidUnderSize frames
+            0 Good (>1 coll) frames                 0 InvalidOverSize frames
+            0 Deferred frames                       0 ValidOverSize frames
+            0 Gold frames dropped                   0 FcsErr frames
+            0 Gold frames truncated
+            0 Gold frames successful
+            0 1 collision frames
+            0 2 collision frames
+            0 3 collision frames
+            0 4 collision frames
+            0 5 collision frames
+            0 6 collision frames
+            0 7 collision frames
+            0 8 collision frames
+            0 9 collision frames
+            0 10 collision frames
+            0 11 collision frames
+            0 12 collision frames
+            0 13 collision frames
+            0 14 collision frames
+            0 15 collision frames
+            0 Excess collision frames
+
+LAST UPDATE 5392 msecs AGO
+
+Transmit                  GigabitEthernet1/0/2          Receive
+      4240316 Total bytes                      547171 Total bytes
+         6695 Unicast frames                        0 Unicast frames
+       453852 Unicast bytes                         0 Unicast bytes
+        25236 Multicast frames                   1269 Multicast frames
+      3758084 Multicast bytes                  546792 Multicast bytes
+          292 Broadcast frames                      1 Broadcast frames
+        28380 Broadcast bytes                     379 Broadcast bytes
+            0 System FCS error frames               0 IpgViolation frames
+            0 MacUnderrun frames                    0 MacOverrun frames
+            0 Pause frames                          0 Pause frames
+            0 Cos 0 Pause frames                    0 Cos 0 Pause frames
+            0 Cos 1 Pause frames                    0 Cos 1 Pause frames
+            0 Cos 2 Pause frames                    0 Cos 2 Pause frames
+            0 Cos 3 Pause frames                    0 Cos 3 Pause frames
+            0 Cos 4 Pause frames                    0 Cos 4 Pause frames
+            0 Cos 5 Pause frames                    0 Cos 5 Pause frames
+            0 Cos 6 Pause frames                    0 Cos 6 Pause frames
+            0 Cos 7 Pause frames                    0 Cos 7 Pause frames
+            0 Oam frames                            0 OamProcessed frames
+            0 Oam frames                            0 OamDropped frames
+         2072 Minimum size frames                   0 Minimum size frames
+        26743 65 to 127 byte frames                11 65 to 127 byte frames
+            0 128 to 255 byte frames                0 128 to 255 byte frames
+         3408 256 to 511 byte frames             1259 256 to 511 byte frames
+            0 512 to 1023 byte frames               0 512 to 1023 byte frames
+            0 1024 to 1518 byte frames              0 1024 to 1518 byte frames
+            0 1519 to 2047 byte frames              0 1519 to 2047 byte frames
+            0 2048 to 4095 byte frames              0 2048 to 4095 byte frames
+            0 4096 to 8191 byte frames              0 4096 to 8191 byte frames
+            0 8192 to 16383 byte frames             0 8192 to 16383 byte frames
+            0 16384 to 32767 byte frame             0 16384 to 32767 byte frame
+            0 > 32768 byte frames                   0 > 32768 byte frames
+            0 Late collision frames                 0 SymbolErr frames
+            0 Excess Defer frames                   0 Collision fragments
+            0 Good (1 coll) frames                  0 ValidUnderSize frames
+            0 Good (>1 coll) frames                 0 InvalidOverSize frames
+            0 Deferred frames                       0 ValidOverSize frames
+            0 Gold frames dropped                   0 FcsErr frames
+            0 Gold frames truncated
+            0 Gold frames successful
+            0 1 collision frames
+            0 2 collision frames
+            0 3 collision frames
+            0 4 collision frames
+            0 5 collision frames
+            0 6 collision frames
+            0 7 collision frames
+            0 8 collision frames
+            0 9 collision frames
+            0 10 collision frames
+            0 11 collision frames
+            0 12 collision frames
+            0 13 collision frames
+            0 14 collision frames
+            0 15 collision frames
+            0 Excess collision frames
+
+LAST UPDATE 1149106114 msecs AGO
+
+Transmit                  GigabitEthernet1/0/3          Receive
+            0 Total bytes                           0 Total bytes
+            0 Unicast frames                        0 Unicast frames
+            0 Unicast bytes                         0 Unicast bytes
+            0 Multicast frames                      0 Multicast frames
+            0 Multicast bytes                       0 Multicast bytes
+            0 Broadcast frames                      0 Broadcast frames
+            0 Broadcast bytes                       0 Broadcast bytes
+            0 System FCS error frames               0 IpgViolation frames
+            0 MacUnderrun frames                    0 MacOverrun frames
+            0 Pause frames                          0 Pause frames
+            0 Cos 0 Pause frames                    0 Cos 0 Pause frames
+            0 Cos 1 Pause frames                    0 Cos 1 Pause frames
+            0 Cos 2 Pause frames                    0 Cos 2 Pause frames
+            0 Cos 3 Pause frames                    0 Cos 3 Pause frames
+            0 Cos 4 Pause frames                    0 Cos 4 Pause frames
+            0 Cos 5 Pause frames                    0 Cos 5 Pause frames

--- a/tests/parsers/iosxe/show_controllers_ethernet-controller/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_controllers_ethernet-controller/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Per-interface ethernet-controller statistics for three GigabitEthernet ports on a Catalyst 9300
+platform: Cisco Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- New IOS-XE parser for `show controllers ethernet-controller`, which emits one block per physical Ethernet interface with transmit/receive counter pairs and an optional `LAST UPDATE` footer.
- Output is keyed by canonical interface name; each entry has a `statistics` sub-dict with `transmit` and `receive` columns, plus an optional `last_update` string field. Counter labels are preserved verbatim as dict keys (with `(2)`, `(3)`, ... suffixes for the few legitimately repeated labels such as `Oam frames`).
- Fixture captured from a Catalyst 9300 testbed (per the issue's sample output); contains three GigabitEthernet1/0/x blocks, including a truncated trailing block that exercises the "missing footer" path.

Closes #1028

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_controllers_ethernet -v` (7 passed)
- [x] `uv run pytest` (8621 passed)
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_controllers_ethernet_controller.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] pre-commit hooks (passed on commit)

## Notes
- A sibling parser already exists for the singular form `show controller ethernet-controller` (`src/muninn/parsers/iosxe/show_controller_ethernet_controller.py`), which targets a single specified interface. This new parser handles the plural multi-interface form and uses a `dict[interface, entry]` shape instead. The per-entry `statistics` sub-shape mirrors the sibling for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)