### PR TITLE
feat(cisco_iosxe): add parser for `show crypto pki trustpoint status`

### DIFF
--- a/changes/1175.parser_added
+++ b/changes/1175.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto pki trustpoint status` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint_status.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint_status.py
@@ -1,0 +1,301 @@
+"""Parser for 'show crypto pki trustpoint status' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Trustpoint header, e.g. ``Trustpoint TP-self-signed-4032138694:``
+_TRUSTPOINT_HEADER_RE = re.compile(r"^Trustpoint\s+(?P<name>\S+)\s*:\s*$")
+
+# Certificate section header, e.g. ``Issuing CA certificate configured:``
+# or ``Router General Purpose certificate configured:``
+_CERT_SECTION_RE = re.compile(
+    r"^\s+(?P<type>.+?)\s+certificate\s+configured\s*:\s*$", re.IGNORECASE
+)
+
+# Subject Name line (the label, not the value)
+_SUBJECT_NAME_LABEL_RE = re.compile(r"^\s+Subject Name\s*:\s*$")
+
+# Subject Name value (indented DN line, e.g. ``cn=...,o=...``)
+_SUBJECT_NAME_VALUE_RE = re.compile(r"^\s+(?P<dn>\S.*\S)\s*$")
+
+# Fingerprint lines
+_FINGERPRINT_MD5_RE = re.compile(
+    r"^\s+Fingerprint MD5\s*:\s*(?P<value>[0-9A-Fa-f ]+)\s*$"
+)
+_FINGERPRINT_SHA1_RE = re.compile(
+    r"^\s+Fingerprint SHA1\s*:\s*(?P<value>[0-9A-Fa-f ]+)\s*$"
+)
+
+# State section header
+_STATE_HEADER_RE = re.compile(r"^\s+State\s*:\s*$")
+
+# State key-value lines, e.g.
+# ``Keys generated ............. Yes (General Purpose, non-exportable)``
+_STATE_LINE_RE = re.compile(
+    r"^\s+(?P<label>[A-Za-z][A-Za-z() ]+?)\s+\.{2,}\s+(?P<value>.+?)\s*$"
+)
+
+# Map state labels to canonical field names
+_STATE_LABEL_MAP: dict[str, str] = {
+    "keys generated": "keys_generated",
+    "issuing ca authenticated": "issuing_ca_authenticated",
+    "certificate request(s)": "certificate_requests",
+}
+
+
+class CertificateInfo(TypedDict):
+    """Schema for a configured certificate within a trustpoint."""
+
+    subject_name: str
+    fingerprint_md5: NotRequired[str]
+    fingerprint_sha1: NotRequired[str]
+
+
+class TrustpointState(TypedDict):
+    """Schema for the state section of a trustpoint."""
+
+    keys_generated: NotRequired[str]
+    issuing_ca_authenticated: NotRequired[str]
+    certificate_requests: NotRequired[str]
+
+
+class TrustpointEntry(TypedDict):
+    """Schema for a single trustpoint entry."""
+
+    name: str
+    certificates: NotRequired[dict[str, CertificateInfo]]
+    state: NotRequired[TrustpointState]
+
+
+class ShowCryptoPkiTrustpointStatusResult(TypedDict):
+    """Schema for 'show crypto pki trustpoint status' parsed output.
+
+    Keyed by trustpoint name.
+    """
+
+    trustpoints: dict[str, TrustpointEntry]
+
+
+def _normalize_cert_type(raw: str) -> str:
+    """Normalize certificate type to a canonical key.
+
+    Examples:
+        'Issuing CA' -> 'issuing_ca'
+        'Router General Purpose' -> 'router_general_purpose'
+    """
+    return raw.strip().lower().replace(" ", "_")
+
+
+def _parse_state_label(label: str) -> str | None:
+    """Map a state label to its canonical field name."""
+    return _STATE_LABEL_MAP.get(label.strip().lower())
+
+
+def _is_section_boundary(line: str) -> bool:
+    """Return True if the line starts a new major section."""
+    return bool(
+        _TRUSTPOINT_HEADER_RE.match(line)
+        or _CERT_SECTION_RE.match(line)
+        or _STATE_HEADER_RE.match(line)
+    )
+
+
+def _try_fingerprint(line: str, cert_info: dict[str, str]) -> bool:
+    """Try to match a fingerprint line and store it.
+
+    Returns True if a fingerprint was matched.
+    """
+    fp_md5 = _FINGERPRINT_MD5_RE.match(line)
+    if fp_md5:
+        cert_info["fingerprint_md5"] = fp_md5.group("value").strip()
+        return True
+    fp_sha1 = _FINGERPRINT_SHA1_RE.match(line)
+    if fp_sha1:
+        cert_info["fingerprint_sha1"] = fp_sha1.group("value").strip()
+        return True
+    return False
+
+
+def _collect_subject_name(
+    lines: list[str],
+    idx: int,
+    cert_info: dict[str, str],
+) -> tuple[list[str], int]:
+    """Collect subject name DN parts until a fingerprint or section boundary.
+
+    Returns the list of DN parts and the next index to process.
+    """
+    subject_parts: list[str] = []
+    while idx < len(lines):
+        line = lines[idx]
+        if _is_section_boundary(line) or _try_fingerprint(line, cert_info):
+            break
+        val_match = _SUBJECT_NAME_VALUE_RE.match(line)
+        if val_match:
+            subject_parts.append(val_match.group("dn"))
+        idx += 1
+    return subject_parts, idx
+
+
+def _try_parse_certificate_section(
+    lines: list[str],
+    idx: int,
+    trustpoint: dict,
+) -> int:
+    r"""Parse a certificate section starting at idx.
+
+    Returns the next index to continue processing from.
+    """
+    match = _CERT_SECTION_RE.match(lines[idx])
+    if match is None:
+        return idx
+    cert_type = _normalize_cert_type(match.group("type"))
+    idx += 1
+    cert_info: dict[str, str] = {}
+    subject_parts: list[str] = []
+
+    while idx < len(lines):
+        line = lines[idx]
+
+        if _is_section_boundary(line):
+            break
+
+        if _SUBJECT_NAME_LABEL_RE.match(line):
+            idx += 1
+            parts, idx = _collect_subject_name(lines, idx, cert_info)
+            subject_parts.extend(parts)
+            continue
+
+        if _try_fingerprint(line, cert_info):
+            idx += 1
+            continue
+
+        if not line.strip():
+            idx += 1
+            break
+
+        idx += 1
+
+    if subject_parts:
+        cert_info["subject_name"] = ",".join(subject_parts)
+
+    if cert_info:
+        certs = trustpoint.setdefault("certificates", {})
+        certs[cert_type] = cert_info
+
+    return idx
+
+
+def _try_parse_state_section(
+    lines: list[str],
+    idx: int,
+    trustpoint: dict,
+) -> int:
+    """Parse the State section starting at idx.
+
+    Returns the next index to continue processing from.
+    """
+    if not _STATE_HEADER_RE.match(lines[idx]):
+        return idx
+    idx += 1
+    state: dict[str, str] = {}
+
+    while idx < len(lines):
+        line = lines[idx]
+
+        if _TRUSTPOINT_HEADER_RE.match(line):
+            break
+
+        if not line.strip():
+            idx += 1
+            break
+
+        state_match = _STATE_LINE_RE.match(line)
+        if state_match:
+            field = _parse_state_label(state_match.group("label"))
+            value = state_match.group("value")
+            if field and value.lower() != "none":
+                state[field] = value
+            idx += 1
+            continue
+
+        idx += 1
+
+    if state:
+        trustpoint["state"] = state
+
+    return idx
+
+
+@register(OS.CISCO_IOSXE, "show crypto pki trustpoint status")
+class ShowCryptoPkiTrustpointStatusParser(
+    BaseParser["ShowCryptoPkiTrustpointStatusResult"],
+):
+    """Parser for 'show crypto pki trustpoint status' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoPkiTrustpointStatusResult:
+        """Parse 'show crypto pki trustpoint status' output.
+
+        Args:
+            output: Raw CLI output from the device.
+
+        Returns:
+            Structured mapping of trustpoint name to its parsed entry.
+
+        Raises:
+            ValueError: If no trustpoint entries are found in output.
+        """
+        lines = output.splitlines()
+        trustpoints: dict[str, TrustpointEntry] = {}
+        idx = 0
+
+        while idx < len(lines):
+            line = lines[idx]
+
+            header = _TRUSTPOINT_HEADER_RE.match(line)
+            if header:
+                tp_name = header.group("name")
+                trustpoint: dict = {"name": tp_name}
+                idx += 1
+
+                # Parse sections within this trustpoint
+                while idx < len(lines):
+                    cur_line = lines[idx]
+
+                    # Next trustpoint starts
+                    if _TRUSTPOINT_HEADER_RE.match(cur_line):
+                        break
+
+                    if _CERT_SECTION_RE.match(cur_line):
+                        idx = _try_parse_certificate_section(lines, idx, trustpoint)
+                        continue
+
+                    if _STATE_HEADER_RE.match(cur_line):
+                        idx = _try_parse_state_section(lines, idx, trustpoint)
+                        continue
+
+                    idx += 1
+
+                trustpoints[tp_name] = cast(TrustpointEntry, trustpoint)
+            else:
+                idx += 1
+
+        if not trustpoints:
+            msg = (
+                "No trustpoint entries found in output; output does not "
+                "appear to be from 'show crypto pki trustpoint status'."
+            )
+            raise ValueError(msg)
+
+        return cast(
+            ShowCryptoPkiTrustpointStatusResult,
+            {"trustpoints": trustpoints},
+        )

--- a/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint_status.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_trustpoint_status.py
@@ -51,7 +51,7 @@ _STATE_LABEL_MAP: dict[str, str] = {
 class CertificateInfo(TypedDict):
     """Schema for a configured certificate within a trustpoint."""
 
-    subject_name: str
+    subject_name: NotRequired[str]
     fingerprint_md5: NotRequired[str]
     fingerprint_sha1: NotRequired[str]
 

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoint_status/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoint_status/001_basic/expected.json
@@ -1,0 +1,78 @@
+{
+    "trustpoints": {
+        "TP-self-signed-4032138694": {
+            "name": "TP-self-signed-4032138694",
+            "certificates": {
+                "issuing_ca": {
+                    "fingerprint_md5": "59570F0F FF433CFE 9D67FB99 F65D6FF4",
+                    "fingerprint_sha1": "35242059 349E5C9E 65CB24E8 FF5F6F25 7E938FFF",
+                    "subject_name": "cn=IOS-Self-Signed-Certificate-4032138694"
+                },
+                "router_general_purpose": {
+                    "fingerprint_md5": "59570F0F FF433CFE 9D67FB99 F65D6FF4",
+                    "fingerprint_sha1": "35242059 349E5C9E 65CB24E8 FF5F6F25 7E938FFF",
+                    "subject_name": "cn=IOS-Self-Signed-Certificate-4032138694"
+                }
+            },
+            "state": {
+                "keys_generated": "Yes (General Purpose, non-exportable)",
+                "issuing_ca_authenticated": "Yes",
+                "certificate_requests": "Yes"
+            }
+        },
+        "SLA-TrustPoint": {
+            "name": "SLA-TrustPoint",
+            "certificates": {
+                "issuing_ca": {
+                    "fingerprint_md5": "1468DC18 250BDFCF 769C29DF E1F7E5A8",
+                    "fingerprint_sha1": "5CA95FB6 E2980EC1 5AFB681B BB7E62B5 AD3FA8B8",
+                    "subject_name": "cn=Cisco Licensing Root CA,o=Cisco"
+                }
+            },
+            "state": {
+                "keys_generated": "Yes (General Purpose, non-exportable)",
+                "issuing_ca_authenticated": "Yes"
+            }
+        },
+        "CISCO_IDEVID_SUDI": {
+            "name": "CISCO_IDEVID_SUDI",
+            "certificates": {
+                "issuing_ca": {
+                    "fingerprint_md5": "E6897BC6 27D7C558 A2330EC7 C2D7A10B",
+                    "fingerprint_sha1": "F81D5550 D67DCD1D D11192B5 7F8FDE09 A4A569B7",
+                    "subject_name": "o=Cisco,cn=High Assurance SUDI CA"
+                },
+                "router_general_purpose": {
+                    "fingerprint_md5": "04FCE6C7 F25C319C 59DF59E8 DBBC407B",
+                    "fingerprint_sha1": "5C5016A4 A5E306DD C840392F 84F19663 4745B3BA",
+                    "subject_name": "cn=C9300-48U,ou=ACT-2 Lite SUDI,o=Cisco,serialNumber=PID:C9300-48U SN:FCW2419C0LC"
+                }
+            },
+            "state": {
+                "keys_generated": "Yes (General Purpose, non-exportable)",
+                "issuing_ca_authenticated": "Yes",
+                "certificate_requests": "Yes"
+            }
+        },
+        "CISCO_IDEVID_SUDI0": {
+            "name": "CISCO_IDEVID_SUDI0",
+            "certificates": {
+                "issuing_ca": {
+                    "fingerprint_md5": "3D5C1E5A 1C7C4AB0 0A28EF6D 57D9A3A1",
+                    "fingerprint_sha1": "30AD0581 3CB0F1B8 14D542C8 54C75A0E 3A0D4C4F",
+                    "subject_name": "cn=Cisco Manufacturing CA SHA2,o=Cisco"
+                },
+                "router_general_purpose": {
+                    "fingerprint_md5": "4B5B9BD0 2CEF3DB4 5EFF2DCA 09C3CA28",
+                    "fingerprint_sha1": "7890CCD9 38FFE6E9 F2BF35F0 82CE1F23 5EA3EA3D",
+                    "subject_name": "cn=C9300-48U,ou=ACT-2 Lite SUDI,o=Cisco,serialNumber=PID:C9300-48U SN:FCW2419C0LC"
+                }
+            },
+            "state": {
+                "keys_generated": "Yes (General Purpose, non-exportable)",
+                "issuing_ca_authenticated": "Yes",
+                "certificate_requests": "Yes"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoint_status/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoint_status/001_basic/input.txt
@@ -1,0 +1,61 @@
+Trustpoint TP-self-signed-4032138694:
+  Issuing CA certificate configured:
+    Subject Name:
+     cn=IOS-Self-Signed-Certificate-4032138694
+    Fingerprint MD5: 59570F0F FF433CFE 9D67FB99 F65D6FF4
+    Fingerprint SHA1: 35242059 349E5C9E 65CB24E8 FF5F6F25 7E938FFF
+  Router General Purpose certificate configured:
+    Subject Name:
+     cn=IOS-Self-Signed-Certificate-4032138694
+    Fingerprint MD5: 59570F0F FF433CFE 9D67FB99 F65D6FF4
+    Fingerprint SHA1: 35242059 349E5C9E 65CB24E8 FF5F6F25 7E938FFF
+  State:
+    Keys generated ............. Yes (General Purpose, non-exportable)
+    Issuing CA authenticated ....... Yes
+    Certificate request(s) ..... Yes
+
+
+Trustpoint SLA-TrustPoint:
+  Issuing CA certificate configured:
+    Subject Name:
+     cn=Cisco Licensing Root CA,o=Cisco
+    Fingerprint MD5: 1468DC18 250BDFCF 769C29DF E1F7E5A8
+    Fingerprint SHA1: 5CA95FB6 E2980EC1 5AFB681B BB7E62B5 AD3FA8B8
+  State:
+    Keys generated ............. Yes (General Purpose, non-exportable)
+    Issuing CA authenticated ....... Yes
+    Certificate request(s) ..... None
+
+
+Trustpoint CISCO_IDEVID_SUDI:
+  Issuing CA certificate configured:
+    Subject Name:
+     o=Cisco,cn=High Assurance SUDI CA
+    Fingerprint MD5: E6897BC6 27D7C558 A2330EC7 C2D7A10B
+    Fingerprint SHA1: F81D5550 D67DCD1D D11192B5 7F8FDE09 A4A569B7
+  Router General Purpose certificate configured:
+    Subject Name:
+     cn=C9300-48U,ou=ACT-2 Lite SUDI,o=Cisco,serialNumber=PID:C9300-48U SN:FCW2419C0LC
+    Fingerprint MD5: 04FCE6C7 F25C319C 59DF59E8 DBBC407B
+    Fingerprint SHA1: 5C5016A4 A5E306DD C840392F 84F19663 4745B3BA
+  State:
+    Keys generated ............. Yes (General Purpose, non-exportable)
+    Issuing CA authenticated ....... Yes
+    Certificate request(s) ..... Yes
+
+
+Trustpoint CISCO_IDEVID_SUDI0:
+  Issuing CA certificate configured:
+    Subject Name:
+     cn=Cisco Manufacturing CA SHA2,o=Cisco
+    Fingerprint MD5: 3D5C1E5A 1C7C4AB0 0A28EF6D 57D9A3A1
+    Fingerprint SHA1: 30AD0581 3CB0F1B8 14D542C8 54C75A0E 3A0D4C4F
+  Router General Purpose certificate configured:
+    Subject Name:
+     cn=C9300-48U,ou=ACT-2 Lite SUDI,o=Cisco,serialNumber=PID:C9300-48U SN:FCW2419C0LC
+    Fingerprint MD5: 4B5B9BD0 2CEF3DB4 5EFF2DCA 09C3CA28
+    Fingerprint SHA1: 7890CCD9 38FFE6E9 F2BF35F0 82CE1F23 5EA3EA3D
+  State:
+    Keys generated ............. Yes (General Purpose, non-exportable)
+    Issuing CA authenticated ....... Yes
+    Certificate request(s) ..... Yes

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoint_status/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoint_status/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show crypto pki trustpoint status with multiple trustpoints
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto pki trustpoint status` on Cisco IOS-XE that produces a `dict[str, TrustpointEntry]` keyed by trustpoint name, with nested certificate info (subject name, MD5/SHA1 fingerprints) and state fields (keys generated, CA authenticated, certificate requests).
- Fixture captured from a C9300-48U running IOS-XE 17.18.02; issue sample was truncated to 50/115 lines so 4 trustpoints are covered in the fixture.

Closes #1175

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_pki_trustpoint_status -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_pki_trustpoint_status.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_pki_trustpoint_status.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

---
Generated with [Claude Code](https://claude.com/claude-code)