### PR TITLE
feat(cisco_iosxe): add parser for `show lldp interface`

### DIFF
--- a/changes/1010.parser_added
+++ b/changes/1010.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show lldp interface` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_lldp_interface.py
+++ b/src/muninn/parsers/ios/show_lldp_interface.py
@@ -1,4 +1,4 @@
-"""Parser for 'show lldp interface' command on IOS."""
+"""Parser for 'show lldp interface' command on IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, TypedDict, cast
@@ -106,9 +106,10 @@ def _finalize_interface(
     interfaces[canonical] = cast(InterfaceEntry, entry)
 
 
+@register(OS.CISCO_IOSXE, "show lldp interface")
 @register(OS.CISCO_IOS, "show lldp interface")
 class ShowLldpInterfaceParser(BaseParser[ShowLldpInterfaceResult]):
-    """Parser for 'show lldp interface' command on IOS.
+    """Parser for 'show lldp interface' command on IOS and IOS-XE.
 
     The command exposes per-interface LLDP Tx/Rx enable state and the
     current Tx/Rx state machine values. When LLDP is globally disabled,

--- a/tests/parsers/iosxe/show_lldp_interface/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_lldp_interface/001_basic/expected.json
@@ -1,0 +1,41 @@
+{
+    "lldp_enabled": true,
+    "interfaces": {
+        "GigabitEthernet0/0/0": {
+            "tx_enabled": true,
+            "rx_enabled": true,
+            "tx_state": "IDLE",
+            "rx_state": "WAIT FOR FRAME"
+        },
+        "GigabitEthernet0/0/1": {
+            "tx_enabled": true,
+            "rx_enabled": true,
+            "tx_state": "INIT",
+            "rx_state": "WAIT PORT OPER"
+        },
+        "GigabitEthernet0/0/2": {
+            "tx_enabled": true,
+            "rx_enabled": true,
+            "tx_state": "IDLE",
+            "rx_state": "WAIT FOR FRAME"
+        },
+        "GigabitEthernet0/0/3": {
+            "tx_enabled": true,
+            "rx_enabled": true,
+            "tx_state": "INIT",
+            "rx_state": "WAIT PORT OPER"
+        },
+        "GigabitEthernet0/0/4": {
+            "tx_enabled": true,
+            "rx_enabled": true,
+            "tx_state": "INIT",
+            "rx_state": "WAIT PORT OPER"
+        },
+        "GigabitEthernet0/0/5": {
+            "tx_enabled": true,
+            "rx_enabled": true,
+            "tx_state": "INIT",
+            "rx_state": "WAIT PORT OPER"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_lldp_interface/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_lldp_interface/001_basic/input.txt
@@ -1,0 +1,40 @@
+GigabitEthernet0/0/0:
+    Tx: enabled
+    Rx: enabled
+    Tx state: IDLE
+    Rx state: WAIT FOR FRAME
+
+
+GigabitEthernet0/0/1:
+    Tx: enabled
+    Rx: enabled
+    Tx state: INIT
+    Rx state: WAIT PORT OPER
+
+
+GigabitEthernet0/0/2:
+    Tx: enabled
+    Rx: enabled
+    Tx state: IDLE
+    Rx state: WAIT FOR FRAME
+
+
+GigabitEthernet0/0/3:
+    Tx: enabled
+    Rx: enabled
+    Tx state: INIT
+    Rx state: WAIT PORT OPER
+
+
+GigabitEthernet0/0/4:
+    Tx: enabled
+    Rx: enabled
+    Tx state: INIT
+    Rx state: WAIT PORT OPER
+
+
+GigabitEthernet0/0/5:
+    Tx: enabled
+    Rx: enabled
+    Tx state: INIT
+    Rx state: WAIT PORT OPER

--- a/tests/parsers/iosxe/show_lldp_interface/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_lldp_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: LLDP enabled with per-interface Tx/Rx state on ISR 1100 fixed-port interfaces
+platform: Cisco ISR 1100
+software_version: IOS-XE

--- a/tests/parsers/iosxe/show_lldp_interface/002_lldp_not_enabled/expected.json
+++ b/tests/parsers/iosxe/show_lldp_interface/002_lldp_not_enabled/expected.json
@@ -1,0 +1,4 @@
+{
+    "lldp_enabled": false,
+    "interfaces": {}
+}

--- a/tests/parsers/iosxe/show_lldp_interface/002_lldp_not_enabled/input.txt
+++ b/tests/parsers/iosxe/show_lldp_interface/002_lldp_not_enabled/input.txt
@@ -1,0 +1,1 @@
+% LLDP is not enabled

--- a/tests/parsers/iosxe/show_lldp_interface/002_lldp_not_enabled/metadata.yaml
+++ b/tests/parsers/iosxe/show_lldp_interface/002_lldp_not_enabled/metadata.yaml
@@ -1,0 +1,3 @@
+description: LLDP globally disabled on IOS-XE - device returns '% LLDP is not enabled'
+platform: Cisco ISR 1100
+software_version: IOS-XE


### PR DESCRIPTION
## Summary
- Adds IOS-XE registration to the existing `show lldp interface` parser; the IOS-XE output format is byte-identical to IOS so the parser is shared via a stacked `@register(OS.CISCO_IOSXE, ...)` decorator.
- Ships a real-device IOS-XE fixture captured from an ISR 1100 with six `GigabitEthernet0/0/x` interfaces, all LLDP-enabled and in various Tx/Rx state combinations.

Closes #1010

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_lldp_interface -v` (21 passed)
- [x] `uv run pytest` (8857 passing)
- [x] `uv run ruff check src/muninn/parsers/ios/show_lldp_interface.py`
- [x] `uv run ruff format src/muninn/parsers/ios/show_lldp_interface.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_lldp_interface.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

Generated with [Claude Code](https://claude.com/claude-code)