### PR TITLE
feat(cisco_iosxe): add parser for `show crypto pki trustpoint`

### DIFF
--- a/changes/1179.parser_added
+++ b/changes/1179.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto pki trustpoint` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint.py
@@ -1,0 +1,165 @@
+"""Parser for 'show crypto pki trustpoint' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Trustpoint header, e.g. ``Trustpoint TP-self-signed-4032138694:``
+_TRUSTPOINT_HEADER_RE = re.compile(r"^\s*Trustpoint\s+(?P<name>.+?)\s*:\s*$")
+
+# Serial Number (hex): 01
+_SERIAL_RE = re.compile(r"^\s*Serial\s+Number\s*\(hex\)\s*:\s*(?P<serial>\S+)\s*$")
+
+# DN attribute line, e.g. ``cn=IOS-Self-Signed-Certificate-4032138694``
+_DN_ATTR_RE = re.compile(r"^\s+(?P<key>\w+)=(?P<value>.+?)\s*$")
+
+# ``Using key label <label>``
+_KEY_LABEL_RE = re.compile(r"^\s*Using\s+key\s+label\s+(?P<label>\S+)\s*$")
+
+
+class TrustpointEntry(TypedDict):
+    """Schema for a single trustpoint entry.
+
+    Attributes:
+        subject_name: Mapping of DN attribute abbreviation to value
+            (e.g. ``{"cn": "...", "o": "..."}``) using standard X.509
+            attribute short names.
+        serial_number_hex: Certificate serial number in hexadecimal.
+        status: Status description line (e.g. "Certificate configured.",
+            "Persistent self-signed certificate trust point").
+        key_label: Key label when the trustpoint uses a named key.
+            Omitted when not present.
+    """
+
+    subject_name: dict[str, str]
+    serial_number_hex: str
+    status: str
+    key_label: NotRequired[str]
+
+
+class ShowCryptoPkiTrustpointResult(TypedDict):
+    """Schema for 'show crypto pki trustpoint' parsed output.
+
+    Keyed by trustpoint name.
+    """
+
+    trustpoints: dict[str, TrustpointEntry]
+
+
+def _is_subject_name_header(line: str) -> bool:
+    """Return True when line is the 'Subject Name:' section header."""
+    return line.strip().lower() == "subject name:"
+
+
+def _is_status_line(line: str) -> bool:
+    """Return True when the line is a known status/description line.
+
+    Status lines are indented text that are not DN attributes, not
+    serial number lines, not key label lines, and not the Subject Name
+    header.  They describe the trustpoint state.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return False
+    # Must be indented content that doesn't match other patterns
+    if _DN_ATTR_RE.match(line):
+        return False
+    if _SERIAL_RE.match(line):
+        return False
+    if _KEY_LABEL_RE.match(line):
+        return False
+    if _is_subject_name_header(line):
+        return False
+    if _TRUSTPOINT_HEADER_RE.match(line):
+        return False
+    return True
+
+
+def _parse_trustpoint_block(
+    lines: list[str],
+) -> TrustpointEntry:
+    """Parse a single trustpoint block into a TrustpointEntry.
+
+    Expects lines after the ``Trustpoint <name>:`` header.
+    """
+    entry: dict[str, object] = {"subject_name": {}}
+    subject_name = cast(dict[str, str], entry["subject_name"])
+
+    for line in lines:
+        serial_m = _SERIAL_RE.match(line)
+        if serial_m:
+            entry["serial_number_hex"] = serial_m.group("serial")
+            continue
+
+        dn_m = _DN_ATTR_RE.match(line)
+        if dn_m:
+            subject_name[dn_m.group("key")] = dn_m.group("value")
+            continue
+
+        key_m = _KEY_LABEL_RE.match(line)
+        if key_m:
+            entry["key_label"] = key_m.group("label")
+            continue
+
+        if _is_subject_name_header(line):
+            continue
+
+        if _is_status_line(line):
+            entry["status"] = line.strip()
+
+    return cast(TrustpointEntry, entry)
+
+
+@register(OS.CISCO_IOSXE, "show crypto pki trustpoint")
+class ShowCryptoPkiTrustpointParser(
+    BaseParser["ShowCryptoPkiTrustpointResult"],
+):
+    """Parser for 'show crypto pki trustpoint' on IOS-XE.
+
+    Produces a mapping of trustpoint name to its parsed entry including
+    subject name DN attributes, serial number, status description, and
+    optional key label.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoPkiTrustpointResult:
+        """Parse 'show crypto pki trustpoint' output.
+
+        Args:
+            output: Raw CLI output from the device.
+
+        Returns:
+            Structured mapping of trustpoint name to its parsed entry.
+
+        Raises:
+            ValueError: If no trustpoint entries are found in the output.
+        """
+        trustpoints: dict[str, TrustpointEntry] = {}
+        current_name: str | None = None
+        current_lines: list[str] = []
+
+        for line in output.splitlines():
+            header_m = _TRUSTPOINT_HEADER_RE.match(line)
+            if header_m:
+                if current_name is not None:
+                    trustpoints[current_name] = _parse_trustpoint_block(current_lines)
+                current_name = header_m.group("name")
+                current_lines = []
+                continue
+            if current_name is not None:
+                current_lines.append(line)
+
+        if current_name is not None:
+            trustpoints[current_name] = _parse_trustpoint_block(current_lines)
+
+        if not trustpoints:
+            msg = "No trustpoint entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowCryptoPkiTrustpointResult, {"trustpoints": trustpoints})

--- a/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint.py
@@ -36,8 +36,8 @@ class TrustpointEntry(TypedDict):
     """
 
     subject_name: dict[str, str]
-    serial_number_hex: str
-    status: str
+    serial_number_hex: NotRequired[str]
+    status: NotRequired[str]
     key_label: NotRequired[str]
 
 

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoint/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoint/001_basic/expected.json
@@ -1,0 +1,60 @@
+{
+    "trustpoints": {
+        "TP-self-signed-4032138694": {
+            "subject_name": {
+                "cn": "IOS-Self-Signed-Certificate-4032138694"
+            },
+            "serial_number_hex": "01",
+            "status": "Persistent self-signed certificate trust point",
+            "key_label": "TP-self-signed-4032138694"
+        },
+        "SLA-TrustPoint": {
+            "subject_name": {
+                "cn": "Cisco Licensing Root CA",
+                "o": "Cisco"
+            },
+            "serial_number_hex": "01",
+            "status": "Certificate configured."
+        },
+        "CISCO_IDEVID_SUDI": {
+            "subject_name": {
+                "o": "Cisco",
+                "cn": "High Assurance SUDI CA"
+            },
+            "serial_number_hex": "0A6475524CD8617C62",
+            "status": "Certificate configured."
+        },
+        "CISCO_IDEVID_SUDI0": {
+            "subject_name": {
+                "cn": "Cisco Root CA 2099",
+                "o": "Cisco"
+            },
+            "serial_number_hex": "019A335878CE16C1C1",
+            "status": "Certificate configured."
+        },
+        "CISCO_IDEVID_CMCA2_SUDI": {
+            "subject_name": {
+                "cn": "Cisco Manufacturing CA SHA2",
+                "o": "Cisco"
+            },
+            "serial_number_hex": "02",
+            "status": "Certificate configured."
+        },
+        "CISCO_IDEVID_CMCA2_SUDI0": {
+            "subject_name": {
+                "cn": "Cisco Root CA M2",
+                "o": "Cisco"
+            },
+            "serial_number_hex": "01",
+            "status": "Certificate configured."
+        },
+        "CISCO_IDEVID_CMCA_SUDI": {
+            "subject_name": {
+                "cn": "Cisco Manufacturing CA",
+                "o": "Cisco Systems"
+            },
+            "serial_number_hex": "6A6967B3000000000003",
+            "status": "Certificate configured."
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoint/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoint/001_basic/input.txt
@@ -1,0 +1,54 @@
+Trustpoint TP-self-signed-4032138694:
+    Subject Name:
+    cn=IOS-Self-Signed-Certificate-4032138694
+          Serial Number (hex): 01
+    Persistent self-signed certificate trust point
+    Using key label TP-self-signed-4032138694
+
+
+Trustpoint SLA-TrustPoint:
+    Subject Name:
+    cn=Cisco Licensing Root CA
+    o=Cisco
+          Serial Number (hex): 01
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_SUDI:
+    Subject Name:
+    o=Cisco
+    cn=High Assurance SUDI CA
+          Serial Number (hex): 0A6475524CD8617C62
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_SUDI0:
+    Subject Name:
+    cn=Cisco Root CA 2099
+    o=Cisco
+          Serial Number (hex): 019A335878CE16C1C1
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_CMCA2_SUDI:
+    Subject Name:
+    cn=Cisco Manufacturing CA SHA2
+    o=Cisco
+          Serial Number (hex): 02
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_CMCA2_SUDI0:
+    Subject Name:
+    cn=Cisco Root CA M2
+    o=Cisco
+          Serial Number (hex): 01
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_CMCA_SUDI:
+    Subject Name:
+    cn=Cisco Manufacturing CA
+    o=Cisco Systems
+          Serial Number (hex): 6A6967B3000000000003
+    Certificate configured.

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoint/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoint/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: show crypto pki trustpoint output from physical testbed device (TAC-S1)
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto pki trustpoint` on Cisco IOS-XE that produces a `dict[str, TrustpointEntry]` keyed by trustpoint name, extracting subject DN attributes, serial number (hex), status description, and optional key label.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1179. Coverage limited to the common trustpoint fields shown in the sample; future fixtures can cover additional attributes (e.g., enrollment mode, revocation check).

Closes #1179

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_pki_trustpoint -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_pki_trustpoint.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_pki_trustpoint.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)