### PR TITLE
feat(cisco_iosxe): add parser for `show ip sla responder`

### DIFF
--- a/changes/1003.parser_added
+++ b/changes/1003.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip sla responder` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_sla_responder.py
+++ b/src/muninn/parsers/iosxe/show_ip_sla_responder.py
@@ -1,0 +1,110 @@
+"""Parser for 'show ip sla responder' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowIpSlaResponderResult(TypedDict):
+    """Schema for 'show ip sla responder' parsed output."""
+
+    general_responder_enabled: bool
+    general_responder_control_port: NotRequired[int]
+    general_responder_control_v2_port: NotRequired[int]
+    permanent_port_responder_enabled: bool
+
+
+@register(OS.CISCO_IOSXE, "show ip sla responder")
+class ShowIpSlaResponderParser(BaseParser[ShowIpSlaResponderResult]):
+    """Parser for 'show ip sla responder' command on IOS-XE.
+
+    Parses the IP SLA responder global status output. The command reports
+    two responder modes:
+
+    * General IP SLA Responder, with its control port and (optionally)
+      Control V2 port numbers.
+    * Permanent Port IP SLA Responder.
+
+    Each mode reports an enabled/disabled status.
+
+    Example output::
+
+        General IP SLA Responder on Control port 1967
+                General IP SLA Responder on Control V2 port 1167
+        General IP SLA Responder is: Disabled
+
+                Permanent Port IP SLA Responder
+        Permanent Port IP SLA Responder is: Disabled
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.CONNECTIVITY})
+
+    _CONTROL_V2_PORT_RE = re.compile(
+        r"General IP SLA Responder on Control V2 port (?P<port>\d+)"
+    )
+    _CONTROL_PORT_RE = re.compile(
+        r"General IP SLA Responder on Control port (?P<port>\d+)"
+    )
+    _GENERAL_STATUS_RE = re.compile(r"General IP SLA Responder is:\s+(?P<status>\S+)")
+    _PERMANENT_STATUS_RE = re.compile(
+        r"Permanent Port IP SLA Responder is:\s+(?P<status>\S+)"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpSlaResponderResult:
+        """Parse 'show ip sla responder' output.
+
+        Args:
+            output: Raw CLI output from 'show ip sla responder'.
+
+        Returns:
+            Parsed responder configuration and status.
+
+        Raises:
+            ValueError: If required responder status lines cannot be found.
+        """
+        result: dict = {}
+
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            # Check Control V2 first since it is a more specific match.
+            match = cls._CONTROL_V2_PORT_RE.search(line)
+            if match:
+                result["general_responder_control_v2_port"] = int(match.group("port"))
+                continue
+
+            match = cls._CONTROL_PORT_RE.search(line)
+            if match:
+                result["general_responder_control_port"] = int(match.group("port"))
+                continue
+
+            match = cls._GENERAL_STATUS_RE.search(line)
+            if match:
+                result["general_responder_enabled"] = (
+                    match.group("status").lower() == "enabled"
+                )
+                continue
+
+            match = cls._PERMANENT_STATUS_RE.search(line)
+            if match:
+                result["permanent_port_responder_enabled"] = (
+                    match.group("status").lower() == "enabled"
+                )
+                continue
+
+        for required in (
+            "general_responder_enabled",
+            "permanent_port_responder_enabled",
+        ):
+            if required not in result:
+                msg = f"Missing required field: {required}"
+                raise ValueError(msg)
+
+        return cast(ShowIpSlaResponderResult, result)

--- a/tests/parsers/iosxe/show_ip_sla_responder/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_sla_responder/001_basic/expected.json
@@ -1,0 +1,6 @@
+{
+    "general_responder_control_port": 1967,
+    "general_responder_control_v2_port": 1167,
+    "general_responder_enabled": false,
+    "permanent_port_responder_enabled": false
+}

--- a/tests/parsers/iosxe/show_ip_sla_responder/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_sla_responder/001_basic/input.txt
@@ -1,0 +1,6 @@
+General IP SLA Responder on Control port 1967
+        General IP SLA Responder on Control V2 port 1167
+General IP SLA Responder is: Disabled
+
+        Permanent Port IP SLA Responder
+Permanent Port IP SLA Responder is: Disabled

--- a/tests/parsers/iosxe/show_ip_sla_responder/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_sla_responder/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show ip sla responder output with both responders disabled
+platform: Unknown
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Parses `show ip sla responder` on Cisco IOS-XE into a flat TypedDict with `general_responder_enabled` / `permanent_port_responder_enabled` booleans and optional `general_responder_control_port` / `general_responder_control_v2_port` integers.
- Fixture taken verbatim from the issue's TAC-R2 sample (both responders disabled). No enabled-responder sample was available, so fields that may appear only when responders are active remain `NotRequired`.

Closes #1003

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_ip_sla_responder -v` (7 passing)
- [x] `uv run pytest` (8985 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_sla_responder.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)