### PR TITLE
feat(cisco_iosxe): add parser for `show license summary`

### DIFF
--- a/changes/1007.parser_added
+++ b/changes/1007.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show license summary` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_license_summary.py
+++ b/src/muninn/parsers/iosxe/show_license_summary.py
@@ -1,0 +1,200 @@
+"""Parser for 'show license summary' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class AccountInformation(TypedDict):
+    """Schema for the Account Information section."""
+
+    smart_account: str
+    virtual_account: str
+
+
+class LicenseUsageEntry(TypedDict):
+    """Schema for a single License Usage table row.
+
+    Keyed in :class:`ShowLicenseSummaryResult.license_usage` by the
+    entitlement tag, which uniquely identifies a license SKU on the device
+    (the ``license`` column may repeat across stacked members).
+    """
+
+    license: str
+    count: int
+    status: str
+
+
+class ShowLicenseSummaryResult(TypedDict):
+    """Schema for 'show license summary' parsed output."""
+
+    account_information: NotRequired[AccountInformation]
+    license_usage: NotRequired[dict[str, LicenseUsageEntry]]
+
+
+# --- Section header markers ---
+_ACCOUNT_SECTION_RE = re.compile(r"^\s*Account\s+Information\s*:\s*$", re.IGNORECASE)
+_LICENSE_SECTION_RE = re.compile(r"^\s*License\s+Usage\s*:\s*$", re.IGNORECASE)
+
+# --- Account information patterns ---
+_SMART_ACCOUNT_RE = re.compile(
+    r"^\s*Smart\s+Account\s*:\s*(?P<value>.+?)\s*$", re.IGNORECASE
+)
+_VIRTUAL_ACCOUNT_RE = re.compile(
+    r"^\s*Virtual\s+Account\s*:\s*(?P<value>.+?)\s*$", re.IGNORECASE
+)
+
+# --- License usage row pattern ---
+# Example rows (the License column is truncated to 23 chars with optional ellipsis):
+#   network-advantage       (C9300-48 Network Advan...)       1 IN USE
+#   network-advantage_10M   (ESR_P_10M_A)                     1 IN USE
+#   Router US Export Lic... (DNA_HSEC)                        0 NOT IN USE
+_LICENSE_ROW_RE = re.compile(
+    r"^\s*(?P<license>\S.*?)\s+"
+    r"\((?P<entitlement>[^)]*)\)\s+"
+    r"(?P<count>\d+)\s+"
+    r"(?P<status>\S.*?)\s*$"
+)
+
+# Lines we should skip inside the License Usage section.
+_TABLE_HEADER_RE = re.compile(
+    r"^\s*License\s+Entitlement\s+Tag\s+Count\s+Status\s*$", re.IGNORECASE
+)
+_SEPARATOR_RE = re.compile(r"^\s*-{3,}\s*$")
+
+
+def _parse_account_information(lines: list[str], start: int) -> tuple[dict, int]:
+    """Parse the Account Information section.
+
+    Returns the partially-populated account information dict and the index of
+    the next unconsumed line.
+    """
+    info: dict[str, str] = {}
+    idx = start
+    while idx < len(lines):
+        line = lines[idx]
+
+        # Stop when we hit another known section header.
+        if _LICENSE_SECTION_RE.match(line) or _ACCOUNT_SECTION_RE.match(line):
+            break
+
+        if match := _SMART_ACCOUNT_RE.match(line):
+            info["smart_account"] = match.group("value").strip()
+            idx += 1
+            continue
+
+        if match := _VIRTUAL_ACCOUNT_RE.match(line):
+            info["virtual_account"] = match.group("value").strip()
+            idx += 1
+            continue
+
+        idx += 1
+
+    return info, idx
+
+
+def _parse_license_usage(
+    lines: list[str], start: int
+) -> tuple[dict[str, LicenseUsageEntry], int]:
+    """Parse the License Usage table.
+
+    Returns a dict keyed by entitlement tag and the index of the next
+    unconsumed line.
+    """
+    entries: dict[str, LicenseUsageEntry] = {}
+    idx = start
+    while idx < len(lines):
+        line = lines[idx]
+
+        if _ACCOUNT_SECTION_RE.match(line) or _LICENSE_SECTION_RE.match(line):
+            break
+
+        stripped = line.strip()
+        if not stripped:
+            idx += 1
+            continue
+
+        if _TABLE_HEADER_RE.match(line) or _SEPARATOR_RE.match(line):
+            idx += 1
+            continue
+
+        if match := _LICENSE_ROW_RE.match(line):
+            entitlement_tag = match.group("entitlement").strip()
+            entries[entitlement_tag] = LicenseUsageEntry(
+                license=match.group("license").strip(),
+                count=int(match.group("count")),
+                status=match.group("status").strip(),
+            )
+
+        idx += 1
+
+    return entries, idx
+
+
+@register(OS.CISCO_IOSXE, "show license summary")
+class ShowLicenseSummaryParser(BaseParser[ShowLicenseSummaryResult]):
+    """Parser for 'show license summary' on IOS-XE.
+
+    Parses optional Smart Licensing account information and the per-license
+    usage table reported by IOS-XE platforms (e.g. Catalyst 9300, ISR 1100).
+
+    Example output:
+        Account Information:
+          Smart Account: <none>
+          Virtual Account: <none>
+
+        License Usage:
+          License                 Entitlement Tag               Count Status
+          -----------------------------------------------------------------------------
+          network-advantage_10M   (ESR_P_10M_A)                     1 IN USE
+          dna-advantage_10M       (DNA_P_10M_A)                     1 IN USE
+          Router US Export Lic... (DNA_HSEC)                        0 NOT IN USE
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowLicenseSummaryResult:
+        """Parse 'show license summary' output.
+
+        Args:
+            output: Raw CLI output from 'show license summary' command.
+
+        Returns:
+            Parsed license summary data.
+
+        Raises:
+            ValueError: If no recognizable sections are found.
+        """
+        lines = output.splitlines()
+        result: dict = {}
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx]
+
+            if _ACCOUNT_SECTION_RE.match(line):
+                idx += 1
+                info, idx = _parse_account_information(lines, idx)
+                if info:
+                    result["account_information"] = info
+                continue
+
+            if _LICENSE_SECTION_RE.match(line):
+                idx += 1
+                entries, idx = _parse_license_usage(lines, idx)
+                if entries:
+                    result["license_usage"] = entries
+                continue
+
+            idx += 1
+
+        if not result:
+            msg = "No license summary information found in output"
+            raise ValueError(msg)
+
+        return cast(ShowLicenseSummaryResult, result)

--- a/src/muninn/parsers/iosxe/show_license_summary.py
+++ b/src/muninn/parsers/iosxe/show_license_summary.py
@@ -10,10 +10,16 @@ from muninn.tags import ParserTag
 
 
 class AccountInformation(TypedDict):
-    """Schema for the Account Information section."""
+    """Schema for the Account Information section.
 
-    smart_account: str
-    virtual_account: str
+    Both fields are optional: IOS-XE only prints the lines that have a
+    configured value, and devices that have never registered with Smart
+    Licensing report ``<none>`` (which this parser treats as "field
+    absent" and omits from the output).
+    """
+
+    smart_account: NotRequired[str]
+    virtual_account: NotRequired[str]
 
 
 class LicenseUsageEntry(TypedDict):
@@ -39,6 +45,11 @@ class ShowLicenseSummaryResult(TypedDict):
 # --- Section header markers ---
 _ACCOUNT_SECTION_RE = re.compile(r"^\s*Account\s+Information\s*:\s*$", re.IGNORECASE)
 _LICENSE_SECTION_RE = re.compile(r"^\s*License\s+Usage\s*:\s*$", re.IGNORECASE)
+
+# Placeholder values IOS-XE prints when a Smart Licensing account is not
+# configured. We omit the key entirely rather than carry the sentinel through
+# to structured output.
+_ACCOUNT_PLACEHOLDERS = frozenset({"<none>", "none"})
 
 # --- Account information patterns ---
 _SMART_ACCOUNT_RE = re.compile(
@@ -83,12 +94,16 @@ def _parse_account_information(lines: list[str], start: int) -> tuple[dict, int]
             break
 
         if match := _SMART_ACCOUNT_RE.match(line):
-            info["smart_account"] = match.group("value").strip()
+            value = match.group("value").strip()
+            if value.lower() not in _ACCOUNT_PLACEHOLDERS:
+                info["smart_account"] = value
             idx += 1
             continue
 
         if match := _VIRTUAL_ACCOUNT_RE.match(line):
-            info["virtual_account"] = match.group("value").strip()
+            value = match.group("value").strip()
+            if value.lower() not in _ACCOUNT_PLACEHOLDERS:
+                info["virtual_account"] = value
             idx += 1
             continue
 

--- a/tests/parsers/iosxe/show_license_summary/001_isr_1100/expected.json
+++ b/tests/parsers/iosxe/show_license_summary/001_isr_1100/expected.json
@@ -1,8 +1,4 @@
 {
-    "account_information": {
-        "smart_account": "<none>",
-        "virtual_account": "<none>"
-    },
     "license_usage": {
         "ESR_P_10M_A": {
             "license": "network-advantage_10M",

--- a/tests/parsers/iosxe/show_license_summary/001_isr_1100/expected.json
+++ b/tests/parsers/iosxe/show_license_summary/001_isr_1100/expected.json
@@ -1,0 +1,23 @@
+{
+    "account_information": {
+        "smart_account": "<none>",
+        "virtual_account": "<none>"
+    },
+    "license_usage": {
+        "ESR_P_10M_A": {
+            "license": "network-advantage_10M",
+            "count": 1,
+            "status": "IN USE"
+        },
+        "DNA_P_10M_A": {
+            "license": "dna-advantage_10M",
+            "count": 1,
+            "status": "IN USE"
+        },
+        "DNA_HSEC": {
+            "license": "Router US Export Lic...",
+            "count": 0,
+            "status": "NOT IN USE"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_license_summary/001_isr_1100/input.txt
+++ b/tests/parsers/iosxe/show_license_summary/001_isr_1100/input.txt
@@ -1,0 +1,10 @@
+Account Information:
+  Smart Account: <none>
+  Virtual Account: <none>
+
+License Usage:
+  License                 Entitlement Tag               Count Status
+  -----------------------------------------------------------------------------
+  network-advantage_10M   (ESR_P_10M_A)                     1 IN USE
+  dna-advantage_10M       (DNA_P_10M_A)                     1 IN USE
+  Router US Export Lic... (DNA_HSEC)                        0 NOT IN USE

--- a/tests/parsers/iosxe/show_license_summary/001_isr_1100/metadata.yaml
+++ b/tests/parsers/iosxe/show_license_summary/001_isr_1100/metadata.yaml
@@ -1,0 +1,3 @@
+description: ISR 1100 with no Smart Account and mixed IN USE / NOT IN USE entitlements
+platform: ISR 1100
+software_version: Unknown

--- a/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/expected.json
+++ b/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/expected.json
@@ -1,8 +1,4 @@
 {
-    "account_information": {
-        "smart_account": "<none>",
-        "virtual_account": "<none>"
-    },
     "license_usage": {
         "C9300-24 Network Advan...": {
             "license": "network-advantage",

--- a/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/expected.json
+++ b/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/expected.json
@@ -1,0 +1,28 @@
+{
+    "account_information": {
+        "smart_account": "<none>",
+        "virtual_account": "<none>"
+    },
+    "license_usage": {
+        "C9300-24 Network Advan...": {
+            "license": "network-advantage",
+            "count": 2,
+            "status": "IN USE"
+        },
+        "C9300-24 DNA Advantage": {
+            "license": "dna-advantage",
+            "count": 2,
+            "status": "IN USE"
+        },
+        "C9300-48 Network Advan...": {
+            "license": "network-advantage",
+            "count": 1,
+            "status": "IN USE"
+        },
+        "C9300-48 DNA Advantage": {
+            "license": "dna-advantage",
+            "count": 1,
+            "status": "IN USE"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/input.txt
+++ b/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/input.txt
@@ -1,0 +1,14 @@
+Load for five secs: 1%/0%; one minute: 0%; five minutes: 0%
+Time source is NTP, 11:43:15.743 UTC Wed Nov 17 2021
+
+Account Information:
+  Smart Account: <none>
+  Virtual Account: <none>
+
+License Usage:
+  License                 Entitlement Tag               Count Status
+  -----------------------------------------------------------------------------
+  network-advantage       (C9300-24 Network Advan...)       2 IN USE
+  dna-advantage           (C9300-24 DNA Advantage)          2 IN USE
+  network-advantage       (C9300-48 Network Advan...)       1 IN USE
+  dna-advantage           (C9300-48 DNA Advantage)          1 IN USE

--- a/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/metadata.yaml
+++ b/tests/parsers/iosxe/show_license_summary/002_catalyst_9300/metadata.yaml
@@ -1,0 +1,3 @@
+description: Stacked Catalyst 9300 with duplicate license keys differentiated by entitlement tag
+platform: Catalyst 9300
+software_version: "16.x"


### PR DESCRIPTION
## Summary

- Adds a new parser `ShowLicenseSummaryParser` for `show license summary` on Cisco IOS-XE (Catalyst 9300, ISR 1100, etc.).
- Captures the optional `Account Information` section (`smart_account`, `virtual_account`) and the `License Usage` table.
- License usage rows are keyed by **entitlement tag**, which uniquely identifies each license SKU on the device (the `License` column can repeat across stacked switch members, e.g. `network-advantage` for both `C9300-24` and `C9300-48`).

Closes #1007

## Test plan

- [x] `uv run pytest` (8896 passed)
- [x] `uv run ruff check --fix .`
- [x] `uv run ruff format .`
- [x] `uv run ty check src/` (no new diagnostics from this change)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `uv run bandit -r src/` (clean)
- [x] Two real-device fixtures: `001_isr_1100` (from the issue's TAC-R2 sample) and `002_catalyst_9300` (stacked C9300 with duplicate license names disambiguated by entitlement tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)