### PR TITLE
feat(cisco_ios): add parser for `show aaa method-lists authentication`

### DIFF
--- a/changes/1033.parser_added
+++ b/changes/1033.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show aaa method-lists authentication` on Cisco IOS.

--- a/src/muninn/parsers/ios/show_aaa_method_lists_authentication.py
+++ b/src/muninn/parsers/ios/show_aaa_method_lists_authentication.py
@@ -1,0 +1,180 @@
+"""Parser for 'show aaa method-lists authentication' command on IOS."""
+
+import re
+from dataclasses import dataclass, field
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_QUEUE_HEADER_RE = re.compile(r"^authen\s+queue=(?P<queue>\S+)\s*$")
+_PERMANENT_HEADER_RE = re.compile(r"^permanent\s+lists\s*$", re.IGNORECASE)
+_ENTRY_RE = re.compile(
+    r"^\s+name=\s*(?P<name>.+?)\s+valid=(?P<valid>\S+)\s+id=(?P<id>\S+)\s+"
+    r":state=(?P<state>\S+)\s+:\s*(?P<methods>.*?)\s*$"
+)
+
+
+class MethodListEntry(TypedDict):
+    """Schema for a single AAA authentication method-list entry."""
+
+    valid: bool
+    id: int
+    state: str
+    methods: list[str]
+    server_group: NotRequired[str]
+
+
+class QueueEntry(TypedDict):
+    """Schema for a single AAA authentication queue.
+
+    Keyed at the outer level by queue name (e.g. ``AAA_ML_AUTHEN_LOGIN``).
+    The ``lists`` map is keyed by method-list name within the queue.
+    """
+
+    lists: dict[str, MethodListEntry]
+
+
+class ShowAaaMethodListsAuthenticationResult(TypedDict):
+    """Schema for 'show aaa method-lists authentication' parsed output."""
+
+    queues: dict[str, QueueEntry]
+    permanent_lists: dict[str, MethodListEntry]
+
+
+@dataclass
+class _ParseState:
+    """Mutable state threaded through line-by-line parsing."""
+
+    queues: dict[str, QueueEntry] = field(default_factory=dict)
+    permanent_lists: dict[str, MethodListEntry] = field(default_factory=dict)
+    current_queue: str | None = None
+    in_permanent: bool = False
+    last_entry: MethodListEntry | None = None
+
+
+def _make_entry(match: re.Match[str]) -> MethodListEntry:
+    """Build a MethodListEntry from a matched entry line."""
+    methods_field = match.group("methods").strip()
+    methods = methods_field.split() if methods_field else []
+    return {
+        "valid": match.group("valid").upper() == "TRUE",
+        "id": int(match.group("id")),
+        "state": match.group("state"),
+        "methods": methods,
+    }
+
+
+def _try_header(raw_line: str, state: _ParseState) -> bool:
+    """Handle queue / permanent-lists section headers.
+
+    Returns True if the line was consumed as a header.
+    """
+    queue_match = _QUEUE_HEADER_RE.match(raw_line)
+    if queue_match:
+        queue = queue_match.group("queue")
+        state.current_queue = queue
+        state.in_permanent = False
+        state.queues.setdefault(queue, {"lists": {}})
+        state.last_entry = None
+        return True
+    if _PERMANENT_HEADER_RE.match(raw_line):
+        state.current_queue = None
+        state.in_permanent = True
+        state.last_entry = None
+        return True
+    return False
+
+
+def _try_entry(raw_line: str, state: _ParseState) -> bool:
+    """Match an indented method-list entry line and record it.
+
+    Returns True if the line was consumed as an entry.
+    """
+    entry_match = _ENTRY_RE.match(raw_line)
+    if not entry_match:
+        return False
+    name = entry_match.group("name").strip()
+    entry = _make_entry(entry_match)
+    if state.in_permanent:
+        state.permanent_lists[name] = entry
+        state.last_entry = entry
+    elif state.current_queue is not None:
+        state.queues[state.current_queue]["lists"][name] = entry
+        state.last_entry = entry
+    else:
+        state.last_entry = None
+    return True
+
+
+def _try_continuation(stripped: str, state: _ParseState) -> None:
+    """Treat an unindented continuation line as the server-group name.
+
+    Applies only when the previous entry's last method was ``SERVER_GROUP``
+    and no ``server_group`` has been recorded yet.
+    """
+    last = state.last_entry
+    if last is None or not last["methods"]:
+        return
+    if last["methods"][-1] != "SERVER_GROUP":
+        return
+    if "server_group" in last:
+        return
+    last["server_group"] = stripped
+    state.last_entry = None
+
+
+@register(OS.CISCO_IOS, "show aaa method-lists authentication")
+class ShowAaaMethodListsAuthenticationParser(
+    BaseParser[ShowAaaMethodListsAuthenticationResult]
+):
+    """Parser for 'show aaa method-lists authentication' on IOS.
+
+    The command emits a section per authentication queue
+    (``authen queue=AAA_ML_AUTHEN_<TYPE>``) followed by any configured
+    method-list entries indented beneath it.  A trailing ``permanent lists``
+    section contains the built-in lists shipped with the platform.
+
+    When the final method on an entry is ``SERVER_GROUP``, the next line
+    holds the unindented server-group name (a CLI line-wrap artifact),
+    which is captured into ``server_group`` on the preceding entry.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.AAA})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowAaaMethodListsAuthenticationResult:
+        """Parse 'show aaa method-lists authentication' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed AAA authentication method-list data, grouped by queue
+            and with a separate ``permanent_lists`` map for the built-in
+            method lists.
+        """
+        state = _ParseState()
+
+        for raw_line in output.splitlines():
+            stripped = raw_line.strip()
+            if not stripped:
+                state.last_entry = None
+                continue
+            if _try_header(raw_line, state):
+                continue
+            if _try_entry(raw_line, state):
+                continue
+            _try_continuation(stripped, state)
+
+        if not state.queues and not state.permanent_lists:
+            msg = "No AAA authentication queues or permanent lists found in output"
+            raise ValueError(msg)
+
+        result: dict = {
+            "queues": state.queues,
+            "permanent_lists": state.permanent_lists,
+        }
+        return cast(ShowAaaMethodListsAuthenticationResult, result)

--- a/src/muninn/parsers/ios/show_aaa_method_lists_authentication.py
+++ b/src/muninn/parsers/ios/show_aaa_method_lists_authentication.py
@@ -12,7 +12,7 @@ from muninn.tags import ParserTag
 _QUEUE_HEADER_RE = re.compile(r"^authen\s+queue=(?P<queue>\S+)\s*$")
 _PERMANENT_HEADER_RE = re.compile(r"^permanent\s+lists\s*$", re.IGNORECASE)
 _ENTRY_RE = re.compile(
-    r"^\s+name=\s*(?P<name>.+?)\s+valid=(?P<valid>\S+)\s+id=(?P<id>\S+)\s+"
+    r"^\s+name=\s*(?P<name>.+?)\s+valid=(?P<valid>\S+)\s+id=(?P<id>\d+)\s+"
     r":state=(?P<state>\S+)\s+:\s*(?P<methods>.*?)\s*$"
 )
 

--- a/tests/parsers/ios/show_aaa_method-lists_authentication/001_basic/expected.json
+++ b/tests/parsers/ios/show_aaa_method-lists_authentication/001_basic/expected.json
@@ -1,0 +1,93 @@
+{
+    "queues": {
+        "AAA_ML_AUTHEN_LOGIN": {
+            "lists": {
+                "default": {
+                    "valid": true,
+                    "id": 0,
+                    "state": "ALIVE",
+                    "methods": [
+                        "LOCAL"
+                    ]
+                }
+            }
+        },
+        "AAA_ML_AUTHEN_ENABLE": {
+            "lists": {}
+        },
+        "AAA_ML_AUTHEN_PPP": {
+            "lists": {}
+        },
+        "AAA_ML_AUTHEN_SGBP": {
+            "lists": {}
+        },
+        "AAA_ML_AUTHEN_ARAP": {
+            "lists": {}
+        },
+        "AAA_ML_AUTHEN_DOT1X": {
+            "lists": {
+                "pvt_authen_0": {
+                    "valid": true,
+                    "id": 56000002,
+                    "state": "DEAD",
+                    "methods": [
+                        "SERVER_GROUP"
+                    ],
+                    "server_group": "private_sg-0"
+                }
+            }
+        },
+        "AAA_ML_AUTHEN_8021X": {
+            "lists": {}
+        },
+        "AAA_ML_AUTHEN_EAPOUDP": {
+            "lists": {}
+        },
+        "AAA_ML_AUTHEN_CONNECTEDAPPS": {
+            "lists": {}
+        }
+    },
+    "permanent_lists": {
+        "Permanent Enable None": {
+            "valid": true,
+            "id": 0,
+            "state": "ALIVE",
+            "methods": [
+                "ENABLE",
+                "NONE"
+            ]
+        },
+        "Permanent Enable": {
+            "valid": true,
+            "id": 0,
+            "state": "ALIVE",
+            "methods": [
+                "ENABLE"
+            ]
+        },
+        "Permanent None": {
+            "valid": true,
+            "id": 0,
+            "state": "ALIVE",
+            "methods": [
+                "NONE"
+            ]
+        },
+        "Permanent Local": {
+            "valid": true,
+            "id": 0,
+            "state": "ALIVE",
+            "methods": [
+                "LOCAL"
+            ]
+        },
+        "Permanent rcmd": {
+            "valid": true,
+            "id": 0,
+            "state": "ALIVE",
+            "methods": [
+                "RCMD"
+            ]
+        }
+    }
+}

--- a/tests/parsers/ios/show_aaa_method-lists_authentication/001_basic/input.txt
+++ b/tests/parsers/ios/show_aaa_method-lists_authentication/001_basic/input.txt
@@ -1,0 +1,18 @@
+authen queue=AAA_ML_AUTHEN_LOGIN
+  name=default valid=TRUE id=0 :state=ALIVE : LOCAL
+authen queue=AAA_ML_AUTHEN_ENABLE
+authen queue=AAA_ML_AUTHEN_PPP
+authen queue=AAA_ML_AUTHEN_SGBP
+authen queue=AAA_ML_AUTHEN_ARAP
+authen queue=AAA_ML_AUTHEN_DOT1X
+  name= pvt_authen_0 valid=TRUE id=56000002 :state=DEAD : SERVER_GROUP
+private_sg-0
+authen queue=AAA_ML_AUTHEN_8021X
+authen queue=AAA_ML_AUTHEN_EAPOUDP
+authen queue=AAA_ML_AUTHEN_CONNECTEDAPPS
+permanent lists
+  name= Permanent Enable None valid=TRUE id=0 :state=ALIVE : ENABLE  NONE
+  name= Permanent Enable valid=TRUE id=0 :state=ALIVE : ENABLE
+  name= Permanent None valid=TRUE id=0 :state=ALIVE : NONE
+  name= Permanent Local valid=TRUE id=0 :state=ALIVE : LOCAL
+  name= Permanent rcmd valid=TRUE id=0 :state=ALIVE : RCMD

--- a/tests/parsers/ios/show_aaa_method-lists_authentication/001_basic/metadata.yaml
+++ b/tests/parsers/ios/show_aaa_method-lists_authentication/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: AAA authentication method-lists with default LOCAL login, a DOT1X SERVER_GROUP entry whose server name wraps to the next line, and the platform's permanent lists
+platform: Cisco Catalyst 3750-X
+software_version: IOS 15.x

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -53,6 +53,10 @@ _NONE_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         # mode for flowcontrol (None / Tx / Rx / Both).
         "cisco_iosxr/show_controllers_hundredgigabitethernet/001_basic/expected.json",
         "cisco_iosxr/show_controllers_hundredgigabitethernet/002_low_power_optic/expected.json",
+        # ``NONE`` is a literal AAA method keyword on IOS (skip authentication),
+        # not a missing-value placeholder. It appears in the platform's permanent
+        # lists alongside ``ENABLE``, ``LOCAL``, ``RCMD``.
+        "ios/show_aaa_method-lists_authentication/001_basic/expected.json",
         "arista_eos/show_version/005_ceos_clab/expected.json",
         "ios/show_crypto_session_detail/001_basic/expected.json",
         "ios/show_license/001_basic/expected.json",


### PR DESCRIPTION
## Summary
- Adds a Cisco IOS parser for `show aaa method-lists authentication` that emits a `queues` map (keyed by queue name like `AAA_ML_AUTHEN_LOGIN`) of method-list entries plus a flat `permanent_lists` map for the platform's built-in lists.
- Handles the CLI line-wrap case where a `SERVER_GROUP` entry's group name appears unindented on the following line — captured into `server_group` on the preceding entry.
- Fixture captured from a Catalyst 3750-X stack (IOS 15.x) per the issue.

Closes #1033

## Open questions
- The fixture is exempted from `test_fixture_placeholder_sentinels.py::test_expected_json_avoids_none_like_placeholder_values` because the IOS `permanent lists` section legitimately contains entries whose methods include the literal AAA keyword `NONE` (meaning "skip authentication"). This follows the pattern already used for `show_snmp_user`, `show_redundancy`, IOS-XR controller flowcontrol, etc., where `NONE`/`None` is a vendor-defined enum value rather than a placeholder. Flagged here so a reviewer can double-check that judgement.

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_aaa_method-lists_authentication -v` — 7 passing
- [x] `uv run pytest` — 8621 passing
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format src/muninn/parsers/ios/show_aaa_method_lists_authentication.py` — no changes
- [x] `uv run ty check src/muninn/parsers/ios/show_aaa_method_lists_authentication.py` — clean (4 unrelated pre-existing warnings elsewhere)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/` — clean
- [x] `uv run pre-commit run --files <touched files>` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)