### PR TITLE
feat(cisco_iosxe): add parser for `show power inline police`

### DIFF
--- a/changes/1177.parser_added
+++ b/changes/1177.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show power inline police` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_power_inline_police.py
+++ b/src/muninn/parsers/iosxe/show_power_inline_police.py
@@ -1,0 +1,191 @@
+"""Parser for 'show power inline police' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_SPACE_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+# Null-equivalent values to omit from output
+_NULL_VALUES = frozenset({"n/a", "none", ""})
+
+
+class ModuleEntry(TypedDict):
+    """Schema for a per-module power summary."""
+
+    available: float
+    used: float
+    remaining: float
+
+
+class InterfacePoliceEntry(TypedDict):
+    """Schema for a single interface power inline police entry."""
+
+    admin_state: str
+    oper_state: str
+    admin_police: NotRequired[str]
+    oper_police: NotRequired[str]
+    cutoff_power: NotRequired[float]
+    oper_power: NotRequired[float]
+
+
+class ShowPowerInlinePoliceResult(TypedDict):
+    """Schema for 'show power inline police' parsed output."""
+
+    modules: NotRequired[dict[str, ModuleEntry]]
+    interfaces: dict[str, InterfacePoliceEntry]
+
+
+# Module data line: "1           857.0        0.0       857.0"
+_MODULE_DATA_RE = re.compile(
+    r"^\s*(?P<module>\d+)\s+"
+    r"(?P<available>[\d.]+)\s+"
+    r"(?P<used>[\d.]+)\s+"
+    r"(?P<remaining>[\d.]+)\s*$"
+)
+
+# Interface row pattern:
+# Gi1/0/1   auto   off        none       n/a        n/a    n/a
+# Gi1/0/5   auto   on         log        errdisable 15.4   12.3
+_INTF_ROW_RE = re.compile(
+    r"^\s*(?P<interface>\S+)\s+"
+    r"(?P<admin_state>\S+)\s+"
+    r"(?P<oper_state>\S+)\s+"
+    r"(?P<admin_police>\S+)\s+"
+    r"(?P<oper_police>\S+)\s+"
+    r"(?P<cutoff_power>\S+)\s+"
+    r"(?P<oper_power>\S+)\s*$"
+)
+
+
+def _is_null(value: str) -> bool:
+    """Return True if value is a null-equivalent."""
+    return value.strip().lower() in _NULL_VALUES
+
+
+def _is_skip_line(line: str) -> bool:
+    """Return True if the line is a header, separator, or blank."""
+    if not line:
+        return True
+    if SEPARATOR_DASH_SPACE_RE.match(line):
+        return True
+    lower = line.lower()
+    if lower.startswith("interface") and "admin" in lower:
+        return True
+    if lower.startswith("module") and "available" in lower:
+        return True
+    if "(watts)" in lower:
+        return True
+    return False
+
+
+def _try_parse_float(value: str) -> float | None:
+    """Attempt to parse a float, return None on failure."""
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _build_interface_entry(
+    match: re.Match[str],
+) -> tuple[str, InterfacePoliceEntry]:
+    """Build an interface entry from a row regex match."""
+    name = canonical_interface_name(match.group("interface"), os=OS.CISCO_IOSXE)
+    entry: dict[str, str | float] = {
+        "admin_state": match.group("admin_state"),
+        "oper_state": match.group("oper_state"),
+    }
+
+    admin_police = match.group("admin_police")
+    if not _is_null(admin_police):
+        entry["admin_police"] = admin_police
+
+    oper_police = match.group("oper_police")
+    if not _is_null(oper_police):
+        entry["oper_police"] = oper_police
+
+    cutoff_raw = match.group("cutoff_power")
+    if not _is_null(cutoff_raw):
+        cutoff_val = _try_parse_float(cutoff_raw)
+        if cutoff_val is not None:
+            entry["cutoff_power"] = cutoff_val
+
+    oper_power_raw = match.group("oper_power")
+    if not _is_null(oper_power_raw):
+        oper_val = _try_parse_float(oper_power_raw)
+        if oper_val is not None:
+            entry["oper_power"] = oper_val
+
+    return name, cast(InterfacePoliceEntry, entry)
+
+
+@register(OS.CISCO_IOSXE, "show power inline police")
+class ShowPowerInlinePoliceParser(
+    BaseParser[ShowPowerInlinePoliceResult],
+):
+    """Parser for 'show power inline police' on IOS-XE.
+
+    Example output::
+
+        Module   Available     Used     Remaining
+                  (Watts)     (Watts)    (Watts)
+        ------   ---------   --------   ---------
+        1           857.0        0.0       857.0
+        Interface Admin  Oper       Admin      Oper       Cutoff Oper
+                  State  State      Police     Police     Power  Power
+        --------- ------ ---------- ---------- ---------- ------ -----
+        Gi1/0/1   auto   off        none       n/a        n/a    n/a
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.POE, ParserTag.SYSTEM})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowPowerInlinePoliceResult:
+        """Parse 'show power inline police' output.
+
+        Args:
+            output: Raw CLI output from 'show power inline police'.
+
+        Returns:
+            Parsed data with interfaces keyed by canonical name.
+
+        Raises:
+            ValueError: If no interface entries are found.
+        """
+        interfaces: dict[str, InterfacePoliceEntry] = {}
+        modules: dict[str, ModuleEntry] = {}
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if _is_skip_line(stripped):
+                continue
+
+            m = _MODULE_DATA_RE.match(stripped)
+            if m:
+                mod_id = m.group("module")
+                modules[mod_id] = {
+                    "available": float(m.group("available")),
+                    "used": float(m.group("used")),
+                    "remaining": float(m.group("remaining")),
+                }
+                continue
+
+            m = _INTF_ROW_RE.match(stripped)
+            if m:
+                name, entry = _build_interface_entry(m)
+                interfaces[name] = entry
+
+        if not interfaces:
+            msg = "No interface entries found in output"
+            raise ValueError(msg)
+
+        result: dict[str, object] = {"interfaces": interfaces}
+        if modules:
+            result["modules"] = modules
+
+        return cast(ShowPowerInlinePoliceResult, result)

--- a/tests/parsers/iosxe/show_power_inline_police/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_power_inline_police/001_basic/expected.json
@@ -1,0 +1,183 @@
+{
+    "interfaces": {
+        "GigabitEthernet1/0/1": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/2": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/3": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/4": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/5": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/6": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/7": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/8": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/9": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/10": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/11": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/12": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/13": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/14": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/15": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/16": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/17": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/18": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/19": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/20": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/21": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/22": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/23": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/24": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/25": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/26": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/27": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/28": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/29": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/30": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/31": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/32": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/33": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/34": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/35": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/36": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/37": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/38": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/39": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/40": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/41": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/42": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        },
+        "GigabitEthernet1/0/43": {
+            "admin_state": "auto",
+            "oper_state": "off"
+        }
+    },
+    "modules": {
+        "1": {
+            "available": 857.0,
+            "used": 0.0,
+            "remaining": 857.0
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_power_inline_police/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_power_inline_police/001_basic/input.txt
@@ -1,0 +1,50 @@
+Module   Available     Used     Remaining
+          (Watts)     (Watts)    (Watts)
+------   ---------   --------   ---------
+1           857.0        0.0       857.0
+Interface Admin  Oper       Admin      Oper       Cutoff Oper
+          State  State      Police     Police     Power  Power
+--------- ------ ---------- ---------- ---------- ------ -----
+Gi1/0/1   auto   off        none       n/a        n/a    n/a
+Gi1/0/2   auto   off        none       n/a        n/a    n/a
+Gi1/0/3   auto   off        none       n/a        n/a    n/a
+Gi1/0/4   auto   off        none       n/a        n/a    n/a
+Gi1/0/5   auto   off        none       n/a        n/a    n/a
+Gi1/0/6   auto   off        none       n/a        n/a    n/a
+Gi1/0/7   auto   off        none       n/a        n/a    n/a
+Gi1/0/8   auto   off        none       n/a        n/a    n/a
+Gi1/0/9   auto   off        none       n/a        n/a    n/a
+Gi1/0/10  auto   off        none       n/a        n/a    n/a
+Gi1/0/11  auto   off        none       n/a        n/a    n/a
+Gi1/0/12  auto   off        none       n/a        n/a    n/a
+Gi1/0/13  auto   off        none       n/a        n/a    n/a
+Gi1/0/14  auto   off        none       n/a        n/a    n/a
+Gi1/0/15  auto   off        none       n/a        n/a    n/a
+Gi1/0/16  auto   off        none       n/a        n/a    n/a
+Gi1/0/17  auto   off        none       n/a        n/a    n/a
+Gi1/0/18  auto   off        none       n/a        n/a    n/a
+Gi1/0/19  auto   off        none       n/a        n/a    n/a
+Gi1/0/20  auto   off        none       n/a        n/a    n/a
+Gi1/0/21  auto   off        none       n/a        n/a    n/a
+Gi1/0/22  auto   off        none       n/a        n/a    n/a
+Gi1/0/23  auto   off        none       n/a        n/a    n/a
+Gi1/0/24  auto   off        none       n/a        n/a    n/a
+Gi1/0/25  auto   off        none       n/a        n/a    n/a
+Gi1/0/26  auto   off        none       n/a        n/a    n/a
+Gi1/0/27  auto   off        none       n/a        n/a    n/a
+Gi1/0/28  auto   off        none       n/a        n/a    n/a
+Gi1/0/29  auto   off        none       n/a        n/a    n/a
+Gi1/0/30  auto   off        none       n/a        n/a    n/a
+Gi1/0/31  auto   off        none       n/a        n/a    n/a
+Gi1/0/32  auto   off        none       n/a        n/a    n/a
+Gi1/0/33  auto   off        none       n/a        n/a    n/a
+Gi1/0/34  auto   off        none       n/a        n/a    n/a
+Gi1/0/35  auto   off        none       n/a        n/a    n/a
+Gi1/0/36  auto   off        none       n/a        n/a    n/a
+Gi1/0/37  auto   off        none       n/a        n/a    n/a
+Gi1/0/38  auto   off        none       n/a        n/a    n/a
+Gi1/0/39  auto   off        none       n/a        n/a    n/a
+Gi1/0/40  auto   off        none       n/a        n/a    n/a
+Gi1/0/41  auto   off        none       n/a        n/a    n/a
+Gi1/0/42  auto   off        none       n/a        n/a    n/a
+Gi1/0/43  auto   off        none       n/a        n/a    n/a

--- a/tests/parsers/iosxe/show_power_inline_police/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_power_inline_police/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output from show power inline police with module summary and all ports in off/none state
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show power inline police` on Cisco IOS-XE that extracts per-module power budget (available/used/remaining watts) and per-interface policing state (admin/oper state, admin/oper police action, cutoff power, oper power) keyed by canonical interface name.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in the issue. All interfaces are in off/none state; placeholder values (`n/a`, `none`) are omitted per convention.

Closes #1177

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_power_inline_police -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_power_inline_police.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_power_inline_police.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

Generated with [Claude Code](https://claude.com/claude-code)