### PR TITLE
feat(cisco_ftd): add parser for `show memory`

### DIFF
--- a/changes/+show-memory-cisco-ftd.parser_added
+++ b/changes/+show-memory-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show memory` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_memory.py
+++ b/src/muninn/parsers/cisco_ftd/show_memory.py
@@ -1,0 +1,78 @@
+"""Parser for 'show memory' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowMemoryResult(TypedDict):
+    """Schema for 'show memory' parsed output on Cisco FTD."""
+
+    free_bytes: int
+    free_pct: int
+    used_bytes: int
+    used_pct: int
+    total_bytes: int
+
+
+@register(OS.CISCO_FTD, "show memory")
+class ShowMemoryParser(BaseParser[ShowMemoryResult]):
+    """Parser for 'show memory' command on Cisco FTD.
+
+    Parses memory utilization output showing free, used, and total
+    memory in bytes with percentage utilization.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.SYSTEM})
+
+    _MEMORY_LINE = re.compile(
+        r"^(?P<label>Free|Used|Total)\s+memory:\s+"
+        r"(?P<bytes>\d+)\s+bytes\s+"
+        r"\((?P<pct>\d+)%\)",
+        re.MULTILINE,
+    )
+
+    @classmethod
+    def parse(cls, output: str) -> ShowMemoryResult:
+        """Parse 'show memory' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed memory utilization with free, used, and total bytes
+            plus percentages.
+
+        Raises:
+            ValueError: If required memory lines are not found.
+        """
+        parsed: dict[str, int] = {}
+
+        for match in cls._MEMORY_LINE.finditer(output):
+            label = match.group("label").lower()
+            parsed[f"{label}_bytes"] = int(match.group("bytes"))
+            parsed[f"{label}_pct"] = int(match.group("pct"))
+
+        required_keys = {
+            "free_bytes",
+            "free_pct",
+            "used_bytes",
+            "used_pct",
+            "total_bytes",
+        }
+        missing = required_keys - parsed.keys()
+        if missing:
+            msg = f"Missing required memory fields: {sorted(missing)}"
+            raise ValueError(msg)
+
+        return ShowMemoryResult(
+            free_bytes=parsed["free_bytes"],
+            free_pct=parsed["free_pct"],
+            used_bytes=parsed["used_bytes"],
+            used_pct=parsed["used_pct"],
+            total_bytes=parsed["total_bytes"],
+        )

--- a/tests/parsers/cisco_ftd/show_memory/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_memory/001_basic/expected.json
@@ -1,0 +1,7 @@
+{
+  "free_bytes": 50102049799,
+  "free_pct": 70,
+  "used_bytes": 21884890416,
+  "used_pct": 30,
+  "total_bytes": 71986940215
+}

--- a/tests/parsers/cisco_ftd/show_memory/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_memory/001_basic/input.txt
@@ -1,0 +1,9 @@
+Free memory:       50102049799 bytes (70%)
+Used memory:       21884890416 bytes (30%)
+-------------     ------------------
+Total memory:      71986940215 bytes (100%)
+
+Note: Free memory is the free system memory. Additional memory may
+      be available from memory pools internal to the firewall process.
+      Use 'show memory detail' to see this information, but use it
+      with care since it may cause CPU hogs and packet loss under load.

--- a/tests/parsers/cisco_ftd/show_memory/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_memory/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Memory utilization showing free, used, and total bytes with percentages
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary

- Adds a new parser for `show memory` on Cisco FTD platform
- Extracts free, used, and total memory in bytes along with percentage utilization
- Includes test fixture from a Cisco Firepower 4215 running version 7.4.2.4

## Test plan

- [x] `uv run pytest tests/parsers/ -k "show_memory" -v` — all 14 tests pass
- [x] `uv run ruff check` — no lint issues
- [x] `uv run ruff format` — formatting compliant
- [x] `uv run pytest -q` — full suite passes (10213 tests)

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + test fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)