### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf max-metric`

### DIFF
--- a/changes/1194.parser_added
+++ b/changes/1194.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf max-metric` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_max_metric.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_max_metric.py
@@ -5,11 +5,12 @@ from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
 from muninn.registry import register
 from muninn.tags import ParserTag
 
 _PROCESS_HEADER_RE = re.compile(
-    r"OSPF Router with ID \((?P<router_id>\S+)\)"
+    rf"OSPF Router with ID \((?P<router_id>{IPV4_ADDRESS})\)"
     r" \(Process ID (?P<process_id>\d+)\)"
 )
 _MTID_RE = re.compile(r"Base Topology \(MTID (?P<mtid>\d+)\)")

--- a/src/muninn/parsers/iosxe/show_ip_ospf_max_metric.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_max_metric.py
@@ -1,0 +1,209 @@
+"""Parser for 'show ip ospf max-metric' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_PROCESS_HEADER_RE = re.compile(
+    r"OSPF Router with ID \((?P<router_id>\S+)\)"
+    r" \(Process ID (?P<process_id>\d+)\)"
+)
+_MTID_RE = re.compile(r"Base Topology \(MTID (?P<mtid>\d+)\)")
+_START_TIME_RE = re.compile(
+    r"Start time:\s+(?P<start_time>\S+),\s+"
+    r"Time elapsed:\s+(?P<time_elapsed>\S+)"
+)
+_NOT_ORIGINATING_RE = re.compile(
+    r"Router is not originating router-LSAs with maximum metric"
+)
+_ORIGINATING_RE = re.compile(r"Router is originating router-LSAs with maximum metric")
+_CONDITION_RE = re.compile(
+    r"Condition:\s+(?P<condition>.+?)(?:,\s+State:\s+(?P<state>.+))?"
+)
+_ADVERTISE_STUB_RE = re.compile(
+    r"Advertise stub links with maximum metric in router-LSAs"
+)
+_ADVERTISE_SUMMARY_RE = re.compile(
+    r"Advertise summary-LSAs with metric (?P<metric>\d+)"
+)
+_ADVERTISE_EXTERNAL_RE = re.compile(
+    r"Advertise external-LSAs with metric (?P<metric>\d+)"
+)
+_UNSET_REASON_RE = re.compile(
+    r"Unset reason:\s+(?P<reason>.+?)(?:,\s+Unset time:\s+(?P<time>.+))?"
+)
+
+
+class TopologyEntry(TypedDict):
+    """Schema for a single Base Topology (MTID) block."""
+
+    start_time: NotRequired[str]
+    time_elapsed: NotRequired[str]
+    max_metric_active: bool
+    condition: NotRequired[str]
+    state: NotRequired[str]
+    advertise_stub_links: NotRequired[bool]
+    summary_lsa_metric: NotRequired[int]
+    external_lsa_metric: NotRequired[int]
+    unset_reason: NotRequired[str]
+    unset_time: NotRequired[str]
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single OSPF process."""
+
+    router_id: str
+    topologies: dict[str, TopologyEntry]
+
+
+ShowIpOspfMaxMetricResult = dict[str, ProcessEntry]
+
+
+def _try_topology_line(line: str, topo: dict) -> bool:
+    """Try to parse a single line within a topology block.
+
+    Returns True if the line was consumed, False otherwise.
+    """
+    start_match = _START_TIME_RE.match(line)
+    if start_match:
+        topo["start_time"] = start_match.group("start_time")
+        topo["time_elapsed"] = start_match.group("time_elapsed")
+        return True
+
+    if _NOT_ORIGINATING_RE.match(line):
+        topo["max_metric_active"] = False
+        return True
+
+    if _ORIGINATING_RE.match(line):
+        topo["max_metric_active"] = True
+        return True
+
+    cond_match = _CONDITION_RE.match(line)
+    if cond_match:
+        topo["condition"] = cond_match.group("condition")
+        if cond_match.group("state"):
+            topo["state"] = cond_match.group("state")
+        return True
+
+    return _try_advertise_line(line, topo)
+
+
+def _try_advertise_line(line: str, topo: dict) -> bool:
+    """Try to parse advertise and unset lines within a topology block."""
+    if _ADVERTISE_STUB_RE.match(line):
+        topo["advertise_stub_links"] = True
+        return True
+
+    summary_match = _ADVERTISE_SUMMARY_RE.match(line)
+    if summary_match:
+        topo["summary_lsa_metric"] = int(summary_match.group("metric"))
+        return True
+
+    external_match = _ADVERTISE_EXTERNAL_RE.match(line)
+    if external_match:
+        topo["external_lsa_metric"] = int(external_match.group("metric"))
+        return True
+
+    unset_match = _UNSET_REASON_RE.match(line)
+    if unset_match:
+        topo["unset_reason"] = unset_match.group("reason")
+        if unset_match.group("time"):
+            topo["unset_time"] = unset_match.group("time")
+        return True
+
+    return False
+
+
+def _finalize_process(
+    result: dict[str, ProcessEntry],
+    process: dict | None,
+    process_id: str | None,
+    topo: dict | None,
+    mtid: str | None,
+) -> None:
+    """Finalize the current process by saving the last topology."""
+    if process is None or process_id is None:
+        return
+    if topo is not None and mtid is not None:
+        process["topologies"][mtid] = topo
+    result[process_id] = cast(ProcessEntry, process)
+
+
+def _parse_output(output: str) -> ShowIpOspfMaxMetricResult:
+    """Parse show ip ospf max-metric output into structured data."""
+    result: dict[str, ProcessEntry] = {}
+    current_process: dict | None = None
+    current_process_id: str | None = None
+    current_topo: dict | None = None
+    current_mtid: str | None = None
+
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        process_match = _PROCESS_HEADER_RE.search(stripped)
+        if process_match:
+            _finalize_process(
+                result,
+                current_process,
+                current_process_id,
+                current_topo,
+                current_mtid,
+            )
+            current_process_id = process_match.group("process_id")
+            current_process = {
+                "router_id": process_match.group("router_id"),
+                "topologies": {},
+            }
+            current_topo = None
+            current_mtid = None
+            continue
+
+        if current_process is None:
+            continue
+
+        mtid_match = _MTID_RE.search(stripped)
+        if mtid_match:
+            if current_topo is not None and current_mtid is not None:
+                current_process["topologies"][current_mtid] = current_topo
+            current_mtid = mtid_match.group("mtid")
+            current_topo = {"max_metric_active": False}
+            continue
+
+        if current_topo is not None:
+            _try_topology_line(stripped, current_topo)
+
+    _finalize_process(
+        result,
+        current_process,
+        current_process_id,
+        current_topo,
+        current_mtid,
+    )
+
+    if not result:
+        msg = "No OSPF process information found in output"
+        raise ValueError(msg)
+
+    return cast(ShowIpOspfMaxMetricResult, result)
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf max-metric")
+class ShowIpOspfMaxMetricParser(BaseParser[ShowIpOspfMaxMetricResult]):
+    """Parser for 'show ip ospf max-metric' on IOS-XE.
+
+    Parses max-metric status per OSPF process and topology.
+    Output is keyed by process ID (string).
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.OSPF})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfMaxMetricResult:
+        """Parse 'show ip ospf max-metric' output."""
+        return _parse_output(output)

--- a/tests/parsers/iosxe/show_ip_ospf_max-metric/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_max-metric/001_basic/expected.json
@@ -1,0 +1,32 @@
+{
+    "1": {
+        "router_id": "192.0.2.3",
+        "topologies": {
+            "0": {
+                "max_metric_active": false,
+                "start_time": "00:55:14.937",
+                "time_elapsed": "6w5d"
+            }
+        }
+    },
+    "20": {
+        "router_id": "203.0.113.3",
+        "topologies": {
+            "0": {
+                "max_metric_active": false,
+                "start_time": "00:55:15.350",
+                "time_elapsed": "6w5d"
+            }
+        }
+    },
+    "10": {
+        "router_id": "198.51.100.3",
+        "topologies": {
+            "0": {
+                "max_metric_active": false,
+                "start_time": "00:55:14.437",
+                "time_elapsed": "6w5d"
+            }
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_max-metric/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_max-metric/001_basic/input.txt
@@ -1,0 +1,25 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+
+                Base Topology (MTID 0)
+
+ Start time: 00:55:14.937, Time elapsed: 6w5d
+ Router is not originating router-LSAs with maximum metric
+
+
+            OSPF Router with ID (203.0.113.3) (Process ID 20)
+
+
+                Base Topology (MTID 0)
+
+ Start time: 00:55:15.350, Time elapsed: 6w5d
+ Router is not originating router-LSAs with maximum metric
+
+
+            OSPF Router with ID (198.51.100.3) (Process ID 10)
+
+
+                Base Topology (MTID 0)
+
+ Start time: 00:55:14.437, Time elapsed: 6w5d
+ Router is not originating router-LSAs with maximum metric

--- a/tests/parsers/iosxe/show_ip_ospf_max-metric/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_max-metric/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with three OSPF processes, none originating max-metric LSAs
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf max-metric` on Cisco IOS-XE, keyed by OSPF process ID (string) with per-topology (MTID) max-metric status, start time, elapsed time, and optional condition/advertise/unset fields.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1194. Covers the common case of multiple OSPF processes not originating max-metric LSAs.

Closes #1194

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_max-metric" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_max_metric.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_max_metric.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + fixture + changelog from issue specification

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)