### PR TITLE
feat(cisco_ftd): add parser for `show route`

### DIFF
--- a/changes/+show-route-cisco-ftd.parser_added
+++ b/changes/+show-route-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show route` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_route.py
+++ b/src/muninn/parsers/cisco_ftd/show_route.py
@@ -1,0 +1,339 @@
+"""Parser for 'show route' command on Cisco FTD.
+
+Parses the routing table from Cisco Firepower Threat Defense devices.
+Handles BGP, connected, local, and static routes including ECMP
+(Equal-Cost Multi-Path) entries with multiple next-hops per prefix.
+Also handles line-wrapped entries where long interface names cause
+the "is directly connected" portion to wrap to the next line.
+"""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.patterns import IPV4_ADDRESS
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NextHopEntry(TypedDict):
+    """Schema for a single next-hop entry within a route."""
+
+    next_hop: str
+    interface: NotRequired[str]
+    admin_distance: NotRequired[int]
+    metric: NotRequired[int]
+    uptime: NotRequired[str]
+
+
+class RouteEntry(TypedDict):
+    """Schema for a single route entry in the routing table."""
+
+    code: str
+    next_hops: list[NextHopEntry]
+
+
+class ShowRouteResult(TypedDict):
+    """Schema for 'show route' parsed output on Cisco FTD."""
+
+    gateway_of_last_resort: str | None
+    routes: dict[str, RouteEntry]
+
+
+def _mask_to_prefix_length(mask: str) -> int:
+    """Convert a dotted-decimal subnet mask to a CIDR prefix length.
+
+    Args:
+        mask: Dotted-decimal mask string (e.g., "255.255.255.0").
+
+    Returns:
+        Integer prefix length (e.g., 24).
+    """
+    octets = mask.split(".")
+    binary = "".join(f"{int(octet):08b}" for octet in octets)
+    return binary.count("1")
+
+
+# --- Regex patterns ---
+
+# Gateway of last resort line
+_GATEWAY_RE = re.compile(r"^Gateway of last resort is (\S+) to network (\S+)\s*$")
+_GATEWAY_NOT_SET_RE = re.compile(r"^Gateway of last resort is not set\s*$")
+
+# Route entry line:
+# Examples:
+#   B*       0.0.0.0 0.0.0.0 [20/0] via 172.16.2.135, 20:41:24
+#   C        192.168.1.0 255.255.255.0 is directly connected, HA
+#   L        192.168.1.1 255.255.255.255 is directly connected, HA
+#   S        172.16.9.0 255.255.192.0 [1/0] is directly connected, Null0
+_ROUTE_RE = re.compile(
+    r"^([A-Z])(\*)?\s+"
+    rf"({IPV4_ADDRESS})\s+"
+    rf"({IPV4_ADDRESS})\s*"
+    r"(.*)$"
+)
+
+# Continuation next-hop line (indented, starts with [AD/metric])
+# Example: [20/0] via 172.16.2.134, 20:41:24
+_CONTINUATION_RE = re.compile(
+    r"^\s+\[(\d+)/(\d+)\]\s+via\s+"
+    rf"({IPV4_ADDRESS})"
+    r"(?:,\s*(\S+))?\s*$"
+)
+
+# Next-hop with [AD/metric] via IP on a route line
+_VIA_NEXTHOP_RE = re.compile(
+    r"\[(\d+)/(\d+)\]\s+via\s+"
+    rf"({IPV4_ADDRESS})"
+    r"(?:,\s*(\S+))?"
+    r"\s*$"
+)
+
+# Directly connected route (with optional AD/metric prefix for static routes)
+_DIRECTLY_CONNECTED_RE = re.compile(
+    r"(?:\[(\d+)/(\d+)\]\s+)?is directly connected,\s*(\S+)\s*$"
+)
+
+# Wrapped continuation: indented "is directly connected, INTERFACE"
+_WRAPPED_CONNECTED_RE = re.compile(r"^\s+is directly connected,\s*(\S+)\s*$")
+
+# Codes legend detection
+_CODES_RE = re.compile(r"^Codes:\s")
+
+
+def _parse_gateway_line(line: str) -> str | None:
+    """Extract the gateway of last resort from a gateway line.
+
+    Returns the next-hop IP address or None if the gateway is not set.
+    """
+    m = _GATEWAY_RE.match(line)
+    if m:
+        return m.group(1)
+    if _GATEWAY_NOT_SET_RE.match(line):
+        return None
+    return None
+
+
+def _parse_route_nexthop(rest: str) -> NextHopEntry | None:
+    """Parse the next-hop portion of a route entry line.
+
+    Handles both "via" next-hops and "is directly connected" entries.
+    """
+    # Try "is directly connected" first
+    m = _DIRECTLY_CONNECTED_RE.search(rest)
+    if m:
+        hop: NextHopEntry = {
+            "next_hop": "directly connected",
+            "interface": m.group(3),
+        }
+        if m.group(1) is not None:
+            hop["admin_distance"] = int(m.group(1))
+            hop["metric"] = int(m.group(2))
+        return hop
+
+    # Try [AD/metric] via next-hop
+    m = _VIA_NEXTHOP_RE.search(rest)
+    if m:
+        hop = {
+            "next_hop": m.group(3),
+            "admin_distance": int(m.group(1)),
+            "metric": int(m.group(2)),
+        }
+        if m.group(4):
+            hop["uptime"] = m.group(4)
+        return hop
+
+    return None
+
+
+def _parse_continuation_line(line: str) -> NextHopEntry | None:
+    """Parse an indented ECMP continuation line."""
+    m = _CONTINUATION_RE.match(line)
+    if not m:
+        return None
+    hop: NextHopEntry = {
+        "next_hop": m.group(3),
+        "admin_distance": int(m.group(1)),
+        "metric": int(m.group(2)),
+    }
+    if m.group(4):
+        hop["uptime"] = m.group(4)
+    return hop
+
+
+def _is_codes_section_line(line: str, in_codes: bool) -> bool:
+    """Determine if a line is part of the Codes legend section."""
+    stripped = line.strip()
+    if _CODES_RE.match(stripped):
+        return True
+    if in_codes and stripped and not _GATEWAY_RE.match(stripped):
+        # Legend continuation lines are indented or contain " - "
+        if line.startswith(" ") and " - " in stripped:
+            return True
+        # Lines that start with code definitions
+        if stripped[0:2] in (
+            "D ",
+            "N1",
+            "E1",
+            "E2",
+            "i ",
+            "ia",
+            "o ",
+            "su",
+            "SI",
+            "BI",
+        ):
+            return True
+    return False
+
+
+class _ParseState:
+    """Mutable state for the route parsing loop."""
+
+    __slots__ = ("gateway", "routes", "current_prefix", "in_codes", "pending_route")
+
+    def __init__(self) -> None:
+        self.gateway: str | None = None
+        self.routes: dict[str, RouteEntry] = {}
+        self.current_prefix: str | None = None
+        self.in_codes: bool = False
+        self.pending_route: tuple[str, str] | None = None
+
+
+def _handle_wrapped_line(line: str, state: _ParseState) -> bool:
+    """Handle a wrapped 'is directly connected' continuation line.
+
+    Returns True if the line was consumed.
+    """
+    m_wrapped = _WRAPPED_CONNECTED_RE.match(line)
+    if not m_wrapped or state.pending_route is None:
+        return False
+
+    prefix_key, code = state.pending_route
+    hop: NextHopEntry = {
+        "next_hop": "directly connected",
+        "interface": m_wrapped.group(1),
+    }
+    if prefix_key in state.routes:
+        state.routes[prefix_key]["next_hops"].append(hop)
+    else:
+        state.routes[prefix_key] = {"code": code, "next_hops": [hop]}
+    state.current_prefix = prefix_key
+    state.pending_route = None
+    return True
+
+
+def _handle_continuation(line: str, stripped: str, state: _ParseState) -> bool:
+    """Handle an ECMP continuation line (indented next-hop).
+
+    Returns True if the line was consumed.
+    """
+    if not line.startswith(" ") or _ROUTE_RE.match(stripped):
+        return False
+    hop_entry = _parse_continuation_line(line)
+    if hop_entry and state.current_prefix and state.current_prefix in state.routes:
+        state.routes[state.current_prefix]["next_hops"].append(hop_entry)
+    return True
+
+
+def _handle_route_entry(stripped: str, state: _ParseState) -> bool:
+    """Handle a primary route entry line.
+
+    Returns True if the line was consumed.
+    """
+    m_route = _ROUTE_RE.match(stripped)
+    if not m_route:
+        return False
+
+    state.pending_route = None
+    code = m_route.group(1)
+    if m_route.group(2):
+        code = code + "*"
+    network = m_route.group(3)
+    mask = m_route.group(4)
+    rest = m_route.group(5)
+
+    prefix_len = _mask_to_prefix_length(mask)
+    prefix_key = f"{network}/{prefix_len}"
+
+    nexthop = _parse_route_nexthop(rest)
+    if nexthop:
+        if prefix_key in state.routes:
+            state.routes[prefix_key]["next_hops"].append(nexthop)
+        else:
+            state.routes[prefix_key] = {"code": code, "next_hops": [nexthop]}
+        state.current_prefix = prefix_key
+    else:
+        state.pending_route = (prefix_key, code)
+        state.current_prefix = prefix_key
+
+    return True
+
+
+def _parse_lines(lines: list[str]) -> ShowRouteResult:
+    """Parse all lines of 'show route' output into structured data."""
+    state = _ParseState()
+
+    for line in lines:
+        stripped = line.strip()
+
+        if not stripped:
+            state.in_codes = False
+            continue
+
+        # Handle codes legend section
+        if _is_codes_section_line(line, state.in_codes):
+            state.in_codes = True
+            continue
+        if state.in_codes and not line.startswith(" "):
+            state.in_codes = False
+
+        # Handle gateway of last resort
+        if stripped.startswith("Gateway of last resort"):
+            state.gateway = _parse_gateway_line(stripped)
+            continue
+
+        # Dispatch to line-type handlers
+        if _handle_wrapped_line(line, state):
+            continue
+        if _handle_continuation(line, stripped, state):
+            continue
+        _handle_route_entry(stripped, state)
+
+    if not state.routes:
+        msg = "No route entries found in output"
+        raise ValueError(msg)
+
+    return {
+        "gateway_of_last_resort": state.gateway,
+        "routes": state.routes,
+    }
+
+
+@register(OS.CISCO_FTD, "show route")
+class ShowRouteParser(BaseParser["ShowRouteResult"]):
+    """Parser for 'show route' command on Cisco FTD.
+
+    Parses the FTD routing table including BGP, connected, local, and
+    static routes. Supports ECMP (multiple next-hops per prefix) and
+    handles line-wrapped entries for long interface names.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteResult:
+        """Parse 'show route' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from the 'show route' command.
+
+        Returns:
+            Parsed routing table with gateway of last resort and routes
+            keyed by network/prefix (e.g., "172.16.1.0/28").
+
+        Raises:
+            ValueError: If no route entries are found in the output.
+        """
+        return _parse_lines(output.splitlines())

--- a/src/muninn/parsers/cisco_ftd/show_route.py
+++ b/src/muninn/parsers/cisco_ftd/show_route.py
@@ -135,7 +135,7 @@ def _parse_route_nexthop(rest: str) -> NextHopEntry | None:
     # Try [AD/metric] via next-hop
     m = _VIA_NEXTHOP_RE.search(rest)
     if m:
-        hop = {
+        hop: NextHopEntry = {
             "next_hop": m.group(3),
             "admin_distance": int(m.group(1)),
             "metric": int(m.group(2)),

--- a/tests/parsers/cisco_ftd/show_route/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_route/001_basic/expected.json
@@ -1,0 +1,783 @@
+{
+    "gateway_of_last_resort": "172.16.2.135",
+    "routes": {
+        "0.0.0.0/0": {
+            "code": "B*",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.2.135",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "20:41:24"
+                },
+                {
+                    "next_hop": "172.16.2.134",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "20:41:24"
+                },
+                {
+                    "next_hop": "172.16.2.133",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "20:41:24"
+                }
+            ]
+        },
+        "192.168.1.0/24": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "HA"
+                }
+            ]
+        },
+        "192.168.1.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "HA"
+                }
+            ]
+        },
+        "198.51.100.0/24": {
+            "code": "B",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.2.135",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "20:41:24"
+                },
+                {
+                    "next_hop": "172.16.2.134",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "20:41:24"
+                },
+                {
+                    "next_hop": "172.16.2.133",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "20:41:24"
+                }
+            ]
+        },
+        "10.0.0.0/8": {
+            "code": "B",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.1.4",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.3",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.2",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.1",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                }
+            ]
+        },
+        "10.103.1.128/25": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone5"
+                }
+            ]
+        },
+        "10.103.1.129/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone5"
+                }
+            ]
+        },
+        "10.102.0.128/25": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone1"
+                }
+            ]
+        },
+        "10.102.0.129/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone1"
+                }
+            ]
+        },
+        "10.102.2.0/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone3"
+                }
+            ]
+        },
+        "10.102.2.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone3"
+                }
+            ]
+        },
+        "10.102.2.128/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone4"
+                }
+            ]
+        },
+        "10.102.2.129/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone4"
+                }
+            ]
+        },
+        "10.102.4.0/24": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone6"
+                }
+            ]
+        },
+        "10.102.4.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone6"
+                }
+            ]
+        },
+        "10.102.5.0/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone7"
+                }
+            ]
+        },
+        "10.102.5.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone7"
+                }
+            ]
+        },
+        "10.102.5.64/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant_Zone8"
+                }
+            ]
+        },
+        "10.102.5.65/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant_Zone8"
+                }
+            ]
+        },
+        "10.102.128.0/22": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone2"
+                }
+            ]
+        },
+        "10.102.128.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-Zone2"
+                }
+            ]
+        },
+        "172.16.1.0/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Inside"
+                }
+            ]
+        },
+        "172.16.1.5/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Inside"
+                }
+            ]
+        },
+        "172.16.3.64/29": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-ADC-M1"
+                }
+            ]
+        },
+        "172.16.3.65/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-ADC-M1"
+                }
+            ]
+        },
+        "10.101.0.0/16": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-Guest"
+                }
+            ]
+        },
+        "10.101.0.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-Guest"
+                }
+            ]
+        },
+        "10.100.0.0/24": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Guest-DNS"
+                }
+            ]
+        },
+        "10.100.0.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Guest-DNS"
+                }
+            ]
+        },
+        "10.100.1.0/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Mgmt"
+                }
+            ]
+        },
+        "10.100.1.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Mgmt"
+                }
+            ]
+        },
+        "10.100.2.0/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-Jabber"
+                }
+            ]
+        },
+        "10.100.2.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-Jabber"
+                }
+            ]
+        },
+        "10.100.2.64/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor1"
+                }
+            ]
+        },
+        "10.100.2.65/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor1"
+                }
+            ]
+        },
+        "10.100.4.0/27": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor2"
+                }
+            ]
+        },
+        "10.100.4.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor2"
+                }
+            ]
+        },
+        "10.100.4.64/27": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor3"
+                }
+            ]
+        },
+        "10.100.4.65/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor3"
+                }
+            ]
+        },
+        "10.100.4.96/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner1-Site1"
+                }
+            ]
+        },
+        "10.100.4.97/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner1-Site1"
+                }
+            ]
+        },
+        "10.100.4.112/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner1-Site2"
+                }
+            ]
+        },
+        "10.100.4.113/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner1-Site2"
+                }
+            ]
+        },
+        "10.100.5.0/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor5"
+                }
+            ]
+        },
+        "10.100.5.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor5"
+                }
+            ]
+        },
+        "10.100.5.32/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-LTE-Out"
+                }
+            ]
+        },
+        "10.100.5.33/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-LTE-Out"
+                }
+            ]
+        },
+        "10.100.5.48/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor6"
+                }
+            ]
+        },
+        "10.100.5.49/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Vendor6"
+                }
+            ]
+        },
+        "10.100.9.0/29": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner2-Ckt1"
+                }
+            ]
+        },
+        "10.100.9.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner2-Ckt1"
+                }
+            ]
+        },
+        "10.100.9.8/29": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner2-Ckt2"
+                }
+            ]
+        },
+        "10.100.9.9/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner2-Ckt2"
+                }
+            ]
+        },
+        "10.100.10.0/29": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner3-Ckt1"
+                }
+            ]
+        },
+        "10.100.10.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner3-Ckt1"
+                }
+            ]
+        },
+        "10.100.10.8/29": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner3-Ckt2"
+                }
+            ]
+        },
+        "10.100.10.9/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "DMZ-Partner3-Ckt2"
+                }
+            ]
+        },
+        "10.100.31.32/28": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-WiFi-Guest"
+                }
+            ]
+        },
+        "10.100.31.38/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Tenant-WiFi-Guest"
+                }
+            ]
+        },
+        "172.16.0.0/12": {
+            "code": "B",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.1.4",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.3",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.2",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.1",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                }
+            ]
+        },
+        "192.168.0.0/16": {
+            "code": "B",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.1.4",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.3",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.2",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.1",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                }
+            ]
+        },
+        "172.16.9.0/18": {
+            "code": "S",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Null0",
+                    "admin_distance": 1,
+                    "metric": 0
+                }
+            ]
+        },
+        "172.16.2.128/26": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "outside"
+                }
+            ]
+        },
+        "172.16.2.182/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "outside"
+                }
+            ]
+        },
+        "172.16.4.0/23": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-LB-MM"
+                }
+            ]
+        },
+        "172.16.4.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-LB-MM"
+                }
+            ]
+        },
+        "172.16.5.0/23": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-LB-And"
+                }
+            ]
+        },
+        "172.16.5.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-LB-And"
+                }
+            ]
+        },
+        "172.16.7.0/24": {
+            "code": "B",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.1.4",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.3",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.2",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.1",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                }
+            ]
+        },
+        "172.16.8.0/22": {
+            "code": "B",
+            "next_hops": [
+                {
+                    "next_hop": "172.16.1.4",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.3",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.2",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                },
+                {
+                    "next_hop": "172.16.1.1",
+                    "admin_distance": 20,
+                    "metric": 0,
+                    "uptime": "1w0d"
+                }
+            ]
+        },
+        "172.16.6.0/22": {
+            "code": "C",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-ADC-M2"
+                }
+            ]
+        },
+        "172.16.6.1/32": {
+            "code": "L",
+            "next_hops": [
+                {
+                    "next_hop": "directly connected",
+                    "interface": "Corp-ADC-M2"
+                }
+            ]
+        }
+    }
+}

--- a/tests/parsers/cisco_ftd/show_route/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_route/001_basic/input.txt
@@ -1,0 +1,111 @@
+
+Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
+       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area 
+       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+       E1 - OSPF external type 1, E2 - OSPF external type 2, V - VPN
+       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
+       ia - IS-IS inter area, * - candidate default, U - per-user static route
+       o - ODR, P - periodic downloaded static route, + - replicated route
+       SI - Static InterVRF, BI - BGP InterVRF
+Gateway of last resort is 172.16.2.135 to network 0.0.0.0
+
+B*       0.0.0.0 0.0.0.0 [20/0] via 172.16.2.135, 20:41:24
+                         [20/0] via 172.16.2.134, 20:41:24
+                         [20/0] via 172.16.2.133, 20:41:24
+C        192.168.1.0 255.255.255.0 is directly connected, HA
+L        192.168.1.1 255.255.255.255 is directly connected, HA
+B        198.51.100.0 255.255.255.0 [20/0] via 172.16.2.135, 20:41:24
+                               [20/0] via 172.16.2.134, 20:41:24
+                               [20/0] via 172.16.2.133, 20:41:24
+B        10.0.0.0 255.0.0.0 [20/0] via 172.16.1.4, 1w0d
+                            [20/0] via 172.16.1.3, 1w0d
+                            [20/0] via 172.16.1.2, 1w0d
+                            [20/0] via 172.16.1.1, 1w0d
+C        10.103.1.128 255.255.255.128 is directly connected, Tenant-Zone5
+L        10.103.1.129 255.255.255.255 is directly connected, Tenant-Zone5
+C        10.102.0.128 255.255.255.128 is directly connected, Tenant-Zone1
+L        10.102.0.129 255.255.255.255 is directly connected, Tenant-Zone1
+C        10.102.2.0 255.255.255.192 is directly connected, Tenant-Zone3
+L        10.102.2.1 255.255.255.255 is directly connected, Tenant-Zone3
+C        10.102.2.128 255.255.255.192 is directly connected, Tenant-Zone4
+L        10.102.2.129 255.255.255.255 is directly connected, Tenant-Zone4
+C        10.102.4.0 255.255.255.0 is directly connected, Tenant-Zone6
+L        10.102.4.1 255.255.255.255 is directly connected, Tenant-Zone6
+C        10.102.5.0 255.255.255.192 is directly connected, Tenant-Zone7
+L        10.102.5.1 255.255.255.255 is directly connected, Tenant-Zone7
+C        10.102.5.64 255.255.255.192 is directly connected, Tenant_Zone8
+L        10.102.5.65 255.255.255.255 is directly connected, Tenant_Zone8
+C        10.102.128.0 255.255.252.0 is directly connected, Tenant-Zone2
+L        10.102.128.1 255.255.255.255 is directly connected, Tenant-Zone2
+C        172.16.1.0 255.255.255.240 is directly connected, Inside
+L        172.16.1.5 255.255.255.255 is directly connected, Inside
+C        172.16.3.64 255.255.255.248 is directly connected, Corp-ADC-M1
+L        172.16.3.65 255.255.255.255 is directly connected, Corp-ADC-M1
+C        10.101.0.0 255.255.0.0 is directly connected, Corp-Guest
+L        10.101.0.1 255.255.255.255 is directly connected, Corp-Guest
+C        10.100.0.0 255.255.255.0 is directly connected, Guest-DNS
+L        10.100.0.1 255.255.255.255 is directly connected, Guest-DNS
+C        10.100.1.0 255.255.255.192 is directly connected, DMZ-Mgmt
+L        10.100.1.1 255.255.255.255 is directly connected, DMZ-Mgmt
+C        10.100.2.0 255.255.255.192 is directly connected, Corp-Jabber
+L        10.100.2.1 255.255.255.255 is directly connected, Corp-Jabber
+C        10.100.2.64 255.255.255.192 is directly connected, DMZ-Vendor1
+L        10.100.2.65 255.255.255.255 is directly connected, DMZ-Vendor1
+C        10.100.4.0 255.255.255.224 is directly connected, DMZ-Vendor2
+L        10.100.4.1 255.255.255.255 is directly connected, DMZ-Vendor2
+C        10.100.4.64 255.255.255.224 is directly connected, DMZ-Vendor3
+L        10.100.4.65 255.255.255.255 is directly connected, DMZ-Vendor3
+C        10.100.4.96 255.255.255.240 
+           is directly connected, DMZ-Partner1-Site1
+L        10.100.4.97 255.255.255.255 
+           is directly connected, DMZ-Partner1-Site1
+C        10.100.4.112 255.255.255.240 
+           is directly connected, DMZ-Partner1-Site2
+L        10.100.4.113 255.255.255.255 
+           is directly connected, DMZ-Partner1-Site2
+C        10.100.5.0 255.255.255.240 is directly connected, DMZ-Vendor5
+L        10.100.5.1 255.255.255.255 is directly connected, DMZ-Vendor5
+C        10.100.5.32 255.255.255.240 is directly connected, Corp-LTE-Out
+L        10.100.5.33 255.255.255.255 is directly connected, Corp-LTE-Out
+C        10.100.5.48 255.255.255.240 is directly connected, DMZ-Vendor6
+L        10.100.5.49 255.255.255.255 is directly connected, DMZ-Vendor6
+C        10.100.9.0 255.255.255.248 
+           is directly connected, DMZ-Partner2-Ckt1
+L        10.100.9.1 255.255.255.255 
+           is directly connected, DMZ-Partner2-Ckt1
+C        10.100.9.8 255.255.255.248 is directly connected, DMZ-Partner2-Ckt2
+L        10.100.9.9 255.255.255.255 is directly connected, DMZ-Partner2-Ckt2
+C        10.100.10.0 255.255.255.248 is directly connected, DMZ-Partner3-Ckt1
+L        10.100.10.1 255.255.255.255 is directly connected, DMZ-Partner3-Ckt1
+C        10.100.10.8 255.255.255.248 
+           is directly connected, DMZ-Partner3-Ckt2
+L        10.100.10.9 255.255.255.255 
+           is directly connected, DMZ-Partner3-Ckt2
+C        10.100.31.32 255.255.255.240 is directly connected, Tenant-WiFi-Guest
+L        10.100.31.38 255.255.255.255 is directly connected, Tenant-WiFi-Guest
+B        172.16.0.0 255.240.0.0 [20/0] via 172.16.1.4, 1w0d
+                                [20/0] via 172.16.1.3, 1w0d
+                                [20/0] via 172.16.1.2, 1w0d
+                                [20/0] via 172.16.1.1, 1w0d
+B        192.168.0.0 255.255.0.0 [20/0] via 172.16.1.4, 1w0d
+                                 [20/0] via 172.16.1.3, 1w0d
+                                 [20/0] via 172.16.1.2, 1w0d
+                                 [20/0] via 172.16.1.1, 1w0d
+S        172.16.9.0 255.255.192.0 [1/0] is directly connected, Null0
+C        172.16.2.128 255.255.255.192 is directly connected, outside
+L        172.16.2.182 255.255.255.255 is directly connected, outside
+C        172.16.4.0 255.255.254.0 is directly connected, Corp-LB-MM
+L        172.16.4.1 255.255.255.255 is directly connected, Corp-LB-MM
+C        172.16.5.0 255.255.254.0 is directly connected, Corp-LB-And
+L        172.16.5.1 255.255.255.255 
+           is directly connected, Corp-LB-And
+B        172.16.7.0 255.255.255.0 [20/0] via 172.16.1.4, 1w0d
+                                    [20/0] via 172.16.1.3, 1w0d
+                                    [20/0] via 172.16.1.2, 1w0d
+                                    [20/0] via 172.16.1.1, 1w0d
+B        172.16.8.0 255.255.252.0 [20/0] via 172.16.1.4, 1w0d
+                                    [20/0] via 172.16.1.3, 1w0d
+                                    [20/0] via 172.16.1.2, 1w0d
+                                    [20/0] via 172.16.1.1, 1w0d
+C        172.16.6.0 255.255.252.0 is directly connected, Corp-ADC-M2
+L        172.16.6.1 255.255.255.255 is directly connected, Corp-ADC-M2

--- a/tests/parsers/cisco_ftd/show_route/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_route/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Full routing table with BGP, connected, local, and static routes including ECMP paths
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -182,6 +182,9 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         # ECMP next-hops have no natural unique key (same interface can appear with
         # different next-hops in equal-cost multipath).
         "cisco_iosxr/show_route_ipv4_isis/001_basic/expected.json",
+        # --- Cisco FTD ---
+        # next_hops is a list-of-dicts; no natural unique key for ECMP entries.
+        "cisco_ftd/show_route/001_basic/expected.json",
         # --- NX-OS ---
         "nxos/show_bgp_all_dampening_flap-statistics/001_basic/expected.json",
         "nxos/show_bgp_vrf_all_all/001_basic/expected.json",


### PR DESCRIPTION
## Summary
- Add new parser for `show route` command on Cisco FTD (Firepower Threat Defense) platform
- Supports BGP, connected, local, and static routes with ECMP (Equal-Cost Multi-Path) entries
- Handles line-wrapped entries where long interface names cause "is directly connected" to wrap to the next line
- Parses gateway of last resort, route codes, admin distance, metric, uptime, and interface names

## Test plan
- [x] Fixture `001_basic` covers full routing table from Cisco Firepower 4215 running 7.4.2.4
- [x] Validates 72 route entries including wrapped lines and 4-way ECMP BGP routes
- [x] `uv run pytest tests/parsers/ -k "show_route"` passes (98 tests)
- [x] `uv run ruff check` and `uv run ruff format` pass
- [x] Full test suite passes (10213 tests)

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + test fixture + changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)