### PR TITLE
feat(cisco_iosxe): add parser for `show crypto pki certificate storage`

### DIFF
--- a/changes/1195.parser_added
+++ b/changes/1195.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show crypto pki certificate storage` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_crypto_pki_certificate_storage.py
+++ b/src/muninn/parsers/iosxe/show_crypto_pki_certificate_storage.py
@@ -1,0 +1,71 @@
+"""Parser for 'show crypto pki certificate storage' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_ENTRY_RE = re.compile(
+    r"^(?P<trustpoint>\S+)"
+    r"\s+-\s+certificates will be stored\s+"
+    r"(?P<storage>.+?)\s*$"
+)
+
+
+class TrustpointEntry(TypedDict):
+    """A single trustpoint certificate storage entry."""
+
+    storage: str
+
+
+class ShowCryptoPkiCertificateStorageResult(TypedDict):
+    """Schema for 'show crypto pki certificate storage' parsed output.
+
+    Keyed by trustpoint name.
+    """
+
+    trustpoints: dict[str, TrustpointEntry]
+
+
+@register(OS.CISCO_IOSXE, "show crypto pki certificate storage")
+class ShowCryptoPkiCertificateStorageParser(
+    BaseParser[ShowCryptoPkiCertificateStorageResult],
+):
+    """Parser for 'show crypto pki certificate storage' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCryptoPkiCertificateStorageResult:
+        """Parse 'show crypto pki certificate storage' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Dictionary with trustpoints keyed by name, each containing
+            the certificate storage location.
+
+        Raises:
+            ValueError: If no trustpoint entries are found in the output.
+        """
+        trustpoints: dict[str, TrustpointEntry] = {}
+        for line in output.splitlines():
+            match = _ENTRY_RE.match(line)
+            if match is None:
+                continue
+            name = match.group("trustpoint")
+            storage = match.group("storage")
+            trustpoints[name] = TrustpointEntry(storage=storage)
+
+        if not trustpoints:
+            msg = "No trustpoint certificate storage entries found in output"
+            raise ValueError(msg)
+
+        return cast(
+            ShowCryptoPkiCertificateStorageResult,
+            {"trustpoints": trustpoints},
+        )

--- a/tests/parsers/iosxe/show_crypto_pki_certificate_storage/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_crypto_pki_certificate_storage/001_basic/expected.json
@@ -1,0 +1,31 @@
+{
+    "trustpoints": {
+        "TP-self-signed-4032138694": {
+            "storage": "in nvram:"
+        },
+        "SLA-TrustPoint": {
+            "storage": "in nvram:"
+        },
+        "Trustpool": {
+            "storage": "in nvram:"
+        },
+        "CISCO_IDEVID_SUDI": {
+            "storage": "with corresponding keypairs"
+        },
+        "CISCO_IDEVID_SUDI0": {
+            "storage": "in nvram:"
+        },
+        "CISCO_IDEVID_CMCA2_SUDI": {
+            "storage": "in nvram:"
+        },
+        "CISCO_IDEVID_CMCA2_SUDI0": {
+            "storage": "in nvram:"
+        },
+        "CISCO_IDEVID_CMCA_SUDI": {
+            "storage": "in nvram:"
+        },
+        "CISCO_IDEVID_CMCA_SUDI0": {
+            "storage": "in nvram:"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_crypto_pki_certificate_storage/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_crypto_pki_certificate_storage/001_basic/input.txt
@@ -1,0 +1,9 @@
+TP-self-signed-4032138694 - certificates will be stored in nvram:
+SLA-TrustPoint - certificates will be stored in nvram:
+Trustpool - certificates will be stored in nvram:
+CISCO_IDEVID_SUDI - certificates will be stored with corresponding keypairs
+CISCO_IDEVID_SUDI0 - certificates will be stored in nvram:
+CISCO_IDEVID_CMCA2_SUDI - certificates will be stored in nvram:
+CISCO_IDEVID_CMCA2_SUDI0 - certificates will be stored in nvram:
+CISCO_IDEVID_CMCA_SUDI - certificates will be stored in nvram:
+CISCO_IDEVID_CMCA_SUDI0 - certificates will be stored in nvram:

--- a/tests/parsers/iosxe/show_crypto_pki_certificate_storage/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_crypto_pki_certificate_storage/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with multiple trustpoints showing nvram and keypair storage
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show crypto pki certificate storage` on IOS-XE that extracts trustpoint names and their certificate storage locations into a `dict[str, TrustpointEntry]` keyed by trustpoint name.
- Fixture captured from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in the issue.

Closes #1195

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_crypto_pki_certificate_storage -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_crypto_pki_certificate_storage.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_crypto_pki_certificate_storage.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + fixture + changelog from issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)