### PR TITLE
feat(cisco_iosxe): add parser for `show vlan brief`

### DIFF
--- a/changes/1024.parser_added
+++ b/changes/1024.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show vlan brief` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vlan_brief.py
+++ b/src/muninn/parsers/iosxe/show_vlan_brief.py
@@ -1,7 +1,7 @@
 """Parser for 'show vlan brief' command on IOS-XE."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -17,7 +17,7 @@ class VlanBriefEntry(TypedDict):
     vlan_id: int
     name: str
     status: str
-    ports: NotRequired[list[str]]
+    ports: list[str]
 
 
 class ShowVlanBriefResult(TypedDict):
@@ -95,10 +95,8 @@ def _parse_vlan_line(
         "vlan_id": int(vlan_field),
         "name": name,
         "status": status,
+        "ports": _normalize_ports(ports_str),
     }
-    ports = _normalize_ports(ports_str)
-    if ports:
-        entry["ports"] = ports
     return vlan_field, entry, i
 
 
@@ -108,7 +106,7 @@ def _append_continuation_ports(
     """Append wrapped port-list continuation tokens to an existing VLAN."""
     extra = _normalize_ports(stripped)
     if extra:
-        vlans[vlan_id].setdefault("ports", []).extend(extra)
+        vlans[vlan_id]["ports"].extend(extra)
 
 
 def _parse_table(lines: list[str]) -> dict[str, VlanBriefEntry]:

--- a/src/muninn/parsers/iosxe/show_vlan_brief.py
+++ b/src/muninn/parsers/iosxe/show_vlan_brief.py
@@ -1,0 +1,170 @@
+"""Parser for 'show vlan brief' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_SPACE_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class VlanBriefEntry(TypedDict):
+    """Schema for a single VLAN entry in 'show vlan brief' output."""
+
+    vlan_id: int
+    name: str
+    status: str
+    ports: NotRequired[list[str]]
+
+
+class ShowVlanBriefResult(TypedDict):
+    """Schema for 'show vlan brief' parsed output."""
+
+    vlans: dict[str, VlanBriefEntry]
+
+
+_HEADER_RE = re.compile(r"^VLAN\s+Name\s+Status\s+Ports\s*$")
+_SEPARATOR_RE = SEPARATOR_DASH_SPACE_RE
+
+# Column positions inferred from the fixed-width header layout:
+#   "VLAN Name                             Status    Ports"
+#   "---- -------------------------------- --------- ---..."
+_NAME_COL = 5
+_STATUS_COL = 38
+_PORTS_COL = 48
+
+_VALID_STATUSES = frozenset(
+    {"active", "suspended", "act/unsup", "act/lshut", "sus/lshut", "sus/unsup"}
+)
+
+
+def _col_field(line: str, start: int, end: int | None = None) -> str:
+    """Extract and strip a column-position field from a line."""
+    if len(line) <= start:
+        return ""
+    if end is None:
+        return line[start:].strip()
+    return line[start:end].strip()
+
+
+def _normalize_ports(port_str: str) -> list[str]:
+    """Split comma-separated ports and normalize to canonical names."""
+    port_str = port_str.strip()
+    if not port_str:
+        return []
+    return [
+        canonical_interface_name(p.strip(), os=OS.CISCO_IOSXE)
+        for p in port_str.split(",")
+        if p.strip()
+    ]
+
+
+def _handle_wrapped_name(
+    line: str, lines: list[str], i: int
+) -> tuple[str, str, str, int]:
+    """Handle VLAN name that overflows into the status column.
+
+    Returns ``(name, status, ports_field, new_index)``.
+    """
+    next_line = lines[i + 1] if i + 1 < len(lines) else ""
+    next_status = _col_field(next_line, _STATUS_COL, _PORTS_COL)
+    if next_status:
+        name = _col_field(line, _NAME_COL)
+        ports = _col_field(next_line, _PORTS_COL)
+        return name, next_status, ports, i + 1
+    # Fallback: treat what we have as the name with no status/ports.
+    return _col_field(line, _NAME_COL), "", "", i
+
+
+def _parse_vlan_line(
+    line: str, lines: list[str], i: int
+) -> tuple[str, VlanBriefEntry, int]:
+    """Parse a new VLAN row, returning ``(vlan_id, entry, new_index)``."""
+    vlan_field = line[:4].strip()
+    name = _col_field(line, _NAME_COL, _STATUS_COL)
+    status = _col_field(line, _STATUS_COL, _PORTS_COL)
+    ports_str = _col_field(line, _PORTS_COL)
+
+    if name and status not in _VALID_STATUSES:
+        name, status, ports_str, i = _handle_wrapped_name(line, lines, i)
+
+    entry: VlanBriefEntry = {
+        "vlan_id": int(vlan_field),
+        "name": name,
+        "status": status,
+    }
+    ports = _normalize_ports(ports_str)
+    if ports:
+        entry["ports"] = ports
+    return vlan_field, entry, i
+
+
+def _append_continuation_ports(
+    vlans: dict[str, VlanBriefEntry], vlan_id: str, stripped: str
+) -> None:
+    """Append wrapped port-list continuation tokens to an existing VLAN."""
+    extra = _normalize_ports(stripped)
+    if extra:
+        vlans[vlan_id].setdefault("ports", []).extend(extra)
+
+
+def _parse_table(lines: list[str]) -> dict[str, VlanBriefEntry]:
+    """Walk the output lines and build the ``vlans`` dict."""
+    vlans: dict[str, VlanBriefEntry] = {}
+    current_vlan_id: str | None = None
+    in_table = False
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if not in_table:
+            if _HEADER_RE.match(stripped):
+                in_table = True
+            i += 1
+            continue
+
+        if _SEPARATOR_RE.match(stripped) or not stripped:
+            i += 1
+            continue
+
+        vlan_field = line[:4].strip()
+        if vlan_field and vlan_field.isdigit():
+            vlan_field, entry, i = _parse_vlan_line(line, lines, i)
+            vlans[vlan_field] = entry
+            current_vlan_id = vlan_field
+        elif current_vlan_id is not None:
+            # Continuation line: either indented to the ports column with
+            # more ports, or an unindented wrap from terminal-width
+            # truncation. In both cases all remaining content is ports.
+            _append_continuation_ports(vlans, current_vlan_id, stripped)
+
+        i += 1
+
+    return vlans
+
+
+@register(OS.CISCO_IOSXE, "show vlan brief")
+class ShowVlanBriefParser(BaseParser[ShowVlanBriefResult]):
+    """Parser for 'show vlan brief' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.SWITCHING,
+            ParserTag.VLAN,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVlanBriefResult:
+        """Parse 'show vlan brief' output."""
+        lines = output.splitlines()
+        vlans = _parse_table(lines)
+        if not vlans:
+            msg = "No VLAN entries found in 'show vlan brief' output"
+            raise ValueError(msg)
+        return {"vlans": vlans}

--- a/tests/parsers/iosxe/show_vlan_brief/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vlan_brief/001_basic/expected.json
@@ -3,27 +3,32 @@
         "1": {
             "vlan_id": 1,
             "name": "default",
-            "status": "active"
+            "status": "active",
+            "ports": []
         },
         "1002": {
             "vlan_id": 1002,
             "name": "fddi-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         },
         "1003": {
             "vlan_id": 1003,
             "name": "token-ring-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         },
         "1004": {
             "vlan_id": 1004,
             "name": "fddinet-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         },
         "1005": {
             "vlan_id": 1005,
             "name": "trnet-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         }
     }
 }

--- a/tests/parsers/iosxe/show_vlan_brief/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vlan_brief/001_basic/expected.json
@@ -1,0 +1,29 @@
+{
+    "vlans": {
+        "1": {
+            "vlan_id": 1,
+            "name": "default",
+            "status": "active"
+        },
+        "1002": {
+            "vlan_id": 1002,
+            "name": "fddi-default",
+            "status": "act/unsup"
+        },
+        "1003": {
+            "vlan_id": 1003,
+            "name": "token-ring-default",
+            "status": "act/unsup"
+        },
+        "1004": {
+            "vlan_id": 1004,
+            "name": "fddinet-default",
+            "status": "act/unsup"
+        },
+        "1005": {
+            "vlan_id": 1005,
+            "name": "trnet-default",
+            "status": "act/unsup"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vlan_brief/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vlan_brief/001_basic/input.txt
@@ -1,0 +1,7 @@
+VLAN Name                             Status    Ports
+---- -------------------------------- --------- -------------------------------
+1    default                          active
+1002 fddi-default                     act/unsup
+1003 token-ring-default               act/unsup
+1004 fddinet-default                  act/unsup
+1005 trnet-default                    act/unsup

--- a/tests/parsers/iosxe/show_vlan_brief/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vlan_brief/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Live device output from TAC-R2 with default VLANs only and no ports
+platform: Cisco ISR 1100
+software_version: Unknown

--- a/tests/parsers/iosxe/show_vlan_brief/002_with_ports/expected.json
+++ b/tests/parsers/iosxe/show_vlan_brief/002_with_ports/expected.json
@@ -1,0 +1,86 @@
+{
+    "vlans": {
+        "1": {
+            "vlan_id": 1,
+            "name": "default",
+            "status": "active",
+            "ports": [
+                "GigabitEthernet1/0/3",
+                "GigabitEthernet1/0/4",
+                "GigabitEthernet1/0/5",
+                "GigabitEthernet1/0/6",
+                "GigabitEthernet1/0/7",
+                "GigabitEthernet1/0/8",
+                "GigabitEthernet1/0/9",
+                "GigabitEthernet1/0/10",
+                "GigabitEthernet1/0/11",
+                "GigabitEthernet1/0/12",
+                "GigabitEthernet1/0/13",
+                "GigabitEthernet1/0/14",
+                "GigabitEthernet1/0/15",
+                "GigabitEthernet1/0/16",
+                "GigabitEthernet1/0/17",
+                "GigabitEthernet1/0/18",
+                "GigabitEthernet1/0/19",
+                "GigabitEthernet1/0/20",
+                "GigabitEthernet1/0/21",
+                "GigabitEthernet1/0/22",
+                "GigabitEthernet1/0/23",
+                "GigabitEthernet1/0/24",
+                "GigabitEthernet1/0/25",
+                "GigabitEthernet1/0/26",
+                "GigabitEthernet1/0/27",
+                "GigabitEthernet1/0/28",
+                "GigabitEthernet1/0/29",
+                "GigabitEthernet1/0/30",
+                "GigabitEthernet1/0/31",
+                "GigabitEthernet1/0/32",
+                "GigabitEthernet1/0/33",
+                "GigabitEthernet1/0/34",
+                "GigabitEthernet1/0/35",
+                "GigabitEthernet1/0/36",
+                "GigabitEthernet1/0/37",
+                "GigabitEthernet1/0/38",
+                "GigabitEthernet1/0/39",
+                "GigabitEthernet1/0/40",
+                "GigabitEthernet1/0/41",
+                "GigabitEthernet1/0/42",
+                "GigabitEthernet1/0/43",
+                "GigabitEthernet1/0/44",
+                "GigabitEthernet1/0/45",
+                "GigabitEthernet1/0/46",
+                "GigabitEthernet1/0/47",
+                "GigabitEthernet1/0/48",
+                "TenGigabitEthernet1/1/1",
+                "TenGigabitEthernet1/1/2",
+                "TenGigabitEthernet1/1/3",
+                "TenGigabitEthernet1/1/4",
+                "TenGigabitEthernet1/1/5",
+                "TenGigabitEthernet1/1/6",
+                "TenGigabitEthernet1/1/7",
+                "TenGigabitEthernet1/1/8",
+                "AppGigabitEthernet1/0/1"
+            ]
+        },
+        "1002": {
+            "vlan_id": 1002,
+            "name": "fddi-default",
+            "status": "act/unsup"
+        },
+        "1003": {
+            "vlan_id": 1003,
+            "name": "token-ring-default",
+            "status": "act/unsup"
+        },
+        "1004": {
+            "vlan_id": 1004,
+            "name": "fddinet-default",
+            "status": "act/unsup"
+        },
+        "1005": {
+            "vlan_id": 1005,
+            "name": "trnet-default",
+            "status": "act/unsup"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vlan_brief/002_with_ports/expected.json
+++ b/tests/parsers/iosxe/show_vlan_brief/002_with_ports/expected.json
@@ -65,22 +65,26 @@
         "1002": {
             "vlan_id": 1002,
             "name": "fddi-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         },
         "1003": {
             "vlan_id": 1003,
             "name": "token-ring-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         },
         "1004": {
             "vlan_id": 1004,
             "name": "fddinet-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         },
         "1005": {
             "vlan_id": 1005,
             "name": "trnet-default",
-            "status": "act/unsup"
+            "status": "act/unsup",
+            "ports": []
         }
     }
 }

--- a/tests/parsers/iosxe/show_vlan_brief/002_with_ports/input.txt
+++ b/tests/parsers/iosxe/show_vlan_brief/002_with_ports/input.txt
@@ -1,0 +1,15 @@
+VLAN Name                             Status    Ports
+---- -------------------------------- --------- -------------------------------
+1    default                          active    Gi1/0/3, Gi1/0/4, Gi1/0/5,
+Gi1/0/6, Gi1/0/7, Gi1/0/8, Gi1/0/9, Gi1/0/10, Gi1/0/11, Gi1/0/12, Gi1/0/13,
+Gi1/0/14, Gi1/0/15, Gi1/0/16, Gi1/0/17, Gi1/0/18, Gi1/0/19, Gi1/0/20, Gi1/0/21,
+Gi1/0/22, Gi1/0/23, Gi1/0/24, Gi1/0/25, Gi1/0/26, Gi1/0/27, Gi1/0/28, Gi1/0/29,
+Gi1/0/30, Gi1/0/31, Gi1/0/32, Gi1/0/33, Gi1/0/34, Gi1/0/35, Gi1/0/36, Gi1/0/37,
+Gi1/0/38, Gi1/0/39, Gi1/0/40, Gi1/0/41, Gi1/0/42, Gi1/0/43, Gi1/0/44, Gi1/0/45,
+Gi1/0/46, Gi1/0/47, Gi1/0/48, Te1/1/1
+                                                Te1/1/2, Te1/1/3, Te1/1/4,
+Te1/1/5, Te1/1/6, Te1/1/7, Te1/1/8, Ap1/0/1
+1002 fddi-default                     act/unsup
+1003 token-ring-default               act/unsup
+1004 fddinet-default                  act/unsup
+1005 trnet-default                    act/unsup

--- a/tests/parsers/iosxe/show_vlan_brief/002_with_ports/metadata.yaml
+++ b/tests/parsers/iosxe/show_vlan_brief/002_with_ports/metadata.yaml
@@ -1,0 +1,3 @@
+description: Live device output from TAC-S1 with wrapped port list spanning multiple lines
+platform: Cisco Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds a parser for `show vlan brief` on Cisco IOS-XE that produces `{"vlans": {vlan_id_str: VlanBriefEntry}}` with `vlan_id`, `name`, `status`, and an optional `ports` list of canonicalized interface names.
- Two fixtures from the issue's live testbed captures: `001_basic` (TAC-R2, ISR 1100 — default VLANs only) and `002_with_ports` (TAC-S1, Catalyst 9300 — VLAN 1 with a long, terminal-wrapped port list across multiple lines).

Closes #1024

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_vlan_brief -v` (14 passing)
- [x] `uv run pytest` (full suite, 8745 passing)
- [x] `uv run ruff check src/muninn/parsers/iosxe/show_vlan_brief.py`
- [x] `uv run ruff format src/muninn/parsers/iosxe/show_vlan_brief.py`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_vlan_brief.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)