### PR TITLE
feat(cisco_iosxe): add parser for `show etherchannel load-balance`

### DIFF
--- a/changes/1200.parser_added
+++ b/changes/1200.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show etherchannel load-balance` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_etherchannel_load_balance.py
+++ b/src/muninn/parsers/iosxe/show_etherchannel_load_balance.py
@@ -1,0 +1,92 @@
+"""Parser for 'show etherchannel load-balance' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_PROTOCOL_RE = re.compile(r"^\s*(?P<protocol>Non-IP|IPv4|IPv6)\s*:\s*(?P<address>.+)$")
+
+_CONFIG_HEADER = "EtherChannel Load-Balancing Configuration"
+_PER_PROTOCOL_HEADER = "EtherChannel Load-Balancing Addresses Used Per-Protocol"
+
+
+class ProtocolEntry(TypedDict):
+    """Schema for per-protocol load-balancing address information."""
+
+    address: str
+
+
+class ShowEtherchannelLoadBalanceResult(TypedDict):
+    """Schema for 'show etherchannel load-balance' parsed output."""
+
+    method: str
+    per_protocol: NotRequired[dict[str, ProtocolEntry]]
+
+
+def _parse_per_protocol(lines: list[str]) -> dict[str, ProtocolEntry]:
+    """Extract per-protocol load-balancing addresses from output lines."""
+    per_protocol: dict[str, ProtocolEntry] = {}
+    for line in lines:
+        match = _PROTOCOL_RE.match(line)
+        if match:
+            protocol = match.group("protocol")
+            address = match.group("address").strip()
+            per_protocol[protocol] = ProtocolEntry(address=address)
+    return per_protocol
+
+
+def _parse_method(lines: list[str]) -> str | None:
+    """Extract the load-balancing method from the configuration section."""
+    in_config_section = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            in_config_section = False
+            continue
+        if stripped.startswith(_CONFIG_HEADER):
+            in_config_section = True
+            continue
+        if in_config_section:
+            return stripped
+    return None
+
+
+@register(OS.CISCO_IOSXE, "show etherchannel load-balance")
+class ShowEtherchannelLoadBalanceParser(
+    BaseParser[ShowEtherchannelLoadBalanceResult],
+):
+    """Parser for 'show etherchannel load-balance' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.LAG})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowEtherchannelLoadBalanceResult:
+        """Parse 'show etherchannel load-balance' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed load-balancing configuration and per-protocol details.
+
+        Raises:
+            ValueError: If required fields cannot be extracted.
+        """
+        lines = output.splitlines()
+
+        method = _parse_method(lines)
+        if method is None:
+            msg = "Missing required field: method"
+            raise ValueError(msg)
+
+        result: dict[str, object] = {"method": method}
+
+        per_protocol = _parse_per_protocol(lines)
+        if per_protocol:
+            result["per_protocol"] = per_protocol
+
+        return cast(ShowEtherchannelLoadBalanceResult, result)

--- a/src/muninn/parsers/iosxe/show_etherchannel_load_balance.py
+++ b/src/muninn/parsers/iosxe/show_etherchannel_load_balance.py
@@ -11,7 +11,6 @@ from muninn.tags import ParserTag
 _PROTOCOL_RE = re.compile(r"^\s*(?P<protocol>Non-IP|IPv4|IPv6)\s*:\s*(?P<address>.+)$")
 
 _CONFIG_HEADER = "EtherChannel Load-Balancing Configuration"
-_PER_PROTOCOL_HEADER = "EtherChannel Load-Balancing Addresses Used Per-Protocol"
 
 
 class ProtocolEntry(TypedDict):

--- a/tests/parsers/iosxe/show_etherchannel_load-balance/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_etherchannel_load-balance/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+    "method": "src-mac",
+    "per_protocol": {
+        "Non-IP": {
+            "address": "Source MAC address"
+        },
+        "IPv4": {
+            "address": "Source MAC address"
+        },
+        "IPv6": {
+            "address": "Source MAC address"
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_etherchannel_load-balance/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_etherchannel_load-balance/001_basic/input.txt
@@ -1,0 +1,7 @@
+EtherChannel Load-Balancing Configuration:
+        src-mac
+
+EtherChannel Load-Balancing Addresses Used Per-Protocol:
+Non-IP: Source MAC address
+  IPv4: Source MAC address
+  IPv6: Source MAC address

--- a/tests/parsers/iosxe/show_etherchannel_load-balance/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_etherchannel_load-balance/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show etherchannel load-balance output with src-mac method
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show etherchannel load-balance` on Cisco IOS-XE that extracts the load-balancing method and per-protocol address details into a `dict` keyed by protocol name (Non-IP, IPv4, IPv6).
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1200.

Closes #1200

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_etherchannel_load-balance" -v` (7 passed)
- [x] `uv run pytest -q` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_etherchannel_load_balance.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_etherchannel_load_balance.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from issue #1200
- **Human Oversight**: Pending code review

Generated with [Claude Code](https://claude.com/claude-code)