### PR TITLE
feat(cisco_iosxe): add parser for `show interfaces summary`

### DIFF
--- a/changes/1172.parser_added
+++ b/changes/1172.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show interfaces summary` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_interfaces_summary.py
+++ b/src/muninn/parsers/iosxe/show_interfaces_summary.py
@@ -1,0 +1,149 @@
+"""Parser for 'show interfaces summary' command on Cisco IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_SPACE_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+# Matches an interface data row.  The leading '*' indicates the interface
+# is up; absence means the interface is down or administratively down.
+# Fields are positional: interface, IHQ, IQD, OHQ, OQD, RXBS, RXPS,
+# TXBS, TXPS, TRTL.  Values may be integers or '-' (placeholder).
+_DATA_ROW_RE = re.compile(
+    r"^(?P<up>[*\s])\s*"
+    r"(?P<interface>\S+)"
+    r"\s+(?P<ihq>\d+|-)"
+    r"\s+(?P<iqd>\d+|-)"
+    r"\s+(?P<ohq>\d+|-)"
+    r"\s+(?P<oqd>\d+|-)"
+    r"\s+(?P<rxbs>\d+|-)"
+    r"\s+(?P<rxps>\d+|-)"
+    r"\s+(?P<txbs>\d+|-)"
+    r"\s+(?P<txps>\d+|-)"
+    r"\s+(?P<trtl>\d+|-)\s*$"
+)
+
+# Matches the column header line to detect the start of the data section.
+_HEADER_RE = re.compile(
+    r"^\s*Interface\s+IHQ\s+IQD\s+OHQ\s+OQD\s+RXBS\s+"
+    r"RXPS\s+TXBS\s+TXPS\s+TRTL\s*$"
+)
+
+
+class InterfaceSummaryEntry(TypedDict):
+    """Per-interface queue and rate statistics.
+
+    All numeric fields are :class:`NotRequired` because sub-interfaces
+    often report ``-`` (no data available) for every counter.
+    """
+
+    is_up: bool
+    ihq: NotRequired[int]
+    iqd: NotRequired[int]
+    ohq: NotRequired[int]
+    oqd: NotRequired[int]
+    rx_rate_bps: NotRequired[int]
+    rx_rate_pps: NotRequired[int]
+    tx_rate_bps: NotRequired[int]
+    tx_rate_pps: NotRequired[int]
+    throttle_count: NotRequired[int]
+
+
+class ShowInterfacesSummaryResult(TypedDict):
+    """Schema for 'show interfaces summary' parsed output on IOS-XE.
+
+    Keyed by canonical interface name.
+    """
+
+    interfaces: dict[str, InterfaceSummaryEntry]
+
+
+@register(OS.CISCO_IOSXE, "show interfaces summary")
+class ShowInterfacesSummaryParser(BaseParser[ShowInterfacesSummaryResult]):
+    """Parser for 'show interfaces summary' on Cisco IOS-XE.
+
+    The command emits a tabular listing of all interfaces with their
+    input/output hold-queue depths, drop counts, rates, and throttle
+    counts.  Interfaces marked with a leading ``*`` are operationally up.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesSummaryResult:
+        """Parse 'show interfaces summary' output on IOS-XE.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed interface summary keyed by canonical interface name.
+
+        Raises:
+            ValueError: If no interface data rows are found.
+        """
+        interfaces: dict[str, InterfaceSummaryEntry] = {}
+        in_data_section = False
+
+        for line in output.splitlines():
+            stripped = line.rstrip()
+            if not stripped:
+                continue
+
+            # Detect the header row to know we are in the data section.
+            if _HEADER_RE.match(stripped):
+                in_data_section = True
+                continue
+
+            # Skip separator lines (dashes).
+            if SEPARATOR_DASH_SPACE_RE.match(stripped):
+                continue
+
+            if not in_data_section:
+                continue
+
+            match = _DATA_ROW_RE.match(stripped)
+            if match is None:
+                continue
+
+            _build_entry(match, interfaces)
+
+        if not interfaces:
+            msg = "No interfaces found in 'show interfaces summary' output"
+            raise ValueError(msg)
+
+        return cast(ShowInterfacesSummaryResult, {"interfaces": interfaces})
+
+
+def _build_entry(
+    match: re.Match[str],
+    interfaces: dict[str, InterfaceSummaryEntry],
+) -> None:
+    """Build and store a single interface entry from a regex match."""
+    is_up = match.group("up") == "*"
+    name = canonical_interface_name(match.group("interface"), os=OS.CISCO_IOSXE)
+
+    entry: dict[str, object] = {"is_up": is_up}
+
+    _set_int_field(entry, "ihq", match.group("ihq"))
+    _set_int_field(entry, "iqd", match.group("iqd"))
+    _set_int_field(entry, "ohq", match.group("ohq"))
+    _set_int_field(entry, "oqd", match.group("oqd"))
+    _set_int_field(entry, "rx_rate_bps", match.group("rxbs"))
+    _set_int_field(entry, "rx_rate_pps", match.group("rxps"))
+    _set_int_field(entry, "tx_rate_bps", match.group("txbs"))
+    _set_int_field(entry, "tx_rate_pps", match.group("txps"))
+    _set_int_field(entry, "throttle_count", match.group("trtl"))
+
+    interfaces[name] = cast(InterfaceSummaryEntry, entry)
+
+
+def _set_int_field(entry: dict[str, object], key: str, raw: str) -> None:
+    """Set an integer field on the entry dict, omitting placeholders."""
+    if raw != "-":
+        entry[key] = int(raw)

--- a/tests/parsers/iosxe/show_interfaces_summary/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_interfaces_summary/001_basic/expected.json
@@ -1,0 +1,208 @@
+{
+    "interfaces": {
+        "Vlan1": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet0/0": {
+            "is_up": true,
+            "ihq": 0,
+            "iqd": 1477690,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 16000,
+            "rx_rate_pps": 24,
+            "tx_rate_bps": 1000,
+            "tx_rate_pps": 1,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/1": {
+            "is_up": true,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/1.10": {
+            "is_up": true
+        },
+        "GigabitEthernet1/0/1.20": {
+            "is_up": true
+        },
+        "GigabitEthernet1/0/2": {
+            "is_up": true,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/2.10": {
+            "is_up": true
+        },
+        "GigabitEthernet1/0/2.20": {
+            "is_up": true
+        },
+        "GigabitEthernet1/0/3": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/4": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/5": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/6": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/7": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/8": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/9": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/10": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/11": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/12": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/13": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        },
+        "GigabitEthernet1/0/14": {
+            "is_up": false,
+            "ihq": 0,
+            "iqd": 0,
+            "ohq": 0,
+            "oqd": 0,
+            "rx_rate_bps": 0,
+            "rx_rate_pps": 0,
+            "tx_rate_bps": 0,
+            "tx_rate_pps": 0,
+            "throttle_count": 0
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_interfaces_summary/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_interfaces_summary/001_basic/input.txt
@@ -1,0 +1,29 @@
+ *: interface is up
+ IHQ: pkts in input hold queue     IQD: pkts dropped from input queue
+ OHQ: pkts in output hold queue    OQD: pkts dropped from output queue
+ RXBS: rx rate (bits/sec)          RXPS: rx rate (pkts/sec)
+ TXBS: tx rate (bits/sec)          TXPS: tx rate (pkts/sec)
+ TRTL: throttle count
+
+  Interface                   IHQ       IQD       OHQ       OQD      RXBS      RXPS      TXBS      TXPS      TRTL
+-----------------------------------------------------------------------------------------------------------------
+  Vlan1                         0         0         0         0         0         0         0         0         0
+* GigabitEthernet0/0            0   1477690         0         0     16000        24      1000         1         0
+* GigabitEthernet1/0/1          0         0         0         0         0         0         0         0         0
+* Gi1/0/1.10                    -         -         -         -         -         -         -         -         -
+* Gi1/0/1.20                    -         -         -         -         -         -         -         -         -
+* GigabitEthernet1/0/2          0         0         0         0         0         0         0         0         0
+* Gi1/0/2.10                    -         -         -         -         -         -         -         -         -
+* Gi1/0/2.20                    -         -         -         -         -         -         -         -         -
+  GigabitEthernet1/0/3          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/4          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/5          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/6          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/7          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/8          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/9          0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/10         0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/11         0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/12         0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/13         0         0         0         0         0         0         0         0         0
+  GigabitEthernet1/0/14         0         0         0         0         0         0         0         0         0

--- a/tests/parsers/iosxe/show_interfaces_summary/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_interfaces_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show interfaces summary output with mix of up/down interfaces and sub-interfaces
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show interfaces summary` on Cisco IOS-XE that extracts per-interface queue depths, drop counts, rate statistics (rx/tx bits/sec and pkts/sec), and throttle counts into a `dict[str, InterfaceSummaryEntry]` keyed by canonical interface name
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02); sub-interface entries with `-` placeholders correctly omit those fields via `NotRequired` markers

Closes #1172

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_interfaces_summary -v` (14 passed)
- [x] `uv run pytest` (full suite, 9201 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_interfaces_summary.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_interfaces_summary.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue #1172

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)