### PR TITLE
chore: switch PyPI publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,11 @@ jobs:
   publish:
     needs: [build, release]
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/p/muninn
+    permissions:
+      id-token: write
     steps:
       - name: Download distribution artifacts
         uses: actions/download-artifact@v8
@@ -67,5 +71,3 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/changes/1285.internal
+++ b/changes/1285.internal
@@ -1,0 +1,1 @@
+Switched PyPI publishing to OIDC trusted publishing (no API token required).


### PR DESCRIPTION
## Summary

- Replace API token-based PyPI publishing with GitHub OIDC trusted publishing
- The workflow now uses `permissions: id-token: write` and lets `pypa/gh-action-pypi-publish` mint a short-lived OIDC token verified by PyPI
- No `PYPI_API_TOKEN` secret needed — the trusted publisher is registered on PyPI for this repo/workflow/environment

## Test plan

- [x] Trusted publisher registered on PyPI for `muninn` package
- [ ] Verify on next release tag that publishing succeeds without the API token

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: CI publishing update

🤖 Generated with [Claude Code](https://claude.com/claude-code)