### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf request-list`

### DIFF
--- a/changes/1188.parser_added
+++ b/changes/1188.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf request-list` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_request_list.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_request_list.py
@@ -1,0 +1,150 @@
+"""Parser for 'show ip ospf request-list' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+# Module-level compiled regexes
+_PROCESS_RE = re.compile(
+    rf"OSPF Router with ID \((?P<router_id>{IPV4_ADDRESS})\)"
+    r" \(Process ID (?P<process_id>\d+)\)"
+)
+
+_NEIGHBOR_RE = re.compile(
+    rf"Neighbor (?P<neighbor_id>{IPV4_ADDRESS}),\s+"
+    r"interface (?P<interface>\S+)\s+"
+    rf"address (?P<address>{IPV4_ADDRESS})"
+)
+
+_REQUEST_LIST_RE = re.compile(
+    r"Request list size (?P<request_list_size>\d+),\s+"
+    r"maximum list size (?P<maximum_list_size>\d+)"
+)
+
+
+class RequestListEntry(TypedDict):
+    """Schema for a single OSPF request-list neighbor entry."""
+
+    address: str
+    request_list_size: int
+    maximum_list_size: int
+
+
+class OspfProcessRequestList(TypedDict):
+    """Schema for an OSPF process request-list section."""
+
+    router_id: str
+    neighbors: dict[str, dict[str, RequestListEntry]]
+
+
+class ShowIpOspfRequestListResult(TypedDict):
+    """Schema for 'show ip ospf request-list' parsed output."""
+
+    processes: dict[str, OspfProcessRequestList]
+
+
+def _try_process_header(
+    line: str,
+    result: dict[str, OspfProcessRequestList],
+) -> str | None:
+    """Try to match a process header line, return process_id if matched."""
+    match = _PROCESS_RE.search(line)
+    if not match:
+        return None
+    process_id = match.group("process_id")
+    if process_id not in result:
+        result[process_id] = {
+            "router_id": match.group("router_id"),
+            "neighbors": {},
+        }
+    return process_id
+
+
+def _try_neighbor_line(line: str) -> tuple[str, str, str] | None:
+    """Try to match a neighbor line, return (neighbor_id, interface, address)."""
+    match = _NEIGHBOR_RE.search(line)
+    if not match:
+        return None
+    interface = canonical_interface_name(match.group("interface"), os=OS.CISCO_IOSXE)
+    return match.group("neighbor_id"), interface, match.group("address")
+
+
+def _store_request_entry(
+    line: str,
+    process_id: str,
+    neighbor: tuple[str, str, str],
+    result: dict[str, OspfProcessRequestList],
+) -> bool:
+    """Try to match and store a request-list entry. Return True if matched."""
+    match = _REQUEST_LIST_RE.search(line)
+    if not match:
+        return False
+    neighbor_id, interface, address = neighbor
+    neighbors = result[process_id]["neighbors"]
+    neighbors.setdefault(interface, {})[neighbor_id] = {
+        "address": address,
+        "request_list_size": int(match.group("request_list_size")),
+        "maximum_list_size": int(match.group("maximum_list_size")),
+    }
+    return True
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf request-list")
+class ShowIpOspfRequestListParser(BaseParser[ShowIpOspfRequestListResult]):
+    """Parser for 'show ip ospf request-list' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.ROUTING}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfRequestListResult:
+        """Parse 'show ip ospf request-list' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed request-list data keyed by process ID, then
+            interface, then neighbor ID.
+
+        Raises:
+            ValueError: If no OSPF processes found in output.
+        """
+        result: dict[str, OspfProcessRequestList] = {}
+        current_process_id: str | None = None
+        current_neighbor: tuple[str, str, str] | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            pid = _try_process_header(stripped, result)
+            if pid is not None:
+                current_process_id = pid
+                current_neighbor = None
+                continue
+
+            neighbor = _try_neighbor_line(stripped)
+            if neighbor is not None:
+                current_neighbor = neighbor
+                continue
+
+            if current_process_id and current_neighbor:
+                if _store_request_entry(
+                    stripped, current_process_id, current_neighbor, result
+                ):
+                    current_neighbor = None
+
+        if not result:
+            msg = "No OSPF processes found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpOspfRequestListResult, {"processes": result})

--- a/tests/parsers/iosxe/show_ip_ospf_request-list/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_request-list/001_basic/expected.json
@@ -1,0 +1,61 @@
+{
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "neighbors": {
+                "GigabitEthernet1/0/1": {
+                    "192.0.2.4": {
+                        "address": "10.0.2.2",
+                        "request_list_size": 0,
+                        "maximum_list_size": 0
+                    }
+                },
+                "GigabitEthernet1/0/2": {
+                    "192.0.2.1": {
+                        "address": "10.0.3.1",
+                        "request_list_size": 0,
+                        "maximum_list_size": 1
+                    }
+                }
+            }
+        },
+        "20": {
+            "router_id": "203.0.113.3",
+            "neighbors": {
+                "GigabitEthernet1/0/1.20": {
+                    "203.0.113.4": {
+                        "address": "10.20.2.2",
+                        "request_list_size": 0,
+                        "maximum_list_size": 0
+                    }
+                },
+                "GigabitEthernet1/0/2.20": {
+                    "203.0.113.1": {
+                        "address": "10.20.3.1",
+                        "request_list_size": 0,
+                        "maximum_list_size": 1
+                    }
+                }
+            }
+        },
+        "10": {
+            "router_id": "198.51.100.3",
+            "neighbors": {
+                "GigabitEthernet1/0/2.10": {
+                    "198.51.100.1": {
+                        "address": "10.10.3.1",
+                        "request_list_size": 0,
+                        "maximum_list_size": 1
+                    }
+                },
+                "GigabitEthernet1/0/1.10": {
+                    "198.51.100.4": {
+                        "address": "10.10.2.2",
+                        "request_list_size": 0,
+                        "maximum_list_size": 0
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_request-list/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_request-list/001_basic/input.txt
@@ -1,0 +1,23 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+ Neighbor 192.0.2.4, interface GigabitEthernet1/0/1 address 10.0.2.2
+ Request list size 0, maximum list size 0
+
+ Neighbor 192.0.2.1, interface GigabitEthernet1/0/2 address 10.0.3.1
+ Request list size 0, maximum list size 1
+
+            OSPF Router with ID (203.0.113.3) (Process ID 20)
+
+ Neighbor 203.0.113.4, interface GigabitEthernet1/0/1.20 address 10.20.2.2
+ Request list size 0, maximum list size 0
+
+ Neighbor 203.0.113.1, interface GigabitEthernet1/0/2.20 address 10.20.3.1
+ Request list size 0, maximum list size 1
+
+            OSPF Router with ID (198.51.100.3) (Process ID 10)
+
+ Neighbor 198.51.100.1, interface GigabitEthernet1/0/2.10 address 10.10.3.1
+ Request list size 0, maximum list size 1
+
+ Neighbor 198.51.100.4, interface GigabitEthernet1/0/1.10 address 10.10.2.2
+ Request list size 0, maximum list size 0

--- a/tests/parsers/iosxe/show_ip_ospf_request-list/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_request-list/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show ip ospf request-list output with multiple OSPF processes
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf request-list` on Cisco IOS-XE that extracts OSPF link-state request list data keyed by process ID, then interface, then neighbor ID (`dict[str, OspfProcessRequestList]` with nested `dict[str, dict[str, RequestListEntry]]`)
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1188; covers multiple OSPF processes with multiple neighbors each

Closes #1188

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_request-list" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_request_list.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_request_list.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)