### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf topology-info`

### DIFF
--- a/changes/1182.parser_added
+++ b/changes/1182.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf topology-info` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_topology_info.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_topology_info.py
@@ -1,0 +1,224 @@
+"""Parser for 'show ip ospf topology-info' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_PROCESS_RE = re.compile(r"OSPF Router with ID \((\S+)\) \(Process ID (\d+)\)")
+_MTID_RE = re.compile(r"Base Topology \(MTID (\d+)\)")
+_TOPOLOGY_PRIORITY_RE = re.compile(r"Topology priority is (\d+)")
+_MAX_METRIC_RE = re.compile(
+    r"Router is (not )?originating router-LSAs with maximum metric"
+)
+_TRANSIT_CAPABLE_RE = re.compile(r"Number of areas transit capable is (\d+)")
+_SPF_INITIAL_RE = re.compile(r"Initial SPF schedule delay (\d+) msecs")
+_SPF_MIN_HOLD_RE = re.compile(
+    r"Minimum hold time between two consecutive SPFs (\d+) msecs"
+)
+_SPF_MAX_WAIT_RE = re.compile(
+    r"Maximum wait time between two consecutive SPFs (\d+) msecs"
+)
+_AREA_RE = re.compile(r"^\s+Area (\S+\(\d+\))\s*$")
+_SPF_LAST_RE = re.compile(r"SPF algorithm last executed (.+) ago")
+_SPF_EXEC_RE = re.compile(r"SPF algorithm executed (\d+) times")
+
+
+class SpfTimers(TypedDict):
+    """SPF timer configuration."""
+
+    initial_delay_ms: int
+    min_hold_ms: int
+    max_wait_ms: int
+
+
+class AreaEntry(TypedDict):
+    """Schema for a single OSPF area in topology-info."""
+
+    spf_last_executed: NotRequired[str]
+    spf_executions: NotRequired[int]
+
+
+class TopologyEntry(TypedDict):
+    """Schema for a base topology within an OSPF process."""
+
+    mtid: int
+    topology_priority: int
+    originating_max_metric: bool
+    num_transit_capable_areas: int
+    spf_timers: SpfTimers
+    areas: NotRequired[dict[str, AreaEntry]]
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single OSPF process in topology-info output."""
+
+    router_id: str
+    topology: TopologyEntry
+
+
+class ShowIpOspfTopologyInfoResult(TypedDict):
+    """Schema for 'show ip ospf topology-info' parsed output."""
+
+    processes: dict[str, ProcessEntry]
+
+
+def _try_topology_fields(line: str, topology: dict) -> bool:
+    """Attempt to parse topology-level fields from a line.
+
+    Returns True if the line was consumed.
+    """
+    match = _MTID_RE.search(line)
+    if match:
+        topology["mtid"] = int(match.group(1))
+        return True
+
+    match = _TOPOLOGY_PRIORITY_RE.search(line)
+    if match:
+        topology["topology_priority"] = int(match.group(1))
+        return True
+
+    match = _MAX_METRIC_RE.search(line)
+    if match:
+        topology["originating_max_metric"] = match.group(1) is None
+        return True
+
+    match = _TRANSIT_CAPABLE_RE.search(line)
+    if match:
+        topology["num_transit_capable_areas"] = int(match.group(1))
+        return True
+
+    return False
+
+
+def _try_spf_timers(line: str, topology: dict) -> bool:
+    """Attempt to parse SPF timer fields from a line.
+
+    Returns True if the line was consumed.
+    """
+    match = _SPF_INITIAL_RE.search(line)
+    if match:
+        topology.setdefault("spf_timers", {})["initial_delay_ms"] = int(match.group(1))
+        return True
+
+    match = _SPF_MIN_HOLD_RE.search(line)
+    if match:
+        topology.setdefault("spf_timers", {})["min_hold_ms"] = int(match.group(1))
+        return True
+
+    match = _SPF_MAX_WAIT_RE.search(line)
+    if match:
+        topology.setdefault("spf_timers", {})["max_wait_ms"] = int(match.group(1))
+        return True
+
+    return False
+
+
+def _try_area_fields(
+    line: str, areas: dict[str, dict], current_area_id: str | None
+) -> str | None:
+    """Attempt to parse area-level fields from a line.
+
+    Returns the current area ID (may be updated if a new area is found).
+    """
+    match = _AREA_RE.match(line)
+    if match:
+        area_id = match.group(1)
+        areas.setdefault(area_id, {})
+        return area_id
+
+    if current_area_id is not None:
+        match = _SPF_LAST_RE.search(line)
+        if match:
+            areas[current_area_id]["spf_last_executed"] = match.group(1)
+            return current_area_id
+
+        match = _SPF_EXEC_RE.search(line)
+        if match:
+            areas[current_area_id]["spf_executions"] = int(match.group(1))
+            return current_area_id
+
+    return current_area_id
+
+
+def _finalize_process(
+    processes: dict[str, ProcessEntry],
+    process_id: str | None,
+    topology: dict | None,
+    areas: dict[str, dict],
+) -> None:
+    """Finalize and store a parsed process entry."""
+    if process_id is None or topology is None:
+        return
+
+    entry: dict = {
+        "router_id": topology["router_id"],
+        "topology": {
+            "mtid": topology.get("mtid", 0),
+            "topology_priority": topology["topology_priority"],
+            "originating_max_metric": topology["originating_max_metric"],
+            "num_transit_capable_areas": topology["num_transit_capable_areas"],
+            "spf_timers": topology["spf_timers"],
+        },
+    }
+    if areas:
+        entry["topology"]["areas"] = areas
+
+    processes[process_id] = cast(ProcessEntry, entry)
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf topology-info")
+class ShowIpOspfTopologyInfoParser(
+    BaseParser[ShowIpOspfTopologyInfoResult],
+):
+    """Parser for 'show ip ospf topology-info' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.OSPF})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfTopologyInfoResult:
+        """Parse show ip ospf topology-info output."""
+        processes: dict[str, ProcessEntry] = {}
+        current_process_id: str | None = None
+        current_topology: dict | None = None
+        current_area_id: str | None = None
+        current_areas: dict[str, dict] = {}
+
+        for line in output.splitlines():
+            match = _PROCESS_RE.search(line)
+            if match:
+                _finalize_process(
+                    processes,
+                    current_process_id,
+                    current_topology,
+                    current_areas,
+                )
+                current_process_id = match.group(2)
+                current_topology = {"router_id": match.group(1)}
+                current_areas = {}
+                current_area_id = None
+                continue
+
+            if current_topology is None:
+                continue
+
+            if _try_topology_fields(line, current_topology):
+                continue
+
+            if _try_spf_timers(line, current_topology):
+                continue
+
+            current_area_id = _try_area_fields(line, current_areas, current_area_id)
+
+        _finalize_process(
+            processes, current_process_id, current_topology, current_areas
+        )
+
+        if not processes:
+            msg = "No OSPF processes found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpOspfTopologyInfoResult, {"processes": processes})

--- a/tests/parsers/iosxe/show_ip_ospf_topology-info/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_topology-info/001_basic/expected.json
@@ -1,0 +1,64 @@
+{
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "topology": {
+                "mtid": 0,
+                "topology_priority": 64,
+                "originating_max_metric": false,
+                "num_transit_capable_areas": 0,
+                "spf_timers": {
+                    "initial_delay_ms": 50,
+                    "min_hold_ms": 200,
+                    "max_wait_ms": 5000
+                },
+                "areas": {
+                    "BACKBONE(0)": {
+                        "spf_last_executed": "1w5d",
+                        "spf_executions": 282
+                    }
+                }
+            }
+        },
+        "20": {
+            "router_id": "203.0.113.3",
+            "topology": {
+                "mtid": 0,
+                "topology_priority": 64,
+                "originating_max_metric": false,
+                "num_transit_capable_areas": 0,
+                "spf_timers": {
+                    "initial_delay_ms": 50,
+                    "min_hold_ms": 200,
+                    "max_wait_ms": 5000
+                },
+                "areas": {
+                    "BACKBONE(0)": {
+                        "spf_last_executed": "1w5d",
+                        "spf_executions": 327
+                    }
+                }
+            }
+        },
+        "10": {
+            "router_id": "198.51.100.3",
+            "topology": {
+                "mtid": 0,
+                "topology_priority": 64,
+                "originating_max_metric": false,
+                "num_transit_capable_areas": 0,
+                "spf_timers": {
+                    "initial_delay_ms": 50,
+                    "min_hold_ms": 200,
+                    "max_wait_ms": 5000
+                },
+                "areas": {
+                    "BACKBONE(0)": {
+                        "spf_last_executed": "1w5d",
+                        "spf_executions": 325
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_topology-info/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_topology-info/001_basic/input.txt
@@ -1,0 +1,47 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+
+                Base Topology (MTID 0)
+
+ Topology priority is 64
+ Router is not originating router-LSAs with maximum metric
+ Number of areas transit capable is 0
+ Initial SPF schedule delay 50 msecs
+ Minimum hold time between two consecutive SPFs 200 msecs
+ Maximum wait time between two consecutive SPFs 5000 msecs
+    Area BACKBONE(0)
+        SPF algorithm last executed 1w5d ago
+        SPF algorithm executed 282 times
+        Area ranges are
+
+            OSPF Router with ID (203.0.113.3) (Process ID 20)
+
+
+                Base Topology (MTID 0)
+
+ Topology priority is 64
+ Router is not originating router-LSAs with maximum metric
+ Number of areas transit capable is 0
+ Initial SPF schedule delay 50 msecs
+ Minimum hold time between two consecutive SPFs 200 msecs
+ Maximum wait time between two consecutive SPFs 5000 msecs
+    Area BACKBONE(0)
+        SPF algorithm last executed 1w5d ago
+        SPF algorithm executed 327 times
+        Area ranges are
+
+            OSPF Router with ID (198.51.100.3) (Process ID 10)
+
+
+                Base Topology (MTID 0)
+
+ Topology priority is 64
+ Router is not originating router-LSAs with maximum metric
+ Number of areas transit capable is 0
+ Initial SPF schedule delay 50 msecs
+ Minimum hold time between two consecutive SPFs 200 msecs
+ Maximum wait time between two consecutive SPFs 5000 msecs
+    Area BACKBONE(0)
+        SPF algorithm last executed 1w5d ago
+        SPF algorithm executed 325 times
+        Area ranges are

--- a/tests/parsers/iosxe/show_ip_ospf_topology-info/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_topology-info/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multi-process OSPF topology info with SPF timers and area details
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf topology-info` on Cisco IOS-XE that extracts per-process topology details including MTID, priority, max-metric origination status, SPF timers, and per-area SPF execution statistics. Output is keyed by OSPF process ID (`dict[str, ProcessEntry]`).
- Fixture sourced from physical testbed (C9300-48U, IOS-XE 17.18.02) with 3 OSPF processes; coverage limited to backbone area with no area ranges populated.

Closes #1182

## Test plan
- [x] \`uv run pytest tests/parsers/ -k "show_ip_ospf_topology-info" -v\` (7 passed)
- [x] \`uv run pytest -q\` (full suite, 9201 passing)
- [x] \`uv run ruff check\` / \`uv run ruff format --check\`
- [x] \`uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_topology_info.py\`
- [x] \`uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_topology_info.py\`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

---
Generated with [Claude Code](https://claude.com/claude-code)