### PR TITLE
feat(cisco_iosxe): add parser for `show dot1x statistics`

### DIFF
--- a/changes/1196.parser_added
+++ b/changes/1196.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show dot1x statistics` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_dot1x_statistics.py
+++ b/src/muninn/parsers/iosxe/show_dot1x_statistics.py
@@ -1,0 +1,100 @@
+"""Parser for 'show dot1x statistics' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import SEPARATOR_DASH_SPACE_RE
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_KV_RE = re.compile(r"(?P<key>\w+)\s*=\s*(?P<value>\d+)")
+
+
+class ShowDot1xStatisticsResult(TypedDict):
+    """Schema for 'show dot1x statistics' parsed output."""
+
+    rx_start: NotRequired[int]
+    rx_logoff: NotRequired[int]
+    rx_resp: NotRequired[int]
+    rx_resp_id: NotRequired[int]
+    rx_req: NotRequired[int]
+    rx_invalid: NotRequired[int]
+    rx_len_err: NotRequired[int]
+    rx_total: NotRequired[int]
+    tx_start: NotRequired[int]
+    tx_logoff: NotRequired[int]
+    tx_resp: NotRequired[int]
+    tx_req: NotRequired[int]
+    re_tx_req: NotRequired[int]
+    re_tx_req_fail: NotRequired[int]
+    tx_req_id: NotRequired[int]
+    re_tx_req_id: NotRequired[int]
+    re_tx_req_id_fail: NotRequired[int]
+    tx_total: NotRequired[int]
+
+
+# Map from CLI counter names to schema field names.
+_KEY_MAP: dict[str, str] = {
+    "RxStart": "rx_start",
+    "RxLogoff": "rx_logoff",
+    "RxResp": "rx_resp",
+    "RxRespID": "rx_resp_id",
+    "RxReq": "rx_req",
+    "RxInvalid": "rx_invalid",
+    "RxLenErr": "rx_len_err",
+    "RxTotal": "rx_total",
+    "TxStart": "tx_start",
+    "TxLogoff": "tx_logoff",
+    "TxResp": "tx_resp",
+    "TxReq": "tx_req",
+    "ReTxReq": "re_tx_req",
+    "ReTxReqFail": "re_tx_req_fail",
+    "TxReqID": "tx_req_id",
+    "ReTxReqID": "re_tx_req_id",
+    "ReTxReqIDFail": "re_tx_req_id_fail",
+    "TxTotal": "tx_total",
+}
+
+
+def _extract_counters(output: str) -> dict[str, int]:
+    """Extract dot1x counter key-value pairs from raw output."""
+    result: dict[str, int] = {}
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped or SEPARATOR_DASH_SPACE_RE.match(stripped):
+            continue
+        for match in _KV_RE.finditer(line):
+            field = _KEY_MAP.get(match.group("key"))
+            if field is not None:
+                result[field] = int(match.group("value"))
+    return result
+
+
+@register(OS.CISCO_IOSXE, "show dot1x statistics")
+class ShowDot1xStatisticsParser(BaseParser[ShowDot1xStatisticsResult]):
+    """Parser for 'show dot1x statistics' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowDot1xStatisticsResult:
+        """Parse 'show dot1x statistics' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed dot1x global statistics counters.
+
+        Raises:
+            ValueError: If no statistics counters are found.
+        """
+        result = _extract_counters(output)
+
+        if not result:
+            msg = "No dot1x statistics counters found in output"
+            raise ValueError(msg)
+
+        return cast(ShowDot1xStatisticsResult, result)

--- a/tests/parsers/iosxe/show_dot1x_statistics/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_dot1x_statistics/001_basic/expected.json
@@ -1,0 +1,20 @@
+{
+    "rx_start": 0,
+    "rx_logoff": 0,
+    "rx_resp": 0,
+    "rx_resp_id": 0,
+    "rx_req": 0,
+    "rx_invalid": 0,
+    "rx_len_err": 0,
+    "rx_total": 0,
+    "tx_start": 0,
+    "tx_logoff": 0,
+    "tx_resp": 0,
+    "tx_req": 0,
+    "re_tx_req": 0,
+    "re_tx_req_fail": 0,
+    "tx_req_id": 0,
+    "re_tx_req_id": 0,
+    "re_tx_req_id_fail": 0,
+    "tx_total": 0
+}

--- a/tests/parsers/iosxe/show_dot1x_statistics/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_dot1x_statistics/001_basic/input.txt
@@ -1,0 +1,10 @@
+Dot1x Global Statistics for
+--------------------------------------------
+RxStart = 0     RxLogoff = 0    RxResp = 0      RxRespID = 0
+RxReq = 0       RxInvalid = 0   RxLenErr = 0
+RxTotal = 0
+
+TxStart = 0     TxLogoff = 0    TxResp = 0
+TxReq = 0       ReTxReq = 0     ReTxReqFail = 0
+TxReqID = 0         ReTxReqID = 0       ReTxReqIDFail = 0
+TxTotal = 0

--- a/tests/parsers/iosxe/show_dot1x_statistics/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_dot1x_statistics/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic dot1x global statistics with all counters at zero.
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show dot1x statistics` on Cisco IOS-XE that extracts all 18 global Rx/Tx counters (start, logoff, resp, req, invalid, len_err, totals, retransmits) into a flat `dict[str, int]` schema with `NotRequired` fields.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in #1196. All counters are zero in this baseline capture.

Closes #1196

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_dot1x_statistics -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_dot1x_statistics.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_dot1x_statistics.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + fixture + changelog from issue spec

Generated with [Claude Code](https://claude.com/claude-code)