### PR TITLE
feat(cisco_iosxe): add parser for `show cdp interface`

### DIFF
--- a/changes/986.parser_added
+++ b/changes/986.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show cdp interface` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_cdp_interface.py
+++ b/src/muninn/parsers/ios/show_cdp_interface.py
@@ -1,4 +1,4 @@
-"""Parser for 'show cdp interface' command on IOS."""
+"""Parser for 'show cdp interface' command on Cisco IOS and IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict, cast
@@ -118,8 +118,9 @@ def _try_match_attribute(line: str, entry: CdpInterfaceEntry) -> bool:
 
 
 @register(OS.CISCO_IOS, "show cdp interface")
+@register(OS.CISCO_IOSXE, "show cdp interface")
 class ShowCdpInterfaceParser(BaseParser[ShowCdpInterfaceResult]):
-    """Parser for 'show cdp interface' on Cisco IOS.
+    """Parser for 'show cdp interface' on Cisco IOS and IOS-XE.
 
     Output consists of a block per CDP-enabled interface followed by a
     footer with aggregate counts. Each interface block looks like::
@@ -136,7 +137,7 @@ class ShowCdpInterfaceParser(BaseParser[ShowCdpInterfaceResult]):
 
     @classmethod
     def parse(cls, output: str) -> ShowCdpInterfaceResult:
-        """Parse 'show cdp interface' output on Cisco IOS.
+        """Parse 'show cdp interface' output on Cisco IOS and IOS-XE.
 
         Args:
             output: Raw CLI output from the command.

--- a/tests/parsers/iosxe/show_cdp_interface/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_cdp_interface/001_basic/expected.json
@@ -1,0 +1,77 @@
+{
+    "cdp_enabled_interfaces": 10,
+    "interfaces_up": 4,
+    "interfaces_down": 6,
+    "interfaces": {
+        "GigabitEthernet0/0/0": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/1": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "802.1Q Virtual LAN, Vlan ID  1.",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/1.10": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "802.1Q Virtual LAN, Vlan ID  10.",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/1.20": {
+            "status": "down",
+            "line_protocol": "down",
+            "encapsulation": "802.1Q Virtual LAN, Vlan ID  20.",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/2": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "802.1Q Virtual LAN, Vlan ID  1.",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/2.10": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "802.1Q Virtual LAN, Vlan ID  10.",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/2.20": {
+            "status": "up",
+            "line_protocol": "up",
+            "encapsulation": "802.1Q Virtual LAN, Vlan ID  20.",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/3": {
+            "status": "administratively down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/4": {
+            "status": "administratively down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        },
+        "GigabitEthernet0/0/5": {
+            "status": "administratively down",
+            "line_protocol": "down",
+            "encapsulation": "ARPA",
+            "send_interval_seconds": 60,
+            "holdtime_seconds": 240
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_cdp_interface/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_cdp_interface/001_basic/input.txt
@@ -1,0 +1,44 @@
+GigabitEthernet0/0/0 is up, line protocol is up
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/1 is down, line protocol is down
+  Encapsulation 802.1Q Virtual LAN, Vlan ID  1.
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/1.10 is down, line protocol is down
+  Encapsulation 802.1Q Virtual LAN, Vlan ID  10.
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/1.20 is down, line protocol is down
+  Encapsulation 802.1Q Virtual LAN, Vlan ID  20.
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/2 is up, line protocol is up
+  Encapsulation 802.1Q Virtual LAN, Vlan ID  1.
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/2.10 is up, line protocol is up
+  Encapsulation 802.1Q Virtual LAN, Vlan ID  10.
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/2.20 is up, line protocol is up
+  Encapsulation 802.1Q Virtual LAN, Vlan ID  20.
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/3 is administratively down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/4 is administratively down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+GigabitEthernet0/0/5 is administratively down, line protocol is down
+  Encapsulation ARPA
+  Sending CDP packets every 60 seconds
+  Holdtime is 240 seconds
+
+ cdp enabled interfaces : 10
+ interfaces up          : 4
+ interfaces down        : 6

--- a/tests/parsers/iosxe/show_cdp_interface/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_cdp_interface/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: CDP interface listing from an IOS-XE router (TAC-R2) showing routed, 802.1Q-trunk, and dot1q subinterface CDP timers with an aggregate summary footer
+platform: Cisco ISR 1100
+software_version: IOS-XE


### PR DESCRIPTION
## Summary
- Registers the existing `ShowCdpInterfaceParser` for `OS.CISCO_IOSXE` by stacking a second `@register` decorator on the IOS implementation, since IOS-XE output and fields are byte-identical to IOS (per-interface header, `Encapsulation`, `Sending CDP packets every N seconds`, `Holdtime is N seconds`, plus the aggregate summary footer).
- Adds an IOS-XE fixture (`tests/parsers/iosxe/show_cdp_interface/001_basic/`) using the verbatim sample from the issue (TAC-R2), covering ARPA, 802.1Q trunk, and dot1q subinterface encapsulations plus `administratively down` status.

Closes #986

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_cdp_interface -v` (14 passed)
- [x] `uv run pytest -q` (9086 passed)
- [x] `uv run ruff check src/muninn/parsers/ios/show_cdp_interface.py`
- [x] `uv run ruff format --check src/muninn/parsers/ios/show_cdp_interface.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_cdp_interface.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `uv run bandit -r src/muninn/parsers/ios/show_cdp_interface.py`

Generated with [Claude Code](https://claude.com/claude-code)