### PR TITLE
feat(nokia_sros): add parser for `oam mac-ping`

### DIFF
--- a/changes/976.parser_added
+++ b/changes/976.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `oam mac-ping` on Nokia SR OS.

--- a/src/muninn/parsers/nokia_sros/oam_mac_ping.py
+++ b/src/muninn/parsers/nokia_sros/oam_mac_ping.py
@@ -1,0 +1,194 @@
+"""Parser for 'oam mac-ping' command on Nokia SR OS."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class MacPingRequest(TypedDict):
+    """Schema for a single ``[Send request ...]`` marker."""
+
+    sequence: int
+    size_bytes: NotRequired[int]
+
+
+class MacPingResponse(TypedDict):
+    """Schema for a single mac-ping response row.
+
+    The Node-id field on Nokia SR OS is encoded as
+    ``<router_ip>:sap<port>:<tag>``. Where the parser can split the
+    components apart, ``router``, ``port`` and ``tag`` are exposed as
+    individual fields. ``node_id`` always carries the raw value as
+    printed by the device.
+
+    The ``path`` field captures everything that the device prints
+    between the node-id and the RTT column. For successful responses
+    this is typically ``In-Band`` or ``Out-of-Band``; for failed
+    responses it is a longer status string such as
+    ``No FIB on Egress In-Band``.
+    """
+
+    sequence: int
+    node_id: str
+    router: NotRequired[str]
+    port: NotRequired[str]
+    tag: NotRequired[str]
+    path: str
+    rtt_ms: NotRequired[float]
+
+
+class OamMacPingResult(TypedDict):
+    """Schema for ``oam mac-ping`` parsed output on Nokia SR OS."""
+
+    requests: dict[str, MacPingRequest]
+    responses: dict[str, MacPingResponse]
+
+
+# ``[Send request Seq. 1, Size 126]``
+_SEND_REQUEST_RE = re.compile(
+    r"^\[Send\s+request\s+Seq\.\s+(?P<seq>\d+)"
+    r"(?:,\s*Size\s+(?P<size>\d+))?\s*\]\s*$"
+)
+
+# ``Seq Node-id ... Path RTT`` header line
+_HEADER_RE = re.compile(
+    r"^Seq\s+Node-id\b.*\bPath\b.*\bRTT\b\s*$",
+    re.IGNORECASE,
+)
+
+# Separator rows of dashes/equals
+_SEPARATOR_RE = re.compile(r"^[=\-]{4,}$")
+
+# Response row, e.g.:
+#   1   192.0.2.4:sap1/1/2:100                 No FIB on Egress In-Band  0.153ms
+#
+# Strategy: anchor on the leading sequence number and node-id token
+# (no whitespace), then capture everything up to the trailing RTT.
+_RESPONSE_RE = re.compile(
+    r"^(?P<seq>\d+)\s+"
+    r"(?P<node_id>\S+)\s+"
+    r"(?P<path>.+?)"
+    r"(?:\s+(?P<rtt>[\d.]+)\s*ms)?"
+    r"\s*$"
+)
+
+# Decompose ``<router>:sap<port>:<tag>``
+_NODE_ID_SAP_RE = re.compile(
+    rf"^(?P<router>{IPV4_ADDRESS}):sap(?P<port>[^:]+):(?P<tag>\S+)$"
+)
+
+
+@register(OS.NOKIA_SROS, "oam mac-ping")
+class OamMacPingParser(BaseParser[OamMacPingResult]):
+    """Parser for ``oam mac-ping`` on Nokia SR OS.
+
+    The command issues one or more Layer-2 OAM ping requests and
+    prints a tabular summary of the responses received. Each
+    ``[Send request Seq. N, Size M]`` marker introduces a probe;
+    response rows follow underneath the column header
+    ``Seq Node-id Path RTT``.
+
+    Returns a dict with two sub-dicts: ``requests`` keyed by the
+    sequence number of the probe, and ``responses`` keyed by the
+    sequence number of the response. The two dicts are independent
+    so that timed-out probes (which produce a request entry but no
+    response) can still be observed.
+
+    Raises:
+        ValueError: If no response rows or send-request markers can
+            be parsed.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {
+            ParserTag.CONNECTIVITY,
+            ParserTag.MAC,
+        }
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> OamMacPingResult:
+        """Parse ``oam mac-ping`` output into a structured result.
+
+        Args:
+            output: Raw CLI output from the ``oam mac-ping`` command.
+
+        Returns:
+            Parsed mac-ping result with per-probe request markers and
+            per-response data rows.
+        """
+        requests: dict[str, MacPingRequest] = {}
+        responses: dict[str, MacPingResponse] = {}
+
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if _SEPARATOR_RE.match(line):
+                continue
+            if _HEADER_RE.match(line):
+                continue
+
+            send_match = _SEND_REQUEST_RE.match(line)
+            if send_match:
+                cls._record_request(send_match, requests)
+                continue
+
+            response_match = _RESPONSE_RE.match(line)
+            if response_match:
+                cls._record_response(response_match, responses)
+
+        if not requests and not responses:
+            msg = "No mac-ping requests or responses found in output"
+            raise ValueError(msg)
+
+        return cast(OamMacPingResult, {"requests": requests, "responses": responses})
+
+    @staticmethod
+    def _record_request(
+        match: re.Match[str],
+        requests: dict[str, MacPingRequest],
+    ) -> None:
+        sequence = int(match.group("seq"))
+        request: MacPingRequest = {"sequence": sequence}
+        size = match.group("size")
+        if size is not None:
+            request["size_bytes"] = int(size)
+        requests[str(sequence)] = request
+
+    @staticmethod
+    def _record_response(
+        match: re.Match[str],
+        responses: dict[str, MacPingResponse],
+    ) -> None:
+        sequence = int(match.group("seq"))
+        node_id = match.group("node_id")
+        path = (match.group("path") or "").strip()
+        if not path:
+            # A response row with no Path column is not a valid data
+            # row; silently skip to avoid mis-classifying unrelated
+            # text that happens to start with a digit.
+            return
+
+        response: MacPingResponse = {
+            "sequence": sequence,
+            "node_id": node_id,
+            "path": path,
+        }
+
+        node_match = _NODE_ID_SAP_RE.match(node_id)
+        if node_match:
+            response["router"] = node_match.group("router")
+            response["port"] = node_match.group("port")
+            response["tag"] = node_match.group("tag")
+
+        rtt = match.group("rtt")
+        if rtt is not None:
+            response["rtt_ms"] = float(rtt)
+
+        responses[str(sequence)] = response

--- a/tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/expected.json
+++ b/tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/expected.json
@@ -1,0 +1,19 @@
+{
+    "requests": {
+        "1": {
+            "sequence": 1,
+            "size_bytes": 126
+        }
+    },
+    "responses": {
+        "1": {
+            "sequence": 1,
+            "node_id": "192.0.2.4:sap1/1/2:100",
+            "router": "192.0.2.4",
+            "port": "1/1/2",
+            "tag": "100",
+            "path": "No FIB on Egress In-Band",
+            "rtt_ms": 0.153
+        }
+    }
+}

--- a/tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/input.txt
+++ b/tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/input.txt
@@ -1,0 +1,4 @@
+Seq Node-id                                                    Path     RTT
+----------------------------------------------------------------------------
+[Send request Seq. 1, Size 126]
+1   192.0.2.4:sap1/1/2:100                 No FIB on Egress In-Band  0.153ms

--- a/tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/metadata.yaml
+++ b/tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/metadata.yaml
@@ -1,0 +1,3 @@
+description: Imported from ntc-templates alcatel_sros_oam_mac-ping.raw - single response showing 'No FIB on Egress' status from SAP 1/1/2 with VLAN tag 100
+platform: Nokia SR OS
+software_version: Unknown


### PR DESCRIPTION
## Summary

- Add `OamMacPingParser` for Nokia SR OS `oam mac-ping`, registered under `OS.NOKIA_SROS`.
- Schema returns two dicts (`requests` and `responses`) keyed by sequence number so that probes and responses can be observed independently.
- Decomposes the Nokia `<router>:sap<port>:<tag>` node-id format into `router`, `port`, and `tag` fields while preserving the raw `node_id`.
- Tags: `CONNECTIVITY`, `MAC`.

## Fixtures

Fixture sourced from ntc-templates (`alcatel_sros/oam_mac-ping`, Apache 2.0) — the only real-device sample currently available for this command.

- `tests/parsers/nokia_sros/oam_mac-ping/001_ntc_single_response_no_fib/` — single response showing a `No FIB on Egress In-Band` status against SAP `1/1/2`, VLAN `100`.

Closes #976.

## Test plan

- [x] `uv run pytest` (full suite, 9086 passed)
- [x] `uv run ruff check .` (clean)
- [x] `uv run ruff format --check .` (clean)
- [x] `uv run ty check src/` (no diagnostics in new file)
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/` (clean)
- [x] `uv run bandit -r src/` (clean)
- [x] `uv run pre-commit run --files ...` (all hooks pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)