### PR TITLE
feat(nokia_sros): add parser for `ping`

### DIFF
--- a/changes/977.parser_added
+++ b/changes/977.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `ping` on Nokia SR OS.

--- a/src/muninn/parsers/nokia_sros/ping.py
+++ b/src/muninn/parsers/nokia_sros/ping.py
@@ -114,6 +114,7 @@ _RAPID_RESULT_MAP: dict[str, str] = {
 }
 
 
+@register(OS.NOKIA_SROS, r"ping (?P<destination>\S+)")
 @register(OS.NOKIA_SROS, "ping")
 class PingParser(BaseParser[PingResult]):
     """Parser for ``ping`` on Nokia SR OS.

--- a/src/muninn/parsers/nokia_sros/ping.py
+++ b/src/muninn/parsers/nokia_sros/ping.py
@@ -1,0 +1,302 @@
+"""Parser for 'ping' command on Nokia SR OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PingPacketData(TypedDict):
+    """Per-packet ping result.
+
+    For verbose-mode pings the parser captures the full reply line
+    (bytes, icmp_seq, ttl, time_ms). For rapid-mode pings only the
+    symbolic ``result`` is available, mapped from the ``!``/``.``/
+    ``U`` characters streamed by the device.
+    """
+
+    result: str
+    bytes: NotRequired[int]
+    icmp_seq: NotRequired[int]
+    ttl: NotRequired[int]
+    time_ms: NotRequired[float]
+
+
+class PingResult(TypedDict):
+    """Schema for 'ping' parsed output on Nokia SR OS.
+
+    Common keys (``packets_sent``/``packets_received``/
+    ``success_rate_percent``/``packet_data``/``rtt_*``) mirror the
+    sibling Cisco parsers' shapes; Nokia-specific keys such as
+    ``packets_bounced``, ``duplicate_count``, ``rtt_stddev_ms``,
+    ``destination``, and ``packet_size_bytes`` are added as optional.
+    """
+
+    packets_sent: int
+    packets_received: int
+    success_rate_percent: int
+    packet_data: dict[str, PingPacketData]
+    destination: NotRequired[str]
+    packet_size_bytes: NotRequired[int]
+    loss_percent: NotRequired[float]
+    packets_bounced: NotRequired[int]
+    duplicate_count: NotRequired[int]
+    rtt_min_ms: NotRequired[float]
+    rtt_avg_ms: NotRequired[float]
+    rtt_max_ms: NotRequired[float]
+    rtt_stddev_ms: NotRequired[float]
+
+
+# --- Regex patterns ---
+
+# Header line:
+#   PING 10.252.117.158 56 data bytes
+_PING_HEADER_RE = re.compile(
+    r"^PING\s+(?P<destination>\S+)\s+(?P<size>\d+)\s+data\s+bytes\s*$"
+)
+
+# Per-packet reply line (verbose ping):
+#   64 bytes from 10.252.117.158: icmp_seq=1 ttl=255 time=1.93ms.
+_REPLY_RE = re.compile(
+    r"^(?P<bytes>\d+)\s+bytes\s+from\s+\S+:\s+"
+    r"icmp_seq=(?P<icmp_seq>\d+)\s+"
+    r"ttl=(?P<ttl>\d+)\s+"
+    r"time=(?P<time>[\d.]+)\s*ms\.?\s*$"
+)
+
+# Per-packet failure indicators (verbose ping):
+#   Request timed out. icmp_seq=1.
+_TIMEOUT_RE = re.compile(
+    r"^Request\s+timed\s+out\.\s*(?:icmp_seq=(?P<icmp_seq>\d+)\.?)?\s*$"
+)
+
+# Per-packet send-failure indicator (verbose ping):
+#   Send failed. Source IP address is not local to the system
+_SEND_FAIL_RE = re.compile(r"^Send\s+failed\.")
+
+# Rapid-mode symbolic stream (lone line of ``!``/``.``/``U``/etc.):
+_RAPID_STREAM_RE = re.compile(r"^[!.UQM&?]+$")
+
+# Statistics summary:
+#   5 packets transmitted, 5 packets received, 0.00% packet loss
+#   5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet loss
+#   5 packets transmitted, 0 packets received, 3 duplicates
+_STATS_RE = re.compile(
+    r"^(?P<sent>\d+)\s+packets\s+transmitted,"
+    r"(?:\s+(?P<bounced>\d+)\s+packets\s+bounced,)?"
+    r"\s+(?P<received>\d+)\s+packets\s+received"
+    r"(?:,\s+(?P<loss>[\d.]+)%\s+packet\s+loss)?"
+    r"(?:,\s+(?P<duplicates>\d+)\s+duplicates)?"
+    r"\s*$"
+)
+
+# RTT summary:
+#   round-trip min = 1.70ms, avg = 1.83ms, max = 1.93ms, stddev = 0.079ms
+_RTT_RE = re.compile(
+    r"^round-trip\s+min\s*=\s*(?P<min>[\d.]+)\s*ms,\s*"
+    r"avg\s*=\s*(?P<avg>[\d.]+)\s*ms,\s*"
+    r"max\s*=\s*(?P<max>[\d.]+)\s*ms"
+    r"(?:,\s*stddev\s*=\s*(?P<stddev>[\d.]+)\s*ms)?\s*$"
+)
+
+
+_RAPID_RESULT_MAP: dict[str, str] = {
+    "!": "successful",
+    ".": "failed",
+    "U": "unreachable",
+    "Q": "source_quench",
+    "M": "cannot_fragment",
+    "&": "time_exceeded",
+    "?": "unknown",
+}
+
+
+@register(OS.NOKIA_SROS, "ping")
+class PingParser(BaseParser[PingResult]):
+    """Parser for ``ping`` on Nokia SR OS.
+
+    Handles both verbose pings (one ``64 bytes from ...`` line per
+    reply, ``Request timed out.`` / ``Send failed.`` lines per
+    failure) and rapid-mode pings (a single ``!!!!!``/``.....``/
+    ``...!!.!.`` stream followed by the statistics block).
+
+    Example verbose output::
+
+        PING 10.252.117.158 56 data bytes
+        64 bytes from 10.252.117.158: icmp_seq=1 ttl=255 time=1.93ms.
+        ...
+        ---- 10.252.117.158 PING Statistics ----
+        5 packets transmitted, 5 packets received, 0.00% packet loss
+        round-trip min = 1.70ms, avg = 1.83ms, max = 1.93ms, stddev = 0.079ms
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.CONNECTIVITY})
+
+    @classmethod
+    def parse(cls, output: str) -> PingResult:
+        """Parse ``ping`` output into a structured result.
+
+        Args:
+            output: Raw CLI output from the ``ping`` command.
+
+        Returns:
+            Parsed ping result with packet counts, success rate, per-packet
+            data, and optional RTT statistics.
+
+        Raises:
+            ValueError: If no statistics summary line is found.
+        """
+        result: dict = {}
+        packet_data: dict[str, PingPacketData] = {}
+        rapid_symbols: list[str] = []
+        seen_stats = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if cls._dispatch_line(stripped, result, packet_data, rapid_symbols):
+                seen_stats = seen_stats or "packets_sent" in result
+
+        if not seen_stats:
+            msg = "No statistics summary line found in ping output"
+            raise ValueError(msg)
+
+        cls._finalize(result, packet_data, rapid_symbols)
+        return cast(PingResult, result)
+
+    @classmethod
+    def _dispatch_line(
+        cls,
+        line: str,
+        result: dict,
+        packet_data: dict[str, PingPacketData],
+        rapid_symbols: list[str],
+    ) -> bool:
+        """Route a single stripped line to its handler. Returns True if handled."""
+        if cls._try_header(line, result):
+            return True
+        if cls._try_verbose_packet(line, packet_data):
+            return True
+        if not packet_data and _RAPID_STREAM_RE.fullmatch(line):
+            rapid_symbols.extend(line)
+            return True
+        if cls._try_stats(line, result):
+            return True
+        return cls._try_rtt(line, result)
+
+    @classmethod
+    def _try_verbose_packet(
+        cls,
+        line: str,
+        packet_data: dict[str, PingPacketData],
+    ) -> bool:
+        """Try parsing line as a verbose reply or failure indicator."""
+        verbose_index = len(packet_data)
+        if cls._try_verbose_reply(line, packet_data, verbose_index):
+            return True
+        return cls._try_verbose_failure(line, packet_data, verbose_index)
+
+    @staticmethod
+    def _finalize(
+        result: dict,
+        packet_data: dict[str, PingPacketData],
+        rapid_symbols: list[str],
+    ) -> None:
+        """Materialize packet_data and derive success_rate_percent."""
+        if not packet_data and rapid_symbols:
+            packet_data = {
+                str(index): {
+                    "result": _RAPID_RESULT_MAP.get(symbol, "unknown"),
+                }
+                for index, symbol in enumerate(rapid_symbols, start=1)
+            }
+        sent = cast(int, result["packets_sent"])
+        received = cast(int, result["packets_received"])
+        result["packet_data"] = packet_data
+        result["success_rate_percent"] = (
+            int(round(received / sent * 100)) if sent else 0
+        )
+
+    @staticmethod
+    def _try_header(line: str, result: dict) -> bool:
+        match = _PING_HEADER_RE.match(line)
+        if not match:
+            return False
+        result["destination"] = match.group("destination")
+        result["packet_size_bytes"] = int(match.group("size"))
+        return True
+
+    @staticmethod
+    def _try_verbose_reply(
+        line: str,
+        packet_data: dict[str, PingPacketData],
+        verbose_index: int,
+    ) -> bool:
+        match = _REPLY_RE.match(line)
+        if not match:
+            return False
+        index = verbose_index + 1
+        packet_data[str(index)] = {
+            "result": "successful",
+            "bytes": int(match.group("bytes")),
+            "icmp_seq": int(match.group("icmp_seq")),
+            "ttl": int(match.group("ttl")),
+            "time_ms": float(match.group("time")),
+        }
+        return True
+
+    @staticmethod
+    def _try_verbose_failure(
+        line: str,
+        packet_data: dict[str, PingPacketData],
+        verbose_index: int,
+    ) -> bool:
+        timeout = _TIMEOUT_RE.match(line)
+        if timeout:
+            index = verbose_index + 1
+            entry: PingPacketData = {"result": "timeout"}
+            seq = timeout.group("icmp_seq")
+            if seq is not None:
+                entry["icmp_seq"] = int(seq)
+            packet_data[str(index)] = entry
+            return True
+        if _SEND_FAIL_RE.match(line):
+            index = verbose_index + 1
+            packet_data[str(index)] = {"result": "send_failed"}
+            return True
+        return False
+
+    @staticmethod
+    def _try_stats(line: str, result: dict) -> bool:
+        match = _STATS_RE.match(line)
+        if not match:
+            return False
+        result["packets_sent"] = int(match.group("sent"))
+        result["packets_received"] = int(match.group("received"))
+        bounced = match.group("bounced")
+        if bounced is not None:
+            result["packets_bounced"] = int(bounced)
+        loss = match.group("loss")
+        if loss is not None:
+            result["loss_percent"] = float(loss)
+        duplicates = match.group("duplicates")
+        if duplicates is not None:
+            result["duplicate_count"] = int(duplicates)
+        return True
+
+    @staticmethod
+    def _try_rtt(line: str, result: dict) -> bool:
+        match = _RTT_RE.match(line)
+        if not match:
+            return False
+        result["rtt_min_ms"] = float(match.group("min"))
+        result["rtt_avg_ms"] = float(match.group("avg"))
+        result["rtt_max_ms"] = float(match.group("max"))
+        stddev = match.group("stddev")
+        if stddev is not None:
+            result["rtt_stddev_ms"] = float(stddev)
+        return True

--- a/tests/parsers/nokia_sros/ping/001_verbose_successful/expected.json
+++ b/tests/parsers/nokia_sros/ping/001_verbose_successful/expected.json
@@ -1,0 +1,49 @@
+{
+    "destination": "10.252.117.158",
+    "packet_size_bytes": 56,
+    "packets_sent": 5,
+    "packets_received": 5,
+    "loss_percent": 0.0,
+    "rtt_min_ms": 1.7,
+    "rtt_avg_ms": 1.83,
+    "rtt_max_ms": 1.93,
+    "rtt_stddev_ms": 0.079,
+    "packet_data": {
+        "1": {
+            "result": "successful",
+            "bytes": 64,
+            "icmp_seq": 1,
+            "ttl": 255,
+            "time_ms": 1.93
+        },
+        "2": {
+            "result": "successful",
+            "bytes": 64,
+            "icmp_seq": 2,
+            "ttl": 255,
+            "time_ms": 1.89
+        },
+        "3": {
+            "result": "successful",
+            "bytes": 64,
+            "icmp_seq": 3,
+            "ttl": 255,
+            "time_ms": 1.8
+        },
+        "4": {
+            "result": "successful",
+            "bytes": 64,
+            "icmp_seq": 4,
+            "ttl": 255,
+            "time_ms": 1.84
+        },
+        "5": {
+            "result": "successful",
+            "bytes": 64,
+            "icmp_seq": 5,
+            "ttl": 255,
+            "time_ms": 1.7
+        }
+    },
+    "success_rate_percent": 100
+}

--- a/tests/parsers/nokia_sros/ping/001_verbose_successful/input.txt
+++ b/tests/parsers/nokia_sros/ping/001_verbose_successful/input.txt
@@ -1,0 +1,10 @@
+PING 10.252.117.158 56 data bytes
+64 bytes from 10.252.117.158: icmp_seq=1 ttl=255 time=1.93ms.
+64 bytes from 10.252.117.158: icmp_seq=2 ttl=255 time=1.89ms.
+64 bytes from 10.252.117.158: icmp_seq=3 ttl=255 time=1.80ms.
+64 bytes from 10.252.117.158: icmp_seq=4 ttl=255 time=1.84ms.
+64 bytes from 10.252.117.158: icmp_seq=5 ttl=255 time=1.70ms.
+
+---- 10.252.117.158 PING Statistics ----
+5 packets transmitted, 5 packets received, 0.00% packet loss
+round-trip min = 1.70ms, avg = 1.83ms, max = 1.93ms, stddev = 0.079ms

--- a/tests/parsers/nokia_sros/ping/001_verbose_successful/metadata.yaml
+++ b/tests/parsers/nokia_sros/ping/001_verbose_successful/metadata.yaml
@@ -1,0 +1,3 @@
+description: Verbose ping with five successful replies and full RTT statistics
+platform: Nokia SR OS
+software_version: Unknown

--- a/tests/parsers/nokia_sros/ping/002_verbose_timeout/expected.json
+++ b/tests/parsers/nokia_sros/ping/002_verbose_timeout/expected.json
@@ -1,0 +1,30 @@
+{
+    "destination": "10.39.119.105",
+    "packet_size_bytes": 56,
+    "packets_sent": 5,
+    "packets_received": 0,
+    "loss_percent": 100.0,
+    "packet_data": {
+        "1": {
+            "result": "timeout",
+            "icmp_seq": 1
+        },
+        "2": {
+            "result": "timeout",
+            "icmp_seq": 2
+        },
+        "3": {
+            "result": "timeout",
+            "icmp_seq": 3
+        },
+        "4": {
+            "result": "timeout",
+            "icmp_seq": 4
+        },
+        "5": {
+            "result": "timeout",
+            "icmp_seq": 5
+        }
+    },
+    "success_rate_percent": 0
+}

--- a/tests/parsers/nokia_sros/ping/002_verbose_timeout/input.txt
+++ b/tests/parsers/nokia_sros/ping/002_verbose_timeout/input.txt
@@ -1,0 +1,9 @@
+PING 10.39.119.105 56 data bytes
+Request timed out. icmp_seq=1.
+Request timed out. icmp_seq=2.
+Request timed out. icmp_seq=3.
+Request timed out. icmp_seq=4.
+Request timed out. icmp_seq=5.
+
+---- 10.39.119.105 PING Statistics ----
+5 packets transmitted, 0 packets received, 100% packet loss

--- a/tests/parsers/nokia_sros/ping/002_verbose_timeout/metadata.yaml
+++ b/tests/parsers/nokia_sros/ping/002_verbose_timeout/metadata.yaml
@@ -1,0 +1,3 @@
+description: Verbose ping with all replies timing out (100% packet loss)
+platform: Nokia SR OS
+software_version: Unknown

--- a/tests/parsers/nokia_sros/ping/003_rapid_successful/expected.json
+++ b/tests/parsers/nokia_sros/ping/003_rapid_successful/expected.json
@@ -1,0 +1,29 @@
+{
+    "destination": "10.42.255.74",
+    "packet_size_bytes": 56,
+    "packets_sent": 5,
+    "packets_received": 5,
+    "loss_percent": 0.0,
+    "rtt_min_ms": 2.36,
+    "rtt_avg_ms": 2.39,
+    "rtt_max_ms": 2.42,
+    "rtt_stddev_ms": 0.025,
+    "packet_data": {
+        "1": {
+            "result": "successful"
+        },
+        "2": {
+            "result": "successful"
+        },
+        "3": {
+            "result": "successful"
+        },
+        "4": {
+            "result": "successful"
+        },
+        "5": {
+            "result": "successful"
+        }
+    },
+    "success_rate_percent": 100
+}

--- a/tests/parsers/nokia_sros/ping/003_rapid_successful/input.txt
+++ b/tests/parsers/nokia_sros/ping/003_rapid_successful/input.txt
@@ -1,0 +1,5 @@
+PING 10.42.255.74 56 data bytes
+!!!!!
+---- 10.42.255.74 PING Statistics ----
+5 packets transmitted, 5 packets received, 0.00% packet loss
+round-trip min = 2.36ms, avg = 2.39ms, max = 2.42ms, stddev = 0.025ms

--- a/tests/parsers/nokia_sros/ping/003_rapid_successful/metadata.yaml
+++ b/tests/parsers/nokia_sros/ping/003_rapid_successful/metadata.yaml
@@ -1,0 +1,3 @@
+description: Rapid-mode ping with all replies successful, symbolic '!!!!!' stream
+platform: Nokia SR OS
+software_version: Unknown

--- a/tests/parsers/nokia_sros/ping/004_rapid_bounce/expected.json
+++ b/tests/parsers/nokia_sros/ping/004_rapid_bounce/expected.json
@@ -1,0 +1,10 @@
+{
+    "destination": "10.30.99.22",
+    "packet_size_bytes": 56,
+    "packets_sent": 5,
+    "packets_received": 0,
+    "packets_bounced": 5,
+    "loss_percent": 100.0,
+    "packet_data": {},
+    "success_rate_percent": 0
+}

--- a/tests/parsers/nokia_sros/ping/004_rapid_bounce/input.txt
+++ b/tests/parsers/nokia_sros/ping/004_rapid_bounce/input.txt
@@ -1,0 +1,4 @@
+PING 10.30.99.22 56 data bytes
+
+---- 10.30.99.22 PING Statistics ----
+5 packets transmitted, 5 packets bounced, 0 packets received, 100% packet loss

--- a/tests/parsers/nokia_sros/ping/004_rapid_bounce/metadata.yaml
+++ b/tests/parsers/nokia_sros/ping/004_rapid_bounce/metadata.yaml
@@ -1,0 +1,3 @@
+description: Rapid-mode ping where all packets were bounced (no responses received)
+platform: Nokia SR OS
+software_version: Unknown

--- a/tests/parsers/nokia_sros/ping/005_rapid_duplicate/expected.json
+++ b/tests/parsers/nokia_sros/ping/005_rapid_duplicate/expected.json
@@ -1,0 +1,34 @@
+{
+    "destination": "10.53.16.134",
+    "packet_size_bytes": 56,
+    "packets_sent": 5,
+    "packets_received": 0,
+    "duplicate_count": 3,
+    "packet_data": {
+        "1": {
+            "result": "failed"
+        },
+        "2": {
+            "result": "failed"
+        },
+        "3": {
+            "result": "failed"
+        },
+        "4": {
+            "result": "successful"
+        },
+        "5": {
+            "result": "successful"
+        },
+        "6": {
+            "result": "failed"
+        },
+        "7": {
+            "result": "successful"
+        },
+        "8": {
+            "result": "failed"
+        }
+    },
+    "success_rate_percent": 0
+}

--- a/tests/parsers/nokia_sros/ping/005_rapid_duplicate/input.txt
+++ b/tests/parsers/nokia_sros/ping/005_rapid_duplicate/input.txt
@@ -1,0 +1,4 @@
+PING 10.53.16.134 56 data bytes
+...!!.!.
+---- 189.53.16.134 PING Statistics ----
+5 packets transmitted, 0 packets received, 3 duplicates

--- a/tests/parsers/nokia_sros/ping/005_rapid_duplicate/metadata.yaml
+++ b/tests/parsers/nokia_sros/ping/005_rapid_duplicate/metadata.yaml
@@ -1,0 +1,3 @@
+description: Rapid-mode ping showing a mixed '...!!.!.' stream and a duplicates summary
+platform: Nokia SR OS
+software_version: Unknown

--- a/tests/parsers/nokia_sros/ping/006_send_failed/expected.json
+++ b/tests/parsers/nokia_sros/ping/006_send_failed/expected.json
@@ -1,0 +1,25 @@
+{
+    "destination": "10.52.198.114",
+    "packet_size_bytes": 56,
+    "packets_sent": 5,
+    "packets_received": 0,
+    "loss_percent": 100.0,
+    "packet_data": {
+        "1": {
+            "result": "send_failed"
+        },
+        "2": {
+            "result": "send_failed"
+        },
+        "3": {
+            "result": "send_failed"
+        },
+        "4": {
+            "result": "send_failed"
+        },
+        "5": {
+            "result": "send_failed"
+        }
+    },
+    "success_rate_percent": 0
+}

--- a/tests/parsers/nokia_sros/ping/006_send_failed/input.txt
+++ b/tests/parsers/nokia_sros/ping/006_send_failed/input.txt
@@ -1,0 +1,9 @@
+PING 10.52.198.114 56 data bytes
+Send failed. Source IP address is not local to the system
+Send failed. Source IP address is not local to the system
+Send failed. Source IP address is not local to the system
+Send failed. Source IP address is not local to the system
+Send failed. Source IP address is not local to the system
+
+---- 10.52.198.114 PING Statistics ----
+5 packets transmitted, 0 packets received, 100% packet loss

--- a/tests/parsers/nokia_sros/ping/006_send_failed/metadata.yaml
+++ b/tests/parsers/nokia_sros/ping/006_send_failed/metadata.yaml
@@ -1,0 +1,3 @@
+description: Verbose ping where every attempt failed at send time (source IP not local)
+platform: Nokia SR OS
+software_version: Unknown


### PR DESCRIPTION
## Summary
- Adds parser for `ping` on Nokia SR OS. Mirrors the sibling Cisco IOS/IOS-XE/IOS-XR ping parsers' schema for the shared fields (`packets_sent`/`packets_received`/`success_rate_percent`/`packet_data`/`rtt_min_ms`/`rtt_avg_ms`/`rtt_max_ms`) and extends them with Nokia-specific optional keys: `destination`, `packet_size_bytes`, `loss_percent`, `packets_bounced`, `duplicate_count`, and `rtt_stddev_ms`.
- Six fixtures sourced from the permissively-licensed `ntc-templates/tests/alcatel_sros/ping` directory cover verbose success, verbose timeout, rapid success, rapid bounce, rapid duplicate, and send-failed paths (the issue had no real device sample; per project memo, ntc-templates is an approved fixture source).

Closes #977

## Test plan
- [x] `uv run pytest tests/parsers/ -k "nokia_sros and ping" -v` (44 passed)
- [x] `uv run pytest -q` (9121 passed)
- [x] `uv run ruff check src/muninn/parsers/nokia_sros/ping.py`
- [x] `uv run ruff format src/muninn/parsers/nokia_sros/ping.py`
- [x] `uv run ty check src/muninn/parsers/nokia_sros/ping.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/nokia_sros/ping.py`
- [x] `uv run bandit -r src/muninn/parsers/nokia_sros/ping.py`
- [x] `uv run pre-commit run --files ...`

Generated with [Claude Code](https://claude.com/claude-code)