### PR TITLE
feat(cisco_ftd): add parser for `show failover state`

### DIFF
--- a/changes/+show-failover-state-cisco-ftd.parser_added
+++ b/changes/+show-failover-state-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show failover state` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_failover_state.py
+++ b/src/muninn/parsers/cisco_ftd/show_failover_state.py
@@ -49,22 +49,18 @@ class ShowFailoverStateParser(BaseParser[ShowFailoverStateResult]):
     _COMM_STATE_RE = re.compile(r"^====Communication State===\s*$")
 
     @classmethod
-    def _parse_host_block(
+    def _find_state_match(
         cls, lines: list[str], start_idx: int
-    ) -> tuple[FailoverHostEntry, int]:
-        """Parse a host block starting at the host header line.
+    ) -> tuple[re.Match[str], int]:
+        """Skip blank lines after a host header and return the state match.
 
-        Returns the parsed entry and the index after the state line.
+        Returns the regex match object and the index of the state line.
+
+        Raises:
+            ValueError: If no state line is found or it cannot be parsed.
         """
-        host_match = cls._HOST_RE.match(lines[start_idx])
-        if not host_match:
-            msg = f"Expected host header at line {start_idx}"
-            raise ValueError(msg)
-
-        role = host_match.group("role")
         idx = start_idx + 1
 
-        # Find the state line (skip blank lines)
         while idx < len(lines) and not lines[idx].strip():
             idx += 1
 
@@ -77,20 +73,49 @@ class ShowFailoverStateParser(BaseParser[ShowFailoverStateResult]):
             msg = f"Cannot parse state line: {lines[idx]!r}"
             raise ValueError(msg)
 
-        entry: FailoverHostEntry = {
-            "role": role,
-            "state": state_match.group("state"),
-        }
+        return state_match, idx
+
+    @staticmethod
+    def _extract_failure_fields(state_match: re.Match[str]) -> dict[str, str]:
+        """Extract optional failure reason and time from a state match.
+
+        Returns a dict with 'last_failure_reason' and/or 'last_failure_time'
+        if present and non-empty.
+        """
+        fields: dict[str, str] = {}
 
         reason = state_match.group("reason")
         if reason and reason.strip() and reason.strip() != "None":
-            entry["last_failure_reason"] = reason.strip()
+            fields["last_failure_reason"] = reason.strip()
 
         time_str = state_match.group("time")
         if time_str and time_str.strip():
-            entry["last_failure_time"] = time_str.strip()
+            fields["last_failure_time"] = time_str.strip()
 
-        return entry, idx + 1
+        return fields
+
+    @classmethod
+    def _parse_host_block(
+        cls, lines: list[str], start_idx: int
+    ) -> tuple[FailoverHostEntry, int]:
+        """Parse a host block starting at the host header line.
+
+        Returns the parsed entry and the index after the state line.
+        """
+        host_match = cls._HOST_RE.match(lines[start_idx])
+        if not host_match:
+            msg = f"Expected host header at line {start_idx}"
+            raise ValueError(msg)
+
+        state_match, state_idx = cls._find_state_match(lines, start_idx)
+
+        entry: FailoverHostEntry = {
+            "role": host_match.group("role"),
+            "state": state_match.group("state"),
+            **cls._extract_failure_fields(state_match),
+        }
+
+        return entry, state_idx + 1
 
     @classmethod
     def _parse_section_value(cls, lines: list[str], start_idx: int) -> str:

--- a/src/muninn/parsers/cisco_ftd/show_failover_state.py
+++ b/src/muninn/parsers/cisco_ftd/show_failover_state.py
@@ -1,0 +1,175 @@
+"""Parser for 'show failover state' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class FailoverHostEntry(TypedDict):
+    """Schema for a single failover host (this or other)."""
+
+    role: str
+    state: str
+    last_failure_reason: NotRequired[str]
+    last_failure_time: NotRequired[str]
+
+
+class ShowFailoverStateResult(TypedDict):
+    """Schema for 'show failover state' parsed output on Cisco FTD."""
+
+    this_host: FailoverHostEntry
+    other_host: FailoverHostEntry
+    configuration_state: str
+    communication_state: str
+
+
+@register(OS.CISCO_FTD, "show failover state")
+class ShowFailoverStateParser(BaseParser[ShowFailoverStateResult]):
+    """Parser for 'show failover state' command on Cisco FTD.
+
+    Parses failover state including host roles, states, failure reasons,
+    and configuration/communication synchronization status.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.REDUNDANCY})
+
+    _HOST_RE = re.compile(
+        r"^(?P<host>This host|Other host)\s+-\s+(?P<role>Primary|Secondary)\s*$"
+    )
+    _STATE_RE = re.compile(
+        r"^\s+(?P<state>Active|Standby Ready|Standby|Cold Standby|Failed|"
+        r"Negotiation|Disabled|Not Detected)"
+        r"(?:\s{2,}(?P<reason>.+?)(?:\s{2,}(?P<time>\S+.*))?)?$"
+    )
+    _CONFIG_STATE_RE = re.compile(r"^====Configuration State===\s*$")
+    _COMM_STATE_RE = re.compile(r"^====Communication State===\s*$")
+
+    @classmethod
+    def _parse_host_block(
+        cls, lines: list[str], start_idx: int
+    ) -> tuple[FailoverHostEntry, int]:
+        """Parse a host block starting at the host header line.
+
+        Returns the parsed entry and the index after the state line.
+        """
+        host_match = cls._HOST_RE.match(lines[start_idx])
+        if not host_match:
+            msg = f"Expected host header at line {start_idx}"
+            raise ValueError(msg)
+
+        role = host_match.group("role")
+        idx = start_idx + 1
+
+        # Find the state line (skip blank lines)
+        while idx < len(lines) and not lines[idx].strip():
+            idx += 1
+
+        if idx >= len(lines):
+            msg = f"No state line found for host at line {start_idx}"
+            raise ValueError(msg)
+
+        state_match = cls._STATE_RE.match(lines[idx])
+        if not state_match:
+            msg = f"Cannot parse state line: {lines[idx]!r}"
+            raise ValueError(msg)
+
+        entry: FailoverHostEntry = {
+            "role": role,
+            "state": state_match.group("state"),
+        }
+
+        reason = state_match.group("reason")
+        if reason and reason.strip() and reason.strip() != "None":
+            entry["last_failure_reason"] = reason.strip()
+
+        time_str = state_match.group("time")
+        if time_str and time_str.strip():
+            entry["last_failure_time"] = time_str.strip()
+
+        return entry, idx + 1
+
+    @classmethod
+    def _parse_section_value(cls, lines: list[str], start_idx: int) -> str:
+        """Parse the value line following a section header.
+
+        Returns the stripped text content.
+        """
+        idx = start_idx + 1
+        while idx < len(lines) and not lines[idx].strip():
+            idx += 1
+
+        if idx >= len(lines):
+            msg = f"No value found after section header at line {start_idx}"
+            raise ValueError(msg)
+
+        return lines[idx].strip()
+
+    @classmethod
+    def parse(cls, output: str) -> ShowFailoverStateResult:
+        """Parse 'show failover state' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed failover state information including host roles, states,
+            and synchronization status.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        lines = output.splitlines()
+        this_host: FailoverHostEntry | None = None
+        other_host: FailoverHostEntry | None = None
+        configuration_state: str | None = None
+        communication_state: str | None = None
+
+        idx = 0
+        while idx < len(lines):
+            line = lines[idx]
+
+            host_match = cls._HOST_RE.match(line)
+            if host_match:
+                host_label = host_match.group("host")
+                entry, idx = cls._parse_host_block(lines, idx)
+                if host_label == "This host":
+                    this_host = entry
+                else:
+                    other_host = entry
+                continue
+
+            if cls._CONFIG_STATE_RE.match(line):
+                configuration_state = cls._parse_section_value(lines, idx)
+                idx += 1
+                continue
+
+            if cls._COMM_STATE_RE.match(line):
+                communication_state = cls._parse_section_value(lines, idx)
+                idx += 1
+                continue
+
+            idx += 1
+
+        if this_host is None:
+            msg = "Failed to parse 'This host' block"
+            raise ValueError(msg)
+        if other_host is None:
+            msg = "Failed to parse 'Other host' block"
+            raise ValueError(msg)
+        if configuration_state is None:
+            msg = "Failed to parse configuration state"
+            raise ValueError(msg)
+        if communication_state is None:
+            msg = "Failed to parse communication state"
+            raise ValueError(msg)
+
+        return ShowFailoverStateResult(
+            this_host=this_host,
+            other_host=other_host,
+            configuration_state=configuration_state,
+            communication_state=communication_state,
+        )

--- a/tests/parsers/cisco_ftd/show_failover_state/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_failover_state/001_basic/expected.json
@@ -1,0 +1,14 @@
+{
+  "this_host": {
+    "role": "Primary",
+    "state": "Active"
+  },
+  "other_host": {
+    "role": "Secondary",
+    "state": "Standby Ready",
+    "last_failure_reason": "Ifc Failure",
+    "last_failure_time": "11:48:35 UTC Aug 6 2026"
+  },
+  "configuration_state": "Sync Done",
+  "communication_state": "Mac set"
+}

--- a/tests/parsers/cisco_ftd/show_failover_state/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_failover_state/001_basic/input.txt
@@ -1,0 +1,11 @@
+
+               State          Last Failure Reason      Date/Time
+This host  -   Primary
+               Active         None
+Other host -   Secondary
+               Standby Ready  Ifc Failure              11:48:35 UTC Aug 6 2026
+
+====Configuration State===
+	Sync Done
+====Communication State===
+	Mac set

--- a/tests/parsers/cisco_ftd/show_failover_state/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_failover_state/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Failover state showing Primary/Active and Secondary/Standby Ready with interface failure
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary

- Add parser for `show failover state` command on Cisco FTD platform
- Extracts host roles (Primary/Secondary), states (Active/Standby Ready/Failed/etc.), last failure reasons, and timestamps
- Parses configuration state (Sync Done) and communication state (Mac set)
- Uses `NotRequired` for failure reason and time fields that may be absent

## Test plan

- [x] Fixture test with Primary/Active + Secondary/Standby Ready with Ifc Failure passes
- [x] `ruff check` passes with no violations
- [x] `ruff format` confirms file is already formatted
- [x] Full test suite (10213 tests) passes

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation

Generated with [Claude Code](https://claude.com/claude-code)