### PR TITLE
feat(cisco_iosxe): add parser for `show crypto pki counters`

### DIFF
--- a/changes/1192.parser_added
+++ b/changes/1192.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto pki counters` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_pki_counters.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_counters.py
@@ -1,0 +1,82 @@
+"""Parser for 'show crypto pki counters' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_COUNTER_RE = re.compile(
+    r"^\s*(?P<label>[A-Za-z][A-Za-z \-]+[A-Za-z]):\s*(?P<value>\d+)\s*$"
+)
+
+_LABEL_TO_FIELD: dict[str, str] = {
+    "PKI Sessions Started": "pki_sessions_started",
+    "PKI Sessions Ended": "pki_sessions_ended",
+    "PKI Sessions Active": "pki_sessions_active",
+    "Successful Validations": "successful_validations",
+    "Failed Validations": "failed_validations",
+    "Bypassed Validations": "bypassed_validations",
+    "Pending Validations": "pending_validations",
+    "CRLs checked": "crls_checked",
+    "CRL - fetch attempts": "crl_fetch_attempts",
+    "CRL - failed attempts": "crl_failed_attempts",
+    "CRL - rejected busy fetching": "crl_rejected_busy_fetching",
+    "AAA authorizations": "aaa_authorizations",
+}
+
+
+class ShowCryptoPkiCountersResult(TypedDict):
+    """Schema for 'show crypto pki counters' parsed output."""
+
+    pki_sessions_started: int
+    pki_sessions_ended: int
+    pki_sessions_active: int
+    successful_validations: int
+    failed_validations: int
+    bypassed_validations: int
+    pending_validations: int
+    crls_checked: int
+    crl_fetch_attempts: int
+    crl_failed_attempts: int
+    crl_rejected_busy_fetching: int
+    aaa_authorizations: int
+
+
+@register(OS.CISCO_IOSXE, "show crypto pki counters")
+class ShowCryptoPkiCountersParser(BaseParser[ShowCryptoPkiCountersResult]):
+    """Parser for 'show crypto pki counters' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoPkiCountersResult:
+        """Parse 'show crypto pki counters' output into structured data.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed PKI counters including session, validation, CRL,
+            and AAA statistics.
+
+        Raises:
+            ValueError: If any of the expected counter lines are missing.
+        """
+        result: dict[str, int] = {}
+        for line in output.splitlines():
+            match = _COUNTER_RE.match(line)
+            if match is None:
+                continue
+            label = match.group("label")
+            if label in _LABEL_TO_FIELD:
+                result[_LABEL_TO_FIELD[label]] = int(match.group("value"))
+
+        for label, field in _LABEL_TO_FIELD.items():
+            if field not in result:
+                msg = f"Missing required PKI counter: {label}"
+                raise ValueError(msg)
+
+        return cast(ShowCryptoPkiCountersResult, result)

--- a/tests/parsers/iosxe/show_crypto_pki_counters/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_pki_counters/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+    "pki_sessions_started": 590,
+    "pki_sessions_ended": 590,
+    "pki_sessions_active": 0,
+    "successful_validations": 3,
+    "failed_validations": 0,
+    "bypassed_validations": 0,
+    "pending_validations": 0,
+    "crls_checked": 0,
+    "crl_fetch_attempts": 0,
+    "crl_failed_attempts": 0,
+    "crl_rejected_busy_fetching": 0,
+    "aaa_authorizations": 0
+}

--- a/tests/parsers/iosxe/show_crypto_pki_counters/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_pki_counters/001_basic/input.txt
@@ -1,0 +1,12 @@
+PKI Sessions Started: 590
+PKI Sessions Ended: 590
+PKI Sessions Active: 0
+Successful Validations: 3
+Failed Validations: 0
+Bypassed Validations: 0
+Pending Validations: 0
+CRLs checked: 0
+CRL - fetch attempts: 0
+CRL - failed attempts: 0
+CRL - rejected busy fetching: 0
+AAA authorizations: 0

--- a/tests/parsers/iosxe/show_crypto_pki_counters/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_pki_counters/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show crypto pki counters output with session, validation, CRL, and AAA counters
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a flat-dict parser for `show crypto pki counters` on IOS-XE, extracting 12 integer counters (PKI sessions, validations, CRL stats, AAA authorizations) into a `ShowCryptoPkiCountersResult` TypedDict.
- Fixture captured from physical testbed (C9300-48U, IOS-XE 17.18.02) as provided in issue #1192.

Closes #1192

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_pki_counters -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_pki_counters.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_pki_counters.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)