### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf events`

### DIFF
--- a/changes/1163.parser_added
+++ b/changes/1163.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf events` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_events.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_events.py
@@ -1,0 +1,146 @@
+"""Parser for 'show ip ospf events' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_HEADER_RE = re.compile(
+    r"OSPF Router with ID \((" + IPV4_ADDRESS + r")\)"
+    r" \(Process ID (\d+)\)"
+)
+
+_EVENT_RE = re.compile(
+    r"(\S+\s+\d+\s+\d+:\d+:\d+\.\d+):\s+"
+    r"(Rcv|Generate)\s+"
+    r"(Changed|Unchanged)\s+"
+    r"Type-(\d+)\s+LSA,\s+"
+    r"LSID\s+(" + IPV4_ADDRESS + r"),"
+)
+
+_ADV_RTR_RE = re.compile(r"Adv-Rtr\s+(" + IPV4_ADDRESS + r"),")
+
+_SEQ_RE = re.compile(r"Seq#\s+([0-9A-Fa-f]+),")
+
+_AGE_RE = re.compile(r"Age\s+(\d+),")
+
+_AREA_RE = re.compile(r"Area\s+(\S+)")
+
+
+class EventEntry(TypedDict):
+    """Schema for a single OSPF event."""
+
+    timestamp: str
+    action: str
+    status: str
+    lsa_type: int
+    lsid: str
+    adv_router: NotRequired[str]
+    sequence: str
+    age: int
+    area: str
+
+
+class ShowIpOspfEventsResult(TypedDict):
+    """Schema for 'show ip ospf events' parsed output."""
+
+    router_id: str
+    process_id: int
+    events: dict[str, EventEntry]
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf events")
+class ShowIpOspfEventsParser(BaseParser["ShowIpOspfEventsResult"]):
+    """Parser for 'show ip ospf events' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.OSPF})
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowIpOspfEventsResult":
+        """Parse show ip ospf events output into structured data."""
+        router_id = ""
+        process_id = 0
+        events: dict[str, EventEntry] = {}
+
+        lines = output.splitlines()
+        full_text = output
+
+        for line in lines:
+            header_match = _HEADER_RE.search(line)
+            if header_match:
+                router_id = header_match.group(1)
+                process_id = int(header_match.group(2))
+                break
+
+        # Events can wrap across lines; split by leading event index.
+        event_blocks = re.split(r"(?m)^(\d+)\s+", full_text)
+
+        # event_blocks: ['preamble', '1', 'rest...', '2', 'rest...', ...]
+        i = 1
+        while i < len(event_blocks) - 1:
+            index = event_blocks[i]
+            block = event_blocks[i + 1]
+            # Collapse any newlines within the block into a single line
+            block_single = " ".join(block.split())
+            event = cls._parse_event_block(block_single)
+            if event is not None:
+                events[index] = event
+            i += 2
+
+        if not router_id:
+            msg = "Missing required field: router_id"
+            raise ValueError(msg)
+
+        return cast(
+            "ShowIpOspfEventsResult",
+            {
+                "router_id": router_id,
+                "process_id": process_id,
+                "events": events,
+            },
+        )
+
+    @classmethod
+    def _parse_event_block(cls, block: str) -> EventEntry | None:
+        """Parse a single event block into an EventEntry."""
+        event_match = _EVENT_RE.search(block)
+        if not event_match:
+            return None
+
+        timestamp = event_match.group(1)
+        action = event_match.group(2)
+        status = event_match.group(3)
+        lsa_type = int(event_match.group(4))
+        lsid = event_match.group(5)
+
+        seq_match = _SEQ_RE.search(block)
+        age_match = _AGE_RE.search(block)
+        area_match = _AREA_RE.search(block)
+
+        if not seq_match or not age_match or not area_match:
+            return None
+
+        sequence = seq_match.group(1)
+        age = int(age_match.group(1))
+        area = area_match.group(1)
+
+        entry: dict[str, str | int] = {
+            "timestamp": timestamp,
+            "action": action,
+            "status": status,
+            "lsa_type": lsa_type,
+            "lsid": lsid,
+            "sequence": sequence,
+            "age": age,
+            "area": area,
+        }
+
+        adv_match = _ADV_RTR_RE.search(block)
+        if adv_match:
+            entry["adv_router"] = adv_match.group(1)
+
+        return cast(EventEntry, entry)

--- a/tests/parsers/iosxe/show_ip_ospf_events/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_events/001_basic/expected.json
@@ -1,0 +1,262 @@
+{
+    "router_id": "192.0.2.3",
+    "process_id": 1,
+    "events": {
+        "1": {
+            "timestamp": "Jun 17 23:51:32.265",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.1",
+            "sequence": "800003CE",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.1"
+        },
+        "2": {
+            "timestamp": "Jun 17 23:50:18.065",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 2,
+            "lsid": "10.0.3.2",
+            "sequence": "80000318",
+            "age": 0,
+            "area": "0"
+        },
+        "3": {
+            "timestamp": "Jun 17 23:50:18.065",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 1,
+            "lsid": "192.0.2.3",
+            "sequence": "80000850",
+            "age": 0,
+            "area": "0"
+        },
+        "4": {
+            "timestamp": "Jun 17 23:43:31.107",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 2,
+            "lsid": "10.0.2.2",
+            "sequence": "8000080D",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.4"
+        },
+        "5": {
+            "timestamp": "Jun 17 23:43:31.107",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.4",
+            "sequence": "800003CC",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.4"
+        },
+        "6": {
+            "timestamp": "Jun 17 23:39:05.115",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 2,
+            "lsid": "10.0.1.2",
+            "sequence": "80000332",
+            "age": 2,
+            "area": "0",
+            "adv_router": "192.0.2.2"
+        },
+        "7": {
+            "timestamp": "Jun 17 23:39:05.115",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.2",
+            "sequence": "800008FA",
+            "age": 2,
+            "area": "0",
+            "adv_router": "192.0.2.2"
+        },
+        "8": {
+            "timestamp": "Jun 17 23:17:30.409",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.1",
+            "sequence": "800003CD",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.1"
+        },
+        "9": {
+            "timestamp": "Jun 17 23:16:51.023",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 2,
+            "lsid": "10.0.3.2",
+            "sequence": "80000317",
+            "age": 0,
+            "area": "0"
+        },
+        "10": {
+            "timestamp": "Jun 17 23:16:51.023",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 1,
+            "lsid": "192.0.2.3",
+            "sequence": "8000084F",
+            "age": 0,
+            "area": "0"
+        },
+        "11": {
+            "timestamp": "Jun 17 23:09:29.251",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 2,
+            "lsid": "10.0.2.2",
+            "sequence": "8000080C",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.4"
+        },
+        "12": {
+            "timestamp": "Jun 17 23:09:29.251",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.4",
+            "sequence": "800003CB",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.4"
+        },
+        "13": {
+            "timestamp": "Jun 17 23:05:43.195",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 2,
+            "lsid": "10.0.1.2",
+            "sequence": "80000331",
+            "age": 2,
+            "area": "0",
+            "adv_router": "192.0.2.2"
+        },
+        "14": {
+            "timestamp": "Jun 17 23:05:43.195",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.2",
+            "sequence": "800008F9",
+            "age": 2,
+            "area": "0",
+            "adv_router": "192.0.2.2"
+        },
+        "15": {
+            "timestamp": "Jun 17 22:43:29.576",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.1",
+            "sequence": "800003CC",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.1"
+        },
+        "16": {
+            "timestamp": "Jun 17 22:43:13.742",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 2,
+            "lsid": "10.0.3.2",
+            "sequence": "80000316",
+            "age": 0,
+            "area": "0"
+        },
+        "17": {
+            "timestamp": "Jun 17 22:43:13.742",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 1,
+            "lsid": "192.0.2.3",
+            "sequence": "8000084E",
+            "age": 0,
+            "area": "0"
+        },
+        "18": {
+            "timestamp": "Jun 17 22:35:26.372",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 2,
+            "lsid": "10.0.2.2",
+            "sequence": "8000080B",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.4"
+        },
+        "19": {
+            "timestamp": "Jun 17 22:35:26.372",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.4",
+            "sequence": "800003CA",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.4"
+        },
+        "20": {
+            "timestamp": "Jun 17 22:32:05.915",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 2,
+            "lsid": "10.0.1.2",
+            "sequence": "80000330",
+            "age": 2,
+            "area": "0",
+            "adv_router": "192.0.2.2"
+        },
+        "21": {
+            "timestamp": "Jun 17 22:32:05.915",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.2",
+            "sequence": "800008F8",
+            "age": 2,
+            "area": "0",
+            "adv_router": "192.0.2.2"
+        },
+        "22": {
+            "timestamp": "Jun 17 22:10:02.063",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 2,
+            "lsid": "10.0.3.2",
+            "sequence": "80000315",
+            "age": 0,
+            "area": "0"
+        },
+        "23": {
+            "timestamp": "Jun 17 22:10:02.063",
+            "action": "Generate",
+            "status": "Changed",
+            "lsa_type": 1,
+            "lsid": "192.0.2.3",
+            "sequence": "8000084D",
+            "age": 0,
+            "area": "0"
+        },
+        "24": {
+            "timestamp": "Jun 17 22:09:58.440",
+            "action": "Rcv",
+            "status": "Unchanged",
+            "lsa_type": 1,
+            "lsid": "192.0.2.1",
+            "sequence": "800003CB",
+            "age": 1,
+            "area": "0",
+            "adv_router": "192.0.2.1"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_events/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_events/001_basic/input.txt
@@ -1,0 +1,50 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+1    Jun 17 23:51:32.265: Rcv Unchanged Type-1 LSA, LSID 192.0.2.1, Adv-Rtr
+192.0.2.1, Seq# 800003CE, Age 1, Area 0
+2    Jun 17 23:50:18.065: Generate Changed Type-2 LSA, LSID 10.0.3.2, Seq#
+80000318, Age 0, Area 0
+3    Jun 17 23:50:18.065: Generate Changed Type-1 LSA, LSID 192.0.2.3, Seq#
+80000850, Age 0, Area 0
+4    Jun 17 23:43:31.107: Rcv Unchanged Type-2 LSA, LSID 10.0.2.2, Adv-Rtr
+192.0.2.4, Seq# 8000080D, Age 1, Area 0
+5    Jun 17 23:43:31.107: Rcv Unchanged Type-1 LSA, LSID 192.0.2.4, Adv-Rtr
+192.0.2.4, Seq# 800003CC, Age 1, Area 0
+6    Jun 17 23:39:05.115: Rcv Unchanged Type-2 LSA, LSID 10.0.1.2, Adv-Rtr
+192.0.2.2, Seq# 80000332, Age 2, Area 0
+7    Jun 17 23:39:05.115: Rcv Unchanged Type-1 LSA, LSID 192.0.2.2, Adv-Rtr
+192.0.2.2, Seq# 800008FA, Age 2, Area 0
+8    Jun 17 23:17:30.409: Rcv Unchanged Type-1 LSA, LSID 192.0.2.1, Adv-Rtr
+192.0.2.1, Seq# 800003CD, Age 1, Area 0
+9    Jun 17 23:16:51.023: Generate Changed Type-2 LSA, LSID 10.0.3.2, Seq#
+80000317, Age 0, Area 0
+10   Jun 17 23:16:51.023: Generate Changed Type-1 LSA, LSID 192.0.2.3, Seq#
+8000084F, Age 0, Area 0
+11   Jun 17 23:09:29.251: Rcv Unchanged Type-2 LSA, LSID 10.0.2.2, Adv-Rtr
+192.0.2.4, Seq# 8000080C, Age 1, Area 0
+12   Jun 17 23:09:29.251: Rcv Unchanged Type-1 LSA, LSID 192.0.2.4, Adv-Rtr
+192.0.2.4, Seq# 800003CB, Age 1, Area 0
+13   Jun 17 23:05:43.195: Rcv Unchanged Type-2 LSA, LSID 10.0.1.2, Adv-Rtr
+192.0.2.2, Seq# 80000331, Age 2, Area 0
+14   Jun 17 23:05:43.195: Rcv Unchanged Type-1 LSA, LSID 192.0.2.2, Adv-Rtr
+192.0.2.2, Seq# 800008F9, Age 2, Area 0
+15   Jun 17 22:43:29.576: Rcv Unchanged Type-1 LSA, LSID 192.0.2.1, Adv-Rtr
+192.0.2.1, Seq# 800003CC, Age 1, Area 0
+16   Jun 17 22:43:13.742: Generate Changed Type-2 LSA, LSID 10.0.3.2, Seq#
+80000316, Age 0, Area 0
+17   Jun 17 22:43:13.742: Generate Changed Type-1 LSA, LSID 192.0.2.3, Seq#
+8000084E, Age 0, Area 0
+18   Jun 17 22:35:26.372: Rcv Unchanged Type-2 LSA, LSID 10.0.2.2, Adv-Rtr
+192.0.2.4, Seq# 8000080B, Age 1, Area 0
+19   Jun 17 22:35:26.372: Rcv Unchanged Type-1 LSA, LSID 192.0.2.4, Adv-Rtr
+192.0.2.4, Seq# 800003CA, Age 1, Area 0
+20   Jun 17 22:32:05.915: Rcv Unchanged Type-2 LSA, LSID 10.0.1.2, Adv-Rtr
+192.0.2.2, Seq# 80000330, Age 2, Area 0
+21   Jun 17 22:32:05.915: Rcv Unchanged Type-1 LSA, LSID 192.0.2.2, Adv-Rtr
+192.0.2.2, Seq# 800008F8, Age 2, Area 0
+22   Jun 17 22:10:02.063: Generate Changed Type-2 LSA, LSID 10.0.3.2, Seq#
+80000315, Age 0, Area 0
+23   Jun 17 22:10:02.063: Generate Changed Type-1 LSA, LSID 192.0.2.3, Seq#
+8000084D, Age 0, Area 0
+24   Jun 17 22:09:58.440: Rcv Unchanged Type-1 LSA, LSID 192.0.2.1, Adv-Rtr
+192.0.2.1, Seq# 800003CB, Age 1, Area 0

--- a/tests/parsers/iosxe/show_ip_ospf_events/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_events/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show ip ospf events output with mixed Rcv and Generate events
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf events` on IOS-XE that extracts OSPF LSA event history into a dict keyed by event index, with each entry containing timestamp, action (Rcv/Generate), status (Changed/Unchanged), LSA type, LSID, advertising router, sequence number, age, and area.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1163. Events wrap across terminal-width lines and are handled by block-splitting on the leading index number.

Closes #1163

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_ip_ospf_events -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_events.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_events.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)