### PR TITLE
feat(cisco_iosxe): add parser for `show boot system`

### DIFF
--- a/changes/985.parser_added
+++ b/changes/985.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show boot system` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_boot.py
+++ b/src/muninn/parsers/iosxe/show_boot.py
@@ -359,8 +359,9 @@ def _process_line(
 
 @register(OS.CISCO_IOS, "show boot")
 @register(OS.CISCO_IOSXE, "show boot")
+@register(OS.CISCO_IOSXE, "show boot system")
 class ShowBootParser(BaseParser[ShowBootResult]):
-    """Parser for 'show boot' command.
+    """Parser for 'show boot' / 'show boot system' command.
 
     Handles two output formats:
       - Variable format (Cat 9k, ASR 1k, Cat 9400/9500)

--- a/tests/parsers/iosxe/show_boot_system/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_boot_system/001_basic/expected.json
@@ -1,0 +1,11 @@
+{
+    "switches": {
+        "1": {
+            "boot_path_list": "flash:packages.conf",
+            "manual_boot": false,
+            "enable_break": false,
+            "boot_mode": "DEVICE",
+            "ipxe_timeout": 0
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_boot_system/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_boot_system/001_basic/input.txt
@@ -1,0 +1,12 @@
+---------------------------
+Switch 1
+---------------------------
+Current Boot Variables:
+BOOT variable = flash:packages.conf;
+
+Boot Variables on next reload:
+BOOT variable = flash:packages.conf;
+Manual Boot = no
+Enable Break = no
+Boot Mode = DEVICE
+iPXE Timeout = 0

--- a/tests/parsers/iosxe/show_boot_system/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_boot_system/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Catalyst 9300 stack section format with single switch (TAC-S1)
+platform: Cisco Catalyst 9300
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds `show boot system` registration for Cisco IOS-XE by stacking a new `@register(OS.CISCO_IOSXE, "show boot system")` decorator on the existing `ShowBootParser`. The command's output on Catalyst 9300 / ISR 1100 matches the stack-section format the parser already handles, so no new module or schema changes are required.
- Fixture `tests/parsers/iosxe/show_boot_system/001_basic/` uses the verbatim TAC-S1 sample output from the issue (Catalyst 9300).

Closes #985

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_boot_system -v` (7 passed)
- [x] `uv run pytest` (full suite, 9227 passing)
- [x] `uv run ruff check` / `uv run ruff format`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_boot.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_boot.py`
- [x] `uv run bandit -r src/muninn/parsers/iosxe/show_boot.py` (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)