### PR TITLE
feat(cisco_iosxe): add parser for `show ip route summary`

### DIFF
--- a/changes/1000.parser_added
+++ b/changes/1000.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip route summary` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_ip_route_summary.py
+++ b/src/muninn/parsers/ios/show_ip_route_summary.py
@@ -1,4 +1,4 @@
-"""Parser for 'show ip route summary' command on IOS."""
+"""Parser for 'show ip route summary' command on IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict, cast
@@ -245,6 +245,7 @@ def _attach_ospf_subdetail(
 
 
 @register(OS.CISCO_IOS, "show ip route summary")
+@register(OS.CISCO_IOSXE, "show ip route summary")
 class ShowIpRouteSummaryParser(BaseParser["ShowIpRouteSummaryResult"]):
     """Parser for 'show ip route summary' command.
 

--- a/tests/parsers/iosxe/show_ip_route_summary/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_route_summary/001_basic/expected.json
@@ -1,0 +1,67 @@
+{
+    "route_sources": {
+        "application": {
+            "memory_bytes": 0,
+            "networks": 0,
+            "overhead": 0,
+            "replicates": 0,
+            "subnets": 0
+        },
+        "bgp 65000": {
+            "bgp": {
+                "external": 0,
+                "internal": 0,
+                "local": 0
+            },
+            "memory_bytes": 0,
+            "networks": 0,
+            "overhead": 0,
+            "replicates": 0,
+            "subnets": 0
+        },
+        "connected": {
+            "memory_bytes": 936,
+            "networks": 0,
+            "overhead": 336,
+            "replicates": 0,
+            "subnets": 3
+        },
+        "internal": {
+            "memory_bytes": 1376,
+            "networks": 3
+        },
+        "ospf 1": {
+            "memory_bytes": 0,
+            "networks": 0,
+            "ospf": {
+                "external_1": 0,
+                "external_2": 0,
+                "inter_area": 0,
+                "intra_area": 0,
+                "nssa_external_1": 0,
+                "nssa_external_2": 0
+            },
+            "overhead": 0,
+            "replicates": 0,
+            "subnets": 0
+        },
+        "static": {
+            "memory_bytes": 312,
+            "networks": 0,
+            "overhead": 112,
+            "replicates": 0,
+            "subnets": 1
+        }
+    },
+    "routing_table": {
+        "maximum_paths": 32,
+        "name": "default"
+    },
+    "total": {
+        "memory_bytes": 2624,
+        "networks": 3,
+        "overhead": 448,
+        "replicates": 0,
+        "subnets": 4
+    }
+}

--- a/tests/parsers/iosxe/show_ip_route_summary/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_route_summary/001_basic/input.txt
@@ -1,0 +1,13 @@
+IP routing table name is default (0x0)
+IP routing table maximum-paths is 32
+Route Source    Networks    Subnets     Replicates  Overhead    Memory (bytes)
+application     0           0           0           0           0
+connected       0           3           0           336         936
+static          0           1           0           112         312
+ospf 1          0           0           0           0           0
+  Intra-area: 0 Inter-area: 0 External-1: 0 External-2: 0
+  NSSA External-1: 0 NSSA External-2: 0
+bgp 65000       0           0           0           0           0
+  External: 0 Internal: 0 Local: 0
+internal        3                                               1376
+Total           3           4           0           448         2624

--- a/tests/parsers/iosxe/show_ip_route_summary/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_route_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output from TAC-R2 with connected, static, OSPF, BGP, and internal sources
+platform: Cisco ISR 1100 / Catalyst 9300
+software_version: IOS-XE


### PR DESCRIPTION
## Summary
- Adds IOS-XE support for `show ip route summary` by stacking an additional `@register(OS.CISCO_IOSXE, "show ip route summary")` decorator on the existing Cisco IOS `ShowIpRouteSummaryParser`. The IOS-XE output shape is identical to IOS — routing table metadata, per-source rows with OSPF / BGP / ISIS sub-details, the `internal` row, and the `Total` footer — so no schema or logic changes were needed.
- Adds a real-device fixture (`tests/parsers/iosxe/show_ip_route_summary/001_basic/`) captured from a TAC-R2 testbed (ISR 1100 / Catalyst 9300), covering connected, static, OSPF with NSSA sub-details, BGP with sub-details, and the `internal` row.

Closes #1000

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_ip_route_summary -v` (21 passed)
- [x] `uv run pytest` (full suite, 8994 passing)
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run ty check src/muninn/parsers/ios/show_ip_route_summary.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

---

Note: a parallel PR (#1001) introduces `show ip route vrf * summary` for IOS-XE; that parser can stack on top of this one for the per-VRF case once both are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)