### PR TITLE
feat(cisco_iosxe): add parser for `show spanning-tree summary`

### DIFF
--- a/changes/1021.parser_added
+++ b/changes/1021.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show spanning-tree summary` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_spanning_tree_summary.py
+++ b/src/muninn/parsers/ios/show_spanning_tree_summary.py
@@ -28,6 +28,11 @@ _SUMMARY_ROW_RE = re.compile(
     r"(?P<learning>\d+)\s+(?P<forwarding>\d+)\s+(?P<active>\d+)\s*$",
     re.IGNORECASE,
 )
+_TOTAL_ROW_RE = re.compile(
+    r"^Total\s+(?P<blocking>\d+)\s+(?P<listening>\d+)\s+"
+    r"(?P<learning>\d+)\s+(?P<forwarding>\d+)\s+(?P<active>\d+)\s*$",
+    re.IGNORECASE,
+)
 
 _FEATURE_LABEL_MAP: dict[str, str] = {
     "etherchannel misconfig guard": "etherchannel_misconfig_guard",
@@ -187,17 +192,34 @@ def _try_vlan_row(line: str, vlans: dict[str, VlanCounts]) -> bool:
 
 
 def _try_summary_row(line: str) -> VlanSummary | None:
-    """Attempt to parse the trailing `N vlans ...` totals row."""
+    """Attempt to parse the trailing totals row.
+
+    Matches both forms emitted by IOS / IOS-XE:
+
+    - ``N vlan[s] <counts>`` (one or more VLANs in the table).
+    - ``Total <counts>`` (no VLANs in the table; IOS-XE on platforms such as
+      the ISR 1100 emits this in place of the ``0 vlans`` row).
+    """
     match = _SUMMARY_ROW_RE.match(line)
-    if match is None:
+    if match is not None:
+        return {
+            "total_vlans": int(match.group("total")),
+            "blocking": int(match.group("blocking")),
+            "listening": int(match.group("listening")),
+            "learning": int(match.group("learning")),
+            "forwarding": int(match.group("forwarding")),
+            "stp_active": int(match.group("active")),
+        }
+    total_match = _TOTAL_ROW_RE.match(line)
+    if total_match is None:
         return None
     return {
-        "total_vlans": int(match.group("total")),
-        "blocking": int(match.group("blocking")),
-        "listening": int(match.group("listening")),
-        "learning": int(match.group("learning")),
-        "forwarding": int(match.group("forwarding")),
-        "stp_active": int(match.group("active")),
+        "total_vlans": 0,
+        "blocking": int(total_match.group("blocking")),
+        "listening": int(total_match.group("listening")),
+        "learning": int(total_match.group("learning")),
+        "forwarding": int(total_match.group("forwarding")),
+        "stp_active": int(total_match.group("active")),
     }
 
 

--- a/src/muninn/parsers/ios/show_spanning_tree_summary.py
+++ b/src/muninn/parsers/ios/show_spanning_tree_summary.py
@@ -1,4 +1,4 @@
-"""Parser for 'show spanning-tree summary' command on IOS."""
+"""Parser for 'show spanning-tree summary' command on IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict, cast
@@ -33,11 +33,14 @@ _FEATURE_LABEL_MAP: dict[str, str] = {
     "etherchannel misconfig guard": "etherchannel_misconfig_guard",
     "extended system id": "extended_system_id",
     "portfast default": "portfast_default",
+    "portfast bpdu guard default": "portfast_bpdu_guard_default",
+    "portfast bpdu filter default": "portfast_bpdu_filter_default",
     "portfast edge bpdu guard default": "portfast_edge_bpdu_guard_default",
     "portfast edge bpdu filter default": "portfast_edge_bpdu_filter_default",
     "loopguard default": "loopguard_default",
     "pvst simulation default": "pvst_simulation_default",
     "bridge assurance": "bridge_assurance",
+    "bpdu sender conflict": "bpdu_sender_conflict",
     "uplinkfast": "uplinkfast",
     "backbonefast": "backbonefast",
 }
@@ -49,11 +52,14 @@ class StpDefaults(TypedDict):
     etherchannel_misconfig_guard: NotRequired[str]
     extended_system_id: NotRequired[str]
     portfast_default: NotRequired[str]
+    portfast_bpdu_guard_default: NotRequired[str]
+    portfast_bpdu_filter_default: NotRequired[str]
     portfast_edge_bpdu_guard_default: NotRequired[str]
     portfast_edge_bpdu_filter_default: NotRequired[str]
     loopguard_default: NotRequired[str]
     pvst_simulation_default: NotRequired[str]
     bridge_assurance: NotRequired[str]
+    bpdu_sender_conflict: NotRequired[str]
     uplinkfast: NotRequired[str]
     backbonefast: NotRequired[str]
 
@@ -229,8 +235,9 @@ def _process_line(line: str, result: dict) -> None:
 
 
 @register(OS.CISCO_IOS, "show spanning-tree summary")
+@register(OS.CISCO_IOSXE, "show spanning-tree summary")
 class ShowSpanningTreeSummaryParser(BaseParser[ShowSpanningTreeSummaryResult]):
-    """Parser for 'show spanning-tree summary' on IOS."""
+    """Parser for 'show spanning-tree summary' on IOS and IOS-XE."""
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset(
         {

--- a/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/expected.json
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/expected.json
@@ -1,0 +1,16 @@
+{
+    "defaults": {
+        "extended_system_id": "enabled",
+        "portfast_default": "disabled",
+        "portfast_bpdu_guard_default": "disabled",
+        "portfast_bpdu_filter_default": "disabled",
+        "loopguard_default": "disabled",
+        "etherchannel_misconfig_guard": "enabled",
+        "uplinkfast": "disabled",
+        "backbonefast": "disabled"
+    },
+    "vlans": {},
+    "mode": "rapid-pvst",
+    "root_bridge_for": [],
+    "pathcost_method": "short"
+}

--- a/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/expected.json
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/expected.json
@@ -12,5 +12,13 @@
     "vlans": {},
     "mode": "rapid-pvst",
     "root_bridge_for": [],
-    "pathcost_method": "short"
+    "pathcost_method": "short",
+    "summary": {
+        "total_vlans": 0,
+        "blocking": 0,
+        "listening": 0,
+        "learning": 0,
+        "forwarding": 0,
+        "stp_active": 0
+    }
 }

--- a/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/input.txt
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/input.txt
@@ -1,0 +1,15 @@
+Switch is in rapid-pvst mode
+Root bridge for: none
+Extended system ID                      is enabled
+Portfast Default                        is disabled
+PortFast BPDU Guard Default            is disabled
+Portfast BPDU Filter Default           is disabled
+Loopguard Default                      is disabled
+EtherChannel misconfig guard            is enabled
+UplinkFast                              is disabled
+BackboneFast                            is disabled
+Configured Pathcost method used is short
+
+Name                   Blocking Listening Learning Forwarding STP Active
+---------------------- -------- --------- -------- ---------- ----------
+Total                        0         0        0          0          0

--- a/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/metadata.yaml
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/001_no_root_bridge/metadata.yaml
@@ -1,0 +1,3 @@
+description: show spanning-tree summary from an ISR 1100 (TAC-R2) with no VLANs/STP active
+platform: Cisco ISR 1100
+software_version: IOS-XE 17.x

--- a/tests/parsers/iosxe/show_spanning-tree_summary/002_root_bridge_for_vlan/expected.json
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/002_root_bridge_for_vlan/expected.json
@@ -1,0 +1,37 @@
+{
+    "defaults": {
+        "extended_system_id": "enabled",
+        "portfast_default": "disabled",
+        "portfast_edge_bpdu_guard_default": "disabled",
+        "portfast_edge_bpdu_filter_default": "disabled",
+        "loopguard_default": "disabled",
+        "bpdu_sender_conflict": "enabled",
+        "pvst_simulation_default": "enabled but inactive in rapid-pvst mode",
+        "bridge_assurance": "disabled",
+        "etherchannel_misconfig_guard": "enabled",
+        "uplinkfast": "disabled",
+        "backbonefast": "disabled"
+    },
+    "vlans": {
+        "1": {
+            "blocking": 0,
+            "listening": 0,
+            "learning": 0,
+            "forwarding": 1,
+            "stp_active": 1
+        }
+    },
+    "mode": "rapid-pvst",
+    "root_bridge_for": [
+        "1"
+    ],
+    "pathcost_method": "long",
+    "summary": {
+        "total_vlans": 1,
+        "blocking": 0,
+        "listening": 0,
+        "learning": 0,
+        "forwarding": 1,
+        "stp_active": 1
+    }
+}

--- a/tests/parsers/iosxe/show_spanning-tree_summary/002_root_bridge_for_vlan/input.txt
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/002_root_bridge_for_vlan/input.txt
@@ -1,0 +1,21 @@
+Switch is in rapid-pvst mode
+Root bridge for: VLAN0001
+Extended system ID                      is enabled
+Portfast Default                        is disabled
+Portfast Edge BPDU Guard Default        is disabled
+Portfast Edge BPDU Filter Default       is disabled
+Loopguard Default                       is disabled
+BPDU sender conflict                    is enabled
+PVST Simulation Default                 is enabled but inactive in rapid-pvst
+mode
+Bridge Assurance                        is disabled
+EtherChannel misconfig guard            is enabled
+UplinkFast                              is disabled
+BackboneFast                            is disabled
+Configured Pathcost method used is long
+
+Name                   Blocking Listening Learning Forwarding STP Active
+---------------------- -------- --------- -------- ---------- ----------
+VLAN0001                     0         0        0          1          1
+---------------------- -------- --------- -------- ---------- ----------
+1 vlan                       0         0        0          1          1

--- a/tests/parsers/iosxe/show_spanning-tree_summary/002_root_bridge_for_vlan/metadata.yaml
+++ b/tests/parsers/iosxe/show_spanning-tree_summary/002_root_bridge_for_vlan/metadata.yaml
@@ -1,0 +1,3 @@
+description: show spanning-tree summary from a Catalyst 9300 (TAC-S1) acting as root bridge for VLAN 1
+platform: Cisco Catalyst 9300
+software_version: IOS-XE 17.x


### PR DESCRIPTION
## Summary

- Extend the existing `show spanning-tree summary` parser to also run for IOS-XE via a stacked `@register(OS.CISCO_IOSXE, ...)` decorator on the IOS class; both platforms render this command identically.
- Broaden the `StpDefaults` schema and feature-label map to cover IOS-XE evidence from the issue: `portfast_bpdu_guard_default` / `portfast_bpdu_filter_default` (non-"Edge" variants used on ISR 1100) and `bpdu_sender_conflict` (Catalyst 9300). All three are `NotRequired` and only appear when the device emits them.
- Add IOS-XE fixtures from the issue samples: TAC-R2 (no STP-active VLANs, non-edge BPDU labels, `Total` footer) and TAC-S1 (root bridge for VLAN 1, edge labels, BPDU sender conflict, PVST simulation default that wraps across two lines, `1 vlan` totals footer).

Closes #1021

## Test plan

- [x] `uv run pytest` (8725 passed)
- [x] `uv run ruff check --fix .` / `uv run ruff format .`
- [x] `uv run ty check src/` (no new diagnostics on touched file)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] Pre-commit hooks pass

Generated with [Claude Code](https://claude.com/claude-code)