### PR TITLE
feat(cisco_ftd): add parser for `show asp drop`

### DIFF
--- a/changes/+show-asp-drop-cisco-ftd.parser_added
+++ b/changes/+show-asp-drop-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show asp drop` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_asp_drop.py
+++ b/src/muninn/parsers/cisco_ftd/show_asp_drop.py
@@ -1,0 +1,131 @@
+"""Parser for 'show asp drop' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class DropEntry(TypedDict):
+    """Schema for a single ASP drop counter entry."""
+
+    description: str
+    count: int
+
+
+class DropSection(TypedDict):
+    """Schema for a drop section (frame or flow)."""
+
+    drops: dict[str, DropEntry]
+    last_clearing: str
+
+
+class ShowAspDropResult(TypedDict):
+    """Schema for 'show asp drop' parsed output."""
+
+    frame_drops: DropSection
+    flow_drops: DropSection
+
+
+# Pattern matches lines like:
+#   No valid adjacency (no-adjacency)                                       797415
+#   Flow is denied by configured rule (acl-drop)                             31803
+_DROP_ENTRY_PATTERN = re.compile(
+    r"^\s+"
+    r"(?P<description>.+?)\s+"
+    r"\((?P<reason>[^)]+)\)\s+"
+    r"(?P<count>\d+)\s*$"
+)
+
+_LAST_CLEARING_PATTERN = re.compile(r"^Last clearing:\s+(.+)$")
+
+_SECTION_HEADERS = {"Frame drop:": "frame", "Flow drop:": "flow"}
+
+
+@register(OS.CISCO_FTD, "show asp drop")
+class ShowAspDropParser(BaseParser[ShowAspDropResult]):
+    """Parser for 'show asp drop' command on Cisco FTD.
+
+    Parses ASP (Accelerated Security Path) drop counters showing
+    frame-level and flow-level packet drops with reasons and counts.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SECURITY})
+
+    @classmethod
+    def _parse_lines(
+        cls, output: str
+    ) -> tuple[dict[str, DropEntry], str, dict[str, DropEntry], str]:
+        """Extract drop entries and last-clearing timestamps from raw output.
+
+        Returns:
+            Tuple of (frame_drops, frame_last_clearing, flow_drops, flow_last_clearing).
+        """
+        sections: dict[str, dict[str, DropEntry]] = {"frame": {}, "flow": {}}
+        last_clearings: dict[str, str] = {"frame": "", "flow": ""}
+        current_section: str | None = None
+
+        for line in output.splitlines():
+            stripped = line.strip()
+
+            # Detect section headers
+            if stripped in _SECTION_HEADERS:
+                current_section = _SECTION_HEADERS[stripped]
+                continue
+
+            # Match last clearing line
+            clearing_match = _LAST_CLEARING_PATTERN.match(stripped)
+            if clearing_match and current_section:
+                last_clearings[current_section] = clearing_match.group(1)
+                continue
+
+            # Match drop entry lines
+            entry_match = _DROP_ENTRY_PATTERN.match(line)
+            if entry_match and current_section:
+                reason = entry_match.group("reason")
+                sections[current_section][reason] = DropEntry(
+                    description=entry_match.group("description"),
+                    count=int(entry_match.group("count")),
+                )
+
+        return (
+            sections["frame"],
+            last_clearings["frame"],
+            sections["flow"],
+            last_clearings["flow"],
+        )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowAspDropResult:
+        """Parse 'show asp drop' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed drop counters organized by frame drops and flow drops.
+
+        Raises:
+            ValueError: If no drop sections found in output.
+        """
+        frame_drops, frame_clearing, flow_drops, flow_clearing = cls._parse_lines(
+            output
+        )
+
+        if not frame_drops and not flow_drops:
+            msg = "No ASP drop entries found in output"
+            raise ValueError(msg)
+
+        return ShowAspDropResult(
+            frame_drops=DropSection(
+                drops=frame_drops,
+                last_clearing=frame_clearing,
+            ),
+            flow_drops=DropSection(
+                drops=flow_drops,
+                last_clearing=flow_clearing,
+            ),
+        )

--- a/tests/parsers/cisco_ftd/show_asp_drop/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_asp_drop/001_basic/expected.json
@@ -1,0 +1,108 @@
+{
+    "frame_drops": {
+        "drops": {
+            "no-adjacency": {
+                "description": "No valid adjacency",
+                "count": 797415
+            },
+            "no-route": {
+                "description": "No route to host",
+                "count": 1197871
+            },
+            "acl-drop": {
+                "description": "Flow is denied by configured rule",
+                "count": 31803
+            },
+            "tcp-not-syn": {
+                "description": "First TCP packet not SYN",
+                "count": 27214963
+            },
+            "bad-tcp-cksum": {
+                "description": "Bad TCP checksum",
+                "count": 961
+            },
+            "tcp-rstfin-ooo": {
+                "description": "TCP RST/FIN out of order",
+                "count": 1481
+            },
+            "tcp-synack-ooo": {
+                "description": "TCP SYNACK on established conn",
+                "count": 15
+            },
+            "fo-standby": {
+                "description": "Dropped by standby unit",
+                "count": 3761
+            },
+            "flow-expired": {
+                "description": "Expired flow",
+                "count": 273
+            },
+            "l2_acl": {
+                "description": "FP L2 rule drop",
+                "count": 16
+            },
+            "interface-down": {
+                "description": "Interface is down",
+                "count": 5545824
+            },
+            "np-socket-closed": {
+                "description": "Dropped pending packets in a closed socket",
+                "count": 62
+            },
+            "cluster-stub-to-full": {
+                "description": "Cluster packet rcvd on director, converted stub to full flow",
+                "count": 1
+            },
+            "cluster-ccl-unknown-stub": {
+                "description": "Cluster packet rcvd over CCL, unit has stub flow and unknown role",
+                "count": 1
+            },
+            "cluster-data-node-data-ifc-not-ready": {
+                "description": "Cluster data-node data interface is not ready",
+                "count": 629
+            },
+            "cluster-bad-ifc-goid-in-trailer": {
+                "description": "Unable to find ifc from goid",
+                "count": 16
+            },
+            "cluster-app-no-forward": {
+                "description": "Application requires packets not be forwarded in cluster",
+                "count": 41
+            },
+            "firewall": {
+                "description": "Blocked or blacklisted by the firewall preprocessor",
+                "count": 34417
+            },
+            "session-preproc": {
+                "description": "Blocked or blacklisted by the session preprocessor",
+                "count": 10
+            },
+            "fragment-reassembly-failed": {
+                "description": "Fragment reassembly failed",
+                "count": 4
+            },
+            "snort-blacklist": {
+                "description": "Packet is blacklisted by snort",
+                "count": 335651
+            }
+        },
+        "last_clearing": "Never"
+    },
+    "flow_drops": {
+        "drops": {
+            "acl-drop": {
+                "description": "Flow is denied by access rule",
+                "count": 190
+            },
+            "inspect-fail": {
+                "description": "Inspection failure",
+                "count": 4814
+            },
+            "cluster-redirect": {
+                "description": "Flow removed, packet sent to owner",
+                "count": 20
+            }
+        },
+        "last_clearing": "Never"
+    }
+}

--- a/tests/parsers/cisco_ftd/show_asp_drop/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_asp_drop/001_basic/input.txt
@@ -1,0 +1,32 @@
+
+Frame drop:
+  No valid adjacency (no-adjacency)                                       797415
+  No route to host (no-route)                                            1197871
+  Flow is denied by configured rule (acl-drop)                             31803
+  First TCP packet not SYN (tcp-not-syn)                                27214963
+  Bad TCP checksum (bad-tcp-cksum)                                           961
+  TCP RST/FIN out of order (tcp-rstfin-ooo)                                 1481
+  TCP SYNACK on established conn (tcp-synack-ooo)                             15
+  Dropped by standby unit (fo-standby)                                      3761
+  Expired flow (flow-expired)                                                273
+  FP L2 rule drop (l2_acl)                                                    16
+  Interface is down (interface-down)                                     5545824
+  Dropped pending packets in a closed socket (np-socket-closed)               62
+  Cluster packet rcvd on director, converted stub to full flow (cluster-stub-to-full)                           1
+  Cluster packet rcvd over CCL, unit has stub flow and unknown role (cluster-ccl-unknown-stub)                  1
+  Cluster data-node data interface is not ready (cluster-data-node-data-ifc-not-ready)                        629
+  Unable to find ifc from goid (cluster-bad-ifc-goid-in-trailer)              16
+  Application requires packets not be forwarded in cluster (cluster-app-no-forward)                            41
+  Blocked or blacklisted by the firewall preprocessor (firewall)           34417
+  Blocked or blacklisted by the session preprocessor (session-preproc)                                         10
+  Fragment reassembly failed (fragment-reassembly-failed)                      4
+  Packet is blacklisted by snort (snort-blacklist)                        335651
+
+Last clearing: Never
+
+Flow drop:
+  Flow is denied by access rule (acl-drop)                                   190
+  Inspection failure (inspect-fail)                                         4814
+  Flow removed, packet sent to owner (cluster-redirect)                       20
+
+Last clearing: Never

--- a/tests/parsers/cisco_ftd/show_asp_drop/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_asp_drop/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: ASP drop counters with frame drops and flow drops sections
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary
- Added new parser for `show asp drop` on Cisco FTD platform
- Parses ASP (Accelerated Security Path) drop counters into structured data with frame-level and flow-level drop sections
- Each section captures drop reasons (keyed by short name), descriptions, counts, and last-clearing timestamp

## Test plan
- [x] Parser test fixture with real device output from Cisco Firepower 4215 running 7.4.2.4
- [x] All fixture convention tests pass (JSON conventions, placeholder sentinels)
- [x] `ruff check` passes (no lint issues)
- [x] `ruff format` passes (no formatting changes)
- [x] Full test suite passes (10213 tests)

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation
- **Human Oversight**: Code reviewed and approved by maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)