### PR TITLE
feat(cisco_iosxe): add parser for `show crypto pki certificates verbose`

### DIFF
--- a/changes/1169.parser_added
+++ b/changes/1169.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto pki certificates verbose` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_pki_certificates_verbose.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_certificates_verbose.py
@@ -1,0 +1,557 @@
+"""Parser for 'show crypto pki certificates verbose' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# --- Regex patterns ---
+
+_CERT_TYPE_RE = re.compile(r"^((?:CA |RA |Router )?Certificate)\s*$")
+_STATUS_RE = re.compile(r"^\s+Status:\s+(.+?)\s*$")
+_VERSION_RE = re.compile(r"^\s+Version:\s+(\d+)\s*$")
+_SERIAL_RE = re.compile(r"^\s+Certificate Serial Number\s*(?:\(hex\))?\s*:\s*(.+?)\s*$")
+_USAGE_RE = re.compile(r"^\s+Certificate Usage:\s+(.+?)\s*$")
+_SECTION_RE = re.compile(r"^\s+(Issuer|Subject)\s*:\s*$")
+_VALIDITY_HEADER_RE = re.compile(r"^\s+Validity Date\s*:\s*$")
+_START_DATE_RE = re.compile(r"^\s+start date:\s+(.+?)\s*$")
+_END_DATE_RE = re.compile(r"^\s+end\s+date:\s+(.+?)\s*$")
+_TRUSTPOINT_RE = re.compile(r"^\s+Associated Trustpoints:\s+(.+?)\s*$")
+_CRL_HEADER_RE = re.compile(r"^\s+CRL Distribution Points?\s*:\s*$")
+_CRL_URL_RE = re.compile(r"^\s+(https?://\S+)\s*$")
+_SUBJECT_NAME_RE = re.compile(r"^\s+Name:\s+(.+?)\s*$")
+_SERIAL_NUMBER_FIELD_RE = re.compile(r"^\s+Serial Number:\s+(.+?)\s*$")
+_DN_ATTR_RE = re.compile(r"^\s+(\w+)=(.+?)\s*$")
+_SUBJECT_KEY_INFO_RE = re.compile(r"^\s+Subject Key Info\s*:\s*$")
+_PUB_KEY_ALGO_RE = re.compile(r"^\s+Public Key Algorithm:\s+(.+?)\s*$")
+_RSA_KEY_RE = re.compile(r"^\s+RSA Public Key:\s+\((\d+)\s+bit\)\s*$")
+_EC_KEY_RE = re.compile(r"^\s+EC Public Key:\s+\((\d+)\s+bit\)\s*$")
+_SIG_ALGO_RE = re.compile(r"^\s+Signature Algorithm:\s+(.+?)\s*$")
+_FP_MD5_RE = re.compile(r"^\s+Fingerprint MD5:\s+(.+?)\s*$")
+_FP_SHA1_RE = re.compile(r"^\s+Fingerprint SHA1:\s+(.+?)\s*$")
+_X509V3_EXT_HEADER_RE = re.compile(r"^\s+X509v3 extensions\s*:\s*$")
+_KEY_USAGE_HEADER_RE = re.compile(r"^\s+X509v3 Key Usage:\s+(.+?)\s*$")
+_SUBJECT_KEY_ID_RE = re.compile(r"^\s+X509v3 Subject Key ID:\s+(.+?)\s*$")
+_AUTH_KEY_ID_RE = re.compile(r"^\s+X509v3 Authority Key ID:\s+(.+?)\s*$")
+_AUTH_INFO_ACCESS_RE = re.compile(r"^\s+Authority Info Access\s*:\s*$")
+_CA_ISSUERS_RE = re.compile(r"^\s+CA ISSUERS:\s+(.+?)\s*$")
+_EXT_KEY_USAGE_HEADER_RE = re.compile(r"^\s+Extended Key Usage\s*:\s*$")
+_CERT_INSTALL_TIME_RE = re.compile(r"^\s+Cert install time:\s+(.+?)\s*$")
+_KEY_LABEL_RE = re.compile(r"^\s+Key Label:\s+(.+?)\s*$")
+_STORAGE_RE = re.compile(r"^\s+Storage:\s+(.+?)\s*$")
+_KEY_USAGE_VALUE_RE = re.compile(r"^\s{6,}([A-Z][A-Za-z ]+)\s*$")
+
+# Simple one-line field patterns mapped to entry keys
+_SIMPLE_FIELDS: list[tuple[re.Pattern[str], str]] = [
+    (_STATUS_RE, "status"),
+    (_SERIAL_RE, "serial_number"),
+    (_USAGE_RE, "usage"),
+    (_SIG_ALGO_RE, "signature_algorithm"),
+    (_FP_MD5_RE, "fingerprint_md5"),
+    (_FP_SHA1_RE, "fingerprint_sha1"),
+    (_CERT_INSTALL_TIME_RE, "cert_install_time"),
+    (_TRUSTPOINT_RE, "associated_trustpoints"),
+    (_KEY_LABEL_RE, "key_label"),
+    (_STORAGE_RE, "storage"),
+]
+
+
+class ValidityDate(TypedDict):
+    """Schema for certificate validity dates."""
+
+    start_date: str
+    end_date: str
+
+
+class SubjectKeyInfo(TypedDict):
+    """Schema for Subject Key Info section."""
+
+    public_key_algorithm: str
+    key_size_bits: NotRequired[int]
+
+
+class X509v3Extensions(TypedDict):
+    """Schema for X509v3 extensions section."""
+
+    key_usage_hex: NotRequired[str]
+    key_usage: NotRequired[list[str]]
+    subject_key_id: NotRequired[str]
+    authority_key_id: NotRequired[str]
+    authority_info_access: NotRequired[str]
+    extended_key_usage: NotRequired[list[str]]
+
+
+class CertificateEntry(TypedDict):
+    """Schema for a single verbose certificate entry."""
+
+    status: str
+    version: int
+    serial_number: str
+    usage: str
+    issuer: dict[str, str]
+    subject: dict[str, str]
+    validity_date: ValidityDate
+    associated_trustpoints: str
+    subject_name: NotRequired[str]
+    subject_serial_number: NotRequired[str]
+    crl_distribution_points: NotRequired[list[str]]
+    subject_key_info: NotRequired[SubjectKeyInfo]
+    signature_algorithm: NotRequired[str]
+    fingerprint_md5: NotRequired[str]
+    fingerprint_sha1: NotRequired[str]
+    x509v3_extensions: NotRequired[X509v3Extensions]
+    cert_install_time: NotRequired[str]
+    key_label: NotRequired[str]
+    storage: NotRequired[str]
+
+
+class ShowCryptoPkiCertificatesVerboseResult(TypedDict):
+    """Schema for 'show crypto pki certificates verbose' parsed output.
+
+    Keyed by trustpoint name, then by certificate type.
+    """
+
+    trustpoints: dict[str, dict[str, CertificateEntry]]
+
+
+def _split_certificate_blocks(output: str) -> list[list[str]]:
+    """Split output into per-certificate blocks."""
+    blocks: list[list[str]] = []
+    current: list[str] = []
+
+    for line in output.splitlines():
+        if _CERT_TYPE_RE.match(line):
+            if current:
+                blocks.append(current)
+            current = [line]
+        elif current:
+            current.append(line)
+
+    if current:
+        blocks.append(current)
+
+    return blocks
+
+
+def _parse_dn_section(
+    lines: list[str],
+    start_idx: int,
+) -> tuple[dict[str, str], int]:
+    """Parse a DN section (Issuer or Subject) returning attributes."""
+    dn: dict[str, str] = {}
+    idx = start_idx
+
+    while idx < len(lines):
+        line = lines[idx]
+        m = _DN_ATTR_RE.match(line)
+        if m:
+            dn[m.group(1)] = m.group(2)
+            idx += 1
+            continue
+        if _SUBJECT_NAME_RE.match(line) or _SERIAL_NUMBER_FIELD_RE.match(line):
+            idx += 1
+            continue
+        break
+
+    return dn, idx
+
+
+def _parse_validity(
+    lines: list[str],
+    start_idx: int,
+) -> tuple[ValidityDate | None, int]:
+    """Parse validity date section."""
+    start_date = ""
+    end_date = ""
+    idx = start_idx
+
+    while idx < len(lines):
+        line = lines[idx]
+        m = _START_DATE_RE.match(line)
+        if m:
+            start_date = m.group(1)
+            idx += 1
+            continue
+        m = _END_DATE_RE.match(line)
+        if m:
+            end_date = m.group(1)
+            idx += 1
+            continue
+        if not line.strip():
+            idx += 1
+            continue
+        break
+
+    if start_date and end_date:
+        return {"start_date": start_date, "end_date": end_date}, idx
+    return None, idx
+
+
+def _parse_subject_key_info(
+    lines: list[str],
+    start_idx: int,
+) -> tuple[SubjectKeyInfo | None, int]:
+    """Parse Subject Key Info section."""
+    algorithm = ""
+    key_size: int | None = None
+    idx = start_idx
+
+    while idx < len(lines):
+        line = lines[idx]
+        m = _PUB_KEY_ALGO_RE.match(line)
+        if m:
+            algorithm = m.group(1)
+            idx += 1
+            continue
+        m = _RSA_KEY_RE.match(line) or _EC_KEY_RE.match(line)
+        if m:
+            key_size = int(m.group(1))
+            idx += 1
+            continue
+        if not line.strip():
+            idx += 1
+            continue
+        break
+
+    if algorithm:
+        info: dict[str, str | int] = {"public_key_algorithm": algorithm}
+        if key_size is not None:
+            info["key_size_bits"] = key_size
+        return cast(SubjectKeyInfo, info), idx
+    return None, idx
+
+
+def _try_ext_key_usage(
+    lines: list[str],
+    idx: int,
+    ext: dict[str, str | list[str]],
+    line: str,
+) -> int | None:
+    """Try to parse X509v3 Key Usage within extensions."""
+    m = _KEY_USAGE_HEADER_RE.match(line)
+    if not m:
+        return None
+    ext["key_usage_hex"] = m.group(1)
+    idx += 1
+    usages: list[str] = []
+    while idx < len(lines):
+        um = _KEY_USAGE_VALUE_RE.match(lines[idx])
+        if um and lines[idx].startswith("      "):
+            usages.append(um.group(1).strip())
+            idx += 1
+        else:
+            break
+    if usages:
+        ext["key_usage"] = usages
+    return idx
+
+
+def _try_ext_extended_key_usage(
+    lines: list[str],
+    idx: int,
+    ext: dict[str, str | list[str]],
+    line: str,
+) -> int | None:
+    """Try to parse Extended Key Usage within extensions."""
+    m = _EXT_KEY_USAGE_HEADER_RE.match(line)
+    if not m:
+        return None
+    idx += 1
+    eku: list[str] = []
+    while idx < len(lines):
+        eku_line = lines[idx]
+        if eku_line.startswith("        "):
+            val = eku_line.strip()
+            if val:
+                eku.append(val)
+            idx += 1
+        else:
+            break
+    if eku:
+        ext["extended_key_usage"] = eku
+    return idx
+
+
+def _try_ext_auth_info_access(
+    lines: list[str],
+    idx: int,
+    ext: dict[str, str | list[str]],
+    line: str,
+) -> int | None:
+    """Try to parse Authority Info Access within extensions."""
+    m = _AUTH_INFO_ACCESS_RE.match(line)
+    if not m:
+        return None
+    idx += 1
+    if idx < len(lines):
+        ca_m = _CA_ISSUERS_RE.match(lines[idx])
+        if ca_m:
+            ext["authority_info_access"] = ca_m.group(1)
+            idx += 1
+    return idx
+
+
+def _parse_x509v3_extensions(
+    lines: list[str],
+    start_idx: int,
+) -> tuple[X509v3Extensions | None, int]:
+    """Parse X509v3 extensions section."""
+    ext: dict[str, str | list[str]] = {}
+    idx = start_idx
+
+    while idx < len(lines):
+        line = lines[idx]
+
+        if line.strip() and not line.startswith("    "):
+            break
+
+        result = _try_ext_key_usage(lines, idx, ext, line)
+        if result is not None:
+            idx = result
+            continue
+
+        m = _SUBJECT_KEY_ID_RE.match(line)
+        if m:
+            ext["subject_key_id"] = m.group(1)
+            idx += 1
+            continue
+
+        m = _AUTH_KEY_ID_RE.match(line)
+        if m:
+            ext["authority_key_id"] = m.group(1)
+            idx += 1
+            continue
+
+        result = _try_ext_auth_info_access(lines, idx, ext, line)
+        if result is not None:
+            idx = result
+            continue
+
+        result = _try_ext_extended_key_usage(lines, idx, ext, line)
+        if result is not None:
+            idx = result
+            continue
+
+        idx += 1
+
+    if ext:
+        return cast(X509v3Extensions, ext), idx
+    return None, idx
+
+
+def _parse_crl_distribution_points(
+    lines: list[str],
+    start_idx: int,
+) -> tuple[list[str], int]:
+    """Parse CRL Distribution Points URLs."""
+    urls: list[str] = []
+    idx = start_idx
+
+    while idx < len(lines):
+        m = _CRL_URL_RE.match(lines[idx])
+        if m:
+            urls.append(m.group(1))
+            idx += 1
+        else:
+            break
+
+    return urls, idx
+
+
+def _try_simple_field(line: str, entry: dict[str, object]) -> bool:
+    """Try to match a line against simple key-value patterns."""
+    for pattern, key in _SIMPLE_FIELDS:
+        m = pattern.match(line)
+        if m:
+            entry[key] = m.group(1)
+            return True
+    return False
+
+
+def _try_version(line: str, entry: dict[str, object]) -> bool:
+    """Try to parse the Version field."""
+    m = _VERSION_RE.match(line)
+    if m:
+        entry["version"] = int(m.group(1))
+        return True
+    return False
+
+
+def _parse_subject_section(
+    lines: list[str],
+    idx: int,
+) -> tuple[str, str, dict[str, str], int]:
+    """Parse Subject section, extracting name and serial number."""
+    subject_name = ""
+    subject_serial = ""
+    if idx < len(lines):
+        name_m = _SUBJECT_NAME_RE.match(lines[idx])
+        if name_m:
+            subject_name = name_m.group(1)
+    scan_idx = idx
+    while scan_idx < len(lines):
+        sn_m = _SERIAL_NUMBER_FIELD_RE.match(lines[scan_idx])
+        if sn_m:
+            subject_serial = sn_m.group(1)
+            break
+        if not _DN_ATTR_RE.match(lines[scan_idx]) and not _SUBJECT_NAME_RE.match(
+            lines[scan_idx]
+        ):
+            break
+        scan_idx += 1
+    dn, idx = _parse_dn_section(lines, idx)
+    return subject_name, subject_serial, dn, idx
+
+
+def _try_dn_section(
+    lines: list[str],
+    idx: int,
+    line: str,
+    entry: dict[str, object],
+    names: list[str],
+) -> int | None:
+    """Try to parse Issuer/Subject DN section.
+
+    Appends [subject_name, subject_serial] into *names* when found.
+    """
+    m = _SECTION_RE.match(line)
+    if not m:
+        return None
+    section_name = m.group(1).lower()
+    idx += 1
+    if section_name == "subject":
+        sn, ss, dn, idx = _parse_subject_section(lines, idx)
+        if sn:
+            names.append(sn)
+        if ss:
+            names.append(ss)
+    else:
+        dn, idx = _parse_dn_section(lines, idx)
+    entry[section_name] = dn
+    return idx
+
+
+def _parse_certificate_block(
+    lines: list[str],
+) -> tuple[str, CertificateEntry] | None:
+    """Parse a single verbose certificate block."""
+    if not lines:
+        return None
+
+    header = _CERT_TYPE_RE.match(lines[0])
+    if not header:
+        return None
+
+    cert_type = header.group(1)
+    entry: dict[str, object] = {}
+    names: list[str] = []
+
+    idx = 1
+    while idx < len(lines):
+        line = lines[idx]
+
+        if _try_simple_field(line, entry) or _try_version(line, entry):
+            idx += 1
+            continue
+
+        dn_result = _try_dn_section(lines, idx, line, entry, names)
+        if dn_result is not None:
+            idx = dn_result
+            continue
+
+        idx = _try_block_sections(lines, idx, line, entry)
+
+    if names:
+        entry["subject_name"] = names[0]
+    if len(names) > 1:
+        entry["subject_serial_number"] = names[1]
+
+    return cert_type, cast(CertificateEntry, entry)
+
+
+def _try_block_sections(
+    lines: list[str],
+    idx: int,
+    line: str,
+    entry: dict[str, object],
+) -> int:
+    """Try to parse block-level sections (validity, CRL, etc.)."""
+    if _VALIDITY_HEADER_RE.match(line):
+        idx += 1
+        validity, idx = _parse_validity(lines, idx)
+        if validity is not None:
+            entry["validity_date"] = validity
+        return idx
+
+    if _CRL_HEADER_RE.match(line):
+        idx += 1
+        urls, idx = _parse_crl_distribution_points(lines, idx)
+        if urls:
+            entry["crl_distribution_points"] = urls
+        return idx
+
+    if _SUBJECT_KEY_INFO_RE.match(line):
+        idx += 1
+        ski, idx = _parse_subject_key_info(lines, idx)
+        if ski is not None:
+            entry["subject_key_info"] = ski
+        return idx
+
+    if _X509V3_EXT_HEADER_RE.match(line):
+        idx += 1
+        extensions, idx = _parse_x509v3_extensions(lines, idx)
+        if extensions is not None:
+            entry["x509v3_extensions"] = extensions
+        return idx
+
+    return idx + 1
+
+
+def _extract_trustpoint(entry: CertificateEntry) -> str:
+    """Extract trustpoint name from associated_trustpoints field."""
+    raw = entry.get("associated_trustpoints", "")
+    return raw.split()[0].strip(",") if raw else ""
+
+
+@register(OS.CISCO_IOSXE, "show crypto pki certificates verbose")
+class ShowCryptoPkiCertificatesVerboseParser(
+    BaseParser["ShowCryptoPkiCertificatesVerboseResult"],
+):
+    """Parser for 'show crypto pki certificates verbose' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoPkiCertificatesVerboseResult:
+        """Parse 'show crypto pki certificates verbose' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed verbose PKI certificate details keyed by
+            trustpoint name, then by certificate type.
+
+        Raises:
+            ValueError: If no certificate entries found in output.
+        """
+        blocks = _split_certificate_blocks(output)
+        trustpoints: dict[str, dict[str, CertificateEntry]] = {}
+
+        for block_lines in blocks:
+            result = _parse_certificate_block(block_lines)
+            if result is None:
+                continue
+            cert_type, cert_entry = result
+            tp_name = _extract_trustpoint(cert_entry)
+            if tp_name:
+                trustpoints.setdefault(tp_name, {})[cert_type] = cert_entry
+
+        if not trustpoints:
+            msg = "No PKI certificate entries found in output"
+            raise ValueError(msg)
+
+        return {"trustpoints": trustpoints}

--- a/tests/parsers/iosxe/show_crypto_pki_certificates_verbose/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_pki_certificates_verbose/001_basic/expected.json
@@ -1,0 +1,94 @@
+{
+    "trustpoints": {
+        "CISCO_IDEVID_CMCA_SUDI": {
+            "Certificate": {
+                "status": "Available",
+                "version": 3,
+                "serial_number": "6E00F7400000000AC45E",
+                "usage": "General Purpose",
+                "issuer": {
+                    "cn": "Cisco Manufacturing CA",
+                    "o": "Cisco Systems"
+                },
+                "subject": {
+                    "cn": "C9300-48U-AC3A67280F80",
+                    "serialNumber": "PID:C9300-48U SN:FCW2419C0LC"
+                },
+                "crl_distribution_points": [
+                    "http://www.cisco.com/security/pki/crl/cmca.crl"
+                ],
+                "validity_date": {
+                    "start_date": "20:11:12 UTC May 5 2020",
+                    "end_date": "20:25:42 UTC May 14 2029"
+                },
+                "subject_key_info": {
+                    "public_key_algorithm": "rsaEncryption",
+                    "key_size_bits": 1024
+                },
+                "signature_algorithm": "SHA1 with RSA Encryption",
+                "fingerprint_md5": "AC2D1A70 FF41D51D 01670FDF 11189231",
+                "fingerprint_sha1": "AF2FC2D4 2BAE6427 B7351C8E 3C179E06 F750C951",
+                "x509v3_extensions": {
+                    "key_usage_hex": "F0000000",
+                    "key_usage": [
+                        "Digital Signature",
+                        "Non Repudiation",
+                        "Key Encipherment",
+                        "Data Encipherment"
+                    ],
+                    "subject_key_id": "C41A6C7F C387DC79 3CAE4BEC C8E53B76 58179C46",
+                    "authority_key_id": "D0C52226 AB4F4660 ECAE0591 C7DC5AD1 B047F76C",
+                    "authority_info_access": "http://www.cisco.com/security/pki/certs/cmca.cer",
+                    "extended_key_usage": [
+                        "Client Auth",
+                        "Server Auth"
+                    ]
+                },
+                "cert_install_time": "01:43:15 UTC May 1 2026",
+                "associated_trustpoints": "CISCO_IDEVID_CMCA_SUDI",
+                "key_label": "CISCO_IDEVID_CMCA_SUDI",
+                "subject_name": "C9300-48U-AC3A67280F80",
+                "subject_serial_number": "PID:C9300-48U SN:FCW2419C0LC"
+            }
+        },
+        "CISCO_IDEVID_CMCA_SUDI_SHA2": {
+            "CA Certificate": {
+                "status": "Available",
+                "version": 3,
+                "serial_number": "18B1BBAD000000059167",
+                "usage": "Signature",
+                "issuer": {
+                    "cn": "Cisco Manufacturing CA SHA2",
+                    "o": "Cisco"
+                },
+                "subject": {
+                    "cn": "Cisco Manufacturing CA SHA2",
+                    "o": "Cisco"
+                },
+                "validity_date": {
+                    "start_date": "13:50:58 UTC Jun 10 2016",
+                    "end_date": "13:50:58 UTC Jun 10 2031"
+                },
+                "subject_key_info": {
+                    "public_key_algorithm": "rsaEncryption",
+                    "key_size_bits": 2048
+                },
+                "signature_algorithm": "SHA256 with RSA Encryption",
+                "fingerprint_md5": "4F07C66E 5AA7401F C6B0E6CF 4E27F838",
+                "fingerprint_sha1": "553ACC5C DE644C04 D77EE855 4B2F6E32 3A79AD4B",
+                "x509v3_extensions": {
+                    "key_usage_hex": "86000000",
+                    "key_usage": [
+                        "Digital Signature",
+                        "Key Cert Sign",
+                        "CRL Signature"
+                    ],
+                    "subject_key_id": "3F72CF6F 50FA5C13 DE198931 D0F64FA0 A4B5C4D3",
+                    "authority_key_id": "C0A3D8AA 2C11B498 A8D7C66A 3D1F4E22 5A4EC67D"
+                },
+                "associated_trustpoints": "CISCO_IDEVID_CMCA_SUDI_SHA2",
+                "storage": "nvram:CiscManufCSH#2CA.cer"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_crypto_pki_certificates_verbose/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_pki_certificates_verbose/001_basic/input.txt
@@ -1,0 +1,70 @@
+Certificate
+  Status: Available
+  Version: 3
+  Certificate Serial Number (hex): 6E00F7400000000AC45E
+  Certificate Usage: General Purpose
+  Issuer:
+    cn=Cisco Manufacturing CA
+    o=Cisco Systems
+  Subject:
+    Name: C9300-48U-AC3A67280F80
+    Serial Number: PID:C9300-48U SN:FCW2419C0LC
+    cn=C9300-48U-AC3A67280F80
+    serialNumber=PID:C9300-48U SN:FCW2419C0LC
+  CRL Distribution Points:
+    http://www.cisco.com/security/pki/crl/cmca.crl
+  Validity Date:
+    start date: 20:11:12 UTC May 5 2020
+    end   date: 20:25:42 UTC May 14 2029
+  Subject Key Info:
+    Public Key Algorithm: rsaEncryption
+    RSA Public Key: (1024 bit)
+  Signature Algorithm: SHA1 with RSA Encryption
+  Fingerprint MD5: AC2D1A70 FF41D51D 01670FDF 11189231
+  Fingerprint SHA1: AF2FC2D4 2BAE6427 B7351C8E 3C179E06 F750C951
+  X509v3 extensions:
+    X509v3 Key Usage: F0000000
+      Digital Signature
+      Non Repudiation
+      Key Encipherment
+      Data Encipherment
+    X509v3 Subject Key ID: C41A6C7F C387DC79 3CAE4BEC C8E53B76 58179C46
+    X509v3 Authority Key ID: D0C52226 AB4F4660 ECAE0591 C7DC5AD1 B047F76C
+    Authority Info Access:
+        CA ISSUERS: http://www.cisco.com/security/pki/certs/cmca.cer
+    Extended Key Usage:
+        Client Auth
+        Server Auth
+  Cert install time: 01:43:15 UTC May 1 2026
+  Associated Trustpoints: CISCO_IDEVID_CMCA_SUDI
+  Key Label: CISCO_IDEVID_CMCA_SUDI
+
+CA Certificate
+  Status: Available
+  Version: 3
+  Certificate Serial Number (hex): 18B1BBAD000000059167
+  Certificate Usage: Signature
+  Issuer:
+    cn=Cisco Manufacturing CA SHA2
+    o=Cisco
+  Subject:
+    cn=Cisco Manufacturing CA SHA2
+    o=Cisco
+  Validity Date:
+    start date: 13:50:58 UTC Jun 10 2016
+    end   date: 13:50:58 UTC Jun 10 2031
+  Subject Key Info:
+    Public Key Algorithm: rsaEncryption
+    RSA Public Key: (2048 bit)
+  Signature Algorithm: SHA256 with RSA Encryption
+  Fingerprint MD5: 4F07C66E 5AA7401F C6B0E6CF 4E27F838
+  Fingerprint SHA1: 553ACC5C DE644C04 D77EE855 4B2F6E32 3A79AD4B
+  X509v3 extensions:
+    X509v3 Key Usage: 86000000
+      Digital Signature
+      Key Cert Sign
+      CRL Signature
+    X509v3 Subject Key ID: 3F72CF6F 50FA5C13 DE198931 D0F64FA0 A4B5C4D3
+    X509v3 Authority Key ID: C0A3D8AA 2C11B498 A8D7C66A 3D1F4E22 5A4EC67D
+  Associated Trustpoints: CISCO_IDEVID_CMCA_SUDI_SHA2
+  Storage: nvram:CiscManufCSH#2CA.cer

--- a/tests/parsers/iosxe/show_crypto_pki_certificates_verbose/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_pki_certificates_verbose/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Verbose PKI certificates with SUDI trustpoints and X509v3 extensions
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto pki certificates verbose` on Cisco IOS-XE, producing a nested dict keyed by trustpoint name then certificate type. Extracts all verbose-only fields including X509v3 extensions, Subject Key Info, signature algorithm, CRL distribution points, cert install time, and fingerprints.
- Fixture sourced from issue #1169 sample output (C9300-48U, IOS-XE 17.18.02); covers both identity certificate and CA certificate blocks.

Closes #1169

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_pki_certificates_verbose -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_pki_certificates_verbose.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)