### PR TITLE
feat(cisco_iosxe): add parser for `show crypto ipsec sa count`

### DIFF
--- a/changes/988.parser_added
+++ b/changes/988.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto ipsec sa count` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_ipsec_sa_count.py
+++ b/src/muninn/parsers/iosxe/show_crypto_ipsec_sa_count.py
@@ -1,0 +1,66 @@
+"""Parser for 'show crypto ipsec sa count' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_COUNT_LINE_RE = re.compile(
+    r"^\s*IPsec\s+SA\s+total:\s*(?P<total>\d+),\s*"
+    r"active:\s*(?P<active>\d+),\s*"
+    r"rekeying:\s*(?P<rekeying>\d+),\s*"
+    r"unused:\s*(?P<unused>\d+),\s*"
+    r"invalid:\s*(?P<invalid>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+
+class ShowCryptoIpsecSaCountResult(TypedDict):
+    """Schema for 'show crypto ipsec sa count' parsed output."""
+
+    total: int
+    active: int
+    rekeying: int
+    unused: int
+    invalid: int
+
+
+@register(OS.CISCO_IOSXE, "show crypto ipsec sa count")
+class ShowCryptoIpsecSaCountParser(BaseParser[ShowCryptoIpsecSaCountResult]):
+    """Parser for 'show crypto ipsec sa count' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.SECURITY, ParserTag.VPN}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoIpsecSaCountResult:
+        """Parse 'show crypto ipsec sa count' output into structured data.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed IPsec SA counters (total, active, rekeying, unused, invalid).
+
+        Raises:
+            ValueError: If the expected counter summary line is not found.
+        """
+        for line in output.splitlines():
+            match = _COUNT_LINE_RE.match(line)
+            if not match:
+                continue
+            result: dict[str, int] = {
+                "total": int(match.group("total")),
+                "active": int(match.group("active")),
+                "rekeying": int(match.group("rekeying")),
+                "unused": int(match.group("unused")),
+                "invalid": int(match.group("invalid")),
+            }
+            return cast(ShowCryptoIpsecSaCountResult, result)
+
+        msg = "No 'IPsec SA total' counter summary line found in output"
+        raise ValueError(msg)

--- a/tests/parsers/iosxe/show_crypto_ipsec_sa_count/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_ipsec_sa_count/001_basic/expected.json
@@ -1,0 +1,7 @@
+{
+    "total": 0,
+    "active": 0,
+    "rekeying": 0,
+    "unused": 0,
+    "invalid": 0
+}

--- a/tests/parsers/iosxe/show_crypto_ipsec_sa_count/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_ipsec_sa_count/001_basic/input.txt
@@ -1,0 +1,1 @@
+IPsec SA total: 0, active: 0, rekeying: 0, unused: 0, invalid: 0

--- a/tests/parsers/iosxe/show_crypto_ipsec_sa_count/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_ipsec_sa_count/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Show crypto ipsec sa count output from TAC-R2 with all counters at zero
+platform: Cisco ISR 1100
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto ipsec sa count` on Cisco IOS-XE that extracts the five IPsec SA counters (total, active, rekeying, unused, invalid) from the single-line summary into a flat `TypedDict` with `int` values.
- Fixture sourced verbatim from issue #988 (TAC-R2, all counters at zero).

Closes #988

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_ipsec_sa_count -v` (7 passed)
- [x] `uv run pytest` (full suite, 8994 passing)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_ipsec_sa_count.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_ipsec_sa_count.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)