### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf nsr`

### DIFF
--- a/changes/1190.parser_added
+++ b/changes/1190.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf nsr` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_nsr.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_nsr.py
@@ -1,0 +1,154 @@
+"""Parser for 'show ip ospf nsr' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_RP_ROLE_RE = re.compile(r"^(?P<role>Active RP|Standby RP)\s*$")
+_MODE_RE = re.compile(r"^\s+Operating in (?P<mode>\S+) mode\s*$")
+_REDUNDANCY_STATE_RE = re.compile(r"^\s+Redundancy state:\s+(?P<state>.+?)\s*$")
+_PEER_STATE_RE = re.compile(r"^\s+Peer redundancy state:\s+(?P<state>.+?)\s*$")
+_CHECKPOINT_PEER_RE = re.compile(r"^\s+Checkpoint peer (?P<status>.+?)\s*$")
+_CHECKPOINT_MSG_RE = re.compile(r"^\s+Checkpoint messages (?P<status>\S+)\s*$")
+_ISSU_NEGOTIATION_RE = re.compile(r"^\s+ISSU negotiation (?P<status>.+?)\s*$")
+_ISSU_VERSIONS_RE = re.compile(r"^\s+ISSU versions (?P<status>.+?)\s*$")
+_PROCESS_RE = re.compile(
+    r"^\s+Routing Process \"ospf (?P<pid>\d+)\""
+    r" with ID (?P<router_id>" + IPV4_ADDRESS + r")\s*$"
+)
+_NSR_STATUS_RE = re.compile(r"^\s+NSR (?P<status>.+?)\s*$")
+
+_HEADER_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (_RP_ROLE_RE, "rp_role", "role"),
+    (_MODE_RE, "operating_mode", "mode"),
+    (_REDUNDANCY_STATE_RE, "redundancy_state", "state"),
+    (_PEER_STATE_RE, "peer_redundancy_state", "state"),
+    (_CHECKPOINT_PEER_RE, "checkpoint_peer_status", "status"),
+    (_CHECKPOINT_MSG_RE, "checkpoint_messages", "status"),
+    (_ISSU_NEGOTIATION_RE, "issu_negotiation", "status"),
+    (_ISSU_VERSIONS_RE, "issu_versions", "status"),
+]
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single OSPF process NSR entry."""
+
+    router_id: str
+    nsr_status: str
+
+
+class ShowIpOspfNsrResult(TypedDict):
+    """Schema for 'show ip ospf nsr' parsed output."""
+
+    rp_role: str
+    operating_mode: str
+    redundancy_state: str
+    peer_redundancy_state: str
+    checkpoint_peer_status: str
+    checkpoint_messages: str
+    issu_negotiation: NotRequired[str]
+    issu_versions: NotRequired[str]
+    processes: dict[str, ProcessEntry]
+
+
+def _try_header_line(line: str, result: dict[str, object]) -> bool:
+    """Attempt to match a header/redundancy line."""
+    for pattern, key, group in _HEADER_PATTERNS:
+        m = pattern.match(line)
+        if m:
+            result[key] = m.group(group)
+            return True
+    return False
+
+
+def _try_process_line(
+    line: str,
+    processes: dict[str, ProcessEntry],
+    current_pid: str | None,
+) -> str | None:
+    """Attempt to match a process or NSR status line.
+
+    Returns the current process ID (updated if a new process was found).
+    """
+    m = _PROCESS_RE.match(line)
+    if m:
+        pid = m.group("pid")
+        processes[pid] = ProcessEntry(
+            router_id=m.group("router_id"),
+            nsr_status="",
+        )
+        return pid
+
+    m = _NSR_STATUS_RE.match(line)
+    if m and current_pid is not None:
+        processes[current_pid]["nsr_status"] = m.group("status")
+
+    return current_pid
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf nsr")
+class ShowIpOspfNsrParser(BaseParser[ShowIpOspfNsrResult]):
+    """Parser for 'show ip ospf nsr' on IOS-XE.
+
+    Parses OSPF NSR (Non-Stop Routing) status including RP role,
+    redundancy state, checkpoint/ISSU status, and per-process NSR
+    configuration.
+
+    Example output::
+
+        Active RP
+         Operating in simplex mode
+         Redundancy state: ACTIVE
+         Peer redundancy state: DISABLED
+         Checkpoint peer not ready
+         Checkpoint messages enabled
+         ISSU negotiation not complete
+         ISSU versions not compatible
+
+         Routing Process "ospf 1" with ID 192.0.2.3
+         NSR not configured
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.REDUNDANCY}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfNsrResult:
+        """Parse 'show ip ospf nsr' output."""
+        result: dict[str, object] = {}
+        processes: dict[str, ProcessEntry] = {}
+        current_pid: str | None = None
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            if _try_header_line(line, result):
+                continue
+
+            current_pid = _try_process_line(line, processes, current_pid)
+
+        for required in (
+            "rp_role",
+            "operating_mode",
+            "redundancy_state",
+            "peer_redundancy_state",
+            "checkpoint_peer_status",
+            "checkpoint_messages",
+        ):
+            if required not in result:
+                msg = f"Missing required field: {required}"
+                raise ValueError(msg)
+
+        if not processes:
+            msg = "No OSPF processes found in output"
+            raise ValueError(msg)
+
+        result["processes"] = processes
+        return cast(ShowIpOspfNsrResult, result)

--- a/tests/parsers/iosxe/show_ip_ospf_nsr/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_nsr/001_basic/expected.json
@@ -1,0 +1,24 @@
+{
+    "rp_role": "Active RP",
+    "operating_mode": "simplex",
+    "redundancy_state": "ACTIVE",
+    "peer_redundancy_state": "DISABLED",
+    "checkpoint_peer_status": "not ready",
+    "checkpoint_messages": "enabled",
+    "issu_negotiation": "not complete",
+    "issu_versions": "not compatible",
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "nsr_status": "not configured"
+        },
+        "20": {
+            "router_id": "203.0.113.3",
+            "nsr_status": "not configured"
+        },
+        "10": {
+            "router_id": "198.51.100.3",
+            "nsr_status": "not configured"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_nsr/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_nsr/001_basic/input.txt
@@ -1,0 +1,17 @@
+Active RP
+ Operating in simplex mode
+ Redundancy state: ACTIVE
+ Peer redundancy state: DISABLED
+ Checkpoint peer not ready
+ Checkpoint messages enabled
+ ISSU negotiation not complete
+ ISSU versions not compatible
+
+ Routing Process "ospf 1" with ID 192.0.2.3
+ NSR not configured
+
+ Routing Process "ospf 20" with ID 203.0.113.3
+ NSR not configured
+
+ Routing Process "ospf 10" with ID 198.51.100.3
+ NSR not configured

--- a/tests/parsers/iosxe/show_ip_ospf_nsr/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_nsr/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: OSPF NSR status with three processes in simplex mode (C9300 live device)
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf nsr` on Cisco IOS-XE that extracts RP role, redundancy/checkpoint/ISSU status, and per-process NSR configuration keyed by OSPF process ID.
- Fixture sourced from issue #1190 sample output (C9300-48U, IOS-XE 17.18.02 physical testbed).

Closes #1190

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_ip_ospf_nsr -v` (7 passed)
- [x] `uv run pytest -q` (full suite, 9201 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_nsr.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_nsr.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)