### PR TITLE
fix: resolve all CI failures on main branch

### DIFF
--- a/changes/+fix-ci-main-failures.internal
+++ b/changes/+fix-ci-main-failures.internal
@@ -1,0 +1,1 @@
+Resolve all CI failures on main: fix ruff formatting, bandit assert suppressions, ty type errors, xenon complexity violations, and list-of-dicts test exemption.

--- a/src/muninn/parsers/cisco_iosxr/show_bgp_all_evpn_summary.py
+++ b/src/muninn/parsers/cisco_iosxr/show_bgp_all_evpn_summary.py
@@ -10,7 +10,7 @@ with an ``address_families`` key containing a ``"default"`` entry (since
 no explicit Address Family header is present in this output).
 """
 
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -51,4 +51,4 @@ class ShowBgpAllEvpnSummaryParser(BaseParser["ShowBgpSummaryResult"]):
         Raises:
             ValueError: If required fields cannot be parsed from the output.
         """
-        return ShowBgpSummaryParser.parse(output)
+        return cast(ShowBgpSummaryResult, ShowBgpSummaryParser.parse(output))

--- a/src/muninn/parsers/cisco_iosxr/show_bgp_l2vpn_evpn.py
+++ b/src/muninn/parsers/cisco_iosxr/show_bgp_l2vpn_evpn.py
@@ -338,6 +338,20 @@ def _try_append_route(
         routes.append(entry)
 
 
+def _handle_evpn_continuation_line(
+    line: str,
+    routes: list[RouteEntry],
+    current_status: str | None,
+    current_network: str | None,
+) -> None:
+    """Handle an indented data continuation line (next-hop on separate line)."""
+    if line[0] != " " or not current_network or not current_status:
+        return
+    data_tokens = line.strip().split()
+    if data_tokens:
+        _try_append_route(routes, current_status, current_network, data_tokens)
+
+
 def _parse_route_lines(lines: list[str]) -> list[RouteEntry]:
     """Parse route entry lines within a Route Distinguisher section.
 
@@ -349,18 +363,13 @@ def _parse_route_lines(lines: list[str]) -> list[RouteEntry]:
     current_status: str | None = None
 
     for line in lines:
-        stripped = line.strip()
-        if not stripped:
+        if not line.strip():
             continue
 
-        # Indented data continuation line (next-hop info on separate line)
         if not _is_route_line(line):
-            if line[0] == " " and current_network and current_status:
-                data_tokens = stripped.split()
-                if data_tokens:
-                    _try_append_route(
-                        routes, current_status, current_network, data_tokens
-                    )
+            _handle_evpn_continuation_line(
+                line, routes, current_status, current_network
+            )
             continue
 
         # Route line with status codes
@@ -538,7 +547,7 @@ def _apply_optional_fields(
     """Apply optional header fields and totals to the result dict."""
     for key, coerce in _OPTIONAL_HEADER_KEYS:
         if key in header:
-            result[key] = coerce(header[key])  # type: ignore[literal-required]
+            result[key] = coerce(header[key])  # type: ignore[literal-required]  # ty: ignore[invalid-key]
     if total_prefixes is not None:
         result["total_prefixes"] = total_prefixes
     if total_paths is not None:
@@ -555,9 +564,7 @@ class ShowBgpL2vpnEvpnParser(BaseParser["ShowBgpL2vpnEvpnResult"]):
     weight, AS path, and origin code.
     """
 
-    tags: ClassVar[frozenset[ParserTag]] = frozenset(
-        {ParserTag.BGP, ParserTag.ROUTING}
-    )
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
 
     @classmethod
     def parse(cls, output: str) -> ShowBgpL2vpnEvpnResult:

--- a/src/muninn/parsers/cisco_iosxr/show_bgp_vpnv4_unicast_summary.py
+++ b/src/muninn/parsers/cisco_iosxr/show_bgp_vpnv4_unicast_summary.py
@@ -10,7 +10,7 @@ with an ``address_families`` key containing a ``"default"`` entry (since
 no explicit Address Family header is present in this output).
 """
 
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -51,4 +51,4 @@ class ShowBgpVpnv4UnicastSummaryParser(BaseParser["ShowBgpSummaryResult"]):
         Raises:
             ValueError: If required fields cannot be parsed from the output.
         """
-        return ShowBgpSummaryParser.parse(output)
+        return cast(ShowBgpSummaryResult, ShowBgpSummaryParser.parse(output))

--- a/src/muninn/parsers/cisco_iosxr/show_bgp_vrf.py
+++ b/src/muninn/parsers/cisco_iosxr/show_bgp_vrf.py
@@ -363,6 +363,20 @@ def _should_skip_route_line(stripped: str) -> bool:
     return bool(_PROCESSED_RE.match(stripped))
 
 
+def _handle_continuation_line(
+    line: str,
+    routes: list[RouteEntry],
+    current_status: str | None,
+    current_network: str | None,
+) -> None:
+    """Handle an indented data continuation line (next-hop on separate line)."""
+    if line[0] != " " or not current_network or not current_status:
+        return
+    data_tokens = line.strip().split()
+    if data_tokens:
+        _try_append_route(routes, current_status, current_network, data_tokens)
+
+
 def _parse_route_lines(lines: list[str]) -> list[RouteEntry]:
     """Parse route entry lines within a Route Distinguisher section.
 
@@ -376,14 +390,8 @@ def _parse_route_lines(lines: list[str]) -> list[RouteEntry]:
         if _should_skip_route_line(line.strip()):
             continue
 
-        # Indented data continuation line (next-hop info on separate line)
         if not _is_route_line(line):
-            if line[0] == " " and current_network and current_status:
-                data_tokens = line.strip().split()
-                if data_tokens:
-                    _try_append_route(
-                        routes, current_status, current_network, data_tokens
-                    )
+            _handle_continuation_line(line, routes, current_status, current_network)
             continue
 
         # Route line with status codes
@@ -586,7 +594,7 @@ def _apply_optional_fields(
     """Apply optional header fields and totals to the result dict."""
     for key, coerce in _OPTIONAL_HEADER_KEYS:
         if key in header:
-            result[key] = coerce(header[key])  # type: ignore[literal-required]
+            result[key] = coerce(header[key])  # type: ignore[literal-required]  # ty: ignore[invalid-key]
     if total_prefixes is not None:
         result["total_prefixes"] = total_prefixes
     if total_paths is not None:

--- a/src/muninn/parsers/cisco_iosxr/show_configuration_rollback_changes.py
+++ b/src/muninn/parsers/cisco_iosxr/show_configuration_rollback_changes.py
@@ -95,6 +95,35 @@ class ShowConfigurationRollbackChangesParser(
             removals.append(config_line)
 
     @classmethod
+    def _parse_action(cls, stripped: str) -> tuple[str, str]:
+        """Determine action and config line content from a stripped line."""
+        if stripped.startswith("no "):
+            return "remove", stripped[3:]
+        return "add", stripped
+
+    @classmethod
+    def _handle_config_line(
+        cls,
+        line: str,
+        sections: dict[str, SectionChanges],
+        section_stack: list[tuple[int, str]],
+    ) -> None:
+        """Process a configuration change line, updating sections and stack."""
+        indent = cls._count_indent(line)
+        stripped = line.strip()
+
+        while section_stack and section_stack[-1][0] >= indent:
+            section_stack.pop()
+
+        action, config_line = cls._parse_action(stripped)
+
+        key = cls._section_key(section_stack)
+        cls._record_change(sections, key, action, config_line)
+
+        if action == "add":
+            section_stack.append((indent, config_line))
+
+    @classmethod
     def parse(cls, output: str) -> "ShowConfigurationRollbackChangesResult":
         """Parse 'show configuration rollback changes last' output.
 
@@ -113,7 +142,6 @@ class ShowConfigurationRollbackChangesParser(
         config_started = False
 
         for line in output.splitlines():
-            # Extract version from the IOS XR Configuration header
             version_match = cls._VERSION_RE.match(line)
             if version_match:
                 ios_xr_version = version_match.group("version")
@@ -123,34 +151,12 @@ class ShowConfigurationRollbackChangesParser(
             if cls._is_skippable(line, config_started):
                 continue
 
-            # Section close marker (standalone !)
             if cls._SECTION_CLOSE_RE.match(line):
                 if section_stack:
                     section_stack.pop()
                 continue
 
-            # Determine indent and adjust section stack
-            indent = cls._count_indent(line)
-            stripped = line.strip()
-
-            while section_stack and section_stack[-1][0] >= indent:
-                section_stack.pop()
-
-            # Determine action and config line content
-            if stripped.startswith("no "):
-                action = "remove"
-                config_line = stripped[3:]
-            else:
-                action = "add"
-                config_line = stripped
-
-            # Record the change in the current section
-            key = cls._section_key(section_stack)
-            cls._record_change(sections, key, action, config_line)
-
-            # Push additions as potential parent sections
-            if action == "add":
-                section_stack.append((indent, config_line))
+            cls._handle_config_line(line, sections, section_stack)
 
         if not ios_xr_version:
             msg = "No IOS XR Configuration version header found in output"

--- a/src/muninn/parsers/cisco_iosxr/show_controllers_interface_stats.py
+++ b/src/muninn/parsers/cisco_iosxr/show_controllers_interface_stats.py
@@ -185,4 +185,4 @@ class ShowControllersInterfaceStatsParser(
         if "egress" in sections:
             result["egress"] = cls._parse_section(sections["egress"])
 
-        return cast(ShowControllersInterfaceStatsResult, result)
+        return result

--- a/src/muninn/parsers/cisco_iosxr/show_evpn_evi_detail.py
+++ b/src/muninn/parsers/cisco_iosxr/show_evpn_evi_detail.py
@@ -112,7 +112,7 @@ def _set_str(key: str) -> _FieldHandler:
     """Create a handler that sets a string field from group 1."""
 
     def handler(m: re.Match[str], entry: EvpnEviDetailEntry) -> None:
-        entry[key] = m.group(1).strip()  # type: ignore[literal-required]
+        entry[key] = m.group(1).strip()  # type: ignore[literal-required]  # ty: ignore[invalid-key]
 
     return handler
 
@@ -121,7 +121,7 @@ def _set_int(key: str) -> _FieldHandler:
     """Create a handler that sets an integer field from group 1."""
 
     def handler(m: re.Match[str], entry: EvpnEviDetailEntry) -> None:
-        entry[key] = int(m.group(1))  # type: ignore[literal-required]
+        entry[key] = int(m.group(1))  # type: ignore[literal-required]  # ty: ignore[invalid-key]
 
     return handler
 
@@ -132,7 +132,7 @@ def _set_non_none(key: str) -> _FieldHandler:
     def handler(m: re.Match[str], entry: EvpnEviDetailEntry) -> None:
         val = m.group(1).strip()
         if val.lower() != "none":
-            entry[key] = val  # type: ignore[literal-required]
+            entry[key] = val  # type: ignore[literal-required]  # ty: ignore[invalid-key]
 
     return handler
 

--- a/src/muninn/parsers/cisco_iosxr/show_install_inactive.py
+++ b/src/muninn/parsers/cisco_iosxr/show_install_inactive.py
@@ -75,21 +75,35 @@ class ShowInstallInactiveParser(BaseParser[ShowInstallInactiveResult]):
                 continue
 
             if in_sdrs:
-                if match := cls._SDR_NAME.match(line):
-                    current_sdr = match.group("sdr_name")
-                    sdrs[current_sdr] = SdrInfo(inactive_packages=[])
+                current_sdr = cls._handle_sdr_line(line, sdrs, current_sdr)
                 continue
 
             if in_packages and current_sdr is not None:
-                if match := cls._PACKAGE.match(line):
-                    sdrs[current_sdr]["inactive_packages"].append(
-                        match.group("package")
-                    )
-                else:
-                    in_packages = False
+                in_packages = cls._handle_package_line(line, sdrs, current_sdr)
 
         if not sdrs:
             msg = "No SDR information found in output"
             raise ValueError(msg)
 
         return ShowInstallInactiveResult(sdrs=sdrs)
+
+    @classmethod
+    def _handle_sdr_line(
+        cls, line: str, sdrs: dict[str, SdrInfo], current_sdr: str | None
+    ) -> str | None:
+        """Handle a line in the SDRs section, returning updated current_sdr."""
+        if match := cls._SDR_NAME.match(line):
+            sdr_name = match.group("sdr_name")
+            sdrs[sdr_name] = SdrInfo(inactive_packages=[])
+            return sdr_name
+        return current_sdr
+
+    @classmethod
+    def _handle_package_line(
+        cls, line: str, sdrs: dict[str, SdrInfo], current_sdr: str
+    ) -> bool:
+        """Handle a line in the packages section."""
+        if match := cls._PACKAGE.match(line):
+            sdrs[current_sdr]["inactive_packages"].append(match.group("package"))
+            return True
+        return False

--- a/src/muninn/parsers/cisco_iosxr/show_install_request.py
+++ b/src/muninn/parsers/cisco_iosxr/show_install_request.py
@@ -44,6 +44,13 @@ class ShowInstallRequestParser(BaseParser[ShowInstallRequestResult]):
     _REQUEST = re.compile(r"^Request\s*:\s*(?P<request>.+\S)")
     _STATE = re.compile(r"^State\s*:\s*(?P<state>.+\S)")
 
+    # Dispatch table: (pattern_attr, field_name, transform)
+    _LINE_MATCHERS: ClassVar[list[tuple[str, str, type]]] = [
+        ("_OPERATION_ID", "operation_id", int),
+        ("_REQUEST", "request", str),
+        ("_STATE", "state", str),
+    ]
+
     @classmethod
     def parse(cls, output: str) -> ShowInstallRequestResult:
         """Parse 'show install request' output on Cisco IOS-XR.
@@ -55,9 +62,11 @@ class ShowInstallRequestParser(BaseParser[ShowInstallRequestResult]):
             Parsed install request status with operation details.
         """
         in_progress = True
-        operation_id: int | None = None
-        request: str | None = None
-        state: str | None = None
+        fields: dict[str, str | int | None] = {
+            "operation_id": None,
+            "request": None,
+            "state": None,
+        }
 
         for line in output.splitlines():
             stripped = line.strip()
@@ -68,25 +77,32 @@ class ShowInstallRequestParser(BaseParser[ShowInstallRequestResult]):
                 in_progress = False
                 continue
 
-            if match := cls._OPERATION_ID.match(stripped):
-                operation_id = int(match.group("id"))
-                continue
+            cls._match_field(stripped, fields)
 
-            if match := cls._REQUEST.match(stripped):
-                request = match.group("request")
-                continue
+        return cls._build_result(in_progress, fields)
 
-            if match := cls._STATE.match(stripped):
-                state = match.group("state")
-                continue
+    @classmethod
+    def _match_field(cls, stripped: str, fields: dict[str, str | int | None]) -> None:
+        """Try each line matcher and store the first match into fields."""
+        for attr, field_name, transform in cls._LINE_MATCHERS:
+            pattern = getattr(cls, attr)
+            match = pattern.match(stripped)
+            if match:
+                fields[field_name] = transform(match.group(1))
+                return
 
+    @classmethod
+    def _build_result(
+        cls, in_progress: bool, fields: dict[str, str | int | None]
+    ) -> ShowInstallRequestResult:
+        """Assemble the final result dict from parsed fields."""
         result: dict[str, object] = {"in_progress": in_progress}
 
-        if operation_id is not None and request is not None and state is not None:
+        if all(fields[k] is not None for k in ("operation_id", "request", "state")):
             result["last_operation"] = LastOperationEntry(
-                operation_id=operation_id,
-                request=request,
-                state=state,
+                operation_id=cast(int, fields["operation_id"]),
+                request=cast(str, fields["request"]),
+                state=cast(str, fields["state"]),
             )
 
         return cast(ShowInstallRequestResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_ip_route.py
+++ b/src/muninn/parsers/cisco_iosxr/show_ip_route.py
@@ -1,7 +1,7 @@
 """Parser for 'show ip route' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -281,4 +281,4 @@ class ShowIpRouteParser(BaseParser[ShowIpRouteResult]):
             msg = "No routes found in output"
             raise ValueError(msg)
 
-        return cast(ShowIpRouteResult, ShowIpRouteResult(routes=routes))
+        return ShowIpRouteResult(routes=routes)

--- a/src/muninn/parsers/cisco_iosxr/show_isis.py
+++ b/src/muninn/parsers/cisco_iosxr/show_isis.py
@@ -262,14 +262,10 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
         cls, line: str, stripped: str, state: _ParseState
     ) -> bool:
         """Dispatch to active section handlers. Returns True if consumed."""
-        if (state.in_manual_area or state.in_routing_area) and cls._handle_area_address(
-            line, stripped, state
-        ):
+        if cls._try_area_handler(line, stripped, state):
             return True
 
-        if state.section == "topologies" and cls._handle_topology_section(
-            line, stripped, state
-        ):
+        if cls._try_topology_handler(line, stripped, state):
             return True
 
         if state.in_sr_mpls and cls._handle_sr_mpls_line(line, state):
@@ -279,6 +275,22 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
             return True
 
         return state.in_interfaces and cls._handle_interface_line(line, state)
+
+    @classmethod
+    def _try_area_handler(cls, line: str, stripped: str, state: _ParseState) -> bool:
+        """Try area address handler if in an area section."""
+        if not (state.in_manual_area or state.in_routing_area):
+            return False
+        return cls._handle_area_address(line, stripped, state)
+
+    @classmethod
+    def _try_topology_handler(
+        cls, line: str, stripped: str, state: _ParseState
+    ) -> bool:
+        """Try topology section handler if in topologies section."""
+        if state.section != "topologies":
+            return False
+        return cls._handle_topology_section(line, stripped, state)
 
     @classmethod
     def _handle_new_instance(cls, m: re.Match[str], state: _ParseState) -> None:
@@ -335,9 +347,9 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
         """Handle area address collection. Returns True if line consumed."""
         if _AREA_ADDRESS_PATTERN.match(line):
             if state.in_manual_area:
-                state.current["manual_area_addresses"].append(stripped)  # type: ignore[index]
+                state.current["manual_area_addresses"].append(stripped)  # type: ignore[index]  # ty: ignore[not-subscriptable]
             elif state.in_routing_area:
-                state.current["routing_area_addresses"].append(stripped)  # type: ignore[index]
+                state.current["routing_area_addresses"].append(stripped)  # type: ignore[index]  # ty: ignore[not-subscriptable]
             return True
         state.in_manual_area = False
         state.in_routing_area = False
@@ -378,7 +390,7 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
     def _handle_topology_content(cls, line: str, state: _ParseState) -> bool:
         """Handle content within an active topology. Returns True if consumed."""
         topo = state.current_topology
-        assert topo is not None  # noqa: S101
+        assert topo is not None  # noqa: S101  # nosec B101
 
         if _RIB_CONNECTED_PATTERN.match(line):
             topo["rib_connected"] = True
@@ -419,7 +431,7 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
     def _handle_level_content(cls, line: str, state: _ParseState) -> bool:
         """Handle metric style/metric/TE within a level. Returns True if consumed."""
         entry = state.current_level_entry
-        assert entry is not None  # noqa: S101
+        assert entry is not None  # noqa: S101  # nosec B101
 
         m = _METRIC_STYLE_PATTERN.match(line)
         if m:
@@ -458,14 +470,14 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
         """Handle SRv6 section lines. Returns True if consumed."""
         if stripped == "Configured locators:":
             state.in_srv6_locators = True
-            if "srv6" not in state.current:  # type: ignore[operator]
-                state.current["srv6"] = IsisSrv6(locators={})  # type: ignore[index]
+            if "srv6" not in state.current:  # type: ignore[operator]  # ty: ignore[unsupported-operator]
+                state.current["srv6"] = IsisSrv6(locators={})  # type: ignore[index]  # ty: ignore[invalid-assignment]
             return True
         if state.in_srv6_locators:
             m = _SRV6_LOCATOR_PATTERN.match(line)
             if m:
                 name = m.group("name")
-                state.current["srv6"]["locators"][name] = IsisSrv6Locator(  # type: ignore[index]
+                state.current["srv6"]["locators"][name] = IsisSrv6Locator(  # type: ignore[index]  # ty: ignore[not-subscriptable]
                     status=m.group("status")
                 )
                 return True
@@ -477,7 +489,7 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
         m = _INTERFACE_PATTERN.match(line)
         if m:
             name = canonical_interface_name(m.group("name"), os=OS.CISCO_IOSXR)
-            state.current["interfaces"][name] = IsisInterface(  # type: ignore[index]
+            state.current["interfaces"][name] = IsisInterface(  # type: ignore[index]  # ty: ignore[not-subscriptable]
                 running_state=m.group("running_state"),
                 config_state=m.group("config_state"),
             )
@@ -490,7 +502,7 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
     ) -> None:
         """Handle top-level instance fields and section headers."""
         current = state.current
-        assert current is not None  # noqa: S101
+        assert current is not None  # noqa: S101  # nosec B101
 
         if cls._handle_section_headers(line, stripped, state):
             return
@@ -550,13 +562,13 @@ class ShowIsisParser(BaseParser["ShowIsisResult"]):
         for pattern, key in _STR_FIELD_PATTERNS:
             m = pattern.match(line)
             if m:
-                current[key] = m.group("val")  # type: ignore[literal-required]
+                current[key] = m.group("val")  # type: ignore[literal-required]  # ty: ignore[invalid-key]
                 return
 
         for pattern, key in _INT_FIELD_PATTERNS:
             m = pattern.match(line)
             if m:
-                current[key] = int(m.group("val"))  # type: ignore[literal-required]
+                current[key] = int(m.group("val"))  # type: ignore[literal-required]  # ty: ignore[invalid-key]
                 return
 
         m = _LSP_FULL_PATTERN.match(line)

--- a/src/muninn/parsers/cisco_iosxr/show_isis_interface.py
+++ b/src/muninn/parsers/cisco_iosxr/show_isis_interface.py
@@ -263,7 +263,7 @@ class ShowIsisInterfaceParser(BaseParser["ShowIsisInterfaceResult"]):
         """Parse a line within a topology section. Returns True if consumed."""
         stripped = line.strip()
         topo = state.topology
-        assert topo is not None  # noqa: S101
+        assert topo is not None  # noqa: S101  # nosec B101
 
         if stripped.startswith("Adjacency Formation:"):
             topo["adjacency_formation"] = stripped.split(":", 1)[1].strip()
@@ -310,29 +310,29 @@ class ShowIsisInterfaceParser(BaseParser["ShowIsisInterfaceResult"]):
     def _handle_level_line(cls, line: str, state: _ParseState) -> bool:
         """Parse a line within a Level section. Returns True if consumed."""
         intf = state.current_interface
-        assert intf is not None  # noqa: S101
+        assert intf is not None  # noqa: S101  # nosec B101
         lvl = state.current_level
-        assert lvl is not None  # noqa: S101
+        assert lvl is not None  # noqa: S101  # nosec B101
 
         adj_match = _ADJ_COUNT_PATTERN.match(line)
         if adj_match:
             count = int(adj_match.group("count"))
             key = f"level{lvl}_adjacency_count"
-            intf[key] = count  # type: ignore[literal-required]
+            intf[key] = count  # type: ignore[literal-required]  # ty: ignore[invalid-key]
             return True
 
         hello_int_match = _HELLO_INTERVAL_PATTERN.match(line)
         if hello_int_match:
             interval = hello_int_match.group("interval").strip()
             key = f"level{lvl}_hello_interval"
-            intf[key] = interval  # type: ignore[literal-required]
+            intf[key] = interval  # type: ignore[literal-required]  # ty: ignore[invalid-key]
             return True
 
         hello_mult_match = _HELLO_MULTIPLIER_PATTERN.match(line)
         if hello_mult_match:
             mult = int(hello_mult_match.group("multiplier"))
             key = f"level{lvl}_hello_multiplier"
-            intf[key] = mult  # type: ignore[literal-required]
+            intf[key] = mult  # type: ignore[literal-required]  # ty: ignore[invalid-key]
             return True
 
         # Section boundary exits level
@@ -347,7 +347,7 @@ class ShowIsisInterfaceParser(BaseParser["ShowIsisInterfaceResult"]):
         """Handle CLNS I/O, Level, and topology entry. Returns True if consumed."""
         stripped = line.strip()
         intf = state.current_interface
-        assert intf is not None  # noqa: S101
+        assert intf is not None  # noqa: S101  # nosec B101
 
         # Topology header
         topo_match = _TOPOLOGY_PATTERN.match(line)
@@ -384,7 +384,7 @@ class ShowIsisInterfaceParser(BaseParser["ShowIsisInterfaceResult"]):
     def _handle_clns_content(cls, line: str, stripped: str, state: _ParseState) -> bool:
         """Parse CLNS I/O section content. Returns True if consumed."""
         intf = state.current_interface
-        assert intf is not None  # noqa: S101
+        assert intf is not None  # noqa: S101  # nosec B101
 
         if stripped.startswith("Protocol State:"):
             intf["clns_protocol_state"] = stripped.split(":", 1)[1].strip()
@@ -425,16 +425,16 @@ class ShowIsisInterfaceParser(BaseParser["ShowIsisInterfaceResult"]):
         """Parse top-level interface fields."""
         stripped = line.strip()
         intf = state.current_interface
-        assert intf is not None  # noqa: S101
+        assert intf is not None  # noqa: S101  # nosec B101
 
         for prefix, key in cls._STR_FIELDS:
             if stripped.startswith(prefix):
-                intf[key] = stripped.split(":", 1)[1].strip()  # type: ignore[literal-required]
+                intf[key] = stripped.split(":", 1)[1].strip()  # type: ignore[literal-required]  # ty: ignore[invalid-key]
                 return
 
         for prefix, key in cls._INT_FIELDS:
             if stripped.startswith(prefix):
-                intf[key] = int(stripped.split(":", 1)[1].strip())  # type: ignore[literal-required]
+                intf[key] = int(stripped.split(":", 1)[1].strip())  # type: ignore[literal-required]  # ty: ignore[invalid-key]
                 return
 
         ct_match = _CIRCUIT_TYPE_PATTERN.match(line)

--- a/src/muninn/parsers/cisco_iosxr/show_isis_statistics.py
+++ b/src/muninn/parsers/cisco_iosxr/show_isis_statistics.py
@@ -1,7 +1,7 @@
 """Parser for 'show isis statistics' command on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -394,8 +394,8 @@ class ShowIsisStatisticsParser(BaseParser["ShowIsisStatisticsResult"]):
             "pdu_counters": pdu_counters,
             "lsp_retransmissions": lsp_retransmissions or 0,
             "lsp_checksum_errors": lsp_checksum_errors or 0,
-            "update_queue": update_queue or dict(_EMPTY_QUEUE),
-            "input_queue": input_queue or dict(_EMPTY_QUEUE),
+            "update_queue": update_queue or cast(QueueStats, dict(_EMPTY_QUEUE)),
+            "input_queue": input_queue or cast(QueueStats, dict(_EMPTY_QUEUE)),
             "levels": levels,
             "interfaces": interfaces,
         }

--- a/src/muninn/parsers/cisco_iosxr/show_l2vpn_api_statistics.py
+++ b/src/muninn/parsers/cisco_iosxr/show_l2vpn_api_statistics.py
@@ -7,7 +7,8 @@ name change.
 """
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from collections.abc import Mapping
+from typing import Any, ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -266,6 +267,46 @@ def _parse_counters(
     )
 
 
+def _try_detail_header(line: str, entries: dict[str, CallDetailEntry]) -> str | None:
+    """Try to match a detail header line. Returns new current_key or None."""
+    m = _DETAIL_RE.match(line)
+    if not m:
+        return None
+    label = _normalize_label(m.group("label"))
+    key = _LABEL_TO_KEY.get(label)
+    if key:
+        entries[key] = _parse_detail_rest(m.group("rest").strip())
+    return key
+
+
+def _try_result_line(
+    line: str, entries: dict[str, CallDetailEntry], current_key: str | None
+) -> bool:
+    """Try to match a result sub-line. Returns True if matched."""
+    if not current_key or current_key not in entries:
+        return False
+    m = _RESULT_RE.match(line)
+    if not m:
+        return False
+    entries[current_key]["result_code"] = m.group("code")
+    entries[current_key]["result_text"] = m.group("text").strip()
+    return True
+
+
+def _try_info_line(
+    line: str, entries: dict[str, CallDetailEntry], current_key: str | None
+) -> bool:
+    """Try to match an info sub-line. Returns True if matched."""
+    if not current_key or current_key not in entries:
+        return False
+    m = _INFO_RE.match(line)
+    if not m:
+        return False
+    info_text = m.group("info").strip()
+    entries[current_key]["info"] = None if info_text == "None available" else info_text
+    return True
+
+
 def _parse_details(lines: list[str]) -> dict[str, CallDetailEntry]:
     """Parse detail entry blocks from output lines.
 
@@ -279,31 +320,15 @@ def _parse_details(lines: list[str]) -> dict[str, CallDetailEntry]:
     current_key: str | None = None
 
     for line in lines:
-        # Detail header
-        m = _DETAIL_RE.match(line)
-        if m:
-            label = _normalize_label(m.group("label"))
-            key = _LABEL_TO_KEY.get(label)
-            if key:
-                current_key = key
-                entries[key] = _parse_detail_rest(m.group("rest").strip())
+        new_key = _try_detail_header(line, entries)
+        if new_key is not None:
+            current_key = new_key
             continue
 
-        # Result sub-line
-        m = _RESULT_RE.match(line)
-        if m and current_key and current_key in entries:
-            entries[current_key]["result_code"] = m.group("code")
-            entries[current_key]["result_text"] = m.group("text").strip()
+        if _try_result_line(line, entries, current_key):
             continue
 
-        # Info sub-line
-        m = _INFO_RE.match(line)
-        if m and current_key and current_key in entries:
-            info_text = m.group("info").strip()
-            entries[current_key]["info"] = (
-                None if info_text == "None available" else info_text
-            )
-            continue
+        _try_info_line(line, entries, current_key)
 
     return entries
 
@@ -363,7 +388,7 @@ class ShowL2vpnApiStatisticsParser(
                 detail_entries[dk] = {"timestamp": "Never"}
 
         # Filter None values from detail entries
-        def _clean(d: dict) -> dict:
+        def _clean(d: Mapping[str, Any]) -> dict[str, Any]:
             return {k: v for k, v in d.items() if v is not None}
 
         result: dict = {
@@ -390,4 +415,4 @@ class ShowL2vpnApiStatisticsParser(
             result["avg_time_ok_ms"] = avg_ok
         if avg_fail is not None:
             result["avg_time_fail_ms"] = avg_fail
-        return result
+        return cast(ShowL2vpnApiStatisticsResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_l2vpn_bridge_domain_brief.py
+++ b/src/muninn/parsers/cisco_iosxr/show_l2vpn_bridge_domain_brief.py
@@ -92,60 +92,77 @@ class ShowL2vpnBridgeDomainBriefParser(
         for line in lines:
             stripped = line.strip()
 
-            # Skip empty lines, timestamp, legend, headers, separators
-            if not stripped:
-                continue
-            if SEPARATOR_DASH_SPACE_RE.match(stripped):
+            if not stripped or SEPARATOR_DASH_SPACE_RE.match(stripped):
                 continue
 
             # Try to match a new BD entry line
             m = _BD_LINE_RE.match(stripped)
             if m:
-                # Flush any pending entry
                 if pending_key is not None and pending_entry is not None:
                     bridge_domains[pending_key] = pending_entry
-
-                group_name = m.group("group_name")
-                group, name = group_name.split(":", 1)
-                bd_id = m.group("bd_id")
-
-                entry: BridgeDomainEntry = {
-                    "bridge_group": group,
-                    "bridge_domain_name": name,
-                    "state": m.group("state"),
-                    "num_acs": int(m.group("num_acs")),
-                    "num_acs_up": int(m.group("num_acs_up")),
-                    "num_pws": int(m.group("num_pws")),
-                    "num_pws_up": int(m.group("num_pws_up")),
-                    "num_pbbs": int(m.group("num_pbbs") or "0"),
-                    "num_pbbs_up": int(m.group("num_pbbs_up") or "0"),
-                    "num_vnis": int(m.group("num_vnis") or "0"),
-                    "num_vnis_up": int(m.group("num_vnis_up") or "0"),
-                }
-
-                # If PBBs and VNIs were on the same line, entry is complete
-                if m.group("num_pbbs") is not None:
-                    bridge_domains[bd_id] = entry
-                    pending_key = None
-                    pending_entry = None
-                else:
-                    pending_key = bd_id
-                    pending_entry = entry
+                pending_key, pending_entry = cls._handle_bd_line(m, bridge_domains)
                 continue
 
             # Try to match a continuation line with PBB/VNI counts
-            m = _BD_CONTINUATION_RE.match(line)
-            if m and pending_entry is not None and pending_key is not None:
-                pending_entry["num_pbbs"] = int(m.group("num_pbbs"))
-                pending_entry["num_pbbs_up"] = int(m.group("num_pbbs_up"))
-                pending_entry["num_vnis"] = int(m.group("num_vnis"))
-                pending_entry["num_vnis_up"] = int(m.group("num_vnis_up"))
-                bridge_domains[pending_key] = pending_entry
-                pending_key = None
-                pending_entry = None
+            pending_key, pending_entry = cls._handle_continuation(
+                line, bridge_domains, pending_key, pending_entry
+            )
 
         # Flush any trailing pending entry
         if pending_key is not None and pending_entry is not None:
             bridge_domains[pending_key] = pending_entry
 
         return {"bridge_domains": bridge_domains}
+
+    @classmethod
+    def _handle_bd_line(
+        cls,
+        m: re.Match[str],
+        bridge_domains: dict[str, BridgeDomainEntry],
+    ) -> tuple[str | None, BridgeDomainEntry | None]:
+        """Build a BD entry from a matched line."""
+        group_name = m.group("group_name")
+        group, name = group_name.split(":", 1)
+        bd_id = m.group("bd_id")
+
+        entry: BridgeDomainEntry = {
+            "bridge_group": group,
+            "bridge_domain_name": name,
+            "state": m.group("state"),
+            "num_acs": int(m.group("num_acs")),
+            "num_acs_up": int(m.group("num_acs_up")),
+            "num_pws": int(m.group("num_pws")),
+            "num_pws_up": int(m.group("num_pws_up")),
+            "num_pbbs": int(m.group("num_pbbs") or "0"),
+            "num_pbbs_up": int(m.group("num_pbbs_up") or "0"),
+            "num_vnis": int(m.group("num_vnis") or "0"),
+            "num_vnis_up": int(m.group("num_vnis_up") or "0"),
+        }
+
+        if m.group("num_pbbs") is not None:
+            bridge_domains[bd_id] = entry
+            return None, None
+        return bd_id, entry
+
+    @classmethod
+    def _handle_continuation(
+        cls,
+        line: str,
+        bridge_domains: dict[str, BridgeDomainEntry],
+        pending_key: str | None,
+        pending_entry: BridgeDomainEntry | None,
+    ) -> tuple[str | None, BridgeDomainEntry | None]:
+        """Handle a continuation line with PBB/VNI counts."""
+        if pending_entry is None or pending_key is None:
+            return pending_key, pending_entry
+
+        m = _BD_CONTINUATION_RE.match(line)
+        if not m:
+            return pending_key, pending_entry
+
+        pending_entry["num_pbbs"] = int(m.group("num_pbbs"))
+        pending_entry["num_pbbs_up"] = int(m.group("num_pbbs_up"))
+        pending_entry["num_vnis"] = int(m.group("num_vnis"))
+        pending_entry["num_vnis_up"] = int(m.group("num_vnis_up"))
+        bridge_domains[pending_key] = pending_entry
+        return None, None

--- a/src/muninn/parsers/cisco_iosxr/show_l2vpn_forwarding_capability.py
+++ b/src/muninn/parsers/cisco_iosxr/show_l2vpn_forwarding_capability.py
@@ -5,7 +5,7 @@ and numeric limits (e.g., VPLS max MAC addresses).
 """
 
 import re
-from typing import ClassVar, TypedDict
+from typing import ClassVar, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -240,4 +240,4 @@ class ShowL2vpnForwardingCapabilityParser(
             msg = "No L2FIB platform capability data found in output"
             raise ValueError(msg)
 
-        return result  # type: ignore[return-value]
+        return cast(ShowL2vpnForwardingCapabilityResult, result)

--- a/src/muninn/parsers/cisco_iosxr/show_l2vpn_forwarding_message_counters.py
+++ b/src/muninn/parsers/cisco_iosxr/show_l2vpn_forwarding_message_counters.py
@@ -151,6 +151,46 @@ _RTD_DATA_LINE = re.compile(
 _SEPARATOR_LINE = re.compile(r"^\s*-{10,}\s*$")
 
 
+def _is_section_boundary(line: str) -> bool:
+    """Return True if line marks the end of a counter section."""
+    if _EVENT_TRACE_HEADER.search(line):
+        return True
+    return bool(_RTD_HEADER.match(line) or _PUNTING_HEADER.match(line))
+
+
+def _try_counter_line1(line: str) -> tuple[str, int, str] | None:
+    """Try both line-1 counter patterns. Returns (message, count, info1) or None."""
+    m = _COUNTER_LINE1.match(line)
+    if m:
+        return m.group("message").strip(), int(m.group("count")), m.group("info1")
+    m = _COUNTER_LINE1_NO_COLON.match(line)
+    if m:
+        return m.group("message").strip(), int(m.group("count")), m.group("info1")
+    return None
+
+
+def _try_counter_line2(
+    line: str,
+    pending_message: str,
+    pending_count: int,
+    pending_info1: str,
+    counters: dict[str, MessageCounterEntry],
+) -> bool:
+    """Try line-2 pattern and finalize the counter entry. Returns True if matched."""
+    m2 = _COUNTER_LINE2.match(line)
+    if not m2:
+        return False
+    entry: MessageCounterEntry = {
+        "count": pending_count,
+        "info1": pending_info1,
+        "info2": m2.group("info2"),
+    }
+    if m2.group("time"):
+        entry["time"] = m2.group("time")
+    counters[pending_message] = entry
+    return True
+
+
 def _parse_counter_section(
     lines: list[str],
     start: int,
@@ -168,43 +208,26 @@ def _parse_counter_section(
     while i < len(lines):
         line = lines[i]
 
-        # Stop at event trace or RTD sections
-        if _EVENT_TRACE_HEADER.search(line):
-            break
-        if _RTD_HEADER.match(line) or _PUNTING_HEADER.match(line):
+        if _is_section_boundary(line):
             break
 
-        # Try line 1 pattern (with colon)
-        m1 = _COUNTER_LINE1.match(line)
-        if m1:
-            pending_message = m1.group("message").strip()
-            pending_count = int(m1.group("count"))
-            pending_info1 = m1.group("info1")
+        # Try line 1 pattern (with or without colon)
+        line1_result = _try_counter_line1(line)
+        if line1_result and pending_message is None:
+            pending_message, pending_count, pending_info1 = line1_result
+            i += 1
+            continue
+        if line1_result and pending_message is not None:
+            # New counter line resets previous pending
+            pending_message, pending_count, pending_info1 = line1_result
             i += 1
             continue
 
-        # Try line 1 pattern (without colon, e.g., "messages received")
-        if pending_message is None:
-            m1_alt = _COUNTER_LINE1_NO_COLON.match(line)
-            if m1_alt:
-                pending_message = m1_alt.group("message").strip()
-                pending_count = int(m1_alt.group("count"))
-                pending_info1 = m1_alt.group("info1")
-                i += 1
-                continue
-
         # Try line 2 pattern (info2 + optional time)
         if pending_message is not None:
-            m2 = _COUNTER_LINE2.match(line)
-            if m2:
-                entry: MessageCounterEntry = {
-                    "count": pending_count,
-                    "info1": pending_info1,
-                    "info2": m2.group("info2"),
-                }
-                if m2.group("time"):
-                    entry["time"] = m2.group("time")
-                counters[pending_message] = entry
+            if _try_counter_line2(
+                line, pending_message, pending_count, pending_info1, counters
+            ):
                 pending_message = None
                 i += 1
                 continue

--- a/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
+++ b/src/muninn/parsers/cisco_iosxr/show_lpts_pifib_hardware_police_location.py
@@ -213,4 +213,4 @@ class ShowLptsPifibHardwarePoliceLocationParser(
         if has_statistics:
             result["statistics"] = cast(StatisticsEntry, statistics)
 
-        return cast(ShowLptsPifibHardwarePoliceLocationResult, result)
+        return result

--- a/src/muninn/parsers/cisco_iosxr/show_macsec_mka_statistics_interface.py
+++ b/src/muninn/parsers/cisco_iosxr/show_macsec_mka_statistics_interface.py
@@ -316,7 +316,7 @@ _MKPDU_FAILURES_MAP: list[tuple[str, str]] = [
 
 def _dispatch_substring(
     norm: str,
-    target: dict[str, Any],
+    target: Any,  # noqa: ANN401
     value: int,
     mapping: list[tuple[str, str]],
 ) -> bool:
@@ -715,7 +715,7 @@ def _parse_ca_stats_line(raw_key: str, value: str, stats: CaStatistics) -> None:
         "group_caks_received": "group_caks_received",
     }
     if norm in field_map:
-        stats[field_map[norm]] = _parse_int(value)  # type: ignore[literal-required]
+        stats[field_map[norm]] = _parse_int(value)  # type: ignore[literal-required]  # ty: ignore[invalid-key]
 
 
 def _parse_sa_stats_line(raw_key: str, value: str, stats: SaStatistics) -> None:
@@ -730,7 +730,7 @@ def _parse_sa_stats_line(raw_key: str, value: str, stats: SaStatistics) -> None:
         "ppk_retrieved": "ppk_retrieved",
     }
     if norm in field_map:
-        stats[field_map[norm]] = _parse_int(value)  # type: ignore[literal-required]
+        stats[field_map[norm]] = _parse_int(value)  # type: ignore[literal-required]  # ty: ignore[invalid-key]
 
 
 def _parse_mkpdu_line(raw_key: str, value: str, state: _ParseState) -> None:
@@ -758,7 +758,7 @@ def _apply_mkpdu_sub_counter(
         "ppk_capable": "ppk_capable",
     }
     if norm_key in sub_map:
-        target[sub_map[norm_key]] = value  # type: ignore[literal-required]
+        target[sub_map[norm_key]] = value  # type: ignore[literal-required]  # ty: ignore[invalid-key]
 
 
 def _parse_sakuse_failures_line(
@@ -784,7 +784,7 @@ def _parse_mka_idb_line(raw_key: str, value: str, stats: MkaIdbStatistics) -> No
     norm = _normalize_key(raw_key)
     # Try exact match first
     if norm in _MKA_IDB_EXACT_MAP:
-        stats[_MKA_IDB_EXACT_MAP[norm]] = _parse_int(value)  # type: ignore[literal-required]
+        stats[_MKA_IDB_EXACT_MAP[norm]] = _parse_int(value)  # type: ignore[literal-required]  # ty: ignore[invalid-key]
         return
     _dispatch_substring(norm, stats, _parse_int(value), _MKA_IDB_MAP)
 

--- a/src/muninn/parsers/cisco_iosxr/show_mpls_forwarding_interface_detail.py
+++ b/src/muninn/parsers/cisco_iosxr/show_mpls_forwarding_interface_detail.py
@@ -1,7 +1,7 @@
 """Parser for 'show mpls forwarding interface <interface> detail' on Cisco IOS-XR."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -10,7 +10,7 @@ from muninn.tags import ParserTag
 from muninn.utils import canonical_interface_name
 
 
-class MplsForwardingDetailEntry(TypedDict):
+class MplsForwardingDetailEntry(TypedDict, total=False):
     """Schema for a single MPLS forwarding table entry with detail."""
 
     outgoing_label: str
@@ -23,7 +23,7 @@ class MplsForwardingDetailEntry(TypedDict):
     priority: int
     label_stack: str
     nhid: str
-    encap_id: NotRequired[str]
+    encap_id: str
     path_idx: int
     backup_path_idx: int
     weight: int

--- a/src/muninn/parsers/cisco_iosxr/show_vrf_all.py
+++ b/src/muninn/parsers/cisco_iosxr/show_vrf_all.py
@@ -88,8 +88,8 @@ class _ParseState:
 
     def _append_rt(self, afi_safi: str) -> None:
         """Add the pending RT value to the appropriate AF and direction list."""
-        assert self.pending_rt is not None  # noqa: S101
-        assert self.current_vrf is not None  # noqa: S101
+        assert self.pending_rt is not None  # noqa: S101  # nosec B101
+        assert self.current_vrf is not None  # noqa: S101  # nosec B101
         vrf_entry = self.vrfs[self.current_vrf]
         af_dict = vrf_entry["address_families"]
         if afi_safi not in af_dict:

--- a/src/muninn/parsers/iosxe/show_isis_database_detail.py
+++ b/src/muninn/parsers/iosxe/show_isis_database_detail.py
@@ -665,31 +665,41 @@ class ShowIsisDatabaseDetailParser(BaseParser["ShowIsisDatabaseDetailResult"]):
         for line in output.splitlines():
             if not line.strip():
                 continue
-
-            if _handle_structural_line(line, state):
-                continue
-
-            if _handle_lsp_header(line, state):
-                continue
-
-            if _handle_continuation_data(line, state):
-                continue
-
-            if _handle_topology(line, state):
-                continue
-
-            if state.current_lsp is not None:
-                (
-                    _parse_sr_pending_state(line, state)
-                    or _parse_sr_router_cap(line, state.current_lsp)
-                    or _parse_srv6_tlv(line, state)
-                    or _parse_identity_tlv(line, state.current_lsp)
-                    or _parse_capability_tlv(line, state.current_lsp)
-                    or _parse_metric_tlv(line, state.current_lsp)
-                )
+            cls._process_line(line, state)
 
         if not state.levels:
             msg = "No IS-IS LSP entries found in output"
             raise ValueError(msg)
 
         return {"tag": state.tag, "levels": state.levels}
+
+    @classmethod
+    def _process_line(cls, line: str, state: _ParseState) -> None:
+        """Dispatch a single non-empty line to the appropriate handler."""
+        if _handle_structural_line(line, state):
+            return
+
+        if _handle_lsp_header(line, state):
+            return
+
+        if _handle_continuation_data(line, state):
+            return
+
+        if _handle_topology(line, state):
+            return
+
+        if state.current_lsp is not None:
+            cls._try_lsp_content_handlers(line, state)
+
+    @classmethod
+    def _try_lsp_content_handlers(cls, line: str, state: _ParseState) -> None:
+        """Try LSP content handlers (SR, SRv6, identity, capability, metric)."""
+        assert state.current_lsp is not None  # noqa: S101  # nosec B101
+        (
+            _parse_sr_pending_state(line, state)
+            or _parse_sr_router_cap(line, state.current_lsp)
+            or _parse_srv6_tlv(line, state)
+            or _parse_identity_tlv(line, state.current_lsp)
+            or _parse_capability_tlv(line, state.current_lsp)
+            or _parse_metric_tlv(line, state.current_lsp)
+        )

--- a/src/muninn/parsers/iosxe/show_isis_node_summary.py
+++ b/src/muninn/parsers/iosxe/show_isis_node_summary.py
@@ -86,7 +86,6 @@ class ShowIsisNodeSummaryParser(BaseParser["ShowIsisNodeSummaryResult"]):
 
         for line in output.splitlines():
             stripped = line.strip()
-
             if not stripped:
                 continue
 
@@ -96,13 +95,31 @@ class ShowIsisNodeSummaryParser(BaseParser["ShowIsisNodeSummaryResult"]):
                 all_tags.setdefault(current_tag, {})
                 continue
 
-            node_match = _NODE_PATTERN.match(stripped)
-            if node_match and current_tag is not None:
-                level_key = f"level-{node_match.group('level')}"
-                system_id = node_match.group("system_id")
-                all_tags[current_tag].setdefault(level_key, [])
-                all_tags[current_tag][level_key].append(system_id)
+            if current_tag is not None:
+                cls._handle_node_line(stripped, all_tags, current_tag)
 
+        return cls._build_result(all_tags)
+
+    @classmethod
+    def _handle_node_line(
+        cls,
+        stripped: str,
+        all_tags: dict[str, dict[str, list[str]]],
+        current_tag: str,
+    ) -> None:
+        """Process a potential node information line."""
+        node_match = _NODE_PATTERN.match(stripped)
+        if node_match:
+            level_key = f"level-{node_match.group('level')}"
+            system_id = node_match.group("system_id")
+            all_tags[current_tag].setdefault(level_key, [])
+            all_tags[current_tag][level_key].append(system_id)
+
+    @classmethod
+    def _build_result(
+        cls, all_tags: dict[str, dict[str, list[str]]]
+    ) -> "ShowIsisNodeSummaryResult":
+        """Validate and build the final result from collected tags."""
         if not all_tags or not any(
             nodes for levels in all_tags.values() for nodes in levels.values()
         ):
@@ -111,11 +128,9 @@ class ShowIsisNodeSummaryParser(BaseParser["ShowIsisNodeSummaryResult"]):
 
         result_tags: dict[str, dict[str, IsisNodeLevelSummary]] = {}
         for tag, levels in all_tags.items():
-            result_tags[tag] = {}
-            for level_key, nodes in levels.items():
-                result_tags[tag][level_key] = {
-                    "nodes": nodes,
-                    "node_count": len(nodes),
-                }
+            result_tags[tag] = {
+                level_key: {"nodes": nodes, "node_count": len(nodes)}
+                for level_key, nodes in levels.items()
+            }
 
         return cast(ShowIsisNodeSummaryResult, {"tags": result_tags})

--- a/src/muninn/parsers/iosxe/show_isis_topology.py
+++ b/src/muninn/parsers/iosxe/show_isis_topology.py
@@ -229,6 +229,14 @@ class ShowIsisTopologyParser(BaseParser["ShowIsisTopologyResult"]):
                 systems, stripped, line, last_system_id, last_metric
             )
 
+        return cls._build_result(all_tags)
+
+    @classmethod
+    def _build_result(
+        cls,
+        all_tags: dict[str, dict[str, dict[str, IsisTopologySystem]]],
+    ) -> "ShowIsisTopologyResult":
+        """Build the final result from collected tags, raising if empty."""
         populated = {
             k: v for k, v in all_tags.items() if any(systems for systems in v.values())
         }

--- a/src/muninn/parsers/iosxe/show_macsec_statistics_interface.py
+++ b/src/muninn/parsers/iosxe/show_macsec_statistics_interface.py
@@ -172,7 +172,7 @@ class _ParseState:
             self.controlled[key] = value
         elif self.section == "tx_sc" and self.tx_sc is not None:
             if key in ("out_pkts_protected", "out_pkts_encrypted"):
-                self.tx_sc[key] = value  # type: ignore[literal-required]
+                self.tx_sc[key] = value  # type: ignore[literal-required]  # ty: ignore[invalid-key]
         elif self.section == "tx_sa" and self.current_tx_sa is not None:
             self.current_tx_sa[key] = value
         elif self.section == "rx_sa" and self.current_rx_sa is not None:

--- a/src/muninn/parsers/iosxe/show_policy-map_interface.py
+++ b/src/muninn/parsers/iosxe/show_policy-map_interface.py
@@ -648,7 +648,7 @@ def _handle_priority_line(
 
     prio_lvl_m = _PRIORITY_LEVEL_RE.match(stripped)
     if prio_lvl_m:
-        prio_entry = cast(PriorityEntry, class_entry.get("priority", {}))
+        prio_entry = class_entry.get("priority", {})
         prio_entry["level"] = int(prio_lvl_m.group(1))
         class_entry["priority"] = prio_entry
         return True

--- a/src/muninn/parsers/juniper_junos/show_bgp_summary.py
+++ b/src/muninn/parsers/juniper_junos/show_bgp_summary.py
@@ -1,7 +1,7 @@
 """Parser for 'show bgp summary' command on Juniper Junos."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict, cast
+from typing import ClassVar, NotRequired, TypedDict
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -267,4 +267,4 @@ class ShowBgpSummaryParser(BaseParser["ShowBgpSummaryResult"]):
         if tables:
             result["tables"] = tables
 
-        return cast(ShowBgpSummaryResult, result)
+        return result

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -176,6 +176,9 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         # is_neighbors/ip_reachability/ipv6_reachability use list-of-dicts; no natural
         # unique key (multiple parallel links to same neighbor with different metrics).
         "cisco_iosxr/show_isis_database_detail/001_basic/expected.json",
+        # event_trace_history uses list-of-dicts; no natural unique key for event
+        # trace entries (same event can repeat at the same timestamp).
+        "cisco_iosxr/show_l2vpn_forwarding_message_counters/001_basic/expected.json",
         # ECMP next-hops have no natural unique key (same interface can appear with
         # different next-hops in equal-cost multipath).
         "cisco_iosxr/show_route_ipv4_isis/001_basic/expected.json",


### PR DESCRIPTION
## Summary

- **Format**: Fixed `show_bgp_l2vpn_evpn.py` multi-line frozenset that ruff wanted collapsed
- **Security scan (bandit)**: Added `# nosec B101` to 12 assert statements across `show_isis.py`, `show_isis_interface.py`, `show_vrf_all.py`, and `show_isis_database_detail.py` (IOS-XE)
- **Type check (ty)**: Resolved all 79 errors — added `# ty: ignore[invalid-key]` for TypedDict subscript patterns, fixed `total=False` on `MplsForwardingDetailEntry`, added casts for return types, removed 5 redundant casts
- **Complexity (xenon)**: Refactored 16 rank-C functions across 12 files by extracting helper methods to reduce cyclomatic complexity below the max-absolute B threshold
- **Unit test**: Added `show_l2vpn_forwarding_message_counters` fixture to the list-of-dicts exemption (event trace entries have no natural unique key)

## Test plan

- [x] `uv run ruff format --check .` — 666 files clean
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run bandit -r src/` — 0 issues
- [x] `uv run xenon --max-absolute B --max-modules B --max-average A src/` — 0 violations
- [x] `uv run ty check .` — all checks passed
- [x] `uv run pytest` — 10204 passed

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: Fix CI failures: format, bandit, ty, xenon, convention test

🤖 Generated with [Claude Code](https://claude.com/claude-code)