### PR TITLE
feat(cisco_iosxe): add parser for `show vtp status`

### DIFF
--- a/changes/1027.parser_added
+++ b/changes/1027.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show vtp status` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_vtp_status.py
+++ b/src/muninn/parsers/ios/show_vtp_status.py
@@ -1,4 +1,4 @@
-"""Parser for 'show vtp status' command on IOS."""
+"""Parser for 'show vtp status' command on IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict, cast
@@ -7,6 +7,7 @@ from muninn.os import OS
 from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
 
 
 class ShowVtpStatusResult(TypedDict):
@@ -17,12 +18,12 @@ class ShowVtpStatusResult(TypedDict):
     """
 
     vtp_version_running: int
-    domain_name: str
     operating_mode: str
     max_vlans: int
     existing_vlans: int
     configuration_revision: int
     vtp_version_capable: NotRequired[str]
+    domain_name: NotRequired[str]
     pruning_mode: NotRequired[str]
     traps_generation: NotRequired[str]
     device_id: NotRequired[str]
@@ -90,11 +91,18 @@ _INT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 
 
 def _try_string_patterns(stripped: str, result: dict) -> bool:
-    """Try single-group string patterns against a line."""
+    """Try single-group string patterns against a line.
+
+    Empty captures are treated as the field not being set (the field is
+    omitted from the result) so callers do not need to special-case empty
+    placeholders such as ``VTP Domain Name :``.
+    """
     for pattern, key in _STRING_PATTERNS:
         match = pattern.match(stripped)
         if match:
-            result[key] = match.group(1)
+            value = match.group(1)
+            if value:
+                result[key] = value
             return True
     return False
 
@@ -120,7 +128,9 @@ def _try_multi_group_patterns(stripped: str, result: dict) -> bool:
     match = _LOCAL_UPDATER_RE.match(stripped)
     if match:
         result["local_updater_id"] = match.group(1)
-        result["local_updater_interface"] = match.group(2)
+        result["local_updater_interface"] = canonical_interface_name(
+            match.group(2), os=OS.CISCO_IOS
+        )
         return True
 
     return False
@@ -172,7 +182,6 @@ def _parse_line(line: str, result: dict, in_md5: list[bool]) -> None:
 # Required fields that must be present in parsed output
 _REQUIRED_FIELDS = (
     "vtp_version_running",
-    "domain_name",
     "operating_mode",
     "max_vlans",
     "existing_vlans",
@@ -181,6 +190,7 @@ _REQUIRED_FIELDS = (
 
 
 @register(OS.CISCO_IOS, "show vtp status")
+@register(OS.CISCO_IOSXE, "show vtp status")
 class ShowVtpStatusParser(BaseParser["ShowVtpStatusResult"]):
     """Parser for 'show vtp status' command."""
 

--- a/tests/parsers/ios/show_vtp_status/001_basic/expected.json
+++ b/tests/parsers/ios/show_vtp_status/001_basic/expected.json
@@ -8,7 +8,7 @@
     "last_modified_by": "10.0.0.1",
     "last_modified_at": "6-12-15 14:06:57",
     "local_updater_id": "10.1.1.1",
-    "local_updater_interface": "Vl1",
+    "local_updater_interface": "VLAN1",
     "operating_mode": "Server",
     "max_vlans": 1005,
     "existing_vlans": 20,

--- a/tests/parsers/iosxe/show_vtp_status/001_isr1100/expected.json
+++ b/tests/parsers/iosxe/show_vtp_status/001_isr1100/expected.json
@@ -1,0 +1,16 @@
+{
+    "vtp_version_capable": "1 to 3",
+    "vtp_version_running": 1,
+    "pruning_mode": "Disabled (Operationally Disabled)",
+    "traps_generation": "Disabled",
+    "device_id": "748f.c25f.0250",
+    "last_modified_by": "0.0.0.0",
+    "last_modified_at": "0-0-00 00:00:00",
+    "local_updater_id": "192.0.2.100",
+    "local_updater_interface": "GigabitEthernet0/0/0",
+    "operating_mode": "Server",
+    "max_vlans": 64,
+    "existing_vlans": 5,
+    "configuration_revision": 0,
+    "md5_digest": "0x57 0xCD 0x40 0x65 0x63 0x59 0x47 0xBD 0x56 0x9D 0x4A 0x3E 0xA5 0x69 0x35 0xBC"
+}

--- a/tests/parsers/iosxe/show_vtp_status/001_isr1100/input.txt
+++ b/tests/parsers/iosxe/show_vtp_status/001_isr1100/input.txt
@@ -1,0 +1,18 @@
+VTP Version capable             : 1 to 3
+VTP version running             : 1
+VTP Domain Name                 :
+VTP Pruning Mode                : Disabled (Operationally Disabled)
+VTP Traps Generation            : Disabled
+Device ID                       : 748f.c25f.0250
+Configuration last modified by 0.0.0.0 at 0-0-00 00:00:00
+Local updater ID is 192.0.2.100 on interface Gi0/0/0 (first layer3 interface
+found)
+
+Feature VLAN:
+--------------
+VTP Operating Mode                : Server
+Maximum VLANs supported locally   : 64
+Number of existing VLANs          : 5
+Configuration Revision            : 0
+MD5 digest                        : 0x57 0xCD 0x40 0x65 0x63 0x59 0x47 0xBD
+                                    0x56 0x9D 0x4A 0x3E 0xA5 0x69 0x35 0xBC

--- a/tests/parsers/iosxe/show_vtp_status/001_isr1100/metadata.yaml
+++ b/tests/parsers/iosxe/show_vtp_status/001_isr1100/metadata.yaml
@@ -1,0 +1,3 @@
+description: VTP status on an ISR 1100 router with default empty VTP domain and 64 max VLANs
+platform: Cisco ISR 1100
+software_version: Unknown

--- a/tests/parsers/iosxe/show_vtp_status/002_catalyst_9300/expected.json
+++ b/tests/parsers/iosxe/show_vtp_status/002_catalyst_9300/expected.json
@@ -1,0 +1,16 @@
+{
+    "vtp_version_capable": "1 to 3",
+    "vtp_version_running": 1,
+    "pruning_mode": "Disabled (Operationally Disabled)",
+    "traps_generation": "Disabled",
+    "device_id": "ac3a.6728.0f80",
+    "last_modified_by": "0.0.0.0",
+    "last_modified_at": "0-0-00 00:00:00",
+    "local_updater_id": "192.0.2.101",
+    "local_updater_interface": "GigabitEthernet0/0",
+    "operating_mode": "Server",
+    "max_vlans": 1005,
+    "existing_vlans": 5,
+    "configuration_revision": 0,
+    "md5_digest": "0x57 0xCD 0x40 0x65 0x63 0x59 0x47 0xBD 0x56 0x9D 0x4A 0x3E 0xA5 0x69 0x35 0xBC"
+}

--- a/tests/parsers/iosxe/show_vtp_status/002_catalyst_9300/input.txt
+++ b/tests/parsers/iosxe/show_vtp_status/002_catalyst_9300/input.txt
@@ -1,0 +1,18 @@
+VTP Version capable             : 1 to 3
+VTP version running             : 1
+VTP Domain Name                 :
+VTP Pruning Mode                : Disabled (Operationally Disabled)
+VTP Traps Generation            : Disabled
+Device ID                       : ac3a.6728.0f80
+Configuration last modified by 0.0.0.0 at 0-0-00 00:00:00
+Local updater ID is 192.0.2.101 on interface Gi0/0 (first layer3 interface
+found)
+
+Feature VLAN:
+--------------
+VTP Operating Mode                : Server
+Maximum VLANs supported locally   : 1005
+Number of existing VLANs          : 5
+Configuration Revision            : 0
+MD5 digest                        : 0x57 0xCD 0x40 0x65 0x63 0x59 0x47 0xBD
+                                    0x56 0x9D 0x4A 0x3E 0xA5 0x69 0x35 0xBC

--- a/tests/parsers/iosxe/show_vtp_status/002_catalyst_9300/metadata.yaml
+++ b/tests/parsers/iosxe/show_vtp_status/002_catalyst_9300/metadata.yaml
@@ -1,0 +1,3 @@
+description: VTP status on a Catalyst 9300 switch with default empty VTP domain and 1005 max VLANs
+platform: Cisco Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Extends the existing IOS `show vtp status` parser to also run on `cisco_iosxe` by adding a second `@register(OS.CISCO_IOSXE, "show vtp status")` decorator — the two platforms render this command identically, so sibling re-use is preferred over a duplicate parser module.
- Two new fixtures (`tests/parsers/iosxe/show_vtp_status/{001_isr1100,002_catalyst_9300}`) capture verbatim output from the testbed devices listed in the issue: an ISR 1100 (Gi0/0/0, 64 max VLANs) and a Catalyst 9300 (Gi0/0, 1005 max VLANs), both with an unconfigured (empty) VTP domain.

### Schema tweaks driven by the new IOS-XE evidence
- `domain_name` moved to `NotRequired` and is now omitted when the captured value is empty (real IOS-XE devices render `VTP Domain Name :` with no value). The shared string-pattern helper now skips empty captures rather than recording `""`, which satisfies the existing empty-string fixture guardrail and matches the project convention of omitting placeholder values.
- `local_updater_interface` is now canonicalized via `canonical_interface_name(..., os=OS.CISCO_IOS)` so values such as `Gi0/0/0` are stored as `GigabitEthernet0/0/0`. The existing IOS fixture's expected output is updated to the canonical form (`Vl1` → `VLAN1`) to match.

Closes #1027

## Test plan
- [x] `uv run pytest tests/parsers/ -k vtp_status -v` (21 tests, all green — covers both new IOS-XE fixtures, the existing IOS fixture, fixture/JSON convention tests, and placeholder/empty-string guardrails)
- [x] `uv run pytest -q` (8628 passed)
- [x] `uv run ruff check src/muninn/parsers/ios/show_vtp_status.py` / `uv run ruff format` (no changes)
- [x] `uv run ty check src/muninn/parsers/ios/show_vtp_status.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `pre-commit` hooks (ran via `git commit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)