### PR TITLE
feat(cisco_iosxe): add parser for `show mka sessions`

### DIFF
--- a/changes/1015.parser_added
+++ b/changes/1015.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show mka sessions` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_mka_sessions.py
+++ b/src/muninn/parsers/iosxe/show_mka_sessions.py
@@ -1,0 +1,232 @@
+"""Parser for 'show mka sessions' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+
+class MkaSessionEntry(TypedDict):
+    """One MKA session row from 'show mka sessions'."""
+
+    interface: str
+    local_tx_sci: str
+    policy_name: str
+    inherited: str
+    key_server: str
+    port_id: str
+    peer_rx_sci: str
+    macsec_peers: str
+    status: str
+    ckn: str
+
+
+class ShowMkaSessionsResult(TypedDict):
+    """Schema for 'show mka sessions' parsed output.
+
+    The ``sessions`` mapping is keyed by the canonical interface name. When the
+    device reports no MKA sessions, the mapping is empty and the three totals
+    fields are still emitted from the header block.
+    """
+
+    total_mka_sessions: int
+    secured_sessions: int
+    pending_sessions: int
+    sessions: dict[str, MkaSessionEntry]
+
+
+_TOTAL_RE = re.compile(r"^Total\s+MKA\s+Sessions\.+\s*(?P<value>\d+)\s*$", re.I)
+_SECURED_RE = re.compile(r"^Secured\s+Sessions\.+\s*(?P<value>\d+)\s*$", re.I)
+_PENDING_RE = re.compile(r"^Pending\s+Sessions\.+\s*(?P<value>\d+)\s*$", re.I)
+
+# Row 1 header: ``Interface  Local-TxSCI  Policy-Name  Inherited  Key-Server``
+# Row 2 header: ``Port-ID    Peer-RxSCI   MACsec-Peers Status     CKN``
+_HEADER_TOP_RE = re.compile(
+    r"^\s*Interface\s+Local-TxSCI\s+Policy-Name\s+Inherited\s+Key-Server\s*$",
+    re.I,
+)
+_HEADER_BOTTOM_RE = re.compile(
+    r"^\s*Port-ID\s+Peer-RxSCI\s+MACsec-Peers\s+Status\s+CKN\s*$",
+    re.I,
+)
+_SEP_RE = re.compile(r"^=+\s*$")
+
+
+class _Columns(TypedDict):
+    """Column slice indexes derived from a header row."""
+
+    starts: list[int]
+    names: list[str]
+
+
+def _column_slices(header: str) -> _Columns:
+    """Return (column_start, column_name) for each whitespace-separated header."""
+    starts: list[int] = []
+    names: list[str] = []
+    i = 0
+    while i < len(header):
+        if header[i].isspace():
+            i += 1
+            continue
+        start = i
+        while i < len(header) and not header[i].isspace():
+            i += 1
+        starts.append(start)
+        names.append(header[start:i])
+    return {"starts": starts, "names": names}
+
+
+def _slice_row(row: str, cols: _Columns) -> dict[str, str]:
+    """Slice ``row`` into named columns using the header start positions.
+
+    Each column extends from its own start to the next column's start (or the
+    end of the line for the last column). Whitespace surrounding the value is
+    stripped.
+    """
+    out: dict[str, str] = {}
+    starts = cols["starts"]
+    names = cols["names"]
+    for idx, name in enumerate(names):
+        start = starts[idx]
+        end = starts[idx + 1] if idx + 1 < len(starts) else len(row)
+        out[name] = row[start:end].strip()
+    return out
+
+
+class _Acc:
+    """Stream-state accumulator for ``show mka sessions`` output."""
+
+    __slots__ = (
+        "top_cols",
+        "bottom_cols",
+        "pending_top",
+        "totals",
+        "sessions",
+    )
+
+    def __init__(self) -> None:
+        self.top_cols: _Columns | None = None
+        self.bottom_cols: _Columns | None = None
+        # Row 1 of a pending session, awaiting its row 2 (Port-ID line).
+        self.pending_top: dict[str, str] | None = None
+        self.totals: dict[str, int] = {}
+        self.sessions: dict[str, MkaSessionEntry] = {}
+
+    def feed(self, raw: str) -> None:
+        """Consume one raw input line."""
+        if self._maybe_totals(raw):
+            return
+        if self._maybe_header(raw):
+            return
+        if _SEP_RE.match(raw):
+            return
+        if not raw.strip():
+            return
+        if self.top_cols is None or self.bottom_cols is None:
+            return
+        if self.pending_top is None:
+            self.pending_top = _slice_row(raw, self.top_cols)
+        else:
+            bottom = _slice_row(raw, self.bottom_cols)
+            self._commit(self.pending_top, bottom)
+            self.pending_top = None
+
+    def _maybe_totals(self, raw: str) -> bool:
+        line = raw.strip()
+        for key, pat in (
+            ("total_mka_sessions", _TOTAL_RE),
+            ("secured_sessions", _SECURED_RE),
+            ("pending_sessions", _PENDING_RE),
+        ):
+            m = pat.match(line)
+            if m:
+                self.totals[key] = int(m.group("value"))
+                return True
+        return False
+
+    def _maybe_header(self, raw: str) -> bool:
+        if _HEADER_TOP_RE.match(raw):
+            self.top_cols = _column_slices(raw)
+            return True
+        if _HEADER_BOTTOM_RE.match(raw):
+            self.bottom_cols = _column_slices(raw)
+            return True
+        return False
+
+    def _commit(self, top: dict[str, str], bottom: dict[str, str]) -> None:
+        interface = top.get("Interface", "").strip()
+        if not interface:
+            return
+        canonical = canonical_interface_name(interface, os=OS.CISCO_IOSXE)
+        self.sessions[canonical] = {
+            "interface": canonical,
+            "local_tx_sci": top.get("Local-TxSCI", ""),
+            "policy_name": top.get("Policy-Name", ""),
+            "inherited": top.get("Inherited", ""),
+            "key_server": top.get("Key-Server", ""),
+            "port_id": bottom.get("Port-ID", ""),
+            "peer_rx_sci": bottom.get("Peer-RxSCI", ""),
+            "macsec_peers": bottom.get("MACsec-Peers", ""),
+            "status": bottom.get("Status", ""),
+            "ckn": bottom.get("CKN", ""),
+        }
+
+
+# ``Summary of All Currently Active MKA Sessions on Interface ...`` preamble
+# emitted by ``show mka sessions interface <if>``. The variant is not
+# registered here, but the line is benign to ignore when present.
+_SUMMARY_PREAMBLE_RE = re.compile(
+    r"^Summary of All Currently Active MKA Sessions",
+    re.I,
+)
+
+
+@register(OS.CISCO_IOSXE, "show mka sessions")
+class ShowMkaSessionsParser(BaseParser[ShowMkaSessionsResult]):
+    """Parser for 'show mka sessions' command on Cisco IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.MACSEC})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMkaSessionsResult:
+        """Parse 'show mka sessions' output.
+
+        Args:
+            output: Raw CLI output.
+
+        Returns:
+            Parsed MKA session totals plus a ``sessions`` mapping keyed by
+            canonical interface name. The totals fields default to 0 when the
+            header block is absent (e.g. on the
+            ``show mka sessions interface <if>`` variant).
+
+        Raises:
+            ValueError: If the output contains neither a recognized header
+                block nor any parseable session rows.
+        """
+        acc = _Acc()
+        saw_marker = False
+        for raw in output.splitlines():
+            if _SUMMARY_PREAMBLE_RE.match(raw.strip()):
+                saw_marker = True
+                continue
+            acc.feed(raw)
+
+        recognized = bool(
+            acc.totals or acc.sessions or saw_marker or acc.top_cols is not None
+        )
+        if not recognized:
+            msg = "Output does not look like 'show mka sessions'"
+            raise ValueError(msg)
+
+        result: dict[str, object] = {
+            "total_mka_sessions": acc.totals.get("total_mka_sessions", 0),
+            "secured_sessions": acc.totals.get("secured_sessions", 0),
+            "pending_sessions": acc.totals.get("pending_sessions", 0),
+            "sessions": acc.sessions,
+        }
+        return cast(ShowMkaSessionsResult, result)

--- a/src/muninn/parsers/iosxe/show_mka_sessions.py
+++ b/src/muninn/parsers/iosxe/show_mka_sessions.py
@@ -176,15 +176,6 @@ class _Acc:
         }
 
 
-# ``Summary of All Currently Active MKA Sessions on Interface ...`` preamble
-# emitted by ``show mka sessions interface <if>``. The variant is not
-# registered here, but the line is benign to ignore when present.
-_SUMMARY_PREAMBLE_RE = re.compile(
-    r"^Summary of All Currently Active MKA Sessions",
-    re.I,
-)
-
-
 @register(OS.CISCO_IOSXE, "show mka sessions")
 class ShowMkaSessionsParser(BaseParser[ShowMkaSessionsResult]):
     """Parser for 'show mka sessions' command on Cisco IOS-XE."""
@@ -200,25 +191,17 @@ class ShowMkaSessionsParser(BaseParser[ShowMkaSessionsResult]):
 
         Returns:
             Parsed MKA session totals plus a ``sessions`` mapping keyed by
-            canonical interface name. The totals fields default to 0 when the
-            header block is absent (e.g. on the
-            ``show mka sessions interface <if>`` variant).
+            canonical interface name.
 
         Raises:
             ValueError: If the output contains neither a recognized header
                 block nor any parseable session rows.
         """
         acc = _Acc()
-        saw_marker = False
         for raw in output.splitlines():
-            if _SUMMARY_PREAMBLE_RE.match(raw.strip()):
-                saw_marker = True
-                continue
             acc.feed(raw)
 
-        recognized = bool(
-            acc.totals or acc.sessions or saw_marker or acc.top_cols is not None
-        )
+        recognized = bool(acc.totals or acc.sessions or acc.top_cols is not None)
         if not recognized:
             msg = "Output does not look like 'show mka sessions'"
             raise ValueError(msg)

--- a/tests/parsers/iosxe/show_mka_sessions/001_tac_r2_no_sessions/expected.json
+++ b/tests/parsers/iosxe/show_mka_sessions/001_tac_r2_no_sessions/expected.json
@@ -1,0 +1,6 @@
+{
+    "total_mka_sessions": 0,
+    "secured_sessions": 0,
+    "pending_sessions": 0,
+    "sessions": {}
+}

--- a/tests/parsers/iosxe/show_mka_sessions/001_tac_r2_no_sessions/input.txt
+++ b/tests/parsers/iosxe/show_mka_sessions/001_tac_r2_no_sessions/input.txt
@@ -1,0 +1,8 @@
+Total MKA Sessions....... 0
+      Secured Sessions... 0
+      Pending Sessions... 0
+
+====================================================================================================
+Interface       Local-TxSCI          Policy-Name       Inherited          Key-Server
+Port-ID         Peer-RxSCI           MACsec-Peers      Status             CKN
+====================================================================================================

--- a/tests/parsers/iosxe/show_mka_sessions/001_tac_r2_no_sessions/metadata.yaml
+++ b/tests/parsers/iosxe/show_mka_sessions/001_tac_r2_no_sessions/metadata.yaml
@@ -1,0 +1,3 @@
+description: Live device with no MKA sessions established (TAC-R2 testbed)
+platform: Cisco ISR 1100
+software_version: IOS-XE

--- a/tests/parsers/iosxe/show_mka_sessions/002_two_sessions_no_peer/expected.json
+++ b/tests/parsers/iosxe/show_mka_sessions/002_two_sessions_no_peer/expected.json
@@ -1,0 +1,31 @@
+{
+    "total_mka_sessions": 2,
+    "secured_sessions": 2,
+    "pending_sessions": 0,
+    "sessions": {
+        "HundredGigabitEthernet1/0/3.5": {
+            "interface": "HundredGigabitEthernet1/0/3.5",
+            "local_tx_sci": "f87a.4125.2702/008b",
+            "policy_name": "*DEFAULT POLICY*",
+            "inherited": "NO",
+            "key_server": "NO",
+            "port_id": "139",
+            "peer_rx_sci": "ecce.1346.f902/008d",
+            "macsec_peers": "0",
+            "status": "Secured, no peer",
+            "ckn": "90"
+        },
+        "HundredGigabitEthernet1/0/3.6": {
+            "interface": "HundredGigabitEthernet1/0/3.6",
+            "local_tx_sci": "f87a.4125.2702/008c",
+            "policy_name": "*DEFAULT POLICY*",
+            "inherited": "NO",
+            "key_server": "NO",
+            "port_id": "140",
+            "peer_rx_sci": "ecce.1346.f902/008e",
+            "macsec_peers": "0",
+            "status": "Secured, no peer",
+            "ckn": "90"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_mka_sessions/002_two_sessions_no_peer/input.txt
+++ b/tests/parsers/iosxe/show_mka_sessions/002_two_sessions_no_peer/input.txt
@@ -1,0 +1,13 @@
+Total MKA Sessions....... 2
+      Secured Sessions... 2
+      Pending Sessions... 0
+
+====================================================================================================
+Interface      Local-TxSCI         Policy-Name      Inherited         Key-Server
+Port-ID        Peer-RxSCI          MACsec-Peers     Status            CKN
+====================================================================================================
+Hu1/0/3.5      f87a.4125.2702/008b *DEFAULT POLICY* NO                NO
+139            ecce.1346.f902/008d 0                Secured, no peer  90
+
+Hu1/0/3.6      f87a.4125.2702/008c *DEFAULT POLICY* NO                NO
+140            ecce.1346.f902/008e 0                Secured, no peer  90

--- a/tests/parsers/iosxe/show_mka_sessions/002_two_sessions_no_peer/metadata.yaml
+++ b/tests/parsers/iosxe/show_mka_sessions/002_two_sessions_no_peer/metadata.yaml
@@ -1,0 +1,3 @@
+description: Two MKA sessions on subinterfaces with no peer responding yet
+platform: Cisco Catalyst 9500
+software_version: IOS-XE

--- a/tests/parsers/iosxe/show_mka_sessions/003_secured_session_with_peer/expected.json
+++ b/tests/parsers/iosxe/show_mka_sessions/003_secured_session_with_peer/expected.json
@@ -1,0 +1,19 @@
+{
+    "total_mka_sessions": 1,
+    "secured_sessions": 1,
+    "pending_sessions": 0,
+    "sessions": {
+        "HundredGigabitEthernet2/6/0/39": {
+            "interface": "HundredGigabitEthernet2/6/0/39",
+            "local_tx_sci": "70b3.171e.b282/0103",
+            "policy_name": "*DEFAULT POLICY*",
+            "inherited": "NO",
+            "key_server": "NO",
+            "port_id": "259",
+            "peer_rx_sci": "00a7.42ce.d57f/0074",
+            "macsec_peers": "1",
+            "status": "Secured",
+            "ckn": "10"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_mka_sessions/003_secured_session_with_peer/input.txt
+++ b/tests/parsers/iosxe/show_mka_sessions/003_secured_session_with_peer/input.txt
@@ -1,0 +1,10 @@
+Total MKA Sessions....... 1
+      Secured Sessions... 1
+      Pending Sessions... 0
+
+====================================================================================================
+Interface      Local-TxSCI         Policy-Name      Inherited         Key-Server
+Port-ID        Peer-RxSCI          MACsec-Peers     Status            CKN
+====================================================================================================
+Hu2/6/0/39     70b3.171e.b282/0103 *DEFAULT POLICY* NO                NO
+259            00a7.42ce.d57f/0074 1                Secured           10

--- a/tests/parsers/iosxe/show_mka_sessions/003_secured_session_with_peer/metadata.yaml
+++ b/tests/parsers/iosxe/show_mka_sessions/003_secured_session_with_peer/metadata.yaml
@@ -1,0 +1,3 @@
+description: One fully-established MKA session with a connected peer (Secured status, MACsec-Peers=1)
+platform: Unknown
+software_version: IOS-XE


### PR DESCRIPTION
## Summary
- New IOS-XE parser for `show mka sessions` that emits the three header totals (`total_mka_sessions`, `secured_sessions`, `pending_sessions`) plus a `sessions` mapping keyed by canonical interface name.
- Session rows are parsed by slicing each data line at the column offsets derived from the two-row header, so values containing spaces (e.g. `*DEFAULT POLICY*`, `Secured, no peer`) survive intact.

Closes #1015

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_mka_sessions -v`
- [x] `uv run pytest` (full suite, 8864 passing)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_mka_sessions.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `uv run pre-commit run` on the changeset

## Fixtures
- `001_tac_r2_no_sessions` — verbatim sample from the issue (Total / Secured / Pending all `0`, header block but no session rows).
- `002_two_sessions_no_peer` — two MKA sessions on `HundredGigE1/0/3.5` and `.3.6` with `Secured, no peer` status; sourced from publicly available Cisco device output and used to exercise the multi-line row parsing and column-slicing logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)