### PR TITLE
feat(cisco_iosxe): add parser for `show crypto isakmp sa count`

### DIFF
--- a/changes/992.parser_added
+++ b/changes/992.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto isakmp sa count` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_isakmp_sa_count.py
+++ b/src/muninn/parsers/iosxe/show_crypto_isakmp_sa_count.py
@@ -1,0 +1,67 @@
+"""Parser for 'show crypto isakmp sa count' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_COUNTER_RE = re.compile(
+    r"^\s*(?P<label>Active|Standby|Currently being negotiated|Dead)"
+    r"\s+ISAKMP SA's:\s*(?P<count>\d+)\s*$"
+)
+
+_LABEL_TO_FIELD: dict[str, str] = {
+    "Active": "active",
+    "Standby": "standby",
+    "Currently being negotiated": "negotiating",
+    "Dead": "dead",
+}
+
+
+class ShowCryptoIsakmpSaCountResult(TypedDict):
+    """Schema for 'show crypto isakmp sa count' parsed output."""
+
+    active: int
+    standby: int
+    negotiating: int
+    dead: int
+
+
+@register(OS.CISCO_IOSXE, "show crypto isakmp sa count")
+class ShowCryptoIsakmpSaCountParser(BaseParser[ShowCryptoIsakmpSaCountResult]):
+    """Parser for 'show crypto isakmp sa count' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.SECURITY, ParserTag.VPN}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoIsakmpSaCountResult:
+        """Parse 'show crypto isakmp sa count' output into structured data.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed ISAKMP SA counters (active, standby, negotiating, dead).
+
+        Raises:
+            ValueError: If any of the expected counter lines are missing.
+        """
+        result: dict[str, int] = {}
+        for line in output.splitlines():
+            match = _COUNTER_RE.match(line)
+            if match is None:
+                continue
+            field = _LABEL_TO_FIELD[match.group("label")]
+            result[field] = int(match.group("count"))
+
+        for required in _LABEL_TO_FIELD.values():
+            if required not in result:
+                msg = f"Missing required ISAKMP SA counter line: {required}"
+                raise ValueError(msg)
+
+        return cast(ShowCryptoIsakmpSaCountResult, result)

--- a/tests/parsers/iosxe/show_crypto_isakmp_sa_count/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_isakmp_sa_count/001_basic/expected.json
@@ -1,0 +1,6 @@
+{
+    "active": 0,
+    "standby": 0,
+    "negotiating": 0,
+    "dead": 0
+}

--- a/tests/parsers/iosxe/show_crypto_isakmp_sa_count/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_isakmp_sa_count/001_basic/input.txt
@@ -1,0 +1,4 @@
+Active ISAKMP SA's: 0
+Standby ISAKMP SA's: 0
+Currently being negotiated ISAKMP SA's: 0
+Dead ISAKMP SA's: 0

--- a/tests/parsers/iosxe/show_crypto_isakmp_sa_count/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_isakmp_sa_count/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: show crypto isakmp sa count output from TAC-R2 with all counters at zero
+platform: Cisco ISR 1100
+software_version: IOS-XE


### PR DESCRIPTION
## Summary
- Adds a TypedDict parser for `show crypto isakmp sa count` on IOS-XE, returning the four ISAKMP SA counters (`active`, `standby`, `negotiating`, `dead`) as `int` values.
- Fixture sourced from the issue's TAC-R2 capture (ISR 1100, IOS-XE) with all counters at zero.

Closes #992

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_isakmp_sa_count -v` (7 passed)
- [x] `uv run pytest` (full suite, 9086 passed)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_isakmp_sa_count.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_isakmp_sa_count.py`
- [x] `uv run bandit -r src/muninn/parsers/iosxe/show_crypto_isakmp_sa_count.py` (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)