### PR TITLE
feat(cisco_iosxe): add parser for `show users`

### DIFF
--- a/changes/1022.parser_added
+++ b/changes/1022.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show users` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_users.py
+++ b/src/muninn/parsers/ios/show_users.py
@@ -1,4 +1,4 @@
-"""Parser for 'show users' command on IOS."""
+"""Parser for 'show users' command on IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict
@@ -96,8 +96,9 @@ def _build_entry(match: re.Match[str]) -> tuple[str, str, UserEntry]:
 
 
 @register(OS.CISCO_IOS, "show users")
+@register(OS.CISCO_IOSXE, "show users")
 class ShowUsersParser(BaseParser[ShowUsersResult]):
-    """Parser for 'show users' on IOS.
+    """Parser for 'show users' on IOS and IOS-XE.
 
     Parses the user session table showing line, user, host, idle time,
     and location for each active terminal session.

--- a/tests/parsers/iosxe/show_users/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_users/001_basic/expected.json
@@ -1,0 +1,28 @@
+{
+    "lines": {
+        "con": {
+            "0": {
+                "active": false,
+                "user": "admin",
+                "host": "idle",
+                "idle": "2w0d"
+            }
+        },
+        "vty": {
+            "0": {
+                "active": false,
+                "user": "admin",
+                "host": "idle",
+                "idle": "1w6d",
+                "location": "192.0.2.50"
+            },
+            "1": {
+                "active": true,
+                "user": "admin",
+                "host": "idle",
+                "idle": "00:00:04",
+                "location": "192.0.2.50"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_users/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_users/001_basic/input.txt
@@ -1,0 +1,6 @@
+Line       User       Host(s)              Idle       Location
+   0 con 0     admin      idle                     2w0d
+ 866 vty 0     admin      idle                     1w6d 192.0.2.50
+*867 vty 1     admin      idle                 00:00:04 192.0.2.50
+
+  Interface    User               Mode         Idle     Peer Address

--- a/tests/parsers/iosxe/show_users/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_users/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show users with console and VTY sessions including active marker and location
+platform: Cisco ISR 1100 / Catalyst 9300
+software_version: IOS-XE


### PR DESCRIPTION
## Summary
- Adds IOS-XE support for the existing `show users` parser by stacking `@register(OS.CISCO_IOSXE, "show users")` on `ShowUsersParser`. The IOS-XE output format is identical to IOS so no new parser module was required.
- Adds a real-device fixture (`tests/parsers/iosxe/show_users/001_basic/`) captured from physical testbed devices (ISR 1100 / Catalyst 9300) including the active-session asterisk marker and a peer-address location.

Closes #1022

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_users -v` (21 passed)
- [x] `uv run pytest` (8718 passed)
- [x] `uv run ruff check --fix .` / `uv run ruff format .`
- [x] `uv run ty check src/muninn/parsers/ios/show_users.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)