### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf <process-id>`

### DIFF
--- a/changes/1178.parser_added
+++ b/changes/1178.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf <process-id>` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf.py
@@ -594,6 +594,7 @@ def _parse_process(
 
 
 @register(OS.CISCO_IOSXE, "show ip ospf")
+@register(OS.CISCO_IOSXE, r"show ip ospf (?P<process_id>\d+)")
 class ShowIpOspfParser(BaseParser[ShowIpOspfResult]):
     """Parser for 'show ip ospf' command.
 

--- a/tests/parsers/iosxe/show_ip_ospf_1/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_1/001_basic/expected.json
@@ -1,0 +1,68 @@
+{
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "areas": {
+                "0": {
+                    "area_type": "backbone",
+                    "num_interfaces": 3,
+                    "num_loopback_interfaces": 1,
+                    "authentication": "no authentication",
+                    "spf_last_executed": "1w5d",
+                    "spf_executions": 282,
+                    "num_lsa": 7,
+                    "lsa_checksum_sum": "0x041E6B",
+                    "num_opaque_link_lsa": 0,
+                    "opaque_link_lsa_checksum": "0x000000",
+                    "num_dcbitless_lsa": 0,
+                    "num_indication_lsa": 0,
+                    "num_donotage_lsa": 0
+                }
+            },
+            "max_lsa_allowed": 50000,
+            "current_non_self_lsa": 5,
+            "max_lsa_warning_threshold_pct": 75,
+            "max_lsa_ignore_time_mins": 5,
+            "max_lsa_reset_time_mins": 10,
+            "max_lsa_ignore_count_allowed": 5,
+            "max_lsa_current_ignore_count": 0,
+            "event_log_enabled": true,
+            "event_log_max_events": 1000,
+            "event_log_mode": "cyclic",
+            "incremental_spf_enabled": false,
+            "per_prefix_distribution_enabled": false,
+            "lsa_group_pacing_secs": 240,
+            "interface_flood_pacing_timer_ms": 33,
+            "retransmission_pacing_timer_ms": 66,
+            "adjacency_limit_initial": 300,
+            "adjacency_limit_max": 300,
+            "num_external_lsa": 0,
+            "external_lsa_checksum": "0x000000",
+            "num_opaque_as_lsa": 0,
+            "opaque_as_lsa_checksum": "0x000000",
+            "num_dcbitless_external_opaque_as_lsa": 0,
+            "num_donotage_external_opaque_as_lsa": 0,
+            "num_areas": 1,
+            "num_normal_areas": 1,
+            "num_stub_areas": 0,
+            "num_nssa_areas": 0,
+            "num_transit_capable_areas": 0,
+            "external_flood_list_length": 0,
+            "nsf_ietf_helper": true,
+            "nsf_cisco_helper": true,
+            "bfd_enabled": true,
+            "reference_bandwidth_mbps": 100,
+            "spf_timers": {
+                "initial_delay_ms": 50,
+                "min_hold_ms": 200,
+                "max_wait_ms": 5000
+            },
+            "lsa_throttle": {
+                "initial_delay_ms": 50,
+                "min_hold_ms": 200,
+                "max_wait_ms": 5000,
+                "min_arrival_ms": 100
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_1/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_1/001_basic/input.txt
@@ -1,0 +1,50 @@
+Routing Process "ospf 1" with ID 192.0.2.3
+ Start time: 00:55:14.937, Time elapsed: 6w5d
+ Supports only single TOS(TOS0) routes
+ Supports opaque LSA
+ Supports Link-local Signaling (LLS)
+ Supports area transit capability
+ Supports NSSA (compatible with RFC 3101)
+ Supports Database Exchange Summary List Optimization (RFC 5243)
+ Maximum number of non self-generated LSA allowed 50000
+    Current number of non self-generated LSA 5
+    Threshold for warning message 75%
+    Ignore-time 5 minutes, reset-time 10 minutes
+    Ignore-count allowed 5, current ignore-count 0
+ Event-log enabled, Maximum number of events: 1000, Mode: cyclic
+ Router is not originating router-LSAs with maximum metric
+ Initial SPF schedule delay 50 msecs
+ Minimum hold time between two consecutive SPFs 200 msecs
+ Maximum wait time between two consecutive SPFs 5000 msecs
+ Incremental-SPF disabled
+ Per-prefix-distribution disabled
+ Initial LSA throttle delay 50 msecs
+ Minimum hold time for LSA throttle 200 msecs
+ Maximum wait time for LSA throttle 5000 msecs
+ Minimum LSA arrival 100 msecs
+ LSA group pacing timer 240 secs
+ Interface flood pacing timer 33 msecs
+ Retransmission pacing timer 66 msecs
+ EXCHANGE/LOADING adjacency limit: initial 300, process maximum 300
+ Number of external LSA 0. Checksum Sum 0x000000
+ Number of opaque AS LSA 0. Checksum Sum 0x000000
+ Number of DCbitless external and opaque AS LSA 0
+ Number of DoNotAge external and opaque AS LSA 0
+ Number of areas in this router is 1. 1 normal 0 stub 0 nssa
+ Number of areas transit capable is 0
+ External flood list length 0
+ IETF NSF helper support enabled
+ Cisco NSF helper support enabled
+ BFD is enabled
+ Reference bandwidth unit is 100 mbps
+    Area BACKBONE(0)
+        Number of interfaces in this area is 3 (1 loopback)
+        Area has no authentication
+        SPF algorithm last executed 1w5d ago
+        SPF algorithm executed 282 times
+        Area ranges are
+        Number of LSA 7. Checksum Sum 0x041E6B
+        Number of opaque link LSA 0. Checksum Sum 0x000000
+        Number of DCbitless LSA 0
+        Number of indication LSA 0
+        Number of DoNotAge LSA 0

--- a/tests/parsers/iosxe/show_ip_ospf_1/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_1/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Single OSPF process with backbone area (C9300-48U physical testbed)
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds regex registration `show ip ospf (?P<process_id>\d+)` to the existing `ShowIpOspfParser`, enabling parsing of process-specific OSPF output (e.g. `show ip ospf 1`). The output format is identical to `show ip ospf` so no new parser logic is needed — only a stacked `@register` decorator.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in the issue.

Closes #1178

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_1" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: regex registration for show ip ospf <process-id> + fixture

<!-- Generated with Claude Code -->