### PR TITLE
feat(cisco_iosxe): add parser for `show vlan summary`

### DIFF
--- a/changes/1214.parser_added
+++ b/changes/1214.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show vlan summary` on Cisco IOS-XE.

--- a/src/muninn/parsers/iosxe/show_vlan_summary.py
+++ b/src/muninn/parsers/iosxe/show_vlan_summary.py
@@ -1,0 +1,76 @@
+"""Parser for 'show vlan summary' command on IOS-XE."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict, cast
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowVlanSummaryResult(TypedDict):
+    """Schema for 'show vlan summary' parsed output.
+
+    ``existing_vlans`` is always present; the other counters are
+    ``NotRequired`` because not all IOS-XE versions emit them.
+    """
+
+    existing_vlans: int
+    vtp_vlans: NotRequired[int]
+    extended_vlans: NotRequired[int]
+
+
+_EXISTING_VLANS_RE = re.compile(
+    r"^\s*Number of existing VLANs\s*:\s*(?P<count>\d+)\s*$"
+)
+_VTP_VLANS_RE = re.compile(r"^\s*Number of existing VTP VLANs\s*:\s*(?P<count>\d+)\s*$")
+_EXTENDED_VLANS_RE = re.compile(
+    r"^\s*Number of existing extended VLANS\s*:\s*(?P<count>\d+)\s*$"
+)
+
+
+@register(OS.CISCO_IOSXE, "show vlan summary")
+class ShowVlanSummaryParser(BaseParser[ShowVlanSummaryResult]):
+    """Parser for 'show vlan summary' on IOS-XE."""
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset(
+        {ParserTag.SWITCHING, ParserTag.VLAN}
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVlanSummaryResult:
+        """Parse 'show vlan summary' output.
+
+        Args:
+            output: Raw CLI output from 'show vlan summary' command.
+
+        Returns:
+            Parsed VLAN summary counters.
+
+        Raises:
+            ValueError: If no VLAN count line is found in the output.
+        """
+        result: dict = {}
+
+        for raw_line in output.splitlines():
+            match = _EXISTING_VLANS_RE.match(raw_line)
+            if match:
+                result["existing_vlans"] = int(match.group("count"))
+                continue
+
+            match = _VTP_VLANS_RE.match(raw_line)
+            if match:
+                result["vtp_vlans"] = int(match.group("count"))
+                continue
+
+            match = _EXTENDED_VLANS_RE.match(raw_line)
+            if match:
+                result["extended_vlans"] = int(match.group("count"))
+                continue
+
+        if "existing_vlans" not in result:
+            msg = "No 'show vlan summary' content recognized in output"
+            raise ValueError(msg)
+
+        return cast(ShowVlanSummaryResult, result)

--- a/tests/parsers/iosxe/show_vlan_summary/001_basic/expected.json
+++ b/tests/parsers/iosxe/show_vlan_summary/001_basic/expected.json
@@ -1,0 +1,5 @@
+{
+    "existing_vlans": 5,
+    "vtp_vlans": 5,
+    "extended_vlans": 0
+}

--- a/tests/parsers/iosxe/show_vlan_summary/001_basic/input.txt
+++ b/tests/parsers/iosxe/show_vlan_summary/001_basic/input.txt
@@ -1,0 +1,3 @@
+Number of existing VLANs               : 5
+ Number of existing VTP VLANs          : 5
+ Number of existing extended VLANS     : 0

--- a/tests/parsers/iosxe/show_vlan_summary/001_basic/metadata.yaml
+++ b/tests/parsers/iosxe/show_vlan_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Basic show vlan summary output with 5 VLANs
+platform: Cisco C9300-48U
+software_version: IOS-XE 17.18.02


### PR DESCRIPTION
## Summary
- Adds a parser for `show vlan summary` on Cisco IOS-XE that extracts VLAN counters (`existing_vlans`, `vtp_vlans`, `extended_vlans`) into a flat TypedDict schema.
- Fixture sourced from physical testbed device (C9300-48U, IOS-XE 17.18.02) as provided in issue #1214.

Closes #1214

## Test plan
- [x] `uv run pytest tests/parsers/ -k show_vlan_summary -v` (7 passed)
- [x] `uv run pytest` (full suite, 9201 passing)
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check src/muninn/parsers/iosxe/show_vlan_summary.py`
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/muninn/parsers/iosxe/show_vlan_summary.py`

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation from issue specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)