### PR TITLE
feat(cisco_ftd): add parser for `show disk`

### DIFF
--- a/changes/+show-disk-cisco-ftd.parser_added
+++ b/changes/+show-disk-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show disk` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_disk.py
+++ b/src/muninn/parsers/cisco_ftd/show_disk.py
@@ -1,0 +1,79 @@
+"""Parser for 'show disk' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FilesystemEntry(TypedDict):
+    """Schema for a single filesystem entry."""
+
+    filesystem: str
+    size: str
+    used: str
+    available: str
+    use_pct: int
+    mounted_on: str
+
+
+ShowDiskResult = dict[str, FilesystemEntry]
+
+
+@register(OS.CISCO_FTD, "show disk")
+class ShowDiskParser(BaseParser[ShowDiskResult]):
+    """Parser for 'show disk' command on Cisco FTD.
+
+    Parses df-style disk usage output containing filesystem name,
+    size, used space, available space, usage percentage, and mount
+    point for each mounted filesystem.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _ENTRY_RE = re.compile(
+        r"^(?P<filesystem>\S+)\s+"
+        r"(?P<size>\S+)\s+"
+        r"(?P<used>\S+)\s+"
+        r"(?P<avail>\S+)\s+"
+        r"(?P<pct>\d+)%\s+"
+        r"(?P<mount>/.*)$"
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowDiskResult:
+        """Parse 'show disk' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Dictionary keyed by mount point with filesystem details.
+
+        Raises:
+            ValueError: If no filesystem entries can be parsed.
+        """
+        result: ShowDiskResult = {}
+
+        for line in output.splitlines():
+            match = cls._ENTRY_RE.match(line)
+            if not match:
+                continue
+            mount = match.group("mount")
+            result[mount] = FilesystemEntry(
+                filesystem=match.group("filesystem"),
+                size=match.group("size"),
+                used=match.group("used"),
+                available=match.group("avail"),
+                use_pct=int(match.group("pct")),
+                mounted_on=mount,
+            )
+
+        if not result:
+            msg = "No filesystem entries found in 'show disk' output"
+            raise ValueError(msg)
+
+        return result

--- a/tests/parsers/cisco_ftd/show_disk/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_disk/001_basic/expected.json
@@ -1,0 +1,98 @@
+{
+    "/": {
+        "filesystem": "rootfs",
+        "size": "126G",
+        "used": "860M",
+        "available": "125G",
+        "use_pct": 1,
+        "mounted_on": "/"
+    },
+    "/dev": {
+        "filesystem": "devtmpfs",
+        "size": "126G",
+        "used": "2.0G",
+        "available": "124G",
+        "use_pct": 2,
+        "mounted_on": "/dev"
+    },
+    "/run": {
+        "filesystem": "tmpfs",
+        "size": "126G",
+        "used": "540K",
+        "available": "126G",
+        "use_pct": 1,
+        "mounted_on": "/run"
+    },
+    "/var/volatile": {
+        "filesystem": "tmpfs",
+        "size": "126G",
+        "used": "223M",
+        "available": "126G",
+        "use_pct": 1,
+        "mounted_on": "/var/volatile"
+    },
+    "/mnt/boot": {
+        "filesystem": "/dev/md0p1",
+        "size": "14G",
+        "used": "2.3G",
+        "available": "11G",
+        "use_pct": 18,
+        "mounted_on": "/mnt/boot"
+    },
+    "/opt/cisco/config": {
+        "filesystem": "/dev/md0p2",
+        "size": "922M",
+        "used": "81M",
+        "available": "794M",
+        "use_pct": 10,
+        "mounted_on": "/opt/cisco/config"
+    },
+    "/opt/cisco/platform/logs": {
+        "filesystem": "/dev/md0p3",
+        "size": "921M",
+        "used": "73M",
+        "available": "801M",
+        "use_pct": 9,
+        "mounted_on": "/opt/cisco/platform/logs"
+    },
+    "/var/data/cores": {
+        "filesystem": "/dev/md0p4",
+        "size": "99G",
+        "used": "1.5M",
+        "available": "94G",
+        "use_pct": 1,
+        "mounted_on": "/var/data/cores"
+    },
+    "/opt/cisco/csp": {
+        "filesystem": "/dev/md0p5",
+        "size": "1.6T",
+        "used": "63G",
+        "available": "1.5T",
+        "use_pct": 5,
+        "mounted_on": "/opt/cisco/csp"
+    },
+    "/dev/cgroups": {
+        "filesystem": "cgroup_root",
+        "size": "126G",
+        "used": "0",
+        "available": "126G",
+        "use_pct": 0,
+        "mounted_on": "/dev/cgroups"
+    },
+    "/dev/shm/snort": {
+        "filesystem": "none",
+        "size": "7.2G",
+        "used": "24M",
+        "available": "7.2G",
+        "use_pct": 1,
+        "mounted_on": "/dev/shm/snort"
+    },
+    "/var/data/cores/sysdebug/tftpd_logs": {
+        "filesystem": "tmpfs",
+        "size": "1.0M",
+        "used": "0",
+        "available": "1.0M",
+        "use_pct": 0,
+        "mounted_on": "/var/data/cores/sysdebug/tftpd_logs"
+    }
+}

--- a/tests/parsers/cisco_ftd/show_disk/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_disk/001_basic/input.txt
@@ -1,0 +1,13 @@
+Filesystem      Size  Used Avail Use% Mounted on
+rootfs          126G  860M  125G   1% /
+devtmpfs        126G  2.0G  124G   2% /dev
+tmpfs           126G  540K  126G   1% /run
+tmpfs           126G  223M  126G   1% /var/volatile
+/dev/md0p1       14G  2.3G   11G  18% /mnt/boot
+/dev/md0p2      922M   81M  794M  10% /opt/cisco/config
+/dev/md0p3      921M   73M  801M   9% /opt/cisco/platform/logs
+/dev/md0p4       99G  1.5M   94G   1% /var/data/cores
+/dev/md0p5      1.6T   63G  1.5T   5% /opt/cisco/csp
+cgroup_root     126G     0  126G   0% /dev/cgroups
+none            7.2G   24M  7.2G   1% /dev/shm/snort
+tmpfs           1.0M     0  1.0M   0% /var/data/cores/sysdebug/tftpd_logs

--- a/tests/parsers/cisco_ftd/show_disk/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_disk/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Disk usage showing multiple filesystems and mount points
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"

--- a/tests/parsers/test_fixture_placeholder_sentinels.py
+++ b/tests/parsers/test_fixture_placeholder_sentinels.py
@@ -77,6 +77,9 @@ _NONE_LIKE_PLACEHOLDER_EXEMPT_EXPECTED_FILES: Final[frozenset[str]] = frozenset(
         "nxos/show_ip_ospf_interface/003_combined_ip_process_line/expected.json",
         "nxos/show_port-channel_summary/003_down_and_empty/expected.json",
         "paloalto_panos/show_system_info/001_pa_vm_basic/expected.json",
+        # "none" is a valid Linux filesystem device name (used for tmpfs/bind
+        # mounts), not a missing-value placeholder.
+        "cisco_ftd/show_disk/001_basic/expected.json",
     }
 )
 


### PR DESCRIPTION
## Summary

- Add new parser for `show disk` command on Cisco FTD platform
- Parses df-style disk usage table into a dictionary keyed by mount point
- Each entry contains filesystem name, size, used, available, usage percentage, and mount path
- Includes fixture from a Cisco Firepower 4215 running 7.4.2.4 with 12 filesystem entries

## Test plan

- [x] Parser-specific tests pass (`pytest tests/parsers/ -k "show_disk"` — 7 tests)
- [x] Full test suite passes (10213 tests)
- [x] Ruff lint and format clean
- [ ] CI passes on this PR

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: Parser implementation, fixture creation, changelog fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)