### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf database database-summary detail`

### DIFF
--- a/changes/1173.parser_added
+++ b/changes/1173.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf database database-summary detail` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_database_database_summary_detail.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_database_database_summary_detail.py
@@ -1,0 +1,126 @@
+"""Parser for 'show ip ospf database database-summary detail' on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# --- Regex patterns ---
+
+_PROCESS_RE = re.compile(r"^OSPF Router with ID \((\S+)\) \(Process ID (\d+)\)$")
+
+_ROUTER_SUMMARY_RE = re.compile(r"^Router (\S+) LSA summary$")
+
+_LSA_TYPE_RE = re.compile(r"^\s{2}(\S+(?: \S+)*?)\s{2,}(\d+)\s+(\d+)\s+(\d+)\s*$")
+
+
+class LsaTypeSummary(TypedDict):
+    """Counts for a single LSA type within a router summary."""
+
+    count: int
+    delete: int
+    maxage: int
+
+
+class RouterSummary(TypedDict):
+    """LSA summary for a single advertising router."""
+
+    lsa_types: dict[str, LsaTypeSummary]
+
+
+class ProcessEntry(TypedDict):
+    """Schema for an OSPF process."""
+
+    router_id: str
+    routers: dict[str, RouterSummary]
+
+
+class ShowIpOspfDatabaseDatabaseSummaryDetailResult(TypedDict):
+    """Schema for 'show ip ospf database database-summary detail' output."""
+
+    processes: dict[str, ProcessEntry]
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf database database-summary detail")
+class ShowIpOspfDatabaseDatabaseSummaryDetailParser(
+    BaseParser[ShowIpOspfDatabaseDatabaseSummaryDetailResult],
+):
+    """Parser for 'show ip ospf database database-summary detail' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.ROUTING}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfDatabaseDatabaseSummaryDetailResult:
+        """Parse 'show ip ospf database database-summary detail' output.
+
+        Args:
+            output: Raw CLI output.
+
+        Returns:
+            Parsed data organized by OSPF process and advertising router.
+
+        Raises:
+            ValueError: If no OSPF process data is found.
+        """
+        processes = _parse_output(output)
+
+        if not processes:
+            msg = "No OSPF database summary entries found in output"
+            raise ValueError(msg)
+
+        return cast(
+            ShowIpOspfDatabaseDatabaseSummaryDetailResult,
+            {"processes": processes},
+        )
+
+
+def _parse_output(output: str) -> dict[str, ProcessEntry]:
+    """Parse all lines and return processes dict."""
+    processes: dict[str, ProcessEntry] = {}
+    current_process: ProcessEntry | None = None
+    current_router: RouterSummary | None = None
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        m = _PROCESS_RE.match(stripped)
+        if m:
+            router_id = m.group(1)
+            process_id = m.group(2)
+            current_process = {"router_id": router_id, "routers": {}}
+            processes[process_id] = current_process
+            current_router = None
+            continue
+
+        if current_process is None:
+            continue
+
+        m = _ROUTER_SUMMARY_RE.match(stripped)
+        if m:
+            adv_router = m.group(1)
+            current_router = {"lsa_types": {}}
+            current_process["routers"][adv_router] = current_router
+            continue
+
+        if current_router is None:
+            continue
+
+        m = _LSA_TYPE_RE.match(line)
+        if m:
+            lsa_type = m.group(1)
+            if lsa_type == "LSA Type" or lsa_type == "Total":
+                continue
+            current_router["lsa_types"][lsa_type] = {
+                "count": int(m.group(2)),
+                "delete": int(m.group(3)),
+                "maxage": int(m.group(4)),
+            }
+
+    return processes

--- a/tests/parsers/iosxe/show_ip_ospf_database_database-summary_detail/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_database_database-summary_detail/001_basic/expected.json
@@ -1,0 +1,205 @@
+{
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "routers": {
+                "192.0.2.4": {
+                    "lsa_types": {
+                        "Router": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Network": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary Net": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary ASBR": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-5 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-7 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Link": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Area": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque AS": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        }
+                    }
+                },
+                "192.0.2.3": {
+                    "lsa_types": {
+                        "Router": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Network": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary Net": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary ASBR": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-5 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-7 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Link": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Area": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque AS": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        }
+                    }
+                },
+                "192.0.2.2": {
+                    "lsa_types": {
+                        "Router": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Network": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary Net": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary ASBR": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-5 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-7 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Link": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Area": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque AS": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        }
+                    }
+                },
+                "192.0.2.1": {
+                    "lsa_types": {
+                        "Router": {
+                            "count": 1,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Network": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary Net": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Summary ASBR": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-5 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Type-7 Ext": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Link": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque Area": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        },
+                        "Opaque AS": {
+                            "count": 0,
+                            "delete": 0,
+                            "maxage": 0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_database_database-summary_detail/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_database_database-summary_detail/001_basic/input.txt
@@ -1,0 +1,53 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+Router 192.0.2.4 LSA summary
+  LSA Type      Count    Delete   Maxage
+  Router        1        0        0
+  Network       1        0        0
+  Summary Net   0        0        0
+  Summary ASBR  0        0        0
+  Type-5 Ext    0        0        0
+  Type-7 Ext    0        0        0
+  Opaque Link   0        0        0
+  Opaque Area   0        0        0
+  Opaque AS     0        0        0
+  Total         2        0        0
+
+Router 192.0.2.3 LSA summary
+  LSA Type      Count    Delete   Maxage
+  Router        1        0        0
+  Network       1        0        0
+  Summary Net   0        0        0
+  Summary ASBR  0        0        0
+  Type-5 Ext    0        0        0
+  Type-7 Ext    0        0        0
+  Opaque Link   0        0        0
+  Opaque Area   0        0        0
+  Opaque AS     0        0        0
+  Total         2        0        0
+
+Router 192.0.2.2 LSA summary
+  LSA Type      Count    Delete   Maxage
+  Router        1        0        0
+  Network       1        0        0
+  Summary Net   0        0        0
+  Summary ASBR  0        0        0
+  Type-5 Ext    0        0        0
+  Type-7 Ext    0        0        0
+  Opaque Link   0        0        0
+  Opaque Area   0        0        0
+  Opaque AS     0        0        0
+  Total         2        0        0
+
+Router 192.0.2.1 LSA summary
+  LSA Type      Count    Delete   Maxage
+  Router        1        0        0
+  Network       0        0        0
+  Summary Net   0        0        0
+  Summary ASBR  0        0        0
+  Type-5 Ext    0        0        0
+  Type-7 Ext    0        0        0
+  Opaque Link   0        0        0
+  Opaque Area   0        0        0
+  Opaque AS     0        0        0
+  Total         1        0        0

--- a/tests/parsers/iosxe/show_ip_ospf_database_database-summary_detail/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_database_database-summary_detail/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single OSPF process with four advertising routers (C9300 physical testbed)
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf database database-summary detail` on Cisco IOS-XE. Output is keyed by OSPF process ID, then by advertising router ID, with per-LSA-type counters (count/delete/maxage).
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in the issue. Note: issue sample was truncated to first 50 of 161 lines; coverage is limited to a single-process, four-router scenario.

Closes #1173

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_database_database-summary_detail" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_database_database_summary_detail.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_database_database_summary_detail.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)