### PR TITLE
feat(cisco_iosxe): add parser for `show access-lists`

### DIFF
--- a/changes/1184.parser_added
+++ b/changes/1184.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show access-lists` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_access-lists.py
+++ b/src/muninn/parsers/iosxe/show_access-lists.py
@@ -1,0 +1,214 @@
+"""Parser for 'show access-lists' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.parsers.ios._acl_common import (
+    AclParsedFields,
+    parse_extended_ace_body,
+    parse_standard_ace_body,
+)
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class AccessListEntry(TypedDict):
+    """Schema for a single access control entry (ACE)."""
+
+    sequence: int
+    action: str
+    line: str
+    parsed: AclParsedFields
+    matches: NotRequired[int]
+
+
+class AccessList(TypedDict):
+    """Schema for a single access list."""
+
+    type: str
+    entries: dict[str, AccessListEntry]
+
+
+class ShowAccessListsResult(TypedDict):
+    """Schema for 'show access-lists' parsed output."""
+
+    access_lists: dict[str, AccessList]
+
+
+# Extended/Standard IP ACL header
+_IPV4_HEADER_RE = re.compile(
+    r"^(?P<type>(?:Extended|Standard)\s+IP\s+access\s+list)"
+    r"\s+(?P<name>\S+)$"
+)
+
+# IPv6 ACL header
+_IPV6_HEADER_RE = re.compile(r"^(?P<type>IPv6\s+access\s+list)\s+(?P<name>\S+)$")
+
+# Extended IP ACE: <seq> <action> <rest>
+_IPV4_ACE_RE = re.compile(
+    r"^(?P<sequence>\d+)\s+(?P<action>permit|deny)\s+(?P<rest>.+)$"
+)
+
+# IPv6 ACE: <action> <rest> sequence <seq>
+_IPV6_ACE_RE = re.compile(
+    r"^(?P<action>permit|deny)\s+(?P<rest>.+)\s+sequence\s+(?P<sequence>\d+)$"
+)
+
+# Match count: (NNN matches) or (NNN match)
+_MATCH_COUNT_RE = re.compile(r"\((\d+)\s+matches?\)")
+
+
+def _parse_ipv4_ace(line: str, acl_type: str) -> AccessListEntry | None:
+    """Parse a single IPv4 ACE line."""
+    match = _IPV4_ACE_RE.match(line)
+    if not match:
+        return None
+
+    sequence = int(match.group("sequence"))
+    action = match.group("action")
+    rest = match.group("rest").strip()
+
+    full_line = f"{action} {rest}"
+
+    # Extract match count if present
+    matches: int | None = None
+    mc_match = _MATCH_COUNT_RE.search(full_line)
+    if mc_match:
+        matches = int(mc_match.group(1))
+        full_line = (
+            full_line[: mc_match.start()] + full_line[mc_match.end() :]
+        ).strip()
+        full_line = " ".join(full_line.split())
+
+    body = full_line.split(None, 1)[1] if " " in full_line else ""
+    if acl_type.startswith("Standard"):
+        parsed = parse_standard_ace_body(body)
+    else:
+        parsed = parse_extended_ace_body(body, ip_version=4)
+
+    entry: dict[str, object] = {
+        "sequence": sequence,
+        "action": action,
+        "line": full_line,
+        "parsed": parsed,
+    }
+    if matches is not None:
+        entry["matches"] = matches
+    return cast(AccessListEntry, entry)
+
+
+def _parse_ipv6_ace(line: str) -> AccessListEntry | None:
+    """Parse a single IPv6 ACE line."""
+    match = _IPV6_ACE_RE.match(line)
+    if not match:
+        return None
+
+    sequence = int(match.group("sequence"))
+    action = match.group("action")
+    rest = match.group("rest").strip()
+
+    # Remove match count from rest if present
+    matches: int | None = None
+    mc_match = _MATCH_COUNT_RE.search(rest)
+    if mc_match:
+        matches = int(mc_match.group(1))
+        rest = (rest[: mc_match.start()] + rest[mc_match.end() :]).strip()
+        rest = " ".join(rest.split())
+
+    full_line = f"{action} {rest}"
+    # rest already includes the protocol as first token (e.g. "ipv6 any any")
+    parsed = parse_extended_ace_body(rest, ip_version=6)
+
+    entry: dict[str, object] = {
+        "sequence": sequence,
+        "action": action,
+        "line": full_line,
+        "parsed": parsed,
+    }
+    if matches is not None:
+        entry["matches"] = matches
+    return cast(AccessListEntry, entry)
+
+
+def _try_header(
+    stripped: str,
+) -> tuple[str, str, bool] | None:
+    """Try to match an ACL header line.
+
+    Returns:
+        Tuple of (name, type, is_ipv6) if a header was matched, else None.
+    """
+    header_match = _IPV4_HEADER_RE.match(stripped)
+    if header_match:
+        return header_match.group("name"), header_match.group("type"), False
+
+    header_match = _IPV6_HEADER_RE.match(stripped)
+    if header_match:
+        return header_match.group("name"), header_match.group("type"), True
+
+    return None
+
+
+@register(OS.CISCO_IOSXE, "show access-lists")
+class ShowAccessListsParser(BaseParser[ShowAccessListsResult]):
+    """Parser for 'show access-lists' on IOS-XE.
+
+    Handles both Extended/Standard IP access lists and IPv6 access lists
+    in a single unified output.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.ACL, ParserTag.SECURITY}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowAccessListsResult:
+        """Parse 'show access-lists' output.
+
+        Args:
+            output: Raw CLI output from 'show access-lists' command.
+
+        Returns:
+            Parsed data with access lists keyed by name.
+
+        Raises:
+            ValueError: If no access lists found in output.
+        """
+        access_lists: dict[str, AccessList] = {}
+        current_name: str | None = None
+        current_type: str | None = None
+        is_ipv6 = False
+
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            header = _try_header(stripped)
+            if header:
+                current_name, current_type, is_ipv6 = header
+                access_lists[current_name] = {
+                    "type": current_type,
+                    "entries": {},
+                }
+                continue
+
+            if current_name is None or current_type is None:
+                continue
+
+            if is_ipv6:
+                entry = _parse_ipv6_ace(stripped)
+            else:
+                entry = _parse_ipv4_ace(stripped, current_type)
+
+            if entry:
+                seq_key = str(entry["sequence"])
+                access_lists[current_name]["entries"][seq_key] = entry
+
+        if not access_lists:
+            msg = "No access lists found in output"
+            raise ValueError(msg)
+
+        return cast(ShowAccessListsResult, {"access_lists": access_lists})

--- a/tests/parsers/iosxe/show_access-lists/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_access-lists/001_basic/expected.json
@@ -1,0 +1,442 @@
+{
+    "access_lists": {
+        "IP-Adm-V4-Int-ACL-global": {
+            "type": "Extended IP access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "permit",
+                    "line": "permit tcp any any eq www",
+                    "parsed": {
+                        "protocol": "tcp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "www"
+                            ]
+                        }
+                    }
+                },
+                "20": {
+                    "sequence": 20,
+                    "action": "permit",
+                    "line": "permit tcp any any eq 443",
+                    "parsed": {
+                        "protocol": "tcp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "443"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "implicit_deny": {
+            "type": "Extended IP access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "deny",
+                    "line": "deny ip any any",
+                    "parsed": {
+                        "protocol": "ip",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                }
+            }
+        },
+        "implicit_permit": {
+            "type": "Extended IP access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "permit",
+                    "line": "permit ip any any",
+                    "parsed": {
+                        "protocol": "ip",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                }
+            }
+        },
+        "meraki-fqdn-dns": {
+            "type": "Extended IP access list",
+            "entries": {}
+        },
+        "preauth_v4": {
+            "type": "Extended IP access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "permit",
+                    "line": "permit udp any any eq domain",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "domain"
+                            ]
+                        }
+                    }
+                },
+                "20": {
+                    "sequence": 20,
+                    "action": "permit",
+                    "line": "permit tcp any any eq domain",
+                    "parsed": {
+                        "protocol": "tcp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "domain"
+                            ]
+                        }
+                    }
+                },
+                "30": {
+                    "sequence": 30,
+                    "action": "permit",
+                    "line": "permit udp any eq bootps any",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "source_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "bootps"
+                            ]
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                },
+                "40": {
+                    "sequence": 40,
+                    "action": "permit",
+                    "line": "permit udp any any eq bootpc",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "bootpc"
+                            ]
+                        }
+                    }
+                },
+                "50": {
+                    "sequence": 50,
+                    "action": "permit",
+                    "line": "permit udp any eq bootpc any",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "source_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "bootpc"
+                            ]
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                },
+                "60": {
+                    "sequence": 60,
+                    "action": "deny",
+                    "line": "deny ip any any",
+                    "parsed": {
+                        "protocol": "ip",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                }
+            }
+        },
+        "implicit_deny_v6": {
+            "type": "IPv6 access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "deny",
+                    "line": "deny ipv6 any any",
+                    "parsed": {
+                        "protocol": "ipv6",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                }
+            }
+        },
+        "implicit_permit_v6": {
+            "type": "IPv6 access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "permit",
+                    "line": "permit ipv6 any any",
+                    "parsed": {
+                        "protocol": "ipv6",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                }
+            }
+        },
+        "preauth_v6": {
+            "type": "IPv6 access list",
+            "entries": {
+                "10": {
+                    "sequence": 10,
+                    "action": "permit",
+                    "line": "permit udp any any eq domain",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "domain"
+                            ]
+                        }
+                    }
+                },
+                "20": {
+                    "sequence": 20,
+                    "action": "permit",
+                    "line": "permit tcp any any eq domain",
+                    "parsed": {
+                        "protocol": "tcp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "domain"
+                            ]
+                        }
+                    }
+                },
+                "30": {
+                    "sequence": 30,
+                    "action": "permit",
+                    "line": "permit icmp any any nd-ns",
+                    "parsed": {
+                        "protocol": "icmp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "extra": [
+                            "nd-ns"
+                        ]
+                    }
+                },
+                "40": {
+                    "sequence": 40,
+                    "action": "permit",
+                    "line": "permit icmp any any nd-na",
+                    "parsed": {
+                        "protocol": "icmp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "extra": [
+                            "nd-na"
+                        ]
+                    }
+                },
+                "50": {
+                    "sequence": 50,
+                    "action": "permit",
+                    "line": "permit icmp any any router-solicitation",
+                    "parsed": {
+                        "protocol": "icmp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "extra": [
+                            "router-solicitation"
+                        ]
+                    }
+                },
+                "60": {
+                    "sequence": 60,
+                    "action": "permit",
+                    "line": "permit icmp any any router-advertisement",
+                    "parsed": {
+                        "protocol": "icmp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "icmp_message": "router-advertisement"
+                    }
+                },
+                "70": {
+                    "sequence": 70,
+                    "action": "permit",
+                    "line": "permit icmp any any redirect",
+                    "parsed": {
+                        "protocol": "icmp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "extra": [
+                            "redirect"
+                        ]
+                    }
+                },
+                "80": {
+                    "sequence": 80,
+                    "action": "permit",
+                    "line": "permit udp any eq 547 any eq 546",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "source_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "547"
+                            ]
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "546"
+                            ]
+                        }
+                    }
+                },
+                "90": {
+                    "sequence": 90,
+                    "action": "permit",
+                    "line": "permit udp any eq 546 any eq 547",
+                    "parsed": {
+                        "protocol": "udp",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "source_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "546"
+                            ]
+                        },
+                        "destination": {
+                            "kind": "any"
+                        },
+                        "destination_port": {
+                            "operator": "eq",
+                            "ports": [
+                                "547"
+                            ]
+                        }
+                    }
+                },
+                "100": {
+                    "sequence": 100,
+                    "action": "deny",
+                    "line": "deny ipv6 any any",
+                    "parsed": {
+                        "protocol": "ipv6",
+                        "source": {
+                            "kind": "any"
+                        },
+                        "destination": {
+                            "kind": "any"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_access-lists/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_access-lists/001_basic/input.txt
@@ -1,0 +1,30 @@
+Extended IP access list IP-Adm-V4-Int-ACL-global
+    10 permit tcp any any eq www
+    20 permit tcp any any eq 443
+Extended IP access list implicit_deny
+    10 deny ip any any
+Extended IP access list implicit_permit
+    10 permit ip any any
+Extended IP access list meraki-fqdn-dns
+Extended IP access list preauth_v4
+    10 permit udp any any eq domain
+    20 permit tcp any any eq domain
+    30 permit udp any eq bootps any
+    40 permit udp any any eq bootpc
+    50 permit udp any eq bootpc any
+    60 deny ip any any
+IPv6 access list implicit_deny_v6
+    deny ipv6 any any sequence 10
+IPv6 access list implicit_permit_v6
+    permit ipv6 any any sequence 10
+IPv6 access list preauth_v6
+    permit udp any any eq domain sequence 10
+    permit tcp any any eq domain sequence 20
+    permit icmp any any nd-ns sequence 30
+    permit icmp any any nd-na sequence 40
+    permit icmp any any router-solicitation sequence 50
+    permit icmp any any router-advertisement sequence 60
+    permit icmp any any redirect sequence 70
+    permit udp any eq 547 any eq 546 sequence 80
+    permit udp any eq 546 any eq 547 sequence 90
+    deny ipv6 any any sequence 100

--- a/tests/parsers/iosxe/show_access-lists/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_access-lists/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show access-lists output with Extended IP and IPv6 ACLs
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show access-lists` on Cisco IOS-XE that handles both Extended/Standard IP access lists and IPv6 access lists in a single unified output, keyed by ACL name with entries keyed by sequence number.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in the issue. Reuses the shared `_acl_common` module from `ios/` for structured ACE body parsing (protocol, source/destination, ports, modifiers).

Closes #1184

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_access-lists" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_access-lists.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_access-lists.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)