### PR TITLE
feat(cisco_ftd): add parser for `show failover`

### DIFF
--- a/changes/+show-failover-cisco-ftd.parser_added
+++ b/changes/+show-failover-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show failover` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_failover.py
+++ b/src/muninn/parsers/cisco_ftd/show_failover.py
@@ -356,11 +356,15 @@ class ShowFailoverParser(BaseParser["ShowFailoverResult"]):
             reconnect_timeout=str(header.get("reconnect_timeout", "")),
             unit_poll_frequency=cast(int, header.get("unit_poll_frequency", 0)),
             unit_poll_holdtime=cast(int, header.get("unit_poll_holdtime", 0)),
-            interface_poll_frequency=cast(int, header.get("interface_poll_frequency", 0)),
+            interface_poll_frequency=cast(
+                int, header.get("interface_poll_frequency", 0)
+            ),
             interface_poll_holdtime=cast(int, header.get("interface_poll_holdtime", 0)),
             interface_policy=cast(int, header.get("interface_policy", 0)),
             monitored_interfaces=cast(int, header.get("monitored_interfaces", 0)),
-            max_monitored_interfaces=cast(int, header.get("max_monitored_interfaces", 0)),
+            max_monitored_interfaces=cast(
+                int, header.get("max_monitored_interfaces", 0)
+            ),
             failover_replication=str(header.get("failover_replication", "")),
             version_ours=str(header.get("version_ours", "")),
             version_mate=str(header.get("version_mate", "")),

--- a/src/muninn/parsers/cisco_ftd/show_failover.py
+++ b/src/muninn/parsers/cisco_ftd/show_failover.py
@@ -1,7 +1,7 @@
 """Parser for 'show failover' command on Cisco FTD."""
 
 import re
-from typing import ClassVar, NotRequired, TypedDict
+from typing import ClassVar, NotRequired, TypedDict, cast
 
 from muninn.os import OS
 from muninn.parser import BaseParser
@@ -348,25 +348,25 @@ class ShowFailoverParser(BaseParser["ShowFailoverResult"]):
                 break
 
         result = ShowFailoverResult(
-            failover_enabled=header["failover_enabled"],  # type: ignore[arg-type]
-            failover_unit=header.get("failover_unit", ""),  # type: ignore[arg-type]
-            lan_interface_name=header.get("lan_interface_name", ""),  # type: ignore[arg-type]
-            lan_interface_id=header.get("lan_interface_id", ""),  # type: ignore[arg-type]
-            lan_interface_status=header.get("lan_interface_status", ""),  # type: ignore[arg-type]
-            reconnect_timeout=header.get("reconnect_timeout", ""),  # type: ignore[arg-type]
-            unit_poll_frequency=header.get("unit_poll_frequency", 0),  # type: ignore[arg-type]
-            unit_poll_holdtime=header.get("unit_poll_holdtime", 0),  # type: ignore[arg-type]
-            interface_poll_frequency=header.get("interface_poll_frequency", 0),  # type: ignore[arg-type]
-            interface_poll_holdtime=header.get("interface_poll_holdtime", 0),  # type: ignore[arg-type]
-            interface_policy=header.get("interface_policy", 0),  # type: ignore[arg-type]
-            monitored_interfaces=header.get("monitored_interfaces", 0),  # type: ignore[arg-type]
-            max_monitored_interfaces=header.get("max_monitored_interfaces", 0),  # type: ignore[arg-type]
-            failover_replication=header.get("failover_replication", ""),  # type: ignore[arg-type]
-            version_ours=header.get("version_ours", ""),  # type: ignore[arg-type]
-            version_mate=header.get("version_mate", ""),  # type: ignore[arg-type]
-            serial_ours=header.get("serial_ours", ""),  # type: ignore[arg-type]
-            serial_mate=header.get("serial_mate", ""),  # type: ignore[arg-type]
-            last_failover=header.get("last_failover", ""),  # type: ignore[arg-type]
+            failover_enabled=bool(header.get("failover_enabled", False)),
+            failover_unit=str(header.get("failover_unit", "")),
+            lan_interface_name=str(header.get("lan_interface_name", "")),
+            lan_interface_id=str(header.get("lan_interface_id", "")),
+            lan_interface_status=str(header.get("lan_interface_status", "")),
+            reconnect_timeout=str(header.get("reconnect_timeout", "")),
+            unit_poll_frequency=cast(int, header.get("unit_poll_frequency", 0)),
+            unit_poll_holdtime=cast(int, header.get("unit_poll_holdtime", 0)),
+            interface_poll_frequency=cast(int, header.get("interface_poll_frequency", 0)),
+            interface_poll_holdtime=cast(int, header.get("interface_poll_holdtime", 0)),
+            interface_policy=cast(int, header.get("interface_policy", 0)),
+            monitored_interfaces=cast(int, header.get("monitored_interfaces", 0)),
+            max_monitored_interfaces=cast(int, header.get("max_monitored_interfaces", 0)),
+            failover_replication=str(header.get("failover_replication", "")),
+            version_ours=str(header.get("version_ours", "")),
+            version_mate=str(header.get("version_mate", "")),
+            serial_ours=str(header.get("serial_ours", "")),
+            serial_mate=str(header.get("serial_mate", "")),
+            last_failover=str(header.get("last_failover", "")),
             this_host=this_host,
             other_host=other_host,
         )

--- a/src/muninn/parsers/cisco_ftd/show_failover.py
+++ b/src/muninn/parsers/cisco_ftd/show_failover.py
@@ -1,0 +1,377 @@
+"""Parser for 'show failover' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class InterfaceEntry(TypedDict):
+    """Schema for an interface status entry within a failover host."""
+
+    ip_address: str
+    status: str
+    monitored: str
+
+
+class SlotEntry(TypedDict):
+    """Schema for a hardware/software slot entry."""
+
+    model: str
+    hw_rev: NotRequired[str]
+    sw_rev: str
+    status: str
+
+
+class HostInfo(TypedDict):
+    """Schema for a failover host (this host or other host)."""
+
+    role: str
+    state: str
+    active_time: int
+    slots: dict[str, SlotEntry]
+    interfaces: dict[str, InterfaceEntry]
+
+
+class StatefulObjectStats(TypedDict):
+    """Schema for a single stateful failover object's counters."""
+
+    xmit: int
+    xerr: int
+    rcv: int
+    rerr: int
+
+
+class ShowFailoverResult(TypedDict):
+    """Schema for 'show failover' parsed output on Cisco FTD."""
+
+    failover_enabled: bool
+    failover_unit: str
+    lan_interface_name: str
+    lan_interface_id: str
+    lan_interface_status: str
+    reconnect_timeout: str
+    unit_poll_frequency: int
+    unit_poll_holdtime: int
+    interface_poll_frequency: int
+    interface_poll_holdtime: int
+    interface_policy: int
+    monitored_interfaces: int
+    max_monitored_interfaces: int
+    failover_replication: str
+    version_ours: str
+    version_mate: str
+    serial_ours: str
+    serial_mate: str
+    last_failover: str
+    this_host: HostInfo
+    other_host: HostInfo
+    stateful_failover_stats: NotRequired[dict[str, StatefulObjectStats]]
+
+
+@register(OS.CISCO_FTD, "show failover")
+class ShowFailoverParser(BaseParser["ShowFailoverResult"]):
+    """Parser for 'show failover' command on Cisco FTD.
+
+    Parses failover configuration, unit status, interface health,
+    and stateful failover statistics.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.REDUNDANCY})
+
+    _FAILOVER_STATE_RE = re.compile(r"^Failover\s+(On|Off)\s*$", re.IGNORECASE)
+    _FAILOVER_UNIT_RE = re.compile(r"^Failover unit\s+(\S+)\s*$", re.IGNORECASE)
+    _LAN_INTF_RE = re.compile(
+        r"^Failover LAN Interface:\s+(\S+)\s+(\S+)\s+\((\w+)\)\s*$"
+    )
+    _RECONNECT_RE = re.compile(r"^Reconnect timeout\s+(\S+)\s*$")
+    _UNIT_POLL_RE = re.compile(
+        r"^Unit Poll frequency\s+(\d+)\s+seconds,"
+        r"\s+holdtime\s+(\d+)\s+seconds"
+    )
+    _INTF_POLL_RE = re.compile(
+        r"^Interface Poll frequency\s+(\d+)\s+seconds,"
+        r"\s+holdtime\s+(\d+)\s+seconds"
+    )
+    _INTF_POLICY_RE = re.compile(r"^Interface Policy\s+(\d+)\s*$")
+    _MONITORED_RE = re.compile(r"^Monitored Interfaces\s+(\d+)\s+of\s+(\d+)\s+maximum")
+    _REPLICATION_RE = re.compile(r"^failover replication\s+(\S+)\s*$")
+    _VERSION_RE = re.compile(r"^Version:\s+Ours\s+(.+?),\s+Mate\s+(.+?)\s*$")
+    _SERIAL_RE = re.compile(r"^Serial Number:\s+Ours\s+(\S+),\s+Mate\s+(\S+)\s*$")
+    _LAST_FAILOVER_RE = re.compile(r"^Last Failover at:\s+(.+?)\s*$")
+    _HOST_RE = re.compile(r"^\s+(This host|Other host):\s+(\S+)\s+-\s+(.+?)\s*$")
+    _ACTIVE_TIME_RE = re.compile(r"^\s+Active time:\s+(\d+)\s+\(sec\)\s*$")
+    _SLOT_RE = re.compile(
+        r"^\s+slot\s+(\d+):\s+(\S+)\s+hw/sw rev\s+"
+        r"\(([^/]+)/(.+?)\)\s+status\s+\((.+?)\)\s*$"
+    )
+    _SLOT_SIMPLE_RE = re.compile(
+        r"^\s+slot\s+(\d+):\s+(\S+)\s+rev\s+"
+        r"\(([^)]+)\)\s+status\s+\((.+?)\)\s*$"
+    )
+    _INTERFACE_RE = re.compile(
+        r"^\s+Interface\s+(\S+)\s+\(([^)]+)\):\s+"
+        r"(\S+(?:\s+\S+)?)\s+\(([^)]+)\)\s*$"
+    )
+    _STATEFUL_OBJ_RE = re.compile(r"^\s+(.+?)\s{2,}(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*$")
+
+    # Maps regex patterns to handler callables for header parsing.
+    # Each handler receives the match object and the result dict.
+    _HEADER_HANDLERS: ClassVar[list[tuple[str, str]]] = [
+        ("_FAILOVER_STATE_RE", "_handle_failover_state"),
+        ("_FAILOVER_UNIT_RE", "_handle_failover_unit"),
+        ("_LAN_INTF_RE", "_handle_lan_interface"),
+        ("_RECONNECT_RE", "_handle_reconnect"),
+        ("_UNIT_POLL_RE", "_handle_unit_poll"),
+        ("_INTF_POLL_RE", "_handle_intf_poll"),
+        ("_INTF_POLICY_RE", "_handle_intf_policy"),
+        ("_MONITORED_RE", "_handle_monitored"),
+        ("_REPLICATION_RE", "_handle_replication"),
+        ("_VERSION_RE", "_handle_version"),
+        ("_SERIAL_RE", "_handle_serial"),
+        ("_LAST_FAILOVER_RE", "_handle_last_failover"),
+    ]
+
+    @classmethod
+    def _handle_failover_state(
+        cls, m: re.Match[str], result: dict[str, object]
+    ) -> None:
+        result["failover_enabled"] = m.group(1).lower() == "on"
+
+    @classmethod
+    def _handle_failover_unit(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["failover_unit"] = m.group(1)
+
+    @classmethod
+    def _handle_lan_interface(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["lan_interface_name"] = m.group(1)
+        result["lan_interface_id"] = m.group(2)
+        result["lan_interface_status"] = m.group(3)
+
+    @classmethod
+    def _handle_reconnect(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["reconnect_timeout"] = m.group(1)
+
+    @classmethod
+    def _handle_unit_poll(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["unit_poll_frequency"] = int(m.group(1))
+        result["unit_poll_holdtime"] = int(m.group(2))
+
+    @classmethod
+    def _handle_intf_poll(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["interface_poll_frequency"] = int(m.group(1))
+        result["interface_poll_holdtime"] = int(m.group(2))
+
+    @classmethod
+    def _handle_intf_policy(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["interface_policy"] = int(m.group(1))
+
+    @classmethod
+    def _handle_monitored(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["monitored_interfaces"] = int(m.group(1))
+        result["max_monitored_interfaces"] = int(m.group(2))
+
+    @classmethod
+    def _handle_replication(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["failover_replication"] = m.group(1)
+
+    @classmethod
+    def _handle_version(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["version_ours"] = m.group(1)
+        result["version_mate"] = m.group(2)
+
+    @classmethod
+    def _handle_serial(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["serial_ours"] = m.group(1)
+        result["serial_mate"] = m.group(2)
+
+    @classmethod
+    def _handle_last_failover(cls, m: re.Match[str], result: dict[str, object]) -> None:
+        result["last_failover"] = m.group(1)
+
+    @classmethod
+    def _parse_header(cls, lines: list[str]) -> dict[str, object]:
+        """Parse the top-level failover configuration header."""
+        result: dict[str, object] = {}
+
+        handlers = [
+            (getattr(cls, pat_name), getattr(cls, handler_name))
+            for pat_name, handler_name in cls._HEADER_HANDLERS
+        ]
+
+        for line in lines:
+            for pattern, handler in handlers:
+                if m := pattern.match(line):
+                    handler(m, result)
+                    break
+
+        return result
+
+    @classmethod
+    def _parse_host_section(
+        cls, lines: list[str], start_idx: int
+    ) -> tuple[HostInfo, int]:
+        """Parse a host section (This host or Other host).
+
+        Returns the parsed HostInfo and the index after this section.
+        """
+        host_match = cls._HOST_RE.match(lines[start_idx])
+        if not host_match:
+            msg = f"Expected host header at line {start_idx}"
+            raise ValueError(msg)
+
+        role = host_match.group(2)
+        state = host_match.group(3).strip()
+        active_time = 0
+        slots: dict[str, SlotEntry] = {}
+        interfaces: dict[str, InterfaceEntry] = {}
+
+        idx = start_idx + 1
+        while idx < len(lines):
+            line = lines[idx]
+
+            # Stop at the next host section or non-indented section
+            if cls._HOST_RE.match(line):
+                break
+            if line.strip() and not line[0].isspace():
+                break
+
+            if m := cls._ACTIVE_TIME_RE.match(line):
+                active_time = int(m.group(1))
+            elif m := cls._SLOT_RE.match(line):
+                slots[m.group(1)] = SlotEntry(
+                    model=m.group(2),
+                    hw_rev=m.group(3),
+                    sw_rev=m.group(4),
+                    status=m.group(5),
+                )
+            elif m := cls._SLOT_SIMPLE_RE.match(line):
+                slots[m.group(1)] = SlotEntry(
+                    model=m.group(2),
+                    sw_rev=m.group(3),
+                    status=m.group(4),
+                )
+            elif m := cls._INTERFACE_RE.match(line):
+                interfaces[m.group(1)] = InterfaceEntry(
+                    ip_address=m.group(2),
+                    status=m.group(3),
+                    monitored=m.group(4),
+                )
+
+            idx += 1
+
+        host_info = HostInfo(
+            role=role,
+            state=state,
+            active_time=active_time,
+            slots=slots,
+            interfaces=interfaces,
+        )
+        return host_info, idx
+
+    @classmethod
+    def _parse_stateful_stats(
+        cls, lines: list[str], start_idx: int
+    ) -> dict[str, StatefulObjectStats]:
+        """Parse stateful failover logical update statistics."""
+        stats: dict[str, StatefulObjectStats] = {}
+
+        for idx in range(start_idx, len(lines)):
+            line = lines[idx]
+            if m := cls._STATEFUL_OBJ_RE.match(line):
+                obj_name = m.group(1).strip()
+                # Skip the header row
+                if obj_name.lower() == "stateful obj":
+                    continue
+                stats[obj_name] = StatefulObjectStats(
+                    xmit=int(m.group(2)),
+                    xerr=int(m.group(3)),
+                    rcv=int(m.group(4)),
+                    rerr=int(m.group(5)),
+                )
+
+        return stats
+
+    @classmethod
+    def parse(cls, output: str) -> "ShowFailoverResult":
+        """Parse 'show failover' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed failover configuration, host status, and stats.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        lines = output.splitlines()
+
+        # Parse header fields
+        header = cls._parse_header(lines)
+
+        if "failover_enabled" not in header:
+            msg = "Could not determine failover state from output"
+            raise ValueError(msg)
+
+        # Parse host sections
+        this_host: HostInfo | None = None
+        other_host: HostInfo | None = None
+
+        idx = 0
+        while idx < len(lines):
+            if host_match := cls._HOST_RE.match(lines[idx]):
+                host_label = host_match.group(1)
+                host_info, idx = cls._parse_host_section(lines, idx)
+                if host_label == "This host":
+                    this_host = host_info
+                else:
+                    other_host = host_info
+            else:
+                idx += 1
+
+        if this_host is None:
+            msg = "Could not parse 'This host' section"
+            raise ValueError(msg)
+        if other_host is None:
+            msg = "Could not parse 'Other host' section"
+            raise ValueError(msg)
+
+        # Parse stateful failover stats
+        stateful_stats: dict[str, StatefulObjectStats] = {}
+        for idx, line in enumerate(lines):
+            if "Stateful Failover Logical Update Statistics" in line:
+                stateful_stats = cls._parse_stateful_stats(lines, idx + 1)
+                break
+
+        result = ShowFailoverResult(
+            failover_enabled=header["failover_enabled"],  # type: ignore[arg-type]
+            failover_unit=header.get("failover_unit", ""),  # type: ignore[arg-type]
+            lan_interface_name=header.get("lan_interface_name", ""),  # type: ignore[arg-type]
+            lan_interface_id=header.get("lan_interface_id", ""),  # type: ignore[arg-type]
+            lan_interface_status=header.get("lan_interface_status", ""),  # type: ignore[arg-type]
+            reconnect_timeout=header.get("reconnect_timeout", ""),  # type: ignore[arg-type]
+            unit_poll_frequency=header.get("unit_poll_frequency", 0),  # type: ignore[arg-type]
+            unit_poll_holdtime=header.get("unit_poll_holdtime", 0),  # type: ignore[arg-type]
+            interface_poll_frequency=header.get("interface_poll_frequency", 0),  # type: ignore[arg-type]
+            interface_poll_holdtime=header.get("interface_poll_holdtime", 0),  # type: ignore[arg-type]
+            interface_policy=header.get("interface_policy", 0),  # type: ignore[arg-type]
+            monitored_interfaces=header.get("monitored_interfaces", 0),  # type: ignore[arg-type]
+            max_monitored_interfaces=header.get("max_monitored_interfaces", 0),  # type: ignore[arg-type]
+            failover_replication=header.get("failover_replication", ""),  # type: ignore[arg-type]
+            version_ours=header.get("version_ours", ""),  # type: ignore[arg-type]
+            version_mate=header.get("version_mate", ""),  # type: ignore[arg-type]
+            serial_ours=header.get("serial_ours", ""),  # type: ignore[arg-type]
+            serial_mate=header.get("serial_mate", ""),  # type: ignore[arg-type]
+            last_failover=header.get("last_failover", ""),  # type: ignore[arg-type]
+            this_host=this_host,
+            other_host=other_host,
+        )
+
+        if stateful_stats:
+            result["stateful_failover_stats"] = stateful_stats
+
+        return result

--- a/tests/parsers/cisco_ftd/show_failover/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_failover/001_basic/expected.json
@@ -1,0 +1,625 @@
+{
+  "failover_enabled": true,
+  "failover_unit": "Primary",
+  "lan_interface_name": "HA",
+  "lan_interface_id": "Port-channel48",
+  "lan_interface_status": "up",
+  "reconnect_timeout": "0:00:00",
+  "unit_poll_frequency": 1,
+  "unit_poll_holdtime": 15,
+  "interface_poll_frequency": 5,
+  "interface_poll_holdtime": 25,
+  "interface_policy": 1,
+  "monitored_interfaces": 4,
+  "max_monitored_interfaces": 1288,
+  "failover_replication": "http",
+  "version_ours": "9.20(2)121",
+  "version_mate": "9.20(2)121",
+  "serial_ours": "ABC1234XYZ2",
+  "serial_mate": "ABC1234XYZ1",
+  "last_failover": "15:56:36 UTC Jul 1 2026",
+  "this_host": {
+    "role": "Primary",
+    "state": "Active",
+    "active_time": 3801119,
+    "slots": {
+      "0": {
+        "model": "FPR-4215",
+        "hw_rev": "1.1",
+        "sw_rev": "9.20(2)121",
+        "status": "Up Sys"
+      },
+      "1": {
+        "model": "snort",
+        "sw_rev": "1.0",
+        "status": "up"
+      },
+      "2": {
+        "model": "diskstatus",
+        "sw_rev": "1.0",
+        "status": "up"
+      }
+    },
+    "interfaces": {
+      "management": {
+        "ip_address": "192.168.50.130",
+        "status": "Normal",
+        "monitored": "Monitored"
+      },
+      "eventing": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Inside-PC": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Waiting"
+      },
+      "Inside": {
+        "ip_address": "172.16.1.5",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "outside": {
+        "ip_address": "172.16.2.182",
+        "status": "Normal",
+        "monitored": "Waiting"
+      },
+      "DMZ-Corp": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Waiting"
+      },
+      "Guest-DNS": {
+        "ip_address": "10.100.0.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Mgmt": {
+        "ip_address": "10.100.1.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-Jabber": {
+        "ip_address": "10.100.2.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor1": {
+        "ip_address": "10.100.2.65",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor2": {
+        "ip_address": "10.100.4.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor3": {
+        "ip_address": "10.100.4.65",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner1-Site1": {
+        "ip_address": "10.100.4.97",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner1-Site2": {
+        "ip_address": "10.100.4.113",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor4": {
+        "ip_address": "0.0.0.0",
+        "status": "Link Down",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-Guest": {
+        "ip_address": "10.101.0.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-LB-MM": {
+        "ip_address": "172.16.4.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-LB-And": {
+        "ip_address": "172.16.5.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-ADC-M1": {
+        "ip_address": "172.16.3.65",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-ADC-M2": {
+        "ip_address": "172.16.6.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor5": {
+        "ip_address": "10.100.5.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-LTE-Out": {
+        "ip_address": "10.100.5.33",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor6": {
+        "ip_address": "10.100.5.49",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner2-Ckt1": {
+        "ip_address": "10.100.9.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner2-Ckt2": {
+        "ip_address": "10.100.9.9",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner3-Ckt1": {
+        "ip_address": "10.100.10.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner3-Ckt2": {
+        "ip_address": "10.100.10.9",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-WiFi-Guest": {
+        "ip_address": "10.100.31.38",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone1": {
+        "ip_address": "10.102.0.129",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone2": {
+        "ip_address": "10.102.128.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone3": {
+        "ip_address": "10.102.2.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone4": {
+        "ip_address": "10.102.2.129",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone5": {
+        "ip_address": "10.103.1.129",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone6": {
+        "ip_address": "10.102.4.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone7": {
+        "ip_address": "10.102.5.1",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant_Zone8": {
+        "ip_address": "10.102.5.65",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      }
+    }
+  },
+  "other_host": {
+    "role": "Secondary",
+    "state": "Standby Ready",
+    "active_time": 964,
+    "slots": {
+      "0": {
+        "model": "FPR-4215",
+        "hw_rev": "1.1",
+        "sw_rev": "9.20(2)121",
+        "status": "Up Sys"
+      },
+      "1": {
+        "model": "snort",
+        "sw_rev": "1.0",
+        "status": "up"
+      },
+      "2": {
+        "model": "diskstatus",
+        "sw_rev": "1.0",
+        "status": "up"
+      }
+    },
+    "interfaces": {
+      "management": {
+        "ip_address": "192.168.50.131",
+        "status": "Normal",
+        "monitored": "Monitored"
+      },
+      "eventing": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Inside-PC": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Waiting"
+      },
+      "Inside": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "outside": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Waiting"
+      },
+      "DMZ-Corp": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Waiting"
+      },
+      "Guest-DNS": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Mgmt": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-Jabber": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor1": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor2": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor3": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner1-Site1": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner1-Site2": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor4": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-Guest": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-LB-MM": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-LB-And": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-ADC-M1": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-ADC-M2": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor5": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Corp-LTE-Out": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Vendor6": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner2-Ckt1": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner2-Ckt2": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner3-Ckt1": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "DMZ-Partner3-Ckt2": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-WiFi-Guest": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone1": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone2": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone3": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone4": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone5": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone6": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant-Zone7": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      },
+      "Tenant_Zone8": {
+        "ip_address": "0.0.0.0",
+        "status": "Normal",
+        "monitored": "Not-Monitored"
+      }
+    }
+  },
+  "stateful_failover_stats": {
+    "General": {
+      "xmit": 659482,
+      "xerr": 0,
+      "rcv": 622258,
+      "rerr": 0
+    },
+    "sys cmd": {
+      "xmit": 596827,
+      "xerr": 0,
+      "rcv": 596826,
+      "rerr": 0
+    },
+    "up time": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "RPC services": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "TCP conn": {
+      "xmit": 3567,
+      "xerr": 0,
+      "rcv": 1516,
+      "rerr": 0
+    },
+    "UDP conn": {
+      "xmit": 28933,
+      "xerr": 0,
+      "rcv": 14519,
+      "rerr": 0
+    },
+    "ARP tbl": {
+      "xmit": 24955,
+      "xerr": 0,
+      "rcv": 7589,
+      "rerr": 0
+    },
+    "Xlate_Timeout": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "IPv6 ND tbl": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN IKEv1 SA": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN IKEv1 P2": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN IKEv2 SA": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN IKEv2 P2": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN CTCP upd": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN SDI upd": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "VPN DHCP upd": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "GTP PDP": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "GTP PDPMCB": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "SIP Session": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "SIP Tx": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "SIP Pinhole": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "Route Session": {
+      "xmit": 1520,
+      "xerr": 0,
+      "rcv": 346,
+      "rerr": 0
+    },
+    "Router ID": {
+      "xmit": 2,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "CTS SGTNAME": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "CTS PAC": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "TrustSec-SXP": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "IPv6 Route": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "STS Table": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "Umbrella Device-ID": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "Rule DB B-Sync": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    },
+    "Rule DB P-Sync": {
+      "xmit": 3678,
+      "xerr": 0,
+      "rcv": 1462,
+      "rerr": 0
+    },
+    "Rule DB Delete": {
+      "xmit": 0,
+      "xerr": 0,
+      "rcv": 0,
+      "rerr": 0
+    }
+  }
+}

--- a/tests/parsers/cisco_ftd/show_failover/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_failover/001_basic/input.txt
@@ -1,0 +1,136 @@
+Failover On 
+Failover unit Primary
+Failover LAN Interface: HA Port-channel48 (up)
+Reconnect timeout 0:00:00
+Unit Poll frequency 1 seconds, holdtime 15 seconds
+Interface Poll frequency 5 seconds, holdtime 25 seconds
+Interface Policy 1
+Monitored Interfaces 4 of 1288 maximum
+MAC Address Move Notification Interval not set
+failover replication http
+Version: Ours 9.20(2)121, Mate 9.20(2)121
+Serial Number: Ours ABC1234XYZ2, Mate ABC1234XYZ1
+Last Failover at: 15:56:36 UTC Jul 1 2026
+	This host: Primary - Active 
+		Active time: 3801119 (sec)
+		slot 0: FPR-4215 hw/sw rev (1.1/9.20(2)121) status (Up Sys)
+		  Interface management (192.168.50.130): Normal (Monitored)
+		  Interface eventing (0.0.0.0): Normal (Not-Monitored)
+		  Interface Inside-PC (0.0.0.0): Normal (Waiting)
+		  Interface Inside (172.16.1.5): Normal (Not-Monitored)
+		  Interface outside (172.16.2.182): Normal (Waiting)
+		  Interface DMZ-Corp (0.0.0.0): Normal (Waiting)
+		  Interface Guest-DNS (10.100.0.1): Normal (Not-Monitored)
+		  Interface DMZ-Mgmt (10.100.1.1): Normal (Not-Monitored)
+		  Interface Corp-Jabber (10.100.2.1): Normal (Not-Monitored)
+		  Interface DMZ-Vendor1 (10.100.2.65): Normal (Not-Monitored)
+		  Interface DMZ-Vendor2 (10.100.4.1): Normal (Not-Monitored)
+		  Interface DMZ-Vendor3 (10.100.4.65): Normal (Not-Monitored)
+		  Interface DMZ-Partner1-Site1 (10.100.4.97): Normal (Not-Monitored)
+		  Interface DMZ-Partner1-Site2 (10.100.4.113): Normal (Not-Monitored)
+		  Interface DMZ-Vendor4 (0.0.0.0): Link Down (Not-Monitored)
+		  Interface Corp-Guest (10.101.0.1): Normal (Not-Monitored)
+		  Interface Corp-LB-MM (172.16.4.1): Normal (Not-Monitored)
+		  Interface Corp-LB-And (172.16.5.1): Normal (Not-Monitored)
+		  Interface Corp-ADC-M1 (172.16.3.65): Normal (Not-Monitored)
+		  Interface Corp-ADC-M2 (172.16.6.1): Normal (Not-Monitored)
+		  Interface DMZ-Vendor5 (10.100.5.1): Normal (Not-Monitored)
+		  Interface Corp-LTE-Out (10.100.5.33): Normal (Not-Monitored)
+		  Interface DMZ-Vendor6 (10.100.5.49): Normal (Not-Monitored)
+		  Interface DMZ-Partner2-Ckt1 (10.100.9.1): Normal (Not-Monitored)
+		  Interface DMZ-Partner2-Ckt2 (10.100.9.9): Normal (Not-Monitored)
+		  Interface DMZ-Partner3-Ckt1 (10.100.10.1): Normal (Not-Monitored)
+		  Interface DMZ-Partner3-Ckt2 (10.100.10.9): Normal (Not-Monitored)
+		  Interface Tenant-WiFi-Guest (10.100.31.38): Normal (Not-Monitored)
+		  Interface Tenant-Zone1 (10.102.0.129): Normal (Not-Monitored)
+		  Interface Tenant-Zone2 (10.102.128.1): Normal (Not-Monitored)
+		  Interface Tenant-Zone3 (10.102.2.1): Normal (Not-Monitored)
+		  Interface Tenant-Zone4 (10.102.2.129): Normal (Not-Monitored)
+		  Interface Tenant-Zone5 (10.103.1.129): Normal (Not-Monitored)
+		  Interface Tenant-Zone6 (10.102.4.1): Normal (Not-Monitored)
+		  Interface Tenant-Zone7 (10.102.5.1): Normal (Not-Monitored)
+		  Interface Tenant_Zone8 (10.102.5.65): Normal (Not-Monitored)
+		slot 1: snort rev (1.0)  status (up)
+		slot 2: diskstatus rev (1.0)  status (up)
+	Other host: Secondary - Standby Ready 
+		Active time: 964 (sec)
+		slot 0: FPR-4215 hw/sw rev (1.1/9.20(2)121) status (Up Sys)
+		  Interface management (192.168.50.131): Normal (Monitored)
+		  Interface eventing (0.0.0.0): Normal (Not-Monitored)
+		  Interface Inside-PC (0.0.0.0): Normal (Waiting)
+		  Interface Inside (0.0.0.0): Normal (Not-Monitored)
+		  Interface outside (0.0.0.0): Normal (Waiting)
+		  Interface DMZ-Corp (0.0.0.0): Normal (Waiting)
+		  Interface Guest-DNS (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Mgmt (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-Jabber (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Vendor1 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Vendor2 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Vendor3 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Partner1-Site1 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Partner1-Site2 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Vendor4 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-Guest (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-LB-MM (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-LB-And (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-ADC-M1 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-ADC-M2 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Vendor5 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Corp-LTE-Out (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Vendor6 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Partner2-Ckt1 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Partner2-Ckt2 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Partner3-Ckt1 (0.0.0.0): Normal (Not-Monitored)
+		  Interface DMZ-Partner3-Ckt2 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-WiFi-Guest (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone1 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone2 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone3 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone4 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone5 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone6 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant-Zone7 (0.0.0.0): Normal (Not-Monitored)
+		  Interface Tenant_Zone8 (0.0.0.0): Normal (Not-Monitored)
+		slot 1: snort rev (1.0)  status (up)
+		slot 2: diskstatus rev (1.0)  status (up)
+
+Stateful Failover Logical Update Statistics
+	Link : HA Port-channel48 (up)
+	Stateful Obj 	xmit       xerr       rcv        rerr      
+	General		659482     0          622258     0         
+	sys cmd  	596827     0          596826     0         
+	up time  	0          0          0          0         
+	RPC services  	0          0          0          0         
+	TCP conn 	3567       0          1516       0         
+	UDP conn 	28933      0          14519      0         
+	ARP tbl  	24955      0          7589       0         
+	Xlate_Timeout  	0          0          0          0         
+	IPv6 ND tbl  	0          0          0          0         
+	VPN IKEv1 SA 	0          0          0          0         
+	VPN IKEv1 P2 	0          0          0          0         
+	VPN IKEv2 SA 	0          0          0          0         
+	VPN IKEv2 P2 	0          0          0          0         
+	VPN CTCP upd 	0          0          0          0         
+	VPN SDI upd 	0          0          0          0         
+	VPN DHCP upd 	0          0          0          0         
+	GTP PDP 	0          0          0          0         
+	GTP PDPMCB 	0          0          0          0         
+	SIP Session 	0          0          0          0         
+	SIP Tx 	0          0          0          0         
+	SIP Pinhole 	0          0          0          0         
+	Route Session 	1520       0          346        0         
+	Router ID 	2          0          0          0         
+	CTS SGTNAME 	0          0          0          0         
+	CTS PAC 	0          0          0          0         
+	TrustSec-SXP 	0          0          0          0         
+	IPv6 Route 	0          0          0          0         
+	STS Table 	0          0          0          0         
+	Umbrella Device-ID 	0          0          0          0         
+	Rule DB B-Sync 	0          0          0          0         
+	Rule DB P-Sync 	3678       0          1462       0         
+	Rule DB Delete 	0          0          0          0         
+
+	Logical Update Queue Information
+	 	 	Cur 	Max 	Total
+	Recv Q: 	0 	10 	1013539
+	Xmit Q: 	0 	15 	2972583

--- a/tests/parsers/cisco_ftd/show_failover/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_failover/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Full failover status showing active/standby pair with monitored interfaces
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary
- Adds a new parser for `show failover` on Cisco FTD (OS.CISCO_FTD)
- Parses failover configuration header, per-host status (role, state, active_time, slots, interfaces), and stateful failover logical update statistics
- Tagged with `ParserTag.REDUNDANCY`

## Test plan
- [x] Parser test fixture (`001_basic`) with full active/standby pair output from FPR-4215
- [x] All 7 targeted tests pass (parser correctness + fixture conventions)
- [x] Full test suite passes (10213 tests)
- [x] `ruff check` passes (no lint errors)
- [x] `ruff format` applied

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~90%
- **AI Reason**: parser implementation + test fixture generation
- **Human Oversight**: Code reviewed before commit

Generated with [Claude Code](https://claude.com/claude-code)