### PR TITLE
feat(cisco_iosxe): add parser for `show mka statistics`

### DIFF
--- a/changes/1016.parser_added
+++ b/changes/1016.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show mka statistics` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_mka_statistics.py
+++ b/src/muninn/parsers/iosxe/show_mka_statistics.py
@@ -1,0 +1,440 @@
+"""Parser for 'show mka statistics' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class MkaSessionTotals(TypedDict):
+    """Schema for the MKA Session Totals block."""
+
+    secured: int
+    fallback_secured: int
+    reauthentication_attempts: int
+    deleted_secured: int
+    keepalive_timeouts: int
+
+
+class MkaCaStatistics(TypedDict):
+    """Schema for the CA Statistics block."""
+
+    pairwise_caks_derived: int
+    pairwise_cak_rekeys: int
+    group_caks_generated: int
+    group_caks_received: int
+
+
+class MkaSaStatistics(TypedDict):
+    """Schema for the SA Statistics block.
+
+    ``sak_rekeyed_as_kn_mismatch`` is emitted on some IOS-XE images and is
+    omitted on platforms that do not report it.
+    """
+
+    saks_generated: int
+    saks_rekeyed: int
+    saks_received: int
+    sak_responses_received: int
+    sak_rekeyed_as_kn_mismatch: NotRequired[int]
+
+
+class MkaDistributedCounters(TypedDict):
+    """Schema for distributed SAK/CAK MKPDU counters."""
+
+    distributed_sak: int
+    distributed_cak: int
+
+
+class MkaMkpduStatistics(TypedDict):
+    """Schema for the MKPDU Statistics block."""
+
+    mkpdus_validated_and_received: int
+    mkpdus_validated_and_received_breakdown: MkaDistributedCounters
+    mkpdus_transmitted: int
+    mkpdus_transmitted_breakdown: MkaDistributedCounters
+
+
+class MkaSessionFailures(TypedDict):
+    """Schema for the Session Failures error block."""
+
+    bring_up_failures: int
+    reauthentication_failures: int
+    duplicate_auth_mgr_handle: int
+
+
+class MkaSakFailures(TypedDict):
+    """Schema for the SAK Failures error block."""
+
+    sak_generation: int
+    hash_key_generation: int
+    sak_encryption_wrap: int
+    sak_decryption_unwrap: int
+    sak_cipher_mismatch: int
+
+
+class MkaCaFailures(TypedDict):
+    """Schema for the CA Failures error block."""
+
+    group_cak_generation: int
+    group_cak_encryption_wrap: int
+    group_cak_decryption_unwrap: int
+    pairwise_cak_derivation: int
+    ckn_derivation: int
+    ick_derivation: int
+    kek_derivation: int
+    invalid_peer_macsec_capability: int
+
+
+class MkaMacsecFailures(TypedDict):
+    """Schema for the MACsec Failures error block."""
+
+    rx_sc_creation: int
+    tx_sc_creation: int
+    rx_sa_installation: int
+    tx_sa_installation: int
+
+
+class MkaMkpduFailures(TypedDict):
+    """Schema for the MKPDU Failures error block."""
+
+    mkpdu_tx: int
+    mkpdu_rx_icv_verification: int
+    mkpdu_rx_fallback_icv_verification: int
+    mkpdu_rx_validation: int
+    mkpdu_rx_bad_peer_mn: int
+    mkpdu_rx_non_recent_peerlist_mn: int
+
+
+class MkaSakUseFailures(TypedDict):
+    """Schema for the SAK USE Failures error block.
+
+    This block is not present on every IOS-XE image.
+    """
+
+    sak_use_latest_kn_mismatch: int
+    sak_use_latest_an_not_in_use: int
+
+
+class MkaErrorCounterTotals(TypedDict):
+    """Schema for the MKA Error Counter Totals section."""
+
+    session_failures: MkaSessionFailures
+    sak_failures: MkaSakFailures
+    ca_failures: MkaCaFailures
+    macsec_failures: MkaMacsecFailures
+    mkpdu_failures: MkaMkpduFailures
+    sak_use_failures: NotRequired[MkaSakUseFailures]
+
+
+class ShowMkaStatisticsResult(TypedDict):
+    """Schema for 'show mka statistics' parsed output."""
+
+    mka_session_totals: MkaSessionTotals
+    ca_statistics: MkaCaStatistics
+    sa_statistics: MkaSaStatistics
+    mkpdu_statistics: MkaMkpduStatistics
+    mka_error_counter_totals: MkaErrorCounterTotals
+
+
+# Section headers (each may end with optional trailing whitespace; ``=====``
+# underline rows are simply ignored as non-matching lines).
+_SEC_SESSION_TOTALS = re.compile(r"^MKA\s+Session\s+Totals$", re.I)
+_SEC_CA_STATS = re.compile(r"^CA\s+Statistics$", re.I)
+_SEC_SA_STATS = re.compile(r"^SA\s+Statistics$", re.I)
+_SEC_MKPDU_STATS = re.compile(r"^MKPDU\s+Statistics$", re.I)
+_SEC_SESSION_FAIL = re.compile(r"^Session\s+Failures$", re.I)
+_SEC_SAK_FAIL = re.compile(r"^SAK\s+Failures$", re.I)
+_SEC_CA_FAIL = re.compile(r"^CA\s+Failures$", re.I)
+_SEC_MACSEC_FAIL = re.compile(r"^MACsec\s+Failures$", re.I)
+_SEC_MKPDU_FAIL = re.compile(r"^MKPDU\s+Failures$", re.I)
+_SEC_SAK_USE_FAIL = re.compile(r"^SAK\s+USE\s+Failures$", re.I)
+
+# Dotted-leader counter rows: ``Label.... 12`` and quoted breakdown rows
+# ``"Distributed SAK"..... 1``.
+_KV_RE = re.compile(r"^(?P<label>.+?)\.{2,}\s*(?P<value>\d+)\s*$")
+_BREAKDOWN_RE = re.compile(
+    r'^"(?P<label>Distributed\s+(?:SAK|CAK))"\.{2,}\s*(?P<value>\d+)\s*$',
+    re.I,
+)
+
+
+# Label -> canonical key mappings for each section. Using exact dotted-label
+# matches keeps the parser robust against unknown fields and lets the schema
+# stay strict.
+_SESSION_TOTALS_MAP = {
+    "secured": "secured",
+    "fallback secured": "fallback_secured",
+    "reauthentication attempts": "reauthentication_attempts",
+    "deleted (secured)": "deleted_secured",
+    "keepalive timeouts": "keepalive_timeouts",
+}
+_CA_STATS_MAP = {
+    "pairwise caks derived": "pairwise_caks_derived",
+    "pairwise cak rekeys": "pairwise_cak_rekeys",
+    "group caks generated": "group_caks_generated",
+    "group caks received": "group_caks_received",
+}
+_SA_STATS_MAP = {
+    "saks generated": "saks_generated",
+    "saks rekeyed": "saks_rekeyed",
+    "saks received": "saks_received",
+    "sak responses received": "sak_responses_received",
+    "sak rekeyed as kn mismatch": "sak_rekeyed_as_kn_mismatch",
+}
+_SESSION_FAIL_MAP = {
+    "bring-up failures": "bring_up_failures",
+    "reauthentication failures": "reauthentication_failures",
+    "duplicate auth-mgr handle": "duplicate_auth_mgr_handle",
+}
+_SAK_FAIL_MAP = {
+    "sak generation": "sak_generation",
+    "hash key generation": "hash_key_generation",
+    "sak encryption/wrap": "sak_encryption_wrap",
+    "sak decryption/unwrap": "sak_decryption_unwrap",
+    "sak cipher mismatch": "sak_cipher_mismatch",
+}
+_CA_FAIL_MAP = {
+    "group cak generation": "group_cak_generation",
+    "group cak encryption/wrap": "group_cak_encryption_wrap",
+    "group cak decryption/unwrap": "group_cak_decryption_unwrap",
+    "pairwise cak derivation": "pairwise_cak_derivation",
+    "ckn derivation": "ckn_derivation",
+    "ick derivation": "ick_derivation",
+    "kek derivation": "kek_derivation",
+    "invalid peer macsec capability": "invalid_peer_macsec_capability",
+}
+_MACSEC_FAIL_MAP = {
+    "rx sc creation": "rx_sc_creation",
+    "tx sc creation": "tx_sc_creation",
+    "rx sa installation": "rx_sa_installation",
+    "tx sa installation": "tx_sa_installation",
+}
+_MKPDU_FAIL_MAP = {
+    "mkpdu tx": "mkpdu_tx",
+    "mkpdu rx icv verification": "mkpdu_rx_icv_verification",
+    "mkpdu rx fallback icv verification": "mkpdu_rx_fallback_icv_verification",
+    "mkpdu rx validation": "mkpdu_rx_validation",
+    "mkpdu rx bad peer mn": "mkpdu_rx_bad_peer_mn",
+    "mkpdu rx non-recent peerlist mn": "mkpdu_rx_non_recent_peerlist_mn",
+}
+_SAK_USE_FAIL_MAP = {
+    "sak use latest kn mismatch": "sak_use_latest_kn_mismatch",
+    "sak use latest an not in use": "sak_use_latest_an_not_in_use",
+}
+
+# Labels in the MKPDU Statistics block whose values are written without a
+# quoted breakdown row. These represent the "total" numbers in that section.
+_MKPDU_TOTALS_MAP = {
+    "mkpdus validated & rx": "mkpdus_validated_and_received",
+    "mkpdus transmitted": "mkpdus_transmitted",
+}
+
+
+class _Acc:
+    """Accumulator that walks the output line-by-line tracking section state."""
+
+    __slots__ = ("section", "mkpdu_target", "data")
+
+    def __init__(self) -> None:
+        self.section: str | None = None
+        # Which MKPDU bucket the next "Distributed SAK/CAK" breakdown row goes
+        # into: either ``mkpdus_validated_and_received_breakdown`` or
+        # ``mkpdus_transmitted_breakdown``.
+        self.mkpdu_target: str | None = None
+        self.data: dict[str, dict[str, int | dict[str, int]]] = {}
+
+    def feed(self, raw: str) -> None:
+        line = raw.strip()
+        if not line:
+            return
+        if self._maybe_switch_section(line):
+            return
+        if self._maybe_breakdown(line):
+            return
+        m = _KV_RE.match(line)
+        if not m:
+            return
+        label = m.group("label").strip().lower()
+        value = int(m.group("value"))
+        self._record(label, value)
+
+    def _maybe_switch_section(self, line: str) -> bool:
+        for section, pattern in _SECTION_HEADERS:
+            if pattern.match(line):
+                self.section = section
+                self.mkpdu_target = None
+                return True
+        return False
+
+    def _maybe_breakdown(self, line: str) -> bool:
+        if self.section != "mkpdu_statistics":
+            return False
+        m = _BREAKDOWN_RE.match(line)
+        if not m:
+            return False
+        if self.mkpdu_target is None:
+            # Stray breakdown row before any totals row; ignore.
+            return True
+        label = m.group("label").lower()
+        key = "distributed_sak" if "sak" in label else "distributed_cak"
+        section = self.data.setdefault("mkpdu_statistics", {})
+        bucket = section.setdefault(self.mkpdu_target, {})
+        if isinstance(bucket, dict):
+            bucket[key] = int(m.group("value"))
+        return True
+
+    def _record(self, label: str, value: int) -> None:
+        if self.section is None:
+            return
+        section_map = _SECTION_FIELD_MAPS.get(self.section)
+        if section_map is None:
+            return
+        if self.section == "mkpdu_statistics":
+            totals_key = _MKPDU_TOTALS_MAP.get(label)
+            if totals_key is not None:
+                section = self.data.setdefault("mkpdu_statistics", {})
+                section[totals_key] = value
+                # The next breakdown rows belong with this total.
+                self.mkpdu_target = (
+                    "mkpdus_validated_and_received_breakdown"
+                    if totals_key == "mkpdus_validated_and_received"
+                    else "mkpdus_transmitted_breakdown"
+                )
+            return
+        key = section_map.get(label)
+        if key is None:
+            return
+        bucket = self.data.setdefault(self.section, {})
+        bucket[key] = value
+
+    def result(self) -> ShowMkaStatisticsResult:
+        if not self.data:
+            msg = "No MKA statistics parsed from input"
+            raise ValueError(msg)
+        return _build_result(self.data)
+
+
+_SECTION_HEADERS: list[tuple[str, re.Pattern[str]]] = [
+    ("mka_session_totals", _SEC_SESSION_TOTALS),
+    ("ca_statistics", _SEC_CA_STATS),
+    ("sa_statistics", _SEC_SA_STATS),
+    ("mkpdu_statistics", _SEC_MKPDU_STATS),
+    ("session_failures", _SEC_SESSION_FAIL),
+    ("sak_failures", _SEC_SAK_FAIL),
+    ("ca_failures", _SEC_CA_FAIL),
+    ("macsec_failures", _SEC_MACSEC_FAIL),
+    ("mkpdu_failures", _SEC_MKPDU_FAIL),
+    ("sak_use_failures", _SEC_SAK_USE_FAIL),
+]
+
+
+_SECTION_FIELD_MAPS: dict[str, dict[str, str]] = {
+    "mka_session_totals": _SESSION_TOTALS_MAP,
+    "ca_statistics": _CA_STATS_MAP,
+    "sa_statistics": _SA_STATS_MAP,
+    # ``mkpdu_statistics`` is handled specially in ``_record``.
+    "mkpdu_statistics": {},
+    "session_failures": _SESSION_FAIL_MAP,
+    "sak_failures": _SAK_FAIL_MAP,
+    "ca_failures": _CA_FAIL_MAP,
+    "macsec_failures": _MACSEC_FAIL_MAP,
+    "mkpdu_failures": _MKPDU_FAIL_MAP,
+    "sak_use_failures": _SAK_USE_FAIL_MAP,
+}
+
+
+def _build_result(
+    data: dict[str, dict[str, int | dict[str, int]]],
+) -> ShowMkaStatisticsResult:
+    """Assemble the final TypedDict result from accumulated section data."""
+    error_totals: dict[str, dict[str, int]] = {
+        "session_failures": _as_int_dict(data.get("session_failures", {})),
+        "sak_failures": _as_int_dict(data.get("sak_failures", {})),
+        "ca_failures": _as_int_dict(data.get("ca_failures", {})),
+        "macsec_failures": _as_int_dict(data.get("macsec_failures", {})),
+        "mkpdu_failures": _as_int_dict(data.get("mkpdu_failures", {})),
+    }
+    if "sak_use_failures" in data:
+        error_totals["sak_use_failures"] = _as_int_dict(data["sak_use_failures"])
+
+    return ShowMkaStatisticsResult(
+        mka_session_totals=cast(
+            MkaSessionTotals, _as_int_dict(data.get("mka_session_totals", {}))
+        ),
+        ca_statistics=cast(
+            MkaCaStatistics, _as_int_dict(data.get("ca_statistics", {}))
+        ),
+        sa_statistics=cast(
+            MkaSaStatistics, _as_int_dict(data.get("sa_statistics", {}))
+        ),
+        mkpdu_statistics=_build_mkpdu_section(data.get("mkpdu_statistics", {})),
+        mka_error_counter_totals=cast(MkaErrorCounterTotals, error_totals),
+    )
+
+
+def _as_int_dict(section: dict[str, int | dict[str, int]]) -> dict[str, int]:
+    """Return a flat int dict, skipping any nested sub-dicts."""
+    return {k: v for k, v in section.items() if isinstance(v, int)}
+
+
+def _breakdown(value: object) -> MkaDistributedCounters:
+    """Build a distributed SAK/CAK counter dict, defaulting missing keys to 0."""
+    if not isinstance(value, dict):
+        return {"distributed_sak": 0, "distributed_cak": 0}
+    typed = cast(dict[str, int], value)
+    return {
+        "distributed_sak": _int(typed.get("distributed_sak")),
+        "distributed_cak": _int(typed.get("distributed_cak")),
+    }
+
+
+def _build_mkpdu_section(
+    section: dict[str, int | dict[str, int]],
+) -> MkaMkpduStatistics:
+    """Build the MKPDU statistics block with empty breakdowns when missing."""
+    return {
+        "mkpdus_validated_and_received": _int(
+            section.get("mkpdus_validated_and_received")
+        ),
+        "mkpdus_validated_and_received_breakdown": _breakdown(
+            section.get("mkpdus_validated_and_received_breakdown")
+        ),
+        "mkpdus_transmitted": _int(section.get("mkpdus_transmitted")),
+        "mkpdus_transmitted_breakdown": _breakdown(
+            section.get("mkpdus_transmitted_breakdown")
+        ),
+    }
+
+
+def _int(value: object) -> int:
+    """Return ``value`` as int, defaulting to 0 when missing."""
+    return value if isinstance(value, int) else 0
+
+
+@register(OS.CISCO_IOSXE, "show mka statistics")
+class ShowMkaStatisticsParser(BaseParser[ShowMkaStatisticsResult]):
+    """Parser for 'show mka statistics' command."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MACSEC})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMkaStatisticsResult:
+        """Parse 'show mka statistics' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed MKA global and error statistics.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        acc = _Acc()
+        for line in output.splitlines():
+            acc.feed(line)
+        return acc.result()

--- a/tests/parsers/iosxe/show_mka_statistics/001_tac_r2_zero_counters/expected.json
+++ b/tests/parsers/iosxe/show_mka_statistics/001_tac_r2_zero_counters/expected.json
@@ -1,0 +1,76 @@
+{
+    "mka_session_totals": {
+        "secured": 0,
+        "fallback_secured": 0,
+        "reauthentication_attempts": 0,
+        "deleted_secured": 0,
+        "keepalive_timeouts": 0
+    },
+    "ca_statistics": {
+        "pairwise_caks_derived": 0,
+        "pairwise_cak_rekeys": 0,
+        "group_caks_generated": 0,
+        "group_caks_received": 0
+    },
+    "sa_statistics": {
+        "saks_generated": 0,
+        "saks_rekeyed": 0,
+        "saks_received": 0,
+        "sak_responses_received": 0,
+        "sak_rekeyed_as_kn_mismatch": 0
+    },
+    "mkpdu_statistics": {
+        "mkpdus_validated_and_received": 0,
+        "mkpdus_validated_and_received_breakdown": {
+            "distributed_sak": 0,
+            "distributed_cak": 0
+        },
+        "mkpdus_transmitted": 0,
+        "mkpdus_transmitted_breakdown": {
+            "distributed_sak": 0,
+            "distributed_cak": 0
+        }
+    },
+    "mka_error_counter_totals": {
+        "session_failures": {
+            "bring_up_failures": 0,
+            "reauthentication_failures": 0,
+            "duplicate_auth_mgr_handle": 0
+        },
+        "sak_failures": {
+            "sak_generation": 0,
+            "hash_key_generation": 0,
+            "sak_encryption_wrap": 0,
+            "sak_decryption_unwrap": 0,
+            "sak_cipher_mismatch": 0
+        },
+        "ca_failures": {
+            "group_cak_generation": 0,
+            "group_cak_encryption_wrap": 0,
+            "group_cak_decryption_unwrap": 0,
+            "pairwise_cak_derivation": 0,
+            "ckn_derivation": 0,
+            "ick_derivation": 0,
+            "kek_derivation": 0,
+            "invalid_peer_macsec_capability": 0
+        },
+        "macsec_failures": {
+            "rx_sc_creation": 0,
+            "tx_sc_creation": 0,
+            "rx_sa_installation": 0,
+            "tx_sa_installation": 0
+        },
+        "mkpdu_failures": {
+            "mkpdu_tx": 0,
+            "mkpdu_rx_icv_verification": 0,
+            "mkpdu_rx_fallback_icv_verification": 0,
+            "mkpdu_rx_validation": 0,
+            "mkpdu_rx_bad_peer_mn": 0,
+            "mkpdu_rx_non_recent_peerlist_mn": 0
+        },
+        "sak_use_failures": {
+            "sak_use_latest_kn_mismatch": 0,
+            "sak_use_latest_an_not_in_use": 0
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_mka_statistics/001_tac_r2_zero_counters/input.txt
+++ b/tests/parsers/iosxe/show_mka_statistics/001_tac_r2_zero_counters/input.txt
@@ -1,0 +1,71 @@
+MKA Global Statistics
+=====================
+MKA Session Totals
+   Secured.................... 0
+   Fallback Secured........... 0
+   Reauthentication Attempts.. 0
+
+   Deleted (Secured).......... 0
+   Keepalive Timeouts......... 0
+
+CA Statistics
+   Pairwise CAKs Derived...... 0
+   Pairwise CAK Rekeys........ 0
+   Group CAKs Generated....... 0
+   Group CAKs Received........ 0
+
+SA Statistics
+   SAKs Generated.............. 0
+   SAKs Rekeyed................ 0
+   SAKs Received............... 0
+   SAK Responses Received...... 0
+   SAK Rekeyed as KN Mismatch.. 0
+
+MKPDU Statistics
+   MKPDUs Validated & Rx...... 0
+      "Distributed SAK"..... 0
+      "Distributed CAK"..... 0
+   MKPDUs Transmitted......... 0
+      "Distributed SAK"..... 0
+      "Distributed CAK"..... 0
+
+MKA Error Counter Totals
+========================
+Session Failures
+   Bring-up Failures................ 0
+   Reauthentication Failures........ 0
+   Duplicate Auth-Mgr Handle........ 0
+
+SAK Failures
+   SAK Generation................... 0
+   Hash Key Generation.............. 0
+   SAK Encryption/Wrap.............. 0
+   SAK Decryption/Unwrap............ 0
+   SAK Cipher Mismatch.............. 0
+
+CA Failures
+   Group CAK Generation............. 0
+   Group CAK Encryption/Wrap........ 0
+   Group CAK Decryption/Unwrap...... 0
+   Pairwise CAK Derivation.......... 0
+   CKN Derivation................... 0
+   ICK Derivation................... 0
+   KEK Derivation................... 0
+   Invalid Peer MACsec Capability... 0
+
+MACsec Failures
+   Rx SC Creation................... 0
+   Tx SC Creation................... 0
+   Rx SA Installation............... 0
+   Tx SA Installation............... 0
+
+MKPDU Failures
+   MKPDU Tx............................... 0
+   MKPDU Rx ICV Verification.............. 0
+   MKPDU Rx Fallback ICV Verification..... 0
+   MKPDU Rx Validation.................... 0
+   MKPDU Rx Bad Peer MN................... 0
+   MKPDU Rx Non-recent Peerlist MN........ 0
+SAK USE Failures
+   SAK USE Latest KN Mismatch............. 0
+   SAK USE Latest AN not in USE........... 0

--- a/tests/parsers/iosxe/show_mka_statistics/001_tac_r2_zero_counters/metadata.yaml
+++ b/tests/parsers/iosxe/show_mka_statistics/001_tac_r2_zero_counters/metadata.yaml
@@ -1,0 +1,3 @@
+description: Live device with all MKA counters at zero (TAC-R2 testbed)
+platform: ISR 1100
+software_version: IOS-XE

--- a/tests/parsers/iosxe/show_mka_statistics/002_secured_session_counters/expected.json
+++ b/tests/parsers/iosxe/show_mka_statistics/002_secured_session_counters/expected.json
@@ -1,0 +1,71 @@
+{
+    "mka_session_totals": {
+        "secured": 3,
+        "fallback_secured": 2,
+        "reauthentication_attempts": 4,
+        "deleted_secured": 2,
+        "keepalive_timeouts": 0
+    },
+    "ca_statistics": {
+        "pairwise_caks_derived": 4,
+        "pairwise_cak_rekeys": 4,
+        "group_caks_generated": 0,
+        "group_caks_received": 0
+    },
+    "sa_statistics": {
+        "saks_generated": 0,
+        "saks_rekeyed": 1479,
+        "saks_received": 1480,
+        "sak_responses_received": 0
+    },
+    "mkpdu_statistics": {
+        "mkpdus_validated_and_received": 44937,
+        "mkpdus_validated_and_received_breakdown": {
+            "distributed_sak": 1480,
+            "distributed_cak": 0
+        },
+        "mkpdus_transmitted": 91067,
+        "mkpdus_transmitted_breakdown": {
+            "distributed_sak": 0,
+            "distributed_cak": 0
+        }
+    },
+    "mka_error_counter_totals": {
+        "session_failures": {
+            "bring_up_failures": 0,
+            "reauthentication_failures": 0,
+            "duplicate_auth_mgr_handle": 0
+        },
+        "sak_failures": {
+            "sak_generation": 0,
+            "hash_key_generation": 0,
+            "sak_encryption_wrap": 0,
+            "sak_decryption_unwrap": 0,
+            "sak_cipher_mismatch": 0
+        },
+        "ca_failures": {
+            "group_cak_generation": 0,
+            "group_cak_encryption_wrap": 0,
+            "group_cak_decryption_unwrap": 0,
+            "pairwise_cak_derivation": 0,
+            "ckn_derivation": 0,
+            "ick_derivation": 0,
+            "kek_derivation": 0,
+            "invalid_peer_macsec_capability": 0
+        },
+        "macsec_failures": {
+            "rx_sc_creation": 0,
+            "tx_sc_creation": 0,
+            "rx_sa_installation": 0,
+            "tx_sa_installation": 0
+        },
+        "mkpdu_failures": {
+            "mkpdu_tx": 0,
+            "mkpdu_rx_icv_verification": 44647,
+            "mkpdu_rx_fallback_icv_verification": 0,
+            "mkpdu_rx_validation": 0,
+            "mkpdu_rx_bad_peer_mn": 0,
+            "mkpdu_rx_non_recent_peerlist_mn": 0
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_mka_statistics/002_secured_session_counters/input.txt
+++ b/tests/parsers/iosxe/show_mka_statistics/002_secured_session_counters/input.txt
@@ -1,0 +1,67 @@
+MKA Global Statistics
+=====================
+MKA Session Totals
+   Secured.................... 3
+   Fallback Secured........... 2
+   Reauthentication Attempts.. 4
+
+   Deleted (Secured).......... 2
+   Keepalive Timeouts......... 0
+
+CA Statistics
+   Pairwise CAKs Derived...... 4
+   Pairwise CAK Rekeys........ 4
+   Group CAKs Generated....... 0
+   Group CAKs Received........ 0
+
+SA Statistics
+   SAKs Generated............. 0
+   SAKs Rekeyed............... 1479
+   SAKs Received.............. 1480
+   SAK Responses Received..... 0
+
+MKPDU Statistics
+   MKPDUs Validated & Rx...... 44937
+      "Distributed SAK"..... 1480
+      "Distributed CAK"..... 0
+   MKPDUs Transmitted......... 91067
+      "Distributed SAK"..... 0
+      "Distributed CAK"..... 0
+
+MKA Error Counter Totals
+========================
+Session Failures
+   Bring-up Failures................ 0
+   Reauthentication Failures........ 0
+   Duplicate Auth-Mgr Handle........ 0
+
+SAK Failures
+   SAK Generation................... 0
+   Hash Key Generation.............. 0
+   SAK Encryption/Wrap.............. 0
+   SAK Decryption/Unwrap............ 0
+   SAK Cipher Mismatch.............. 0
+
+CA Failures
+   Group CAK Generation............. 0
+   Group CAK Encryption/Wrap........ 0
+   Group CAK Decryption/Unwrap...... 0
+   Pairwise CAK Derivation.......... 0
+   CKN Derivation................... 0
+   ICK Derivation................... 0
+   KEK Derivation................... 0
+   Invalid Peer MACsec Capability... 0
+
+MACsec Failures
+   Rx SC Creation................... 0
+   Tx SC Creation................... 0
+   Rx SA Installation............... 0
+   Tx SA Installation............... 0
+
+MKPDU Failures
+   MKPDU Tx............................... 0
+   MKPDU Rx ICV Verification.............. 44647
+   MKPDU Rx Fallback ICV Verification..... 0
+   MKPDU Rx Validation.................... 0
+   MKPDU Rx Bad Peer MN................... 0
+   MKPDU Rx Non-recent Peerlist MN........ 0

--- a/tests/parsers/iosxe/show_mka_statistics/002_secured_session_counters/metadata.yaml
+++ b/tests/parsers/iosxe/show_mka_statistics/002_secured_session_counters/metadata.yaml
@@ -1,0 +1,3 @@
+description: Active MKA sessions with non-zero counters and no SAK USE Failures section
+platform: Catalyst 9300
+software_version: IOS-XE


### PR DESCRIPTION
## Summary

- Adds a new `cisco_iosxe` parser for `show mka statistics` that captures the MKA Global Statistics block (session totals, CA stats, SA stats, MKPDU stats) and the MKA Error Counter Totals block (session, SAK, CA, MACsec, MKPDU, and optional SAK USE failures).
- The TypedDict schema models each subsection explicitly and uses `NotRequired` for fields that only appear on some images (`sak_rekeyed_as_kn_mismatch` and the `sak_use_failures` block).
- Ships with two real-output fixtures: the TAC-R2 zero-counters sample from the issue (ISR 1100) and an active-session counters sample (Catalyst 9300 reference output) that exercises the non-zero / missing-optional paths.

Closes #1016

## Test plan

- [x] `uv run pytest` (8727 passed)
- [x] `uv run ruff check --fix .`
- [x] `uv run ruff format .`
- [x] `uv run ty check src/` (only pre-existing redundant-cast warnings in unrelated files)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `uv run bandit -r src/`
- [x] `uv run pre-commit run --files ...` (all hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)