### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf ls-distribution`

### DIFF
--- a/changes/1202.parser_added
+++ b/changes/1202.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf ls-distribution` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_ls_distribution.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_ls_distribution.py
@@ -1,0 +1,71 @@
+"""Parser for 'show ip ospf ls-distribution' command on IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_PROCESS_HEADER_RE = re.compile(r"OSPF Router with ID \((\S+)\) \(Process ID (\d+)\)")
+_LS_DIST_RE = re.compile(r"OSPF LS Distribution is (Enabled|Disabled)")
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single OSPF process LS distribution entry."""
+
+    router_id: str
+    ls_distribution_enabled: bool
+
+
+class ShowIpOspfLsDistributionResult(TypedDict):
+    """Schema for 'show ip ospf ls-distribution' parsed output.
+
+    Keyed by OSPF process ID (as string).
+    """
+
+    processes: dict[str, ProcessEntry]
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf ls-distribution")
+class ShowIpOspfLsDistributionParser(
+    BaseParser[ShowIpOspfLsDistributionResult],
+):
+    """Parser for 'show ip ospf ls-distribution' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.OSPF})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfLsDistributionResult:
+        """Parse show ip ospf ls-distribution output.
+
+        Returns a dict keyed by process ID with router ID and
+        LS distribution status for each OSPF process.
+        """
+        processes: dict[str, ProcessEntry] = {}
+        current_pid: str | None = None
+        current_rid: str | None = None
+
+        for line in output.splitlines():
+            header_match = _PROCESS_HEADER_RE.search(line)
+            if header_match:
+                current_rid = header_match.group(1)
+                current_pid = header_match.group(2)
+                continue
+
+            dist_match = _LS_DIST_RE.search(line)
+            if dist_match and current_pid is not None and current_rid is not None:
+                enabled = dist_match.group(1) == "Enabled"
+                processes[current_pid] = ProcessEntry(
+                    router_id=current_rid,
+                    ls_distribution_enabled=enabled,
+                )
+                current_pid = None
+                current_rid = None
+
+        if not processes:
+            msg = "No OSPF process entries found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpOspfLsDistributionResult, {"processes": processes})

--- a/tests/parsers/iosxe/show_ip_ospf_ls-distribution/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_ls-distribution/001_basic/expected.json
@@ -1,0 +1,16 @@
+{
+    "processes": {
+        "1": {
+            "router_id": "192.0.2.3",
+            "ls_distribution_enabled": false
+        },
+        "20": {
+            "router_id": "203.0.113.3",
+            "ls_distribution_enabled": false
+        },
+        "10": {
+            "router_id": "198.51.100.3",
+            "ls_distribution_enabled": false
+        }
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_ls-distribution/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_ls-distribution/001_basic/input.txt
@@ -1,0 +1,8 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+OSPF LS Distribution is Disabled
+
+            OSPF Router with ID (203.0.113.3) (Process ID 20)
+OSPF LS Distribution is Disabled
+
+            OSPF Router with ID (198.51.100.3) (Process ID 10)
+OSPF LS Distribution is Disabled

--- a/tests/parsers/iosxe/show_ip_ospf_ls-distribution/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_ls-distribution/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Multiple OSPF processes with LS distribution disabled (C9300 live device)
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf ls-distribution` on Cisco IOS-XE that extracts per-process OSPF LS distribution status, keyed by process ID with router ID and enabled/disabled boolean.
- Fixture sourced from issue #1202 sample output captured from a C9300-48U running IOS-XE 17.18.02 (3 processes, all disabled).

Closes #1202

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_ls-distribution" -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_ls_distribution.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_ls_distribution.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)