### PR TITLE
feat(cisco_iosxe): add parser for `show interfaces status`

### DIFF
--- a/changes/998.parser_added
+++ b/changes/998.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show interfaces status` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_interfaces_status.py
+++ b/src/muninn/parsers/ios/show_interfaces_status.py
@@ -1,4 +1,4 @@
-"""Parser for 'show interfaces status' command on IOS."""
+"""Parser for 'show interfaces status' command on IOS / IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict, cast
@@ -152,14 +152,17 @@ def _parse_data_line(line: str) -> tuple[str, InterfaceStatusEntry] | None:
 
 
 @register(OS.CISCO_IOS, "show interfaces status")
+@register(OS.CISCO_IOSXE, "show interfaces status")
 class ShowInterfacesStatusParser(BaseParser[ShowInterfacesStatusResult]):
-    """Parser for 'show interfaces status' on IOS.
+    """Parser for 'show interfaces status' on IOS / IOS-XE.
 
-    Parses the columnar status table emitted by Cisco IOS, returning a
-    mapping keyed by canonical interface name. Handles terminal-wrapped
-    Type-column continuations (long media descriptors like
-    ``10/100/1000BaseTX`` or ``SFP-10GBase-LR`` are commonly pushed onto
-    the following line by 80-column wrapping).
+    Parses the columnar status table emitted by Cisco IOS and IOS-XE,
+    returning a mapping keyed by canonical interface name. Handles
+    terminal-wrapped Type-column continuations (long media descriptors
+    like ``10/100/1000BaseTX`` or ``SFP-10GBase-LR`` are commonly pushed
+    onto the following line by 80-column wrapping). Both platforms emit
+    the same five-column format (Port/Name/Status/Vlan/Duplex/Speed plus
+    optional Type), so a single implementation serves both.
     """
 
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})

--- a/tests/parsers/iosxe/show_interfaces_status/001_tac_s1/expected.json
+++ b/tests/parsers/iosxe/show_interfaces_status/001_tac_s1/expected.json
@@ -1,0 +1,405 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/1": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "name": "S1 to S2 802.1Q pa",
+            "vlan": "routed",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/2": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "name": "S1 to R1 802.1Q pa",
+            "vlan": "routed",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/5": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/6": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/7": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/8": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/9": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/10": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/11": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/12": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/13": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/14": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/15": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/16": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/17": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/18": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/19": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/20": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/21": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/22": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/23": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/24": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/25": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/26": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/27": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/28": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/29": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/30": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/31": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/32": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/33": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/34": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/35": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/36": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/37": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/38": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/39": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/40": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/41": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/42": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/43": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/44": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/45": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/46": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/47": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "GigabitEthernet1/0/48": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "10/100/1000BaseTX"
+        },
+        "TenGigabitEthernet1/1/1": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/2": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/3": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/4": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/5": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/6": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/7": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "TenGigabitEthernet1/1/8": {
+            "status": "notconnect",
+            "duplex": "auto",
+            "speed": "auto",
+            "vlan": "1",
+            "type": "unknown"
+        },
+        "AppGigabitEthernet1/0/1": {
+            "status": "connected",
+            "duplex": "a-full",
+            "speed": "a-1000",
+            "vlan": "1",
+            "type": "App-hosting port"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interfaces_status/001_tac_s1/input.txt
+++ b/tests/parsers/iosxe/show_interfaces_status/001_tac_s1/input.txt
@@ -1,0 +1,107 @@
+Port         Name               Status       Vlan       Duplex  Speed Type
+Gi1/0/1      S1 to S2 802.1Q pa connected    routed     a-full a-1000
+10/100/1000BaseTX
+Gi1/0/2      S1 to R1 802.1Q pa notconnect   routed       auto   auto
+10/100/1000BaseTX
+Gi1/0/3                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/4                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/5                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/6                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/7                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/8                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/9                         notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/10                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/11                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/12                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/13                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/14                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/15                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/16                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/17                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/18                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/19                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/20                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/21                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/22                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/23                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/24                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/25                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/26                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/27                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/28                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/29                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/30                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/31                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/32                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/33                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/34                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/35                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/36                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/37                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/38                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/39                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/40                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/41                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/42                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/43                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/44                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/45                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/46                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/47                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Gi1/0/48                        notconnect   1            auto   auto
+10/100/1000BaseTX
+Te1/1/1                         notconnect   1            auto   auto unknown
+Te1/1/2                         notconnect   1            auto   auto unknown
+Te1/1/3                         notconnect   1            auto   auto unknown
+Te1/1/4                         notconnect   1            auto   auto unknown
+Te1/1/5                         notconnect   1            auto   auto unknown
+Te1/1/6                         notconnect   1            auto   auto unknown
+Te1/1/7                         notconnect   1            auto   auto unknown
+Te1/1/8                         notconnect   1            auto   auto unknown
+Ap1/0/1                         connected    1          a-full a-1000
+App-hosting port

--- a/tests/parsers/iosxe/show_interfaces_status/001_tac_s1/metadata.yaml
+++ b/tests/parsers/iosxe/show_interfaces_status/001_tac_s1/metadata.yaml
@@ -1,0 +1,11 @@
+description: >-
+  'show interfaces status' output from a Catalyst 9300 (TAC-S1) running
+  IOS-XE. Exercises 'connected' and 'notconnect' statuses, the 'routed'
+  vlan value, descriptions truncated at column width
+  ('S1 to S2 802.1Q pa', 'S1 to R1 802.1Q pa'), terminal-wrapped Type
+  values (10/100/1000BaseTX), the inline 'unknown' Type emitted by
+  TenGigabitEthernet uplinks with no transceiver, and an
+  AppGigabitEthernet row whose wrapped Type contains a space
+  ('App-hosting port').
+platform: Cisco Catalyst 9300
+software_version: IOS-XE 17.x


### PR DESCRIPTION
## Summary

- Adds IOS-XE support for `show interfaces status` by stacking an `@register(OS.CISCO_IOSXE, ...)` decorator on the existing `ShowInterfacesStatusParser` (originally added in #1087 for cisco_ios). Both platforms emit the same five-column table (Port/Name/Status/Vlan/Duplex/Speed [Type]) with identical 80-column Type-wrap behaviour, so one implementation now serves both.
- Updates the module/class docstrings to reflect the dual-platform registration.
- Adds a Catalyst 9300 (TAC-S1) fixture from the issue exercising connected/notconnect statuses, the `routed` vlan value, descriptions truncated at the column width, wrapped `10/100/1000BaseTX` Type values, the inline `unknown` Type used by uplinks with no transceiver, and an `AppGigabitEthernet` row whose wrapped Type contains a space (`App-hosting port`).

Closes #998

## Test plan

- [x] `uv run pytest` (8994 passed)
- [x] `uv run ruff check --fix .` / `uv run ruff format .`
- [x] `uv run ty check src/` (no new diagnostics)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `uv run pre-commit run` on changed files