### PR TITLE
feat(cisco_ftd): add parser for `show conn count`

### DIFF
--- a/changes/+show-conn-count-cisco-ftd.parser_added
+++ b/changes/+show-conn-count-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show conn count` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_conn_count.py
+++ b/src/muninn/parsers/cisco_ftd/show_conn_count.py
@@ -1,0 +1,92 @@
+"""Parser for 'show conn count' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class PreserveConnectionStats(TypedDict):
+    """Schema for Snort preserve-connection statistics."""
+
+    enabled: int
+    in_effect: int
+    most_enabled: int
+    most_in_effect: int
+
+
+class ShowConnCountResult(TypedDict):
+    """Schema for 'show conn count' parsed output on Cisco FTD."""
+
+    in_use: int
+    most_used: int
+    preserve_connection: NotRequired[PreserveConnectionStats]
+
+
+@register(OS.CISCO_FTD, "show conn count")
+class ShowConnCountParser(BaseParser[ShowConnCountResult]):
+    """Parser for 'show conn count' command on Cisco FTD.
+
+    Parses connection count summary showing current and peak connection
+    usage, along with optional Snort inspect preserve-connection statistics.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.CONNECTIVITY})
+
+    _CONN_COUNT_PATTERN = re.compile(
+        r"^(?P<in_use>\d+)\s+in use,\s+(?P<most_used>\d+)\s+most used$"
+    )
+
+    _PRESERVE_CONN_PATTERN = re.compile(
+        r"preserve-connection:\s+"
+        r"(?P<enabled>\d+)\s+enabled,\s+"
+        r"(?P<in_effect>\d+)\s+in effect,\s+"
+        r"(?P<most_enabled>\d+)\s+most enabled,\s+"
+        r"(?P<most_in_effect>\d+)\s+most in effect"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowConnCountResult:
+        """Parse 'show conn count' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed connection count with optional preserve-connection stats.
+
+        Raises:
+            ValueError: If connection count line is not found.
+        """
+        result: ShowConnCountResult | None = None
+
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+
+            conn_match = cls._CONN_COUNT_PATTERN.match(line)
+            if conn_match:
+                result = ShowConnCountResult(
+                    in_use=int(conn_match.group("in_use")),
+                    most_used=int(conn_match.group("most_used")),
+                )
+                continue
+
+            preserve_match = cls._PRESERVE_CONN_PATTERN.search(line)
+            if preserve_match and result is not None:
+                result["preserve_connection"] = PreserveConnectionStats(
+                    enabled=int(preserve_match.group("enabled")),
+                    in_effect=int(preserve_match.group("in_effect")),
+                    most_enabled=int(preserve_match.group("most_enabled")),
+                    most_in_effect=int(preserve_match.group("most_in_effect")),
+                )
+
+        if result is None:
+            msg = "No connection count found in output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_ftd/show_conn_count/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_conn_count/001_basic/expected.json
@@ -1,0 +1,10 @@
+{
+  "in_use": 11,
+  "most_used": 191,
+  "preserve_connection": {
+    "enabled": 0,
+    "in_effect": 0,
+    "most_enabled": 169,
+    "most_in_effect": 0
+  }
+}

--- a/tests/parsers/cisco_ftd/show_conn_count/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_conn_count/001_basic/input.txt
@@ -1,0 +1,3 @@
+11 in use, 191 most used
+Inspect Snort:
+	preserve-connection: 0 enabled, 0 in effect, 169 most enabled, 0 most in effect

--- a/tests/parsers/cisco_ftd/show_conn_count/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_conn_count/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Connection count with Snort inspect preserve-connection statistics
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary
- Adds a new parser for `show conn count` on Cisco FTD (OS.CISCO_FTD)
- Parses connection count (in_use, most_used) and optional Snort inspect preserve-connection statistics
- Tagged with `ParserTag.CONNECTIVITY`

## Test plan
- [x] Fixture-based test passes (`tests/parsers/cisco_ftd/show_conn_count/001_basic`)
- [x] `ruff check` passes with no warnings
- [x] `ruff format` reports no changes
- [x] Full test suite passes (10213 tests)

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation + fixture + changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)