### PR TITLE
feat(cisco_ftd): add parser for `show cpu usage`

### DIFF
--- a/changes/+show-cpu-usage-cisco-ftd.parser_added
+++ b/changes/+show-cpu-usage-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show cpu usage` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_cpu_usage.py
+++ b/src/muninn/parsers/cisco_ftd/show_cpu_usage.py
@@ -1,0 +1,66 @@
+"""Parser for 'show cpu usage' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowCpuUsageResult(TypedDict):
+    """Schema for 'show cpu usage' parsed output on Cisco FTD."""
+
+    cpu_5_seconds_pct: int
+    cpu_1_minute_pct: int
+    cpu_5_minutes_pct: int
+
+
+@register(OS.CISCO_FTD, "show cpu usage")
+class ShowCpuUsageParser(BaseParser[ShowCpuUsageResult]):
+    """Parser for 'show cpu usage' command on Cisco FTD.
+
+    Parses CPU utilization percentages for 5-second, 1-minute, and 5-minute
+    intervals.
+
+    Expected CLI output format::
+
+        CPU utilization for 5 seconds = 0%; 1 minute: 0%; 5 minutes: 0%
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _CPU_PATTERN = re.compile(
+        r"CPU utilization for 5 seconds = (?P<five_sec>\d+)%;\s*"
+        r"1 minute:\s*(?P<one_min>\d+)%;\s*"
+        r"5 minutes:\s*(?P<five_min>\d+)%"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowCpuUsageResult:
+        """Parse 'show cpu usage' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed CPU utilization percentages for each time interval.
+
+        Raises:
+            ValueError: If CPU utilization line cannot be parsed from the output.
+        """
+        for line in output.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if match := cls._CPU_PATTERN.search(stripped):
+                return ShowCpuUsageResult(
+                    cpu_5_seconds_pct=int(match.group("five_sec")),
+                    cpu_1_minute_pct=int(match.group("one_min")),
+                    cpu_5_minutes_pct=int(match.group("five_min")),
+                )
+
+        msg = "No CPU utilization line found in output"
+        raise ValueError(msg)

--- a/tests/parsers/cisco_ftd/show_cpu_usage/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_cpu_usage/001_basic/expected.json
@@ -1,0 +1,5 @@
+{
+    "cpu_5_seconds_pct": 0,
+    "cpu_1_minute_pct": 0,
+    "cpu_5_minutes_pct": 0
+}

--- a/tests/parsers/cisco_ftd/show_cpu_usage/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_cpu_usage/001_basic/input.txt
@@ -1,0 +1,2 @@
+
+CPU utilization for 5 seconds = 0%; 1 minute: 0%; 5 minutes: 0%

--- a/tests/parsers/cisco_ftd/show_cpu_usage/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_cpu_usage/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: CPU utilization showing 5-second, 1-minute, and 5-minute averages
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary
- Added new parser for `show cpu usage` command on Cisco FTD platform
- Extracts CPU utilization percentages for 5-second, 1-minute, and 5-minute intervals
- Includes test fixture from Cisco Firepower 4215 running 7.4.2.4

## Test plan
- [x] Parser unit test passes (`tests/parsers/test_parsers.py::test_parser[cisco_ftd/show_cpu_usage/001_basic]`)
- [x] All fixture convention tests pass (JSON conventions, placeholder sentinels)
- [x] Full test suite passes (10213 tests)
- [x] Ruff check and format clean

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation
- **Human Oversight**: Code reviewed and approved by maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)