### PR TITLE
feat(cisco_iosxe): add parser for `show interfaces stats`

### DIFF
--- a/changes/1166.parser_added
+++ b/changes/1166.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show interfaces stats` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_interfaces_stats.py
+++ b/src/muninn/parsers/iosxe/show_interfaces_stats.py
@@ -48,7 +48,7 @@ class InterfaceStatsEntry(TypedDict):
     """Stats for a single interface.
 
     Each key in ``switching_paths`` is a normalized switching-path name
-    (e.g. ``"Processor"``, ``"Route cache"``, ``"Distributed cache"``,
+    (e.g. ``"Processor"``, ``"Route Cache"``, ``"Distributed Cache"``,
     ``"Total"``).
     """
 

--- a/src/muninn/parsers/iosxe/show_interfaces_stats.py
+++ b/src/muninn/parsers/iosxe/show_interfaces_stats.py
@@ -1,0 +1,145 @@
+"""Parser for 'show interfaces stats' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+# Matches an interface line that introduces a new block, e.g.:
+#   GigabitEthernet0/0
+#   GigabitEthernet1/0/1
+_INTERFACE_RE = re.compile(r"^(?P<interface>[A-Za-z][A-Za-z\-]*\d[\w/.:-]*)\s*$")
+
+# Matches a disabled interface line, e.g.:
+#   Interface Vlan1 is disabled
+_DISABLED_RE = re.compile(r"^\s*Interface\s+(?P<interface>\S+)\s+is\s+disabled\s*$")
+
+# Matches a switching-path data row with four counters, e.g.:
+#                Processor  111620314 9269233375    1660962  350653952
+_DATA_ROW_RE = re.compile(
+    r"^\s+(?P<path>.+?)\s{2,}"
+    r"(?P<pkts_in>\d+)\s+"
+    r"(?P<chars_in>\d+)\s+"
+    r"(?P<pkts_out>\d+)\s+"
+    r"(?P<chars_out>\d+)\s*$"
+)
+
+# Matches the column header line (not data).
+_HEADER_RE = re.compile(
+    r"^\s+Switching\s+path\s+Pkts\s+In\s+Chars\s+In"
+    r"\s+Pkts\s+Out\s+Chars\s+Out\s*$"
+)
+
+
+class SwitchingPathEntry(TypedDict):
+    """Counters for a single switching path on an interface."""
+
+    pkts_in: int
+    chars_in: int
+    pkts_out: int
+    chars_out: int
+
+
+class InterfaceStatsEntry(TypedDict):
+    """Stats for a single interface.
+
+    Each key in ``switching_paths`` is a normalized switching-path name
+    (e.g. ``"Processor"``, ``"Route cache"``, ``"Distributed cache"``,
+    ``"Total"``).
+    """
+
+    disabled: NotRequired[bool]
+    switching_paths: NotRequired[dict[str, SwitchingPathEntry]]
+
+
+class ShowInterfacesStatsResult(TypedDict):
+    """Schema for 'show interfaces stats' parsed output."""
+
+    interfaces: dict[str, InterfaceStatsEntry]
+
+
+def _normalize_path_name(raw: str) -> str:
+    """Normalize a switching-path label to title case with single spaces."""
+    return " ".join(raw.split()).title()
+
+
+@register(OS.CISCO_IOSXE, "show interfaces stats")
+class ShowInterfacesStatsParser(BaseParser[ShowInterfacesStatsResult]):
+    """Parser for 'show interfaces stats' on IOS-XE.
+
+    The command emits per-interface blocks showing packet and character
+    counters broken down by switching path (Processor, Route cache,
+    Distributed cache, Total). Disabled interfaces are noted with a
+    single ``Interface <name> is disabled`` line.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesStatsResult:
+        """Parse 'show interfaces stats' output.
+
+        Args:
+            output: Raw CLI output from the
+                ``show interfaces stats`` command.
+
+        Returns:
+            Parsed interface stats keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interface data is found in the output.
+        """
+        interfaces: dict[str, InterfaceStatsEntry] = {}
+        current_interface: str | None = None
+
+        for raw_line in output.splitlines():
+            line = raw_line.rstrip()
+
+            # Check for disabled interface line.
+            disabled_match = _DISABLED_RE.match(line)
+            if disabled_match:
+                iface = canonical_interface_name(
+                    disabled_match.group("interface"), os=OS.CISCO_IOSXE
+                )
+                interfaces[iface] = {"disabled": True}
+                current_interface = None
+                continue
+
+            # Check for a new interface block header.
+            iface_match = _INTERFACE_RE.match(line)
+            if iface_match:
+                current_interface = canonical_interface_name(
+                    iface_match.group("interface"), os=OS.CISCO_IOSXE
+                )
+                interfaces.setdefault(current_interface, {})
+                continue
+
+            # Skip the column-header line.
+            if _HEADER_RE.match(line):
+                continue
+
+            # Try to parse a switching-path data row.
+            if current_interface is None:
+                continue
+            data_match = _DATA_ROW_RE.match(line)
+            if data_match:
+                path_name = _normalize_path_name(data_match.group("path"))
+                entry: SwitchingPathEntry = {
+                    "pkts_in": int(data_match.group("pkts_in")),
+                    "chars_in": int(data_match.group("chars_in")),
+                    "pkts_out": int(data_match.group("pkts_out")),
+                    "chars_out": int(data_match.group("chars_out")),
+                }
+                iface_data = interfaces[current_interface]
+                paths = iface_data.setdefault("switching_paths", {})
+                paths[path_name] = entry
+
+        if not interfaces:
+            msg = "No interfaces found in 'show interfaces stats' output"
+            raise ValueError(msg)
+
+        return cast(ShowInterfacesStatsResult, {"interfaces": interfaces})

--- a/tests/parsers/iosxe/show_interfaces_stats/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_interfaces_stats/001_basic/expected.json
@@ -1,0 +1,231 @@
+{
+    "interfaces": {
+        "Vlan1": {
+            "disabled": true
+        },
+        "GigabitEthernet0/0": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 111620314,
+                    "chars_in": 9269233375,
+                    "pkts_out": 1660962,
+                    "chars_out": 350653952
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Total": {
+                    "pkts_in": 111620314,
+                    "chars_in": 9269233375,
+                    "pkts_out": 1660962,
+                    "chars_out": 350653952
+                }
+            }
+        },
+        "GigabitEthernet1/0/1": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 1541774,
+                    "chars_out": 171225793
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 1337840,
+                    "chars_in": 117059332,
+                    "pkts_out": 540354,
+                    "chars_out": 38129574
+                },
+                "Total": {
+                    "pkts_in": 1337840,
+                    "chars_in": 117059332,
+                    "pkts_out": 2082128,
+                    "chars_out": 209355367
+                }
+            }
+        },
+        "GigabitEthernet1/0/2": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 778297,
+                    "chars_out": 79459927
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 1069208,
+                    "chars_in": 83559707,
+                    "pkts_out": 540723,
+                    "chars_out": 39220898
+                },
+                "Total": {
+                    "pkts_in": 1069208,
+                    "chars_in": 83559707,
+                    "pkts_out": 1319020,
+                    "chars_out": 118680825
+                }
+            }
+        },
+        "GigabitEthernet1/0/3": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Total": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                }
+            }
+        },
+        "GigabitEthernet1/0/4": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Total": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                }
+            }
+        },
+        "GigabitEthernet1/0/5": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 46013,
+                    "chars_out": 3970455
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Total": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 46013,
+                    "chars_out": 3970455
+                }
+            }
+        },
+        "GigabitEthernet1/0/6": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Total": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                }
+            }
+        },
+        "GigabitEthernet1/0/7": {
+            "switching_paths": {
+                "Processor": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Route Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Distributed Cache": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                },
+                "Total": {
+                    "pkts_in": 0,
+                    "chars_in": 0,
+                    "pkts_out": 0,
+                    "chars_out": 0
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interfaces_stats/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_interfaces_stats/001_basic/input.txt
@@ -1,0 +1,50 @@
+Interface Vlan1 is disabled
+
+GigabitEthernet0/0
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor  111620314 9269233375    1660962  350653952
+             Route cache          0          0          0          0
+       Distributed cache          0          0          0          0
+                   Total  111620314 9269233375    1660962  350653952
+GigabitEthernet1/0/1
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0    1541774  171225793
+             Route cache          0          0          0          0
+       Distributed cache    1337840  117059332     540354   38129574
+                   Total    1337840  117059332    2082128  209355367
+GigabitEthernet1/0/2
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0     778297   79459927
+             Route cache          0          0          0          0
+       Distributed cache    1069208   83559707     540723   39220898
+                   Total    1069208   83559707    1319020  118680825
+GigabitEthernet1/0/3
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0          0          0
+             Route cache          0          0          0          0
+       Distributed cache          0          0          0          0
+                   Total          0          0          0          0
+GigabitEthernet1/0/4
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0          0          0
+             Route cache          0          0          0          0
+       Distributed cache          0          0          0          0
+                   Total          0          0          0          0
+GigabitEthernet1/0/5
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0      46013    3970455
+             Route cache          0          0          0          0
+       Distributed cache          0          0          0          0
+                   Total          0          0      46013    3970455
+GigabitEthernet1/0/6
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0          0          0
+             Route cache          0          0          0          0
+       Distributed cache          0          0          0          0
+                   Total          0          0          0          0
+GigabitEthernet1/0/7
+          Switching path    Pkts In   Chars In   Pkts Out  Chars Out
+               Processor          0          0          0          0
+             Route cache          0          0          0          0
+       Distributed cache          0          0          0          0
+                   Total          0          0          0          0

--- a/tests/parsers/iosxe/show_interfaces_stats/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_interfaces_stats/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show interfaces stats output with disabled and active interfaces
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show interfaces stats` on Cisco IOS-XE that returns per-interface switching-path counters (Processor, Route cache, Distributed cache, Total) keyed by canonical interface name, with disabled interfaces noted via a `disabled: true` flag.
- Fixture sourced from a physical C9300-48U testbed running IOS-XE 17.18.02 (truncated to first 50 lines per issue).

Closes #1166

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_interfaces_stats -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_interfaces_stats.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_interfaces_stats.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + fixture + changelog

<!-- Generated PR -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)