### PR TITLE
feat(cisco_iosxe): add parser for `show lldp`

### DIFF
--- a/changes/1009.parser_added
+++ b/changes/1009.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show lldp` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_lldp.py
+++ b/src/muninn/parsers/ios/show_lldp.py
@@ -1,4 +1,4 @@
-"""Parser for 'show lldp' command on Cisco IOS."""
+"""Parser for 'show lldp' command on Cisco IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict
@@ -134,12 +134,14 @@ def _consume_line(line: str, result: ShowLldpResult, state: _ParseState) -> None
 
 
 @register(OS.CISCO_IOS, "show lldp")
+@register(OS.CISCO_IOSXE, "show lldp")
 class ShowLldpParser(BaseParser[ShowLldpResult]):
-    """Parser for 'show lldp' command on Cisco IOS.
+    """Parser for 'show lldp' command on Cisco IOS and IOS-XE.
 
     Parses global LLDP configuration. The command may report either that
     LLDP is not enabled (a single status line) or, when enabled, a block
-    of global LLDP timer/status fields.
+    of global LLDP timer/status fields. The output format is identical
+    across both IOS and IOS-XE platforms.
 
     Example output when enabled::
 

--- a/tests/parsers/iosxe/show_lldp/001_disabled/expected.json
+++ b/tests/parsers/iosxe/show_lldp/001_disabled/expected.json
@@ -1,0 +1,3 @@
+{
+    "lldp_enabled": false
+}

--- a/tests/parsers/iosxe/show_lldp/001_disabled/input.txt
+++ b/tests/parsers/iosxe/show_lldp/001_disabled/input.txt
@@ -1,0 +1,1 @@
+% LLDP is not enabled

--- a/tests/parsers/iosxe/show_lldp/001_disabled/metadata.yaml
+++ b/tests/parsers/iosxe/show_lldp/001_disabled/metadata.yaml
@@ -1,0 +1,3 @@
+description: show lldp output when LLDP is not enabled globally on IOS-XE
+platform: Cisco ISR 1100
+software_version: IOS-XE 17.x

--- a/tests/parsers/iosxe/show_lldp/002_enabled/expected.json
+++ b/tests/parsers/iosxe/show_lldp/002_enabled/expected.json
@@ -1,0 +1,7 @@
+{
+    "lldp_enabled": true,
+    "status": "ACTIVE",
+    "hello_timer_seconds": 30,
+    "hold_timer_seconds": 120,
+    "reinit_delay_seconds": 2
+}

--- a/tests/parsers/iosxe/show_lldp/002_enabled/input.txt
+++ b/tests/parsers/iosxe/show_lldp/002_enabled/input.txt
@@ -1,0 +1,5 @@
+Global LLDP Information:
+    Status: ACTIVE
+    LLDP advertisements are sent every 30 seconds
+    LLDP hold time advertised is 120 seconds
+    LLDP interface reinitialisation delay is 2 seconds

--- a/tests/parsers/iosxe/show_lldp/002_enabled/metadata.yaml
+++ b/tests/parsers/iosxe/show_lldp/002_enabled/metadata.yaml
@@ -1,0 +1,3 @@
+description: show lldp output with LLDP enabled showing global timer settings on IOS-XE
+platform: Cisco Catalyst 9300
+software_version: IOS-XE 17.x


### PR DESCRIPTION
## Summary
- Adds IOS-XE support for `show lldp` by stacking `@register(OS.CISCO_IOSXE, "show lldp")` on the existing IOS `ShowLldpParser` — the output format is identical across both platforms (verified against the sample in #1009).
- Updates the parser module/class docstring to reflect that both Cisco IOS and IOS-XE are now supported.
- Adds two IOS-XE fixtures: `001_disabled` (`% LLDP is not enabled`) and `002_enabled` (Global LLDP Information block from the issue's TAC-R2 capture).

Closes #1009

## Test plan
- [x] `uv run pytest -q` (8864 passing)
- [x] `uv run pytest -k "show_lldp and iosxe" -v` (35 passing)
- [x] `uv run ruff check src/ tests/ changes/`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check src/muninn/parsers/ios/show_lldp.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn`
- [x] Pre-commit hooks all passed

Generated with [Claude Code](https://claude.com/claude-code)