### PR TITLE
feat(cisco_iosxe): add parser for `show ntp associations`

### DIFF
--- a/changes/1017.parser_added
+++ b/changes/1017.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ntp associations` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_ntp_associations.py
+++ b/src/muninn/parsers/ios/show_ntp_associations.py
@@ -1,4 +1,4 @@
-"""Parser for 'show ntp associations' command on Cisco IOS."""
+"""Parser for 'show ntp associations' command on Cisco IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict
@@ -8,7 +8,7 @@ from muninn.parser import BaseParser
 from muninn.registry import register
 from muninn.tags import ParserTag
 
-# NTP tally code meanings on Cisco IOS:
+# NTP tally code meanings on Cisco IOS/IOS-XE:
 #   * = sys.peer (current sync source)
 #   # = selected (selected for sync, distance exceeds maximum value)
 #   + = candidate
@@ -23,13 +23,13 @@ _TALLY_CODES: dict[str, str] = {
     "x": "falseticker",
 }
 
-# Second-character configuration marker meanings on Cisco IOS:
+# Second-character configuration marker meanings on Cisco IOS/IOS-XE:
 #   ~ = configured (statically configured peer/server)
 _CONFIG_MARKER_CONFIGURED = "~"
 
 
 class NtpPeerEntry(TypedDict):
-    """Schema for a single NTP peer association entry on Cisco IOS.
+    """Schema for a single NTP peer association entry on Cisco IOS/IOS-XE.
 
     The ``reach`` field is an 8-bit shift register from ``ntpq``: each bit
     records whether one of the most recent eight polls succeeded.  The raw
@@ -57,7 +57,7 @@ class NtpPeerEntry(TypedDict):
 ShowNtpAssociationsResult = dict[str, NtpPeerEntry]
 
 
-# Match NTP association lines.  IOS prefixes each peer with a two-character
+# Match NTP association lines.  IOS/IOS-XE prefixes each peer with a two-character
 # prefix: the first character is the tally code (``*+-x# `` or space) and the
 # second character is the configuration marker (``~`` for configured peers,
 # space otherwise).  The reference clock token may contain dots (``.GPS.``),
@@ -82,18 +82,21 @@ _HEADER_RE = re.compile(
     r"delay\s+offset\s+disp\s*$"
 )
 
-# The legend line on IOS starts with "* sys.peer" after some leading
+# The legend line on IOS/IOS-XE starts with "* sys.peer" after some leading
 # whitespace; matching it lets us skip the legend cleanly.
 _LEGEND_RE = re.compile(r"^\s*\*\s*sys\.peer,")
 
 
 @register(OS.CISCO_IOS, "show ntp associations")
+@register(OS.CISCO_IOSXE, "show ntp associations")
 class ShowNtpAssociationsParser(BaseParser[ShowNtpAssociationsResult]):
-    """Parser for 'show ntp associations' command on Cisco IOS.
+    """Parser for 'show ntp associations' command on Cisco IOS and IOS-XE.
 
     Parses the NTP peer association table including tally code, configuration
     marker, reference clock, stratum, polling interval, reachability, and
-    timing metrics (delay, offset, dispersion).
+    timing metrics (delay, offset, dispersion).  IOS and IOS-XE share an
+    identical output format for this command, so a single parser handles both
+    platforms.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
@@ -150,7 +153,7 @@ class ShowNtpAssociationsParser(BaseParser[ShowNtpAssociationsResult]):
 
     @classmethod
     def parse(cls, output: str) -> ShowNtpAssociationsResult:
-        """Parse 'show ntp associations' output on Cisco IOS.
+        """Parse 'show ntp associations' output on Cisco IOS/IOS-XE.
 
         Args:
             output: Raw CLI output from the command.

--- a/tests/parsers/iosxe/show_ntp_associations/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ntp_associations/001_basic/expected.json
@@ -1,0 +1,28 @@
+{
+    "192.0.2.10": {
+        "address": "192.0.2.10",
+        "ref_clock": ".GNSS.",
+        "stratum": 1,
+        "poll_seconds": 1024,
+        "reach": 255,
+        "reach_raw": "377",
+        "delay_ms": 39.781,
+        "offset_ms": -1.893,
+        "dispersion_ms": 1.071,
+        "tally": "sys.peer",
+        "configured": true,
+        "when_seconds": 932
+    },
+    "192.0.2.11": {
+        "address": "192.0.2.11",
+        "ref_clock": ".TIME.",
+        "stratum": 16,
+        "poll_seconds": 64,
+        "reach": 0,
+        "reach_raw": "0",
+        "delay_ms": 0.0,
+        "offset_ms": 0.0,
+        "dispersion_ms": 15937.0,
+        "configured": true
+    }
+}

--- a/tests/parsers/iosxe/show_ntp_associations/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ntp_associations/001_basic/input.txt
@@ -1,0 +1,4 @@
+address         ref clock       st   when   poll reach  delay  offset   disp
+*~192.0.2.10  .GNSS.           1    932   1024   377 39.781  -1.893  1.071
+ ~192.0.2.11  .TIME.          16      -     64     0  0.000   0.000 15937.
+ * sys.peer, # selected, + candidate, - outlyer, x falseticker, ~ configured

--- a/tests/parsers/iosxe/show_ntp_associations/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ntp_associations/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: NTP associations table from a TAC-R2 IOS-XE device with a GNSS-referenced sys.peer and an unreachable stratum-16 configured peer
+platform: Cisco ISR 1100 / Catalyst 9300
+software_version: IOS-XE


### PR DESCRIPTION
## Summary

- Extend the existing Cisco IOS `show ntp associations` parser to also handle Cisco IOS-XE via a stacked `@register(OS.CISCO_IOSXE, ...)` decorator. IOS and IOS-XE share an identical output format for this command, so reusing the parser avoids duplicating the regex, schema, and decoding logic.
- Update the parser docstring, module docstring, and inline comments to reflect the dual-platform coverage.
- Add a new IOS-XE test fixture (`tests/parsers/iosxe/show_ntp_associations/001_basic/`) captured from a TAC-R2 device (ISR 1100 / Catalyst 9300). The fixture exercises a GNSS-referenced sys.peer, an unreachable stratum-16 configured peer with a non-numeric `when` value, a trailing-dot dispersion, and a negative offset — none of which were covered by the existing IOS fixture.

Closes #1017

## Test plan

- [x] `uv run pytest` (8718 passed locally)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format` (no changes)
- [x] `uv run ty check src/` (no new diagnostics in changed files)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

Generated with [Claude Code](https://claude.com/claude-code)