### PR TITLE
feat(cisco_ftd): add parser for `show bgp summary`

### DIFF
--- a/changes/+show-bgp-summary-cisco-ftd.parser_added
+++ b/changes/+show-bgp-summary-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show bgp summary` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_bgp_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_bgp_summary.py
@@ -1,0 +1,199 @@
+"""Parser for 'show bgp summary' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NeighborEntry(TypedDict):
+    """Schema for a single BGP neighbor in the summary table."""
+
+    version: int
+    remote_as: int
+    msg_rcvd: int
+    msg_sent: int
+    table_version: int
+    in_queue: int
+    out_queue: int
+    up_down: str
+    state: NotRequired[str]
+    prefixes_received: NotRequired[int]
+
+
+class ShowBgpSummaryResult(TypedDict):
+    """Schema for 'show bgp summary' parsed output."""
+
+    router_id: str
+    local_as: int
+    neighbors: dict[str, NeighborEntry]
+
+
+def _parse_local_as(raw: str) -> int:
+    """Parse local AS number, handling asdot notation (e.g., '304.304')."""
+    if "." in raw:
+        high, low = raw.split(".", 1)
+        return int(high) * 65536 + int(low)
+    return int(raw)
+
+
+def _is_noise_line(line: str) -> bool:
+    """Return True if the line is a prompt, load, or time source line."""
+    if not line:
+        return True
+    if line.endswith("#") or line.endswith(">") or "#show " in line.lower():
+        return True
+    return line.startswith("Load for ") or line.startswith("Time source ")
+
+
+def _parse_state_pfxrcd(value: str) -> tuple[str | None, int | None]:
+    """Parse the State/PfxRcd field into state and prefix count.
+
+    If the value is a plain integer, it represents prefixes received.
+    Otherwise, it is a state string (e.g., 'Idle', 'Active', 'Connect').
+    """
+    try:
+        return (None, int(value))
+    except ValueError:
+        return (value, None)
+
+
+_NEIGHBOR_PATTERN = re.compile(
+    r"^(?P<neighbor>\S+)\s+"
+    r"(?P<version>\d+)\s+"
+    r"(?P<remote_as>\S+)\s+"
+    r"(?P<msg_rcvd>\d+)\s+"
+    r"(?P<msg_sent>\d+)\s+"
+    r"(?P<tbl_ver>\d+)\s+"
+    r"(?P<in_q>\d+)\s+"
+    r"(?P<out_q>\d+)\s+"
+    r"(?P<up_down>\S+)\s+"
+    r"(?P<state_pfxrcd>\S+)\s*$"
+)
+
+_ROUTER_ID_PATTERN = re.compile(
+    r"BGP\s+router\s+identifier\s+(?P<router_id>\S+),\s+"
+    r"local\s+AS\s+number\s+(?P<local_as>\S+)"
+)
+
+_HEADER_PATTERN = re.compile(r"^\s*Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent")
+
+
+def _build_neighbor_entry(
+    match: re.Match[str],
+) -> tuple[str, NeighborEntry]:
+    """Build a NeighborEntry from a regex match on a neighbor row."""
+    neighbor = match.group("neighbor")
+    state, prefixes = _parse_state_pfxrcd(match.group("state_pfxrcd"))
+
+    entry: NeighborEntry = {
+        "version": int(match.group("version")),
+        "remote_as": _parse_local_as(match.group("remote_as")),
+        "msg_rcvd": int(match.group("msg_rcvd")),
+        "msg_sent": int(match.group("msg_sent")),
+        "table_version": int(match.group("tbl_ver")),
+        "in_queue": int(match.group("in_q")),
+        "out_queue": int(match.group("out_q")),
+        "up_down": match.group("up_down"),
+    }
+
+    if state is not None:
+        entry["state"] = state
+    if prefixes is not None:
+        entry["prefixes_received"] = prefixes
+
+    return (neighbor, entry)
+
+
+def _find_router_id(
+    lines: list[str],
+) -> tuple[str | None, int | None]:
+    """Find the first BGP router identifier line and extract ID and AS."""
+    for line in lines:
+        stripped = line.strip()
+        if _is_noise_line(stripped):
+            continue
+        id_match = _ROUTER_ID_PATTERN.search(stripped)
+        if id_match:
+            rid = id_match.group("router_id")
+            las = _parse_local_as(id_match.group("local_as"))
+            return (rid, las)
+    return (None, None)
+
+
+def _parse_neighbors(
+    lines: list[str],
+) -> dict[str, NeighborEntry]:
+    """Parse neighbor rows from lines following the table header."""
+    neighbors: dict[str, NeighborEntry] = {}
+    in_table = False
+
+    for line in lines:
+        stripped = line.strip()
+        if _is_noise_line(stripped):
+            continue
+
+        if _HEADER_PATTERN.match(stripped):
+            in_table = True
+            continue
+
+        if not in_table:
+            continue
+
+        match = _NEIGHBOR_PATTERN.match(stripped)
+        if match:
+            key, entry = _build_neighbor_entry(match)
+            neighbors[key] = entry
+
+    return neighbors
+
+
+@register(OS.CISCO_FTD, "show bgp summary")
+class ShowBgpSummaryParser(BaseParser["ShowBgpSummaryResult"]):
+    """Parser for 'show bgp summary' command on Cisco FTD.
+
+    Example output::
+
+        BGP router identifier 172.16.6.1, local AS number 65001
+        BGP table version is 111, main routing table version 111
+
+        Neighbor      V    AS MsgRcvd MsgSent TblVer InQ OutQ Up/Down State/PfxRcd
+        172.16.1.1    4 65002  691200  669802    111   0    0 1w0d  5
+        172.16.2.133  4 65003   93953   91053    111   0    0 1d02h 2
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.BGP, ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowBgpSummaryResult:
+        """Parse 'show bgp summary' output.
+
+        Args:
+            output: Raw CLI output from 'show bgp summary' command.
+
+        Returns:
+            Parsed data with neighbors keyed by neighbor address.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+
+        router_id, local_as = _find_router_id(lines)
+        if router_id is None or local_as is None:
+            msg = "Could not find BGP router identifier in output"
+            raise ValueError(msg)
+
+        neighbors = _parse_neighbors(lines)
+        if not neighbors:
+            msg = "No BGP neighbors found in output"
+            raise ValueError(msg)
+
+        return ShowBgpSummaryResult(
+            router_id=router_id,
+            local_as=local_as,
+            neighbors=neighbors,
+        )

--- a/src/muninn/parsers/cisco_ftd/show_bgp_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_bgp_summary.py
@@ -27,6 +27,7 @@ class NeighborEntry(TypedDict):
 class ShowBgpSummaryResult(TypedDict):
     """Schema for 'show bgp summary' parsed output."""
 
+    bgp_operational: bool
     router_id: str
     local_as: int
     neighbors: dict[str, NeighborEntry]
@@ -182,6 +183,8 @@ class ShowBgpSummaryParser(BaseParser["ShowBgpSummaryResult"]):
         """
         lines = output.splitlines()
 
+        bgp_operational = "% BGP cannot run" not in output
+
         router_id, local_as = _find_router_id(lines)
         if router_id is None or local_as is None:
             msg = "Could not find BGP router identifier in output"
@@ -193,6 +196,7 @@ class ShowBgpSummaryParser(BaseParser["ShowBgpSummaryResult"]):
             raise ValueError(msg)
 
         return ShowBgpSummaryResult(
+            bgp_operational=bgp_operational,
             router_id=router_id,
             local_as=local_as,
             neighbors=neighbors,

--- a/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/expected.json
@@ -1,4 +1,5 @@
 {
+    "bgp_operational": true,
     "local_as": 65001,
     "neighbors": {
         "172.16.1.1": {

--- a/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/expected.json
@@ -1,0 +1,83 @@
+{
+    "local_as": 65001,
+    "neighbors": {
+        "172.16.1.1": {
+            "in_queue": 0,
+            "msg_rcvd": 691200,
+            "msg_sent": 669802,
+            "out_queue": 0,
+            "prefixes_received": 5,
+            "remote_as": 65002,
+            "table_version": 111,
+            "up_down": "1w0d",
+            "version": 4
+        },
+        "172.16.1.2": {
+            "in_queue": 0,
+            "msg_rcvd": 691204,
+            "msg_sent": 669802,
+            "out_queue": 0,
+            "prefixes_received": 5,
+            "remote_as": 65002,
+            "table_version": 111,
+            "up_down": "1w0d",
+            "version": 4
+        },
+        "172.16.1.3": {
+            "in_queue": 0,
+            "msg_rcvd": 691209,
+            "msg_sent": 669814,
+            "out_queue": 0,
+            "prefixes_received": 5,
+            "remote_as": 65002,
+            "table_version": 111,
+            "up_down": "1w0d",
+            "version": 4
+        },
+        "172.16.1.4": {
+            "in_queue": 0,
+            "msg_rcvd": 691199,
+            "msg_sent": 669803,
+            "out_queue": 0,
+            "prefixes_received": 5,
+            "remote_as": 65002,
+            "table_version": 111,
+            "up_down": "1w0d",
+            "version": 4
+        },
+        "172.16.2.133": {
+            "in_queue": 0,
+            "msg_rcvd": 93953,
+            "msg_sent": 91053,
+            "out_queue": 0,
+            "prefixes_received": 2,
+            "remote_as": 65003,
+            "table_version": 111,
+            "up_down": "1d02h",
+            "version": 4
+        },
+        "172.16.2.134": {
+            "in_queue": 0,
+            "msg_rcvd": 93954,
+            "msg_sent": 91055,
+            "out_queue": 0,
+            "prefixes_received": 2,
+            "remote_as": 65003,
+            "table_version": 111,
+            "up_down": "1d02h",
+            "version": 4
+        },
+        "172.16.2.135": {
+            "in_queue": 0,
+            "msg_rcvd": 93955,
+            "msg_sent": 91055,
+            "out_queue": 0,
+            "prefixes_received": 2,
+            "remote_as": 65003,
+            "table_version": 111,
+            "up_down": "1d02h",
+            "version": 4
+        }
+    },
+    "router_id": "172.16.6.1"
+}

--- a/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/input.txt
@@ -1,0 +1,20 @@
+BGP router identifier 172.16.6.1, local AS number 65001
+BGP table version is 111, main routing table version 111
+39 network entries using 7800 bytes of memory
+58 path entries using 4640 bytes of memory
+7 multipath network entries and 26 multipath paths
+8/5 BGP path/bestpath attribute entries using 1664 bytes of memory
+2 BGP AS-PATH entries using 64 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 14168 total bytes of memory
+BGP activity 46/7 prefixes, 85/27 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+172.16.1.1    4        65002 691200  669802       111    0    0 1w0d  5
+172.16.1.2    4        65002 691204  669802       111    0    0 1w0d  5
+172.16.1.3    4        65002 691209  669814       111    0    0 1w0d  5
+172.16.1.4    4        65002 691199  669803       111    0    0 1w0d  5
+172.16.2.133  4        65003 93953   91053        111    0    0 1d02h  2
+172.16.2.134  4        65003 93954   91055        111    0    0 1d02h  2
+172.16.2.135  4        65003 93955   91055        111    0    0 1d02h  2

--- a/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: BGP summary with 7 neighbors in established and idle states
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"

--- a/tests/parsers/cisco_ftd/show_bgp_summary/002_bgp_inactive/expected.json
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/002_bgp_inactive/expected.json
@@ -1,0 +1,84 @@
+{
+    "bgp_operational": false,
+    "local_as": 65001,
+    "neighbors": {
+        "172.16.1.1": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65002,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "172.16.1.2": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65002,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "172.16.1.3": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65002,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "172.16.1.4": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65002,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "172.16.2.133": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65003,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "172.16.2.134": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65003,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        },
+        "172.16.2.135": {
+            "in_queue": 0,
+            "msg_rcvd": 0,
+            "msg_sent": 0,
+            "out_queue": 0,
+            "remote_as": 65003,
+            "state": "Idle",
+            "table_version": 1,
+            "up_down": "never",
+            "version": 4
+        }
+    },
+    "router_id": "0.0.0.0"
+}

--- a/tests/parsers/cisco_ftd/show_bgp_summary/002_bgp_inactive/input.txt
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/002_bgp_inactive/input.txt
@@ -1,0 +1,19 @@
+% BGP cannot run because the router-id is not configured
+BGP router identifier 0.0.0.0, local AS number 65001
+BGP table version is 47, main routing table version 47
+32 network entries using 6400 bytes of memory
+32 path entries using 2560 bytes of memory
+2/2 BGP path/bestpath attribute entries using 416 bytes of memory
+0 BGP route-map cache entries using 0 bytes of memory
+0 BGP filter-list cache entries using 0 bytes of memory
+BGP using 9376 total bytes of memory
+BGP activity 33/1 prefixes, 39/7 paths, scan interval 60 secs
+
+Neighbor        V           AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+172.16.1.1    4        65002 0       0              1    0    0 never  Idle
+172.16.1.2    4        65002 0       0              1    0    0 never  Idle
+172.16.1.3    4        65002 0       0              1    0    0 never  Idle
+172.16.1.4    4        65002 0       0              1    0    0 never  Idle
+172.16.2.133  4        65003 0       0              1    0    0 never  Idle
+172.16.2.134  4        65003 0       0              1    0    0 never  Idle
+172.16.2.135  4        65003 0       0              1    0    0 never  Idle

--- a/tests/parsers/cisco_ftd/show_bgp_summary/002_bgp_inactive/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_bgp_summary/002_bgp_inactive/metadata.yaml
@@ -1,0 +1,3 @@
+description: BGP summary when BGP is non-operational (router-id not configured), all neighbors Idle
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary

- Adds a new parser for `show bgp summary` on Cisco FTD (OS.CISCO_FTD)
- Extracts router_id, local_as, and a neighbor dict keyed by neighbor IP
- Each neighbor entry includes version, remote_as, msg_rcvd, msg_sent, table_version, in_queue, out_queue, up_down, and state or prefixes_received
- Schema aligns with the existing IOS-XE `show bgp summary` parser for cross-platform consistency

## Test plan

- [x] Fixture `001_basic` with 7 neighbors (4 x AS 65002, 3 x AS 65003) from a Firepower 4215 running 7.4.2.4
- [x] `uv run pytest tests/parsers/ -k "show_bgp_summary"` — 56 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run pytest -q` — full suite 10213 passed

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation + fixture + changelog

Generated with [Claude Code](https://claude.com/claude-code)