### PR TITLE
feat(cisco_iosxe): add parser for `show vlans`

### DIFF
--- a/changes/1025.parser_added
+++ b/changes/1025.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show vlans` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_vlans.py
+++ b/src/muninn/parsers/ios/show_vlans.py
@@ -331,8 +331,9 @@ def _parse_vlans(lines: list[str]) -> dict[str, VlanEntry]:
 
 
 @register(OS.CISCO_IOS, "show vlans")
+@register(OS.CISCO_IOSXE, "show vlans")
 class ShowVlansParser(BaseParser[ShowVlansResult]):
-    """Parser for 'show vlans' on IOS.
+    """Parser for 'show vlans' on IOS and IOS-XE.
 
     Parses dot1q VLAN information including trunk interfaces,
     protocol counters, and per-interface traffic statistics.

--- a/tests/parsers/iosxe/show_vlans/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vlans/001_basic/expected.json
@@ -1,0 +1,107 @@
+{
+    "vlans": {
+        "1": {
+            "vlan_id": 1,
+            "encapsulation": "IEEE 802.1Q Encapsulation",
+            "is_native": true,
+            "protocols": {
+                "IP": {
+                    "received": 171535,
+                    "transmitted": 156451
+                }
+            },
+            "interfaces": {
+                "GigabitEthernet0/0/1": {
+                    "interface": "GigabitEthernet0/0/1",
+                    "vlan_tag": "1",
+                    "addresses": {
+                        "IP": "10.0.1.2"
+                    },
+                    "packets_input": 1191,
+                    "bytes_input": 509225,
+                    "packets_output": 10213,
+                    "bytes_output": 2010424
+                },
+                "GigabitEthernet0/0/2": {
+                    "interface": "GigabitEthernet0/0/2",
+                    "vlan_tag": "1",
+                    "addresses": {
+                        "IP": "10.0.4.1"
+                    },
+                    "packets_input": 234722,
+                    "bytes_input": 41356180,
+                    "packets_output": 212754,
+                    "bytes_output": 38745511
+                }
+            }
+        },
+        "10": {
+            "vlan_id": 10,
+            "encapsulation": "IEEE 802.1Q Encapsulation",
+            "protocols": {
+                "IP": {
+                    "received": 218504,
+                    "transmitted": 225194
+                }
+            },
+            "interfaces": {
+                "GigabitEthernet0/0/1.10": {
+                    "interface": "GigabitEthernet0/0/1.10",
+                    "vlan_tag": "10",
+                    "addresses": {
+                        "IP": "10.10.1.2"
+                    },
+                    "packets_input": 0,
+                    "bytes_input": 0,
+                    "packets_output": 6689,
+                    "bytes_output": 761696
+                },
+                "GigabitEthernet0/0/2.10": {
+                    "interface": "GigabitEthernet0/0/2.10",
+                    "vlan_tag": "10",
+                    "addresses": {
+                        "IP": "10.10.4.1"
+                    },
+                    "packets_input": 218586,
+                    "bytes_input": 21582995,
+                    "packets_output": 218606,
+                    "bytes_output": 21277881
+                }
+            }
+        },
+        "20": {
+            "vlan_id": 20,
+            "encapsulation": "IEEE 802.1Q Encapsulation",
+            "protocols": {
+                "IP": {
+                    "received": 218463,
+                    "transmitted": 225115
+                }
+            },
+            "interfaces": {
+                "GigabitEthernet0/0/1.20": {
+                    "interface": "GigabitEthernet0/0/1.20",
+                    "vlan_tag": "20",
+                    "addresses": {
+                        "IP": "10.20.1.2"
+                    },
+                    "packets_input": 0,
+                    "bytes_input": 0,
+                    "packets_output": 6690,
+                    "bytes_output": 761810
+                },
+                "GigabitEthernet0/0/2.20": {
+                    "interface": "GigabitEthernet0/0/2.20",
+                    "vlan_tag": "20",
+                    "addresses": {
+                        "IP": "10.20.4.1"
+                    },
+                    "packets_input": 218546,
+                    "bytes_input": 21579328,
+                    "packets_output": 218526,
+                    "bytes_output": 21271637
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_vlans/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vlans/001_basic/input.txt
@@ -1,0 +1,72 @@
+VLAN ID: 1 (IEEE 802.1Q Encapsulation)
+
+ This is configured as native Vlan for the following interface(s) :
+GigabitEthernet0/0/1    Native-vlan Tx-type: Untagged
+GigabitEthernet0/0/2    Native-vlan Tx-type: Untagged
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP             171535              156451
+
+VLAN trunk interfaces for VLAN ID 1:
+GigabitEthernet0/0/1
+
+GigabitEthernet0/0/1 (1)
+
+                     IP: 10.0.1.2
+
+      Total 1191 packets, 509225 bytes input
+      Total 10213 packets, 2010424 bytes output
+GigabitEthernet0/0/2
+
+GigabitEthernet0/0/2 (1)
+
+                     IP: 10.0.4.1
+
+      Total 234722 packets, 41356180 bytes input
+      Total 212754 packets, 38745511 bytes output
+
+VLAN ID: 10 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP             218504              225194
+
+VLAN trunk interfaces for VLAN ID 10:
+GigabitEthernet0/0/1.10
+
+GigabitEthernet0/0/1.10 (10)
+
+                     IP: 10.10.1.2
+
+      Total 0 packets, 0 bytes input
+      Total 6689 packets, 761696 bytes output
+GigabitEthernet0/0/2.10
+
+GigabitEthernet0/0/2.10 (10)
+
+                     IP: 10.10.4.1
+
+      Total 218586 packets, 21582995 bytes input
+      Total 218606 packets, 21277881 bytes output
+
+VLAN ID: 20 (IEEE 802.1Q Encapsulation)
+
+   Protocols Configured:          Received:        Transmitted:
+                     IP             218463              225115
+
+VLAN trunk interfaces for VLAN ID 20:
+GigabitEthernet0/0/1.20
+
+GigabitEthernet0/0/1.20 (20)
+
+                     IP: 10.20.1.2
+
+      Total 0 packets, 0 bytes input
+      Total 6690 packets, 761810 bytes output
+GigabitEthernet0/0/2.20
+
+GigabitEthernet0/0/2.20 (20)
+
+                     IP: 10.20.4.1
+
+      Total 218546 packets, 21579328 bytes input
+      Total 218526 packets, 21271637 bytes output

--- a/tests/parsers/iosxe/show_vlans/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vlans/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple dot1q VLANs with native VLAN, trunk interfaces, protocol counters, and per-interface traffic statistics captured from physical testbed devices
+platform: Cisco ISR 1100 / Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds `show vlans` support for Cisco IOS-XE by stacking an extra `@register(OS.CISCO_IOSXE, ...)` decorator on the existing IOS parser. The IOS-XE output format is identical, so a single parser implementation covers both platforms.
- Ships a real-device fixture (`tests/parsers/iosxe/show_vlans/001_basic/`) captured from ISR 1100 / Catalyst 9300 testbeds, exercising native VLAN, trunk interfaces, protocol counters, and per-interface traffic statistics.

Closes #1025

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_vlans -v` (21 passed)
- [x] `uv run pytest -q` (8718 passed)
- [x] `uv run ruff check .` / `uv run ruff format src/muninn/parsers/ios/show_vlans.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_vlans.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/ios/show_vlans.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)