### PR TITLE
feat(cisco_iosxe): add parser for `show crypto tech-support`

### DIFF
--- a/changes/1171.parser_added
+++ b/changes/1171.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto tech-support` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_tech-support.py
+++ b/src/muninn/parsers/iosxe/show_crypto_tech-support.py
@@ -1,0 +1,90 @@
+"""Parser for 'show crypto tech-support' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_SECTION_HEADER_RE = re.compile(r"^-{2,}\s+(?P<command>.+?)\s+-{2,}$")
+
+
+class TechSupportSection(TypedDict):
+    """A single section within show crypto tech-support output."""
+
+    content: str
+
+
+class ShowCryptoTechSupportResult(TypedDict):
+    """Schema for 'show crypto tech-support' parsed output.
+
+    Top-level dict keyed by sub-command name (e.g.
+    ``"show crypto isakmp sa count"``). Each value contains the raw
+    text content of that section.
+    """
+
+    sections: dict[str, TechSupportSection]
+
+
+def _store_section(
+    sections: dict[str, TechSupportSection],
+    command: str,
+    lines: list[str],
+) -> None:
+    """Store a section only if it has non-empty content."""
+    content = "\n".join(lines).strip()
+    if content:
+        sections[command] = cast(TechSupportSection, {"content": content})
+
+
+@register(OS.CISCO_IOSXE, "show crypto tech-support")
+class ShowCryptoTechSupportParser(BaseParser[ShowCryptoTechSupportResult]):
+    """Parser for 'show crypto tech-support' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.SECURITY, ParserTag.VPN}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoTechSupportResult:
+        r"""Parse 'show crypto tech-support' output into structured data.
+
+        The command aggregates output from multiple crypto sub-commands,
+        each delimited by a dashed header line containing the sub-command
+        name (e.g. ``--- show crypto isakmp sa count ---``).
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dict with a ``sections`` key mapping sub-command names to
+            their text content.
+
+        Raises:
+            ValueError: If no section headers are found in the output.
+        """
+        sections: dict[str, TechSupportSection] = {}
+        current_command: str | None = None
+        current_lines: list[str] = []
+
+        for line in output.splitlines():
+            header_match = _SECTION_HEADER_RE.match(line)
+            if header_match:
+                if current_command is not None:
+                    _store_section(sections, current_command, current_lines)
+                current_command = header_match.group("command")
+                current_lines = []
+            elif current_command is not None:
+                current_lines.append(line)
+
+        if current_command is not None:
+            _store_section(sections, current_command, current_lines)
+
+        if not sections:
+            msg = "No section headers found in show crypto tech-support output"
+            raise ValueError(msg)
+
+        result: dict[str, object] = {"sections": sections}
+        return cast(ShowCryptoTechSupportResult, result)

--- a/tests/parsers/iosxe/show_crypto_tech-support/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_tech-support/001_basic/expected.json
@@ -1,0 +1,16 @@
+{
+    "sections": {
+        "show crypto isakmp sa count": {
+            "content": "Active ISAKMP SA's: 0\nStandby ISAKMP SA's: 0\nCurrently being negotiated ISAKMP SA's: 0\nDead ISAKMP SA's: 0"
+        },
+        "show crypto ipsec sa count": {
+            "content": "IPsec SA total: 0, active: 0, rekeying: 0, unused: 0, invalid: 0"
+        },
+        "show crypto isakmp sa detail": {
+            "content": "Codes: C - IKE configuration mode, D - Dead Peer Detection\n       K - Keepalives, N - NAT-traversal\n       T - cTCP encapsulation, X - IKE Extended Authentication\n       psk - Preshared key, rsig - RSA signature\n       renc - RSA encryption\nIPv4 Crypto ISAKMP SA\n\nC-id  Local           Remote          I-VRF  Status Encr Hash   Auth DH Lifetime\nCap.\n\nIPv6 Crypto ISAKMP SA"
+        },
+        "show crypto ipsec sa detail": {
+            "content": "No SAs found"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_crypto_tech-support/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_tech-support/001_basic/input.txt
@@ -1,0 +1,49 @@
+------------------ show crypto isakmp sa count ------------------
+
+
+Active ISAKMP SA's: 0
+Standby ISAKMP SA's: 0
+Currently being negotiated ISAKMP SA's: 0
+Dead ISAKMP SA's: 0
+
+------------------ show crypto ipsec sa count ------------------
+
+IPsec SA total: 0, active: 0, rekeying: 0, unused: 0, invalid: 0
+
+
+------------------ show crypto isakmp sa detail ------------------
+
+
+Codes: C - IKE configuration mode, D - Dead Peer Detection
+       K - Keepalives, N - NAT-traversal
+       T - cTCP encapsulation, X - IKE Extended Authentication
+       psk - Preshared key, rsig - RSA signature
+       renc - RSA encryption
+IPv4 Crypto ISAKMP SA
+
+C-id  Local           Remote          I-VRF  Status Encr Hash   Auth DH Lifetime
+Cap.
+
+IPv6 Crypto ISAKMP SA
+
+
+------------------ show crypto ipsec sa detail ------------------
+
+
+No SAs found
+
+------------------ show crypto ipsec internal error ------------------
+
+
+
+------------------ show crypto session summary ------------------
+
+
+
+------------------ show crypto session detail ------------------
+
+
+
+------------------ show crypto session stats closed brief ------------------
+
+

--- a/tests/parsers/iosxe/show_crypto_tech-support/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_tech-support/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show crypto tech-support output with empty crypto sessions
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a section-based parser for `show crypto tech-support` on IOS-XE that splits the umbrella output into sub-command sections keyed by their header names (e.g. `"show crypto isakmp sa count"`), omitting empty sections per project convention.
- Fixture captured from physical testbed device (C9300-48U, IOS-XE 17.18.02); only sections with content are represented in the output.

Closes #1171

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_crypto_tech-support" -v` (7 passed)
- [x] `uv run pytest -q` (full suite, 9201 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_tech-support.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_tech-support.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue #1171

<!-- generated PR -->
🤖 Generated with [Claude Code](https://claude.com/claude-code)