### PR TITLE
feat(cisco_iosxe): add parser for `show etherchannel summary`

### DIFF
--- a/changes/995.parser_added
+++ b/changes/995.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show etherchannel summary` on Cisco IOS-XE.

--- a/src/muninn/parsers/ios/show_etherchannel_summary.py
+++ b/src/muninn/parsers/ios/show_etherchannel_summary.py
@@ -1,4 +1,4 @@
-"""Parser for 'show etherchannel summary' command on IOS."""
+"""Parser for 'show etherchannel summary' command on IOS / IOS-XE."""
 
 import re
 from typing import ClassVar, NotRequired, TypedDict, cast
@@ -158,8 +158,9 @@ def _validate_required_fields(
 
 
 @register(OS.CISCO_IOS, "show etherchannel summary")
+@register(OS.CISCO_IOSXE, "show etherchannel summary")
 class ShowEtherchannelSummaryParser(BaseParser[ShowEtherchannelSummaryResult]):
-    """Parser for 'show etherchannel summary' command.
+    """Parser for 'show etherchannel summary' command on IOS / IOS-XE.
 
     Example output:
         Group  Port-channel  Protocol    Ports

--- a/tests/parsers/iosxe/show_etherchannel_summary/001_tac_r2_no_groups/expected.json
+++ b/tests/parsers/iosxe/show_etherchannel_summary/001_tac_r2_no_groups/expected.json
@@ -1,0 +1,5 @@
+{
+    "num_channel_groups": 0,
+    "num_aggregators": 0,
+    "port_channels": {}
+}

--- a/tests/parsers/iosxe/show_etherchannel_summary/001_tac_r2_no_groups/input.txt
+++ b/tests/parsers/iosxe/show_etherchannel_summary/001_tac_r2_no_groups/input.txt
@@ -1,0 +1,22 @@
+Flags:  D - down        P/bndl - bundled in port-channel
+        I - stand-alone s/susp - suspended
+        H - Hot-standby (LACP only)
+        R - Layer3      S - Layer2
+        U - in use      f - failed to allocate aggregator
+
+        M - not in use, minimum links not met
+        u - unsuitable for bundling
+        w - waiting to be aggregated
+        d - default port
+
+
+Number of channel-groups in use: 0
+Number of aggregators:           0
+
+Group  Port-channel  Protocol    Ports
+------+-------------+-----------+-----------------------------------------------
+
+RU - L3 port-channel UP State
+SU - L2 port-channel UP state
+P/bndl -  Bundled
+S/susp  - Suspended

--- a/tests/parsers/iosxe/show_etherchannel_summary/001_tac_r2_no_groups/metadata.yaml
+++ b/tests/parsers/iosxe/show_etherchannel_summary/001_tac_r2_no_groups/metadata.yaml
@@ -1,0 +1,3 @@
+description: No channel-groups in use; output includes flag legend appendix below the table
+platform: Cisco ISR 1100 / Catalyst 9300
+software_version: Unknown

--- a/tests/parsers/iosxe/show_etherchannel_summary/002_tac_s1_no_groups/expected.json
+++ b/tests/parsers/iosxe/show_etherchannel_summary/002_tac_s1_no_groups/expected.json
@@ -1,0 +1,5 @@
+{
+    "num_channel_groups": 0,
+    "num_aggregators": 0,
+    "port_channels": {}
+}

--- a/tests/parsers/iosxe/show_etherchannel_summary/002_tac_s1_no_groups/input.txt
+++ b/tests/parsers/iosxe/show_etherchannel_summary/002_tac_s1_no_groups/input.txt
@@ -1,0 +1,19 @@
+Flags:  D - down        P - bundled in port-channel
+        I - stand-alone s - suspended
+        H - Hot-standby (LACP only)
+        R - Layer3      S - Layer2
+        U - in use      f - failed to allocate aggregator
+
+        M - not in use, minimum links not met
+        u - unsuitable for bundling
+        w - waiting to be aggregated
+        d - default port
+
+        A - formed by Auto LAG
+
+
+Number of channel-groups in use: 0
+Number of aggregators:           0
+
+Group  Port-channel  Protocol    Ports
+------+-------------+-----------+-----------------------------------------------

--- a/tests/parsers/iosxe/show_etherchannel_summary/002_tac_s1_no_groups/metadata.yaml
+++ b/tests/parsers/iosxe/show_etherchannel_summary/002_tac_s1_no_groups/metadata.yaml
@@ -1,0 +1,3 @@
+description: No channel-groups in use; flag legend includes Auto LAG flag
+platform: Cisco ISR 1100 / Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Registers the existing Cisco IOS `show etherchannel summary` parser for `OS.CISCO_IOSXE` by stacking an additional `@register` decorator. The schema and parsing logic are identical to the IOS sibling; the IOS-XE output format matches verbatim (same column layout, flag legend, and group lines).
- Adds two IOS-XE fixtures captured from physical testbed devices (`TAC-R2` and `TAC-S1`, ISR 1100 / Catalyst 9300). Both samples report zero channel-groups in use, exercising the empty-port-channels path on slightly different flag legends (one includes the `A - formed by Auto LAG` flag, the other has a trailing appendix of `RU/SU/P/bndl/S/susp` legend lines).

Closes #995

## Test plan
- [x] `uv run pytest tests/parsers/ -k etherchannel -v` (32 passing)
- [x] `uv run pytest -q` (9093 passing)
- [x] `uv run ruff check src/muninn/parsers/ios/show_etherchannel_summary.py`
- [x] `uv run ruff format --check src/muninn/parsers/ios/show_etherchannel_summary.py`
- [x] `uv run ty check src/muninn/parsers/ios/show_etherchannel_summary.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`
- [x] `uv run bandit -r src/` (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)