### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf retransmission-list`

### DIFF
--- a/changes/1197.parser_added
+++ b/changes/1197.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf retransmission-list` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_retransmission_list.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_retransmission_list.py
@@ -1,0 +1,104 @@
+"""Parser for 'show ip ospf retransmission-list' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+from muninn.utils import canonical_interface_name
+
+_PROCESS_RE = re.compile(
+    rf"OSPF Router with ID \((?P<router_id>{IPV4_ADDRESS})\)"
+    r" \(Process ID (?P<process_id>\d+)\)"
+)
+
+_NEIGHBOR_RE = re.compile(
+    rf"Neighbor (?P<neighbor_id>{IPV4_ADDRESS}),\s+"
+    rf"interface (?P<interface>\S+)\s+"
+    rf"address (?P<address>{IPV4_ADDRESS})"
+)
+
+
+class RetransmissionNeighborEntry(TypedDict):
+    """Schema for a single retransmission-list neighbor entry."""
+
+    address: str
+
+
+class OspfProcessRetransmissionEntry(TypedDict):
+    """Schema for a single OSPF process retransmission-list block."""
+
+    router_id: str
+    neighbors: dict[str, dict[str, RetransmissionNeighborEntry]]
+
+
+class ShowIpOspfRetransmissionListResult(TypedDict):
+    """Schema for 'show ip ospf retransmission-list' parsed output."""
+
+    processes: dict[str, OspfProcessRetransmissionEntry]
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf retransmission-list")
+class ShowIpOspfRetransmissionListParser(
+    BaseParser[ShowIpOspfRetransmissionListResult],
+):
+    """Parser for 'show ip ospf retransmission-list' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.ROUTING}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfRetransmissionListResult:
+        """Parse 'show ip ospf retransmission-list' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed retransmission-list data keyed by process ID.
+
+        Raises:
+            ValueError: If no OSPF processes found in output.
+        """
+        processes: dict[str, dict] = {}
+        current_process_id: str | None = None
+
+        for line in output.splitlines():
+            process_match = _PROCESS_RE.search(line)
+            if process_match:
+                current_process_id = process_match.group("process_id")
+                router_id = process_match.group("router_id")
+                processes[current_process_id] = {
+                    "router_id": router_id,
+                    "neighbors": {},
+                }
+                continue
+
+            if current_process_id is None:
+                continue
+
+            neighbor_match = _NEIGHBOR_RE.search(line)
+            if neighbor_match:
+                neighbor_id = neighbor_match.group("neighbor_id")
+                interface = canonical_interface_name(
+                    neighbor_match.group("interface"), os=OS.CISCO_IOSXE
+                )
+                address = neighbor_match.group("address")
+
+                neighbors = processes[current_process_id]["neighbors"]
+                if interface not in neighbors:
+                    neighbors[interface] = {}
+
+                neighbors[interface][neighbor_id] = {
+                    "address": address,
+                }
+
+        if not processes:
+            msg = "No OSPF processes found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpOspfRetransmissionListResult, {"processes": processes})

--- a/tests/parsers/iosxe/show_ip_ospf_retransmission-list/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_retransmission-list/001_basic/expected.json
@@ -1,0 +1,49 @@
+{
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "neighbors": {
+                "GigabitEthernet1/0/1": {
+                    "192.0.2.4": {
+                        "address": "10.0.2.2"
+                    }
+                },
+                "GigabitEthernet1/0/2": {
+                    "192.0.2.1": {
+                        "address": "10.0.3.1"
+                    }
+                }
+            }
+        },
+        "20": {
+            "router_id": "203.0.113.3",
+            "neighbors": {
+                "GigabitEthernet1/0/1.20": {
+                    "203.0.113.4": {
+                        "address": "10.20.2.2"
+                    }
+                },
+                "GigabitEthernet1/0/2.20": {
+                    "203.0.113.1": {
+                        "address": "10.20.3.1"
+                    }
+                }
+            }
+        },
+        "10": {
+            "router_id": "198.51.100.3",
+            "neighbors": {
+                "GigabitEthernet1/0/2.10": {
+                    "198.51.100.1": {
+                        "address": "10.10.3.1"
+                    }
+                },
+                "GigabitEthernet1/0/1.10": {
+                    "198.51.100.4": {
+                        "address": "10.10.2.2"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_retransmission-list/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_retransmission-list/001_basic/input.txt
@@ -1,0 +1,17 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+ Neighbor 192.0.2.4, interface GigabitEthernet1/0/1 address 10.0.2.2
+
+ Neighbor 192.0.2.1, interface GigabitEthernet1/0/2 address 10.0.3.1
+
+            OSPF Router with ID (203.0.113.3) (Process ID 20)
+
+ Neighbor 203.0.113.4, interface GigabitEthernet1/0/1.20 address 10.20.2.2
+
+ Neighbor 203.0.113.1, interface GigabitEthernet1/0/2.20 address 10.20.3.1
+
+            OSPF Router with ID (198.51.100.3) (Process ID 10)
+
+ Neighbor 198.51.100.1, interface GigabitEthernet1/0/2.10 address 10.10.3.1
+
+ Neighbor 198.51.100.4, interface GigabitEthernet1/0/1.10 address 10.10.2.2

--- a/tests/parsers/iosxe/show_ip_ospf_retransmission-list/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_retransmission-list/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic multi-process OSPF retransmission-list output with multiple neighbors
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf retransmission-list` on Cisco IOS-XE, outputting a `dict[str, OspfProcessRetransmissionEntry]` keyed by process ID, with neighbors nested by interface then neighbor ID.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1197; covers multi-process output with multiple neighbors per process.

Closes #1197

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_retransmission-list" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_retransmission_list.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)