### PR TITLE
feat(cisco_iosxe): add parser for `show interfaces summary vlan`

### DIFF
--- a/changes/1204.parser_added
+++ b/changes/1204.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show interfaces summary vlan` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_interfaces_summary_vlan.py
+++ b/src/muninn/parsers/iosxe/show_interfaces_summary_vlan.py
@@ -1,0 +1,102 @@
+"""Parser for 'show interfaces summary vlan' command on Cisco IOS-XE."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+# Matches "Total number of Vlan interfaces: <N>"
+_TOTAL_RE = re.compile(
+    r"^\s*Total\s+number\s+of\s+Vlan\s+interfaces:\s*(?P<total>\d+)\s*$",
+    re.IGNORECASE,
+)
+
+# Matches the "Vlan interfaces configured:" section header.
+_CONFIGURED_HEADER_RE = re.compile(
+    r"^\s*Vlan\s+interfaces\s+configured:\s*$",
+    re.IGNORECASE,
+)
+
+# Matches a line containing only VLAN IDs (one or more integers).
+_VLAN_IDS_RE = re.compile(r"^\s*(\d+(?:\s+\d+)*)\s*$")
+
+
+class ShowInterfacesSummaryVlanResult(TypedDict):
+    """Schema for 'show interfaces summary vlan' parsed output.
+
+    Contains the total count of VLAN interfaces and a sorted list
+    of configured VLAN IDs.
+    """
+
+    total: int
+    configured_vlans: list[int]
+
+
+def _parse_vlan_ids(lines: list[str], start: int) -> list[int]:
+    """Extract VLAN IDs from lines following the configured header.
+
+    Args:
+        lines: All output lines.
+        start: Index of the first line after the header.
+
+    Returns:
+        Sorted list of VLAN IDs found.
+    """
+    vlans: list[int] = []
+    for line in lines[start:]:
+        ids_match = _VLAN_IDS_RE.match(line)
+        if ids_match:
+            vlans.extend(int(v) for v in ids_match.group(1).split())
+    vlans.sort()
+    return vlans
+
+
+@register(OS.CISCO_IOSXE, "show interfaces summary vlan")
+class ShowInterfacesSummaryVlanParser(
+    BaseParser[ShowInterfacesSummaryVlanResult],
+):
+    """Parser for 'show interfaces summary vlan' on Cisco IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.INTERFACES, ParserTag.VLAN}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowInterfacesSummaryVlanResult:
+        """Parse 'show interfaces summary vlan' output.
+
+        Args:
+            output: Raw CLI output from the command.
+
+        Returns:
+            Parsed result with total VLAN interface count and list of
+            configured VLAN IDs.
+
+        Raises:
+            ValueError: If the total count line cannot be found.
+        """
+        lines = output.splitlines()
+        total: int | None = None
+        configured_vlans: list[int] = []
+
+        for idx, line in enumerate(lines):
+            total_match = _TOTAL_RE.match(line)
+            if total_match:
+                total = int(total_match.group("total"))
+                continue
+
+            if _CONFIGURED_HEADER_RE.match(line):
+                configured_vlans = _parse_vlan_ids(lines, idx + 1)
+                break
+
+        if total is None:
+            msg = "Missing 'Total number of Vlan interfaces' line in output"
+            raise ValueError(msg)
+
+        return ShowInterfacesSummaryVlanResult(
+            total=total,
+            configured_vlans=configured_vlans,
+        )

--- a/tests/parsers/iosxe/show_interfaces_summary_vlan/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_interfaces_summary_vlan/001_basic/expected.json
@@ -1,0 +1,6 @@
+{
+    "total": 1,
+    "configured_vlans": [
+        1
+    ]
+}

--- a/tests/parsers/iosxe/show_interfaces_summary_vlan/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_interfaces_summary_vlan/001_basic/input.txt
@@ -1,0 +1,4 @@
+Total number of Vlan interfaces: 1
+
+Vlan interfaces configured:
+1

--- a/tests/parsers/iosxe/show_interfaces_summary_vlan/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_interfaces_summary_vlan/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show interfaces summary vlan output with single VLAN
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show interfaces summary vlan` on Cisco IOS-XE that extracts the total VLAN interface count and a sorted list of configured VLAN IDs into a flat `ShowInterfacesSummaryVlanResult` TypedDict.
- Fixture sourced from issue #1204 sample output (C9300-48U, IOS-XE 17.18.02); single-VLAN scenario only — additional multi-VLAN fixtures would improve coverage.

Closes #1204

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_interfaces_summary_vlan -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_interfaces_summary_vlan.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_interfaces_summary_vlan.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation from GitHub issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)