### PR TITLE
feat(cisco_iosxe): add parser for `show crypto pki trustpoints`

### DIFF
--- a/changes/1180.parser_added
+++ b/changes/1180.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto pki trustpoints` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_pki_trustpoints.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_trustpoints.py
@@ -1,0 +1,160 @@
+"""Parser for 'show crypto pki trustpoints' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Module-level compiled regexes
+_TRUSTPOINT_HEADER_RE = re.compile(r"^Trustpoint\s+(.+?)\s*:\s*$")
+_SUBJECT_NAME_RE = re.compile(r"^\s+Subject Name:\s*$")
+_DN_ATTR_RE = re.compile(r"^\s+(\w+)=(.+?)\s*$")
+_SERIAL_RE = re.compile(r"^\s+Serial Number\s*\(hex\)\s*:\s*([0-9A-Fa-f]+)\s*$")
+_KEY_LABEL_RE = re.compile(r"^\s+Using key label\s+(.+?)\s*$")
+
+
+class TrustpointEntry(TypedDict):
+    """Schema for a single trustpoint entry."""
+
+    subject_name: NotRequired[dict[str, str]]
+    serial_number: NotRequired[str]
+    status: NotRequired[str]
+    key_label: NotRequired[str]
+
+
+class ShowCryptoPkiTrustpointsResult(TypedDict):
+    """Schema for 'show crypto pki trustpoints' parsed output.
+
+    Keyed by trustpoint name.
+    """
+
+    trustpoints: dict[str, TrustpointEntry]
+
+
+class _ParseState:
+    """Mutable state for the trustpoint parser loop."""
+
+    __slots__ = (
+        "current_name",
+        "current_entry",
+        "in_subject_name",
+        "subject_dn",
+        "trustpoints",
+    )
+
+    def __init__(self) -> None:
+        self.trustpoints: dict[str, TrustpointEntry] = {}
+        self.current_name: str | None = None
+        self.current_entry: dict[str, str | dict[str, str]] = {}
+        self.in_subject_name: bool = False
+        self.subject_dn: dict[str, str] = {}
+
+    def start_new_trustpoint(self, name: str) -> None:
+        """Finalize current entry and start a new trustpoint."""
+        _finalize_entry(self)
+        self.current_name = name
+        self.current_entry = {}
+        self.in_subject_name = False
+        self.subject_dn = {}
+
+
+def _finalize_entry(state: "_ParseState") -> None:
+    """Finalize and store the current trustpoint entry."""
+    if state.current_name is None:
+        return
+
+    if state.subject_dn:
+        state.current_entry["subject_name"] = state.subject_dn
+
+    state.trustpoints[state.current_name] = cast(
+        TrustpointEntry, dict(state.current_entry)
+    )
+
+
+def _try_detail_line(
+    line: str,
+    state: "_ParseState",
+) -> bool:
+    """Try to parse a detail line (serial, key label, or status).
+
+    Returns True if the line was consumed.
+    """
+    serial_m = _SERIAL_RE.match(line)
+    if serial_m:
+        state.current_entry["serial_number"] = serial_m.group(1)
+        return True
+
+    key_m = _KEY_LABEL_RE.match(line)
+    if key_m:
+        state.current_entry["key_label"] = key_m.group(1)
+        return True
+
+    # Status line (e.g. "Certificate configured.",
+    # "Persistent self-signed certificate trust point")
+    stripped = line.strip()
+    if stripped:
+        state.current_entry["status"] = stripped
+        return True
+
+    return False
+
+
+@register(OS.CISCO_IOSXE, "show crypto pki trustpoints")
+class ShowCryptoPkiTrustpointsParser(
+    BaseParser["ShowCryptoPkiTrustpointsResult"],
+):
+    """Parser for 'show crypto pki trustpoints' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoPkiTrustpointsResult:
+        """Parse 'show crypto pki trustpoints' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed trustpoint details keyed by trustpoint name.
+
+        Raises:
+            ValueError: If no trustpoint entries found in output.
+        """
+        state = _ParseState()
+
+        for line in output.splitlines():
+            m = _TRUSTPOINT_HEADER_RE.match(line)
+            if m:
+                state.start_new_trustpoint(m.group(1))
+                continue
+
+            if state.current_name is None:
+                continue
+
+            if _SUBJECT_NAME_RE.match(line):
+                state.in_subject_name = True
+                continue
+
+            if state.in_subject_name:
+                dn_m = _DN_ATTR_RE.match(line)
+                if dn_m:
+                    state.subject_dn[dn_m.group(1)] = dn_m.group(2)
+                    continue
+                state.in_subject_name = False
+
+            _try_detail_line(line, state)
+
+        # Finalize last entry
+        _finalize_entry(state)
+
+        if not state.trustpoints:
+            msg = "No PKI trustpoint entries found in output"
+            raise ValueError(msg)
+
+        return cast(
+            ShowCryptoPkiTrustpointsResult,
+            {"trustpoints": state.trustpoints},
+        )

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoints/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoints/001_basic/expected.json
@@ -1,0 +1,53 @@
+{
+    "trustpoints": {
+        "TP-self-signed-4032138694": {
+            "serial_number": "01",
+            "status": "Persistent self-signed certificate trust point",
+            "key_label": "TP-self-signed-4032138694",
+            "subject_name": {
+                "cn": "IOS-Self-Signed-Certificate-4032138694"
+            }
+        },
+        "SLA-TrustPoint": {
+            "serial_number": "01",
+            "status": "Certificate configured.",
+            "subject_name": {
+                "cn": "Cisco Licensing Root CA",
+                "o": "Cisco"
+            }
+        },
+        "CISCO_IDEVID_SUDI": {
+            "serial_number": "0A6475524CD8617C62",
+            "status": "Certificate configured.",
+            "subject_name": {
+                "o": "Cisco",
+                "cn": "High Assurance SUDI CA"
+            }
+        },
+        "CISCO_IDEVID_SUDI0": {
+            "serial_number": "019A335878CE16C1C1",
+            "status": "Certificate configured.",
+            "subject_name": {
+                "cn": "Cisco Root CA 2099",
+                "o": "Cisco"
+            }
+        },
+        "CISCO_IDEVID_CMCA2_SUDI": {
+            "serial_number": "02",
+            "status": "Certificate configured.",
+            "subject_name": {
+                "cn": "Cisco Manufacturing CA SHA2",
+                "o": "Cisco"
+            }
+        },
+        "CISCO_IDEVID_CMCA2_SUDI0": {
+            "serial_number": "01",
+            "status": "Certificate configured.",
+            "subject_name": {
+                "cn": "Cisco Root CA M2",
+                "o": "Cisco"
+            }
+        },
+        "CISCO_IDEVID_CMCA_SUDI": {}
+    }
+}

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoints/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoints/001_basic/input.txt
@@ -1,0 +1,50 @@
+Trustpoint TP-self-signed-4032138694:
+    Subject Name:
+    cn=IOS-Self-Signed-Certificate-4032138694
+          Serial Number (hex): 01
+    Persistent self-signed certificate trust point
+    Using key label TP-self-signed-4032138694
+
+
+Trustpoint SLA-TrustPoint:
+    Subject Name:
+    cn=Cisco Licensing Root CA
+    o=Cisco
+          Serial Number (hex): 01
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_SUDI:
+    Subject Name:
+    o=Cisco
+    cn=High Assurance SUDI CA
+          Serial Number (hex): 0A6475524CD8617C62
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_SUDI0:
+    Subject Name:
+    cn=Cisco Root CA 2099
+    o=Cisco
+          Serial Number (hex): 019A335878CE16C1C1
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_CMCA2_SUDI:
+    Subject Name:
+    cn=Cisco Manufacturing CA SHA2
+    o=Cisco
+          Serial Number (hex): 02
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_CMCA2_SUDI0:
+    Subject Name:
+    cn=Cisco Root CA M2
+    o=Cisco
+          Serial Number (hex): 01
+    Certificate configured.
+
+
+Trustpoint CISCO_IDEVID_CMCA_SUDI:
+    Subject Name:

--- a/tests/parsers/iosxe/show_crypto_pki_trustpoints/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_pki_trustpoints/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show crypto pki trustpoints output with multiple trustpoints
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto pki trustpoints` on Cisco IOS-XE that outputs a `dict[str, TrustpointEntry]` keyed by trustpoint name, extracting subject DN attributes, serial number, status description, and key label.
- Fixture sourced from a physical C9300-48U testbed running IOS-XE 17.18.02; sample was truncated at 50 of 62 lines per the issue, so the last entry appears empty.

Closes #1180

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_pki_trustpoints -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_pki_trustpoints.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_pki_trustpoints.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)