### PR TITLE
feat(cisco_ftd): add parser for `show ip`

### DIFF
--- a/changes/+show-ip-cisco-ftd.parser_added
+++ b/changes/+show-ip-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show ip` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_ip.py
+++ b/src/muninn/parsers/cisco_ftd/show_ip.py
@@ -1,0 +1,158 @@
+"""Parser for 'show ip' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class IpEntry(TypedDict):
+    """Schema for a single IP address entry."""
+
+    nameif: str
+    ip_address: str
+    subnet_mask: str
+    method: str
+
+
+class ShowIpResult(TypedDict):
+    """Schema for 'show ip' parsed output."""
+
+    system_addresses: dict[str, IpEntry]
+    current_addresses: dict[str, IpEntry]
+
+
+@register(OS.CISCO_FTD, "show ip")
+class ShowIpParser(BaseParser[ShowIpResult]):
+    """Parser for 'show ip' command on Cisco FTD.
+
+    Parses system and current IP address tables showing interface IP
+    configuration including nameif, IP address, subnet mask, and method.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INTERFACES})
+
+    _IP_OCTET = r"\d{1,3}(?:\.\d{1,3}){3}"
+
+    # Full entry: Interface  Name  IP  Mask  Method
+    _ENTRY_PATTERN = re.compile(
+        r"^(?P<interface>\S+)\s+"
+        r"(?P<nameif>\S+)\s+"
+        rf"(?P<ip_address>{_IP_OCTET})\s+"
+        rf"(?P<subnet_mask>{_IP_OCTET})\s+"
+        r"(?P<method>\S+)\s*$"
+    )
+
+    # Continuation line (wrapped IP/mask/method from previous line)
+    _CONTINUATION_PATTERN = re.compile(
+        r"^\s+"
+        rf"(?P<ip_address>{_IP_OCTET})\s+"
+        rf"(?P<subnet_mask>{_IP_OCTET})\s+"
+        r"(?P<method>\S+)\s*$"
+    )
+
+    # Partial line: interface + nameif only, IP wraps to next line
+    _PARTIAL_PATTERN = re.compile(r"^(?P<interface>\S+)\s+(?P<nameif>\S+)\s*$")
+
+    @classmethod
+    def _parse_section(cls, lines: list[str]) -> dict[str, IpEntry]:
+        """Parse a single section of the show ip output.
+
+        Args:
+            lines: Lines belonging to one section (after the header).
+
+        Returns:
+            Dict of interface name to IpEntry.
+        """
+        entries: dict[str, IpEntry] = {}
+        pending_interface: str | None = None
+        pending_nameif: str | None = None
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("Interface"):
+                pending_interface = None
+                pending_nameif = None
+                continue
+
+            # Try full entry on one line
+            match = cls._ENTRY_PATTERN.match(stripped)
+            if match:
+                pending_interface = None
+                pending_nameif = None
+                entries[match.group("interface")] = IpEntry(
+                    nameif=match.group("nameif"),
+                    ip_address=match.group("ip_address"),
+                    subnet_mask=match.group("subnet_mask"),
+                    method=match.group("method"),
+                )
+                continue
+
+            # Try continuation line (uses raw line for leading whitespace)
+            if pending_interface is not None:
+                cont_match = cls._CONTINUATION_PATTERN.match(line)
+                if cont_match:
+                    entries[pending_interface] = IpEntry(
+                        nameif=pending_nameif or "",
+                        ip_address=cont_match.group("ip_address"),
+                        subnet_mask=cont_match.group("subnet_mask"),
+                        method=cont_match.group("method"),
+                    )
+                    pending_interface = None
+                    pending_nameif = None
+                    continue
+
+            # Try partial line (interface + nameif, IP wraps)
+            partial_match = cls._PARTIAL_PATTERN.match(stripped)
+            if partial_match:
+                pending_interface = partial_match.group("interface")
+                pending_nameif = partial_match.group("nameif")
+                continue
+
+            # Unrecognized line resets pending state
+            pending_interface = None
+            pending_nameif = None
+
+        return entries
+
+    @classmethod
+    def parse(cls, output: str) -> ShowIpResult:
+        """Parse 'show ip' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed IP address entries for system and current sections.
+
+        Raises:
+            ValueError: If no IP entries found in output.
+        """
+        system_lines: list[str] = []
+        current_lines: list[str] = []
+        active: list[str] | None = None
+
+        for line in output.splitlines():
+            if line.startswith("System IP Addresses"):
+                active = system_lines
+                continue
+            if line.startswith("Current IP Addresses"):
+                active = current_lines
+                continue
+            if active is not None:
+                active.append(line)
+
+        system_addresses = cls._parse_section(system_lines)
+        current_addresses = cls._parse_section(current_lines)
+
+        if not system_addresses and not current_addresses:
+            msg = "No IP address entries found in output"
+            raise ValueError(msg)
+
+        return ShowIpResult(
+            system_addresses=system_addresses,
+            current_addresses=current_addresses,
+        )

--- a/tests/parsers/cisco_ftd/show_ip/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_ip/001_basic/expected.json
@@ -1,0 +1,390 @@
+{
+  "system_addresses": {
+    "Port-channel1.111": {
+      "nameif": "Inside",
+      "ip_address": "172.16.1.5",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel2": {
+      "nameif": "outside",
+      "ip_address": "172.16.2.182",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.200": {
+      "nameif": "Guest-DNS",
+      "ip_address": "10.100.0.1",
+      "subnet_mask": "255.255.255.0",
+      "method": "manual"
+    },
+    "Port-channel3.201": {
+      "nameif": "DMZ-Mgmt",
+      "ip_address": "10.100.1.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.202": {
+      "nameif": "Corp-Jabber",
+      "ip_address": "10.100.2.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.203": {
+      "nameif": "DMZ-Vendor1",
+      "ip_address": "10.100.2.65",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.204": {
+      "nameif": "DMZ-Vendor2",
+      "ip_address": "10.100.4.1",
+      "subnet_mask": "255.255.255.224",
+      "method": "manual"
+    },
+    "Port-channel3.206": {
+      "nameif": "DMZ-Vendor3",
+      "ip_address": "10.100.4.65",
+      "subnet_mask": "255.255.255.224",
+      "method": "manual"
+    },
+    "Port-channel3.207": {
+      "nameif": "DMZ-Partner1-Site1",
+      "ip_address": "10.100.4.97",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.208": {
+      "nameif": "DMZ-Partner1-Site2",
+      "ip_address": "10.100.4.113",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.217": {
+      "nameif": "Corp-Guest",
+      "ip_address": "10.101.0.1",
+      "subnet_mask": "255.255.0.0",
+      "method": "manual"
+    },
+    "Port-channel3.230": {
+      "nameif": "Corp-LB-MM",
+      "ip_address": "172.16.4.1",
+      "subnet_mask": "255.255.254.0",
+      "method": "manual"
+    },
+    "Port-channel3.231": {
+      "nameif": "Corp-LB-And",
+      "ip_address": "172.16.5.1",
+      "subnet_mask": "255.255.254.0",
+      "method": "manual"
+    },
+    "Port-channel3.233": {
+      "nameif": "Corp-ADC-M1",
+      "ip_address": "172.16.3.65",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.234": {
+      "nameif": "Corp-ADC-M2",
+      "ip_address": "172.16.6.1",
+      "subnet_mask": "255.255.252.0",
+      "method": "manual"
+    },
+    "Port-channel3.240": {
+      "nameif": "DMZ-Vendor5",
+      "ip_address": "10.100.5.1",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.242": {
+      "nameif": "Corp-LTE-Out",
+      "ip_address": "10.100.5.33",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.243": {
+      "nameif": "DMZ-Vendor6",
+      "ip_address": "10.100.5.49",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.244": {
+      "nameif": "DMZ-Partner2-Ckt1",
+      "ip_address": "10.100.9.1",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.245": {
+      "nameif": "DMZ-Partner2-Ckt2",
+      "ip_address": "10.100.9.9",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.246": {
+      "nameif": "DMZ-Partner3-Ckt1",
+      "ip_address": "10.100.10.1",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.247": {
+      "nameif": "DMZ-Partner3-Ckt2",
+      "ip_address": "10.100.10.9",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.361": {
+      "nameif": "Tenant-WiFi-Guest",
+      "ip_address": "10.100.31.38",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.3006": {
+      "nameif": "Tenant-Zone1",
+      "ip_address": "10.102.0.129",
+      "subnet_mask": "255.255.255.128",
+      "method": "manual"
+    },
+    "Port-channel3.3007": {
+      "nameif": "Tenant-Zone2",
+      "ip_address": "10.102.128.1",
+      "subnet_mask": "255.255.252.0",
+      "method": "manual"
+    },
+    "Port-channel3.3011": {
+      "nameif": "Tenant-Zone3",
+      "ip_address": "10.102.2.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.3012": {
+      "nameif": "Tenant-Zone4",
+      "ip_address": "10.102.2.129",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.3015": {
+      "nameif": "Tenant-Zone5",
+      "ip_address": "10.103.1.129",
+      "subnet_mask": "255.255.255.128",
+      "method": "manual"
+    },
+    "Port-channel3.3017": {
+      "nameif": "Tenant-Zone6",
+      "ip_address": "10.102.4.1",
+      "subnet_mask": "255.255.255.0",
+      "method": "manual"
+    },
+    "Port-channel3.3018": {
+      "nameif": "Tenant-Zone7",
+      "ip_address": "10.102.5.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.3019": {
+      "nameif": "Tenant_Zone8",
+      "ip_address": "10.102.5.65",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel48": {
+      "nameif": "HA",
+      "ip_address": "192.168.1.1",
+      "subnet_mask": "255.255.255.0",
+      "method": "CONFIG"
+    }
+  },
+  "current_addresses": {
+    "Port-channel1.111": {
+      "nameif": "Inside",
+      "ip_address": "172.16.1.5",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel2": {
+      "nameif": "outside",
+      "ip_address": "172.16.2.182",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.200": {
+      "nameif": "Guest-DNS",
+      "ip_address": "10.100.0.1",
+      "subnet_mask": "255.255.255.0",
+      "method": "manual"
+    },
+    "Port-channel3.201": {
+      "nameif": "DMZ-Mgmt",
+      "ip_address": "10.100.1.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.202": {
+      "nameif": "Corp-Jabber",
+      "ip_address": "10.100.2.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.203": {
+      "nameif": "DMZ-Vendor1",
+      "ip_address": "10.100.2.65",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.204": {
+      "nameif": "DMZ-Vendor2",
+      "ip_address": "10.100.4.1",
+      "subnet_mask": "255.255.255.224",
+      "method": "manual"
+    },
+    "Port-channel3.206": {
+      "nameif": "DMZ-Vendor3",
+      "ip_address": "10.100.4.65",
+      "subnet_mask": "255.255.255.224",
+      "method": "manual"
+    },
+    "Port-channel3.207": {
+      "nameif": "DMZ-Partner1-Site1",
+      "ip_address": "10.100.4.97",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.208": {
+      "nameif": "DMZ-Partner1-Site2",
+      "ip_address": "10.100.4.113",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.217": {
+      "nameif": "Corp-Guest",
+      "ip_address": "10.101.0.1",
+      "subnet_mask": "255.255.0.0",
+      "method": "manual"
+    },
+    "Port-channel3.230": {
+      "nameif": "Corp-LB-MM",
+      "ip_address": "172.16.4.1",
+      "subnet_mask": "255.255.254.0",
+      "method": "manual"
+    },
+    "Port-channel3.231": {
+      "nameif": "Corp-LB-And",
+      "ip_address": "172.16.5.1",
+      "subnet_mask": "255.255.254.0",
+      "method": "manual"
+    },
+    "Port-channel3.233": {
+      "nameif": "Corp-ADC-M1",
+      "ip_address": "172.16.3.65",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.234": {
+      "nameif": "Corp-ADC-M2",
+      "ip_address": "172.16.6.1",
+      "subnet_mask": "255.255.252.0",
+      "method": "manual"
+    },
+    "Port-channel3.240": {
+      "nameif": "DMZ-Vendor5",
+      "ip_address": "10.100.5.1",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.242": {
+      "nameif": "Corp-LTE-Out",
+      "ip_address": "10.100.5.33",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.243": {
+      "nameif": "DMZ-Vendor6",
+      "ip_address": "10.100.5.49",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.244": {
+      "nameif": "DMZ-Partner2-Ckt1",
+      "ip_address": "10.100.9.1",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.245": {
+      "nameif": "DMZ-Partner2-Ckt2",
+      "ip_address": "10.100.9.9",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.246": {
+      "nameif": "DMZ-Partner3-Ckt1",
+      "ip_address": "10.100.10.1",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.247": {
+      "nameif": "DMZ-Partner3-Ckt2",
+      "ip_address": "10.100.10.9",
+      "subnet_mask": "255.255.255.248",
+      "method": "manual"
+    },
+    "Port-channel3.361": {
+      "nameif": "Tenant-WiFi-Guest",
+      "ip_address": "10.100.31.38",
+      "subnet_mask": "255.255.255.240",
+      "method": "manual"
+    },
+    "Port-channel3.3006": {
+      "nameif": "Tenant-Zone1",
+      "ip_address": "10.102.0.129",
+      "subnet_mask": "255.255.255.128",
+      "method": "manual"
+    },
+    "Port-channel3.3007": {
+      "nameif": "Tenant-Zone2",
+      "ip_address": "10.102.128.1",
+      "subnet_mask": "255.255.252.0",
+      "method": "manual"
+    },
+    "Port-channel3.3011": {
+      "nameif": "Tenant-Zone3",
+      "ip_address": "10.102.2.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.3012": {
+      "nameif": "Tenant-Zone4",
+      "ip_address": "10.102.2.129",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.3015": {
+      "nameif": "Tenant-Zone5",
+      "ip_address": "10.103.1.129",
+      "subnet_mask": "255.255.255.128",
+      "method": "manual"
+    },
+    "Port-channel3.3017": {
+      "nameif": "Tenant-Zone6",
+      "ip_address": "10.102.4.1",
+      "subnet_mask": "255.255.255.0",
+      "method": "manual"
+    },
+    "Port-channel3.3018": {
+      "nameif": "Tenant-Zone7",
+      "ip_address": "10.102.5.1",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel3.3019": {
+      "nameif": "Tenant_Zone8",
+      "ip_address": "10.102.5.65",
+      "subnet_mask": "255.255.255.192",
+      "method": "manual"
+    },
+    "Port-channel48": {
+      "nameif": "HA",
+      "ip_address": "192.168.1.1",
+      "subnet_mask": "255.255.255.0",
+      "method": "CONFIG"
+    }
+  }
+}

--- a/tests/parsers/cisco_ftd/show_ip/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_ip/001_basic/input.txt
@@ -1,0 +1,70 @@
+System IP Addresses:
+Interface                Name                   IP address      Subnet mask     Method 
+Port-channel1.111        Inside                 172.16.1.5    255.255.255.240 manual
+Port-channel2            outside                172.16.2.182  255.255.255.192 manual
+Port-channel3.200        Guest-DNS              10.100.0.1      255.255.255.0   manual
+Port-channel3.201        DMZ-Mgmt               10.100.1.1      255.255.255.192 manual
+Port-channel3.202        Corp-Jabber            10.100.2.1      255.255.255.192 manual
+Port-channel3.203        DMZ-Vendor1           10.100.2.65     255.255.255.192 manual
+Port-channel3.204        DMZ-Vendor2             10.100.4.1      255.255.255.224 manual
+Port-channel3.206        DMZ-Vendor3            10.100.4.65     255.255.255.224 manual
+Port-channel3.207        DMZ-Partner1-Site1   10.100.4.97     255.255.255.240 manual
+Port-channel3.208        DMZ-Partner1-Site2    10.100.4.113    255.255.255.240 manual
+Port-channel3.217        Corp-Guest             10.101.0.1      255.255.0.0     manual
+Port-channel3.230        Corp-LB-MM      172.16.4.1    255.255.254.0   manual
+Port-channel3.231        Corp-LB-And     172.16.5.1    255.255.254.0   manual
+Port-channel3.233        Corp-ADC-M1            172.16.3.65   255.255.255.248 manual
+Port-channel3.234        Corp-ADC-M2            172.16.6.1    255.255.252.0   manual
+Port-channel3.240        DMZ-Vendor5        10.100.5.1      255.255.255.240 manual
+Port-channel3.242        Corp-LTE-Out           10.100.5.33     255.255.255.240 manual
+Port-channel3.243        DMZ-Vendor6            10.100.5.49     255.255.255.240 manual
+Port-channel3.244        DMZ-Partner2-Ckt1  10.100.9.1      255.255.255.248 manual
+Port-channel3.245        DMZ-Partner2-Ckt2     10.100.9.9      255.255.255.248 manual
+Port-channel3.246        DMZ-Partner3-Ckt1       10.100.10.1     255.255.255.248 manual
+Port-channel3.247        DMZ-Partner3-Ckt2
+                                                10.100.10.9     255.255.255.248 manual
+Port-channel3.361        Tenant-WiFi-Guest      10.100.31.38    255.255.255.240 manual
+Port-channel3.3006       Tenant-Zone1               10.102.0.129     255.255.255.128 manual
+Port-channel3.3007       Tenant-Zone2             10.102.128.1     255.255.252.0   manual
+Port-channel3.3011       Tenant-Zone3           10.102.2.1       255.255.255.192 manual
+Port-channel3.3012       Tenant-Zone4                10.102.2.129     255.255.255.192 manual
+Port-channel3.3015       Tenant-Zone5             10.103.1.129      255.255.255.128 manual
+Port-channel3.3017       Tenant-Zone6         10.102.4.1       255.255.255.0   manual
+Port-channel3.3018       Tenant-Zone7               10.102.5.1       255.255.255.192 manual
+Port-channel3.3019       Tenant_Zone8    10.102.5.65      255.255.255.192 manual
+Port-channel48           HA                     192.168.1.1         255.255.255.0   CONFIG
+Current IP Addresses:
+Interface                Name                   IP address      Subnet mask     Method 
+Port-channel1.111        Inside                 172.16.1.5    255.255.255.240 manual
+Port-channel2            outside                172.16.2.182  255.255.255.192 manual
+Port-channel3.200        Guest-DNS              10.100.0.1      255.255.255.0   manual
+Port-channel3.201        DMZ-Mgmt               10.100.1.1      255.255.255.192 manual
+Port-channel3.202        Corp-Jabber            10.100.2.1      255.255.255.192 manual
+Port-channel3.203        DMZ-Vendor1           10.100.2.65     255.255.255.192 manual
+Port-channel3.204        DMZ-Vendor2             10.100.4.1      255.255.255.224 manual
+Port-channel3.206        DMZ-Vendor3            10.100.4.65     255.255.255.224 manual
+Port-channel3.207        DMZ-Partner1-Site1   10.100.4.97     255.255.255.240 manual
+Port-channel3.208        DMZ-Partner1-Site2    10.100.4.113    255.255.255.240 manual
+Port-channel3.217        Corp-Guest             10.101.0.1      255.255.0.0     manual
+Port-channel3.230        Corp-LB-MM      172.16.4.1    255.255.254.0   manual
+Port-channel3.231        Corp-LB-And     172.16.5.1    255.255.254.0   manual
+Port-channel3.233        Corp-ADC-M1            172.16.3.65   255.255.255.248 manual
+Port-channel3.234        Corp-ADC-M2            172.16.6.1    255.255.252.0   manual
+Port-channel3.240        DMZ-Vendor5        10.100.5.1      255.255.255.240 manual
+Port-channel3.242        Corp-LTE-Out           10.100.5.33     255.255.255.240 manual
+Port-channel3.243        DMZ-Vendor6            10.100.5.49     255.255.255.240 manual
+Port-channel3.244        DMZ-Partner2-Ckt1  10.100.9.1      255.255.255.248 manual
+Port-channel3.245        DMZ-Partner2-Ckt2     10.100.9.9      255.255.255.248 manual
+Port-channel3.246        DMZ-Partner3-Ckt1       10.100.10.1     255.255.255.248 manual
+Port-channel3.247        DMZ-Partner3-Ckt2
+                                                10.100.10.9     255.255.255.248 manual
+Port-channel3.361        Tenant-WiFi-Guest      10.100.31.38    255.255.255.240 manual
+Port-channel3.3006       Tenant-Zone1               10.102.0.129     255.255.255.128 manual
+Port-channel3.3007       Tenant-Zone2             10.102.128.1     255.255.252.0   manual
+Port-channel3.3011       Tenant-Zone3           10.102.2.1       255.255.255.192 manual
+Port-channel3.3012       Tenant-Zone4                10.102.2.129     255.255.255.192 manual
+Port-channel3.3015       Tenant-Zone5             10.103.1.129      255.255.255.128 manual
+Port-channel3.3017       Tenant-Zone6         10.102.4.1       255.255.255.0   manual
+Port-channel3.3018       Tenant-Zone7               10.102.5.1       255.255.255.192 manual
+Port-channel3.3019       Tenant_Zone8    10.102.5.65      255.255.255.192 manual
+Port-channel48           HA                     192.168.1.1         255.255.255.0   CONFIG

--- a/tests/parsers/cisco_ftd/show_ip/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_ip/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: System and current IP addresses for all FTD interfaces
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary

- Adds a new parser for the `show ip` command on Cisco FTD (Firepower Threat Defense)
- Parses both "System IP Addresses" and "Current IP Addresses" sections into structured dicts keyed by interface name
- Handles line-wrapped entries where long nameif values cause the IP/mask/method to wrap to the next line

## Test plan

- [x] Fixture-based test passes (`tests/parsers/cisco_ftd/show_ip/001_basic`)
- [x] Full test suite passes (10213 tests)
- [x] Ruff lint and format checks pass
- [x] Changelog fragment added

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation + fixture + changelog

Generated with [Claude Code](https://claude.com/claude-code)