### PR TITLE
feat(cisco_iosxe): add parser for `show mac address-table count`

### DIFF
--- a/changes/1011.parser_added
+++ b/changes/1011.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show mac address-table count` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_mac_address_table_count.py
+++ b/src/muninn/parsers/ios/show_mac_address_table_count.py
@@ -66,9 +66,8 @@ def _try_count_line(line: str, current_entry: dict[str, int]) -> bool:
 
 
 @register(OS.CISCO_IOS, "show mac address-table count")
-@register(OS.CISCO_IOSXE, "show mac address-table count")
 class ShowMacAddressTableCountParser(BaseParser[ShowMacAddressTableCountResult]):
-    """Parser for 'show mac address-table count' command on IOS/IOS-XE."""
+    """Parser for 'show mac address-table count' command on IOS."""
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset(
         {ParserTag.MAC, ParserTag.SWITCHING, ParserTag.VLAN}

--- a/src/muninn/parsers/iosxe/show_mac_address_table_count.py
+++ b/src/muninn/parsers/iosxe/show_mac_address_table_count.py
@@ -1,0 +1,99 @@
+"""Parser for 'show mac address-table count' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_TOTAL_DYNAMIC_RE = re.compile(
+    r"^\s*Total\s+Dynamic\s+Address\s+Count\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_TOTAL_STATIC_RE = re.compile(
+    r"^\s*Total\s+Static\s+Address\s+Count\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_TOTAL_IN_USE_RE = re.compile(
+    r"^\s*Total\s+Mac\s+Address(?:es)?\s+In\s+Use\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+_TOTAL_SPACE_RE = re.compile(
+    r"^\s*Total\s+Mac\s+Address\s+Space\s+Available\s*:\s*(?P<count>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+
+class ShowMacAddressTableCountResult(TypedDict):
+    """Schema for 'show mac address-table count' parsed output."""
+
+    total_dynamic_address_count: int
+    total_static_address_count: int
+    total_mac_address_in_use: int
+    total_mac_address_space_available: NotRequired[int]
+
+
+_REQUIRED_FIELDS: tuple[str, ...] = (
+    "total_dynamic_address_count",
+    "total_static_address_count",
+    "total_mac_address_in_use",
+)
+
+
+@register(OS.CISCO_IOSXE, "show mac address-table count")
+class ShowMacAddressTableCountParser(BaseParser[ShowMacAddressTableCountResult]):
+    """Parser for 'show mac address-table count' command on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.MAC, ParserTag.SWITCHING}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMacAddressTableCountResult:
+        """Parse 'show mac address-table count' output into structured data.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed MAC address-table summary counts plus optional total
+            available MAC address space.
+
+        Raises:
+            ValueError: If any required count field is missing.
+        """
+        result: dict[str, int] = {}
+
+        for line in output.splitlines():
+            dynamic_match = _TOTAL_DYNAMIC_RE.match(line)
+            if dynamic_match:
+                result["total_dynamic_address_count"] = int(
+                    dynamic_match.group("count")
+                )
+                continue
+
+            static_match = _TOTAL_STATIC_RE.match(line)
+            if static_match:
+                result["total_static_address_count"] = int(static_match.group("count"))
+                continue
+
+            in_use_match = _TOTAL_IN_USE_RE.match(line)
+            if in_use_match:
+                result["total_mac_address_in_use"] = int(in_use_match.group("count"))
+                continue
+
+            space_match = _TOTAL_SPACE_RE.match(line)
+            if space_match:
+                result["total_mac_address_space_available"] = int(
+                    space_match.group("count")
+                )
+                continue
+
+        for required in _REQUIRED_FIELDS:
+            if required not in result:
+                msg = f"Missing required field: {required}"
+                raise ValueError(msg)
+
+        return cast(ShowMacAddressTableCountResult, result)

--- a/tests/parsers/iosxe/show_mac_address-table_count/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_mac_address-table_count/001_basic/expected.json
@@ -1,0 +1,5 @@
+{
+    "total_dynamic_address_count": 0,
+    "total_static_address_count": 0,
+    "total_mac_address_in_use": 0
+}

--- a/tests/parsers/iosxe/show_mac_address-table_count/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_mac_address-table_count/001_basic/input.txt
@@ -1,0 +1,3 @@
+Total Dynamic Address Count  : 0
+Total Static  Address Count  : 0
+Total Mac Address In Use     : 0

--- a/tests/parsers/iosxe/show_mac_address-table_count/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_mac_address-table_count/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic MAC address-table count summary captured from TAC-R2 testbed device (no MAC address space available footer)
+platform: Cisco ISR 1100
+software_version: Unknown

--- a/tests/parsers/iosxe/show_mac_address-table_count/002_with_space_available/expected.json
+++ b/tests/parsers/iosxe/show_mac_address-table_count/002_with_space_available/expected.json
@@ -1,0 +1,6 @@
+{
+    "total_dynamic_address_count": 0,
+    "total_static_address_count": 0,
+    "total_mac_address_in_use": 0,
+    "total_mac_address_space_available": 32764
+}

--- a/tests/parsers/iosxe/show_mac_address-table_count/002_with_space_available/input.txt
+++ b/tests/parsers/iosxe/show_mac_address-table_count/002_with_space_available/input.txt
@@ -1,0 +1,4 @@
+Total Dynamic Address Count  : 0
+Total Static  Address Count  : 0
+Total Mac Address In Use     : 0
+Total Mac Address Space Available: 32764

--- a/tests/parsers/iosxe/show_mac_address-table_count/002_with_space_available/metadata.yaml
+++ b/tests/parsers/iosxe/show_mac_address-table_count/002_with_space_available/metadata.yaml
@@ -1,0 +1,3 @@
+description: MAC address-table count summary captured from TAC-S1 testbed device including the Total Mac Address Space Available footer
+platform: Cisco Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds a `cisco_iosxe` parser for `show mac address-table count` returning a flat summary `TypedDict` with `total_dynamic_address_count`, `total_static_address_count`, `total_mac_address_in_use`, and an optional `total_mac_address_space_available` (present on platforms like the Catalyst 9300 that report the footer).
- Removes the speculative `@register(OS.CISCO_IOSXE, ...)` decorator that #1071 added to the IOS parser. That parser expects per-VLAN `Mac Entries for Vlan N:` blocks, which IOS-XE does not emit for this command, so it always raised `ValueError` on real IOS-XE output. The new IOS-XE parser owns the registration.
- Ships two fixtures sourced verbatim from the issue: TAC-R2 (no space-available footer) and TAC-S1 (with footer).

Closes #1011

## Test plan
- [x] `uv run pytest tests/parsers/ -k mac_address-table_count -v` (21 passing)
- [x] `uv run pytest` (8862 passing)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_mac_address_table_count.py src/muninn/parsers/ios/show_mac_address_table_count.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)