### PR TITLE
feat(cisco_iosxe): add parser for `show ip ospf summary-address`

### DIFF
--- a/changes/1203.parser_added
+++ b/changes/1203.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip ospf summary-address` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_ip_ospf_summary_address.py
+++ b/src/muninn/parsers/iosxe/show_ip_ospf_summary_address.py
@@ -1,0 +1,107 @@
+"""Parser for 'show ip ospf summary-address' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+_PROCESS_HEADER_RE = re.compile(
+    rf"^\s*OSPF Router with ID \((?P<router_id>{IPV4_ADDRESS})\)"
+    r"\s+\(Process ID (?P<pid>\d+)\)\s*$"
+)
+
+_TOPOLOGY_RE = re.compile(r"^\s*Base Topology \(MTID (?P<mtid>\d+)\)\s*$")
+
+_ADDRESS_RE = re.compile(
+    rf"^\s*(?P<prefix>{IPV4_ADDRESS})/(?P<mask>{IPV4_ADDRESS})"
+    r"\s+Metric (?P<metric>-?\d+),\s*Tag (?P<tag>\d+)\s*$"
+)
+
+
+class SummaryAddressEntry(TypedDict):
+    """Schema for a single summary-address entry."""
+
+    metric: int
+    tag: int
+
+
+class ProcessEntry(TypedDict):
+    """Schema for a single OSPF process in summary-address output."""
+
+    router_id: str
+    mtid: NotRequired[int]
+    addresses: dict[str, SummaryAddressEntry]
+
+
+ShowIpOspfSummaryAddressResult = dict[str, ProcessEntry]
+
+
+@register(OS.CISCO_IOSXE, "show ip ospf summary-address")
+class ShowIpOspfSummaryAddressParser(
+    BaseParser[ShowIpOspfSummaryAddressResult],
+):
+    """Parser for 'show ip ospf summary-address' on IOS-XE.
+
+    Parses OSPF summary-address configuration per process, including
+    metric and tag values for each advertised prefix.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.OSPF, ParserTag.ROUTING}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpOspfSummaryAddressResult:
+        """Parse 'show ip ospf summary-address' output.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dict keyed by OSPF process ID with router ID, MTID,
+            and summary addresses per process.
+
+        Raises:
+            ValueError: If no OSPF processes are found in output.
+        """
+        result: dict[str, ProcessEntry] = {}
+        current_pid: str | None = None
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            proc_match = _PROCESS_HEADER_RE.match(line)
+            if proc_match:
+                current_pid = proc_match.group("pid")
+                result[current_pid] = {
+                    "router_id": proc_match.group("router_id"),
+                    "addresses": {},
+                }
+                continue
+
+            if current_pid is None:
+                continue
+
+            topo_match = _TOPOLOGY_RE.match(line)
+            if topo_match:
+                result[current_pid]["mtid"] = int(topo_match.group("mtid"))
+                continue
+
+            addr_match = _ADDRESS_RE.match(line)
+            if addr_match:
+                prefix_key = f"{addr_match.group('prefix')}/{addr_match.group('mask')}"
+                result[current_pid]["addresses"][prefix_key] = {
+                    "metric": int(addr_match.group("metric")),
+                    "tag": int(addr_match.group("tag")),
+                }
+
+        if not result:
+            msg = "No OSPF processes found in output"
+            raise ValueError(msg)
+
+        return cast(ShowIpOspfSummaryAddressResult, result)

--- a/tests/parsers/iosxe/show_ip_ospf_summary-address/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_ip_ospf_summary-address/001_basic/expected.json
@@ -1,0 +1,17 @@
+{
+    "1": {
+        "router_id": "192.0.2.3",
+        "addresses": {},
+        "mtid": 0
+    },
+    "20": {
+        "router_id": "203.0.113.3",
+        "addresses": {},
+        "mtid": 0
+    },
+    "10": {
+        "router_id": "198.51.100.3",
+        "addresses": {},
+        "mtid": 0
+    }
+}

--- a/tests/parsers/iosxe/show_ip_ospf_summary-address/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_ip_ospf_summary-address/001_basic/input.txt
@@ -1,0 +1,16 @@
+OSPF Router with ID (192.0.2.3) (Process ID 1)
+
+
+                Base Topology (MTID 0)
+
+
+            OSPF Router with ID (203.0.113.3) (Process ID 20)
+
+
+                Base Topology (MTID 0)
+
+
+            OSPF Router with ID (198.51.100.3) (Process ID 10)
+
+
+                Base Topology (MTID 0)

--- a/tests/parsers/iosxe/show_ip_ospf_summary-address/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_ip_ospf_summary-address/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic output with multiple OSPF processes and no summary addresses configured
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show ip ospf summary-address` on IOS-XE, keyed by OSPF process ID with router_id, mtid, and summary addresses (prefix/mask -> metric + tag) per process.
- Fixture sourced from physical testbed (C9300-48U, IOS-XE 17.18.02) showing three OSPF processes with no summary addresses configured.

Closes #1203

## Test plan
- [x] `uv run pytest tests/parsers/ -k "show_ip_ospf_summary-address" -v` (7 passed)
- [x] `uv run pytest -q` (full suite, 9201 passed)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_ip_ospf_summary_address.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_ip_ospf_summary_address.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

Generated with [Claude Code](https://claude.com/claude-code)