### PR TITLE
feat(cisco_ftd): add parser for `show version`

### DIFF
--- a/changes/+show-version-cisco-ftd.parser_added
+++ b/changes/+show-version-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show version` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_version.py
+++ b/src/muninn/parsers/cisco_ftd/show_version.py
@@ -40,6 +40,69 @@ class ShowVersionParser(BaseParser[ShowVersionResult]):
     _LSP_VERSION = re.compile(r"^LSP version\s*:\s*(?P<lsp_version>\S+)")
     _VDB_VERSION = re.compile(r"^VDB version\s*:\s*(?P<vdb_version>\S+)")
 
+    # Ordered list of patterns to try against each line.
+    # Each entry maps a compiled regex to field names that need .strip().
+    _PATTERNS: ClassVar[list[tuple[re.Pattern[str], tuple[str, ...]]]] = []
+
+    _REQUIRED_FIELDS: ClassVar[list[str]] = [
+        "hostname",
+        "model",
+        "version",
+        "build",
+        "uuid",
+        "lsp_version",
+        "vdb_version",
+    ]
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Populate _PATTERNS after class attributes are bound."""
+        super().__init_subclass__(**kwargs)
+
+    @classmethod
+    def _init_patterns(cls) -> list[tuple[re.Pattern[str], tuple[str, ...]]]:
+        """Build pattern list on first use (lazy class-level init)."""
+        return [
+            (cls._HOSTNAME, ("hostname",)),
+            (cls._MODEL_VERSION, ("model", "version", "build")),
+            (cls._UUID, ("uuid",)),
+            (cls._LSP_VERSION, ("lsp_version",)),
+            (cls._VDB_VERSION, ("vdb_version",)),
+        ]
+
+    @classmethod
+    def _extract_fields(cls, output: str) -> dict[str, str]:
+        """Extract all fields from raw CLI output using pattern matching."""
+        patterns = cls._init_patterns()
+        result: dict[str, str] = {}
+
+        for line in output.splitlines():
+            cls._match_line(line.strip(), patterns, result)
+
+        return result
+
+    @classmethod
+    def _match_line(
+        cls,
+        line: str,
+        patterns: list[tuple[re.Pattern[str], tuple[str, ...]]],
+        result: dict[str, str],
+    ) -> None:
+        """Try each pattern against a single line, storing matches."""
+        for pattern, fields in patterns:
+            match = pattern.match(line)
+            if match:
+                for field in fields:
+                    result[field] = match.group(field).strip()
+                return
+
+    @classmethod
+    def _validate(cls, result: dict[str, str]) -> None:
+        """Raise ValueError if any required fields are missing."""
+        missing = [f for f in cls._REQUIRED_FIELDS if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
     @classmethod
     def parse(cls, output: str) -> ShowVersionResult:
         """Parse 'show version' output on Cisco FTD.
@@ -53,37 +116,8 @@ class ShowVersionParser(BaseParser[ShowVersionResult]):
         Raises:
             ValueError: If required fields cannot be parsed.
         """
-        result: dict[str, str] = {}
-
-        for line in output.splitlines():
-            line = line.strip()
-
-            if match := cls._HOSTNAME.match(line):
-                result["hostname"] = match.group("hostname")
-            elif match := cls._MODEL_VERSION.match(line):
-                result["model"] = match.group("model").strip()
-                result["version"] = match.group("version")
-                result["build"] = match.group("build")
-            elif match := cls._UUID.match(line):
-                result["uuid"] = match.group("uuid")
-            elif match := cls._LSP_VERSION.match(line):
-                result["lsp_version"] = match.group("lsp_version")
-            elif match := cls._VDB_VERSION.match(line):
-                result["vdb_version"] = match.group("vdb_version")
-
-        required = [
-            "hostname",
-            "model",
-            "version",
-            "build",
-            "uuid",
-            "lsp_version",
-            "vdb_version",
-        ]
-        missing = [f for f in required if f not in result]
-        if missing:
-            msg = f"Missing required fields: {', '.join(missing)}"
-            raise ValueError(msg)
+        result = cls._extract_fields(output)
+        cls._validate(result)
 
         return ShowVersionResult(
             hostname=result["hostname"],

--- a/src/muninn/parsers/cisco_ftd/show_version.py
+++ b/src/muninn/parsers/cisco_ftd/show_version.py
@@ -1,0 +1,96 @@
+"""Parser for 'show version' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class ShowVersionResult(TypedDict):
+    """Schema for 'show version' parsed output on Cisco FTD."""
+
+    hostname: str
+    model: str
+    version: str
+    build: str
+    uuid: str
+    lsp_version: str
+    vdb_version: str
+
+
+@register(OS.CISCO_FTD, "show version")
+class ShowVersionParser(BaseParser[ShowVersionResult]):
+    """Parser for 'show version' command on Cisco FTD.
+
+    Parses device identity, software version, and signature database
+    versions from the FTD version summary output.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.INVENTORY})
+
+    _HOSTNAME = re.compile(r"^-+\[\s*(?P<hostname>\S+)\s*\]-+$")
+    _MODEL_VERSION = re.compile(
+        r"^Model\s*:\s*(?P<model>.+?)\s+Version\s+(?P<version>\S+)\s+"
+        r"\(Build\s+(?P<build>\d+)\)",
+    )
+    _UUID = re.compile(r"^UUID\s*:\s*(?P<uuid>\S+)")
+    _LSP_VERSION = re.compile(r"^LSP version\s*:\s*(?P<lsp_version>\S+)")
+    _VDB_VERSION = re.compile(r"^VDB version\s*:\s*(?P<vdb_version>\S+)")
+
+    @classmethod
+    def parse(cls, output: str) -> ShowVersionResult:
+        """Parse 'show version' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed version information.
+
+        Raises:
+            ValueError: If required fields cannot be parsed.
+        """
+        result: dict[str, str] = {}
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            if match := cls._HOSTNAME.match(line):
+                result["hostname"] = match.group("hostname")
+            elif match := cls._MODEL_VERSION.match(line):
+                result["model"] = match.group("model").strip()
+                result["version"] = match.group("version")
+                result["build"] = match.group("build")
+            elif match := cls._UUID.match(line):
+                result["uuid"] = match.group("uuid")
+            elif match := cls._LSP_VERSION.match(line):
+                result["lsp_version"] = match.group("lsp_version")
+            elif match := cls._VDB_VERSION.match(line):
+                result["vdb_version"] = match.group("vdb_version")
+
+        required = [
+            "hostname",
+            "model",
+            "version",
+            "build",
+            "uuid",
+            "lsp_version",
+            "vdb_version",
+        ]
+        missing = [f for f in required if f not in result]
+        if missing:
+            msg = f"Missing required fields: {', '.join(missing)}"
+            raise ValueError(msg)
+
+        return ShowVersionResult(
+            hostname=result["hostname"],
+            model=result["model"],
+            version=result["version"],
+            build=result["build"],
+            uuid=result["uuid"],
+            lsp_version=result["lsp_version"],
+            vdb_version=result["vdb_version"],
+        )

--- a/tests/parsers/cisco_ftd/show_version/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_version/001_basic/expected.json
@@ -1,0 +1,9 @@
+{
+    "hostname": "M2-4215-A",
+    "model": "Cisco Firepower 4215 Threat Defense (79)",
+    "version": "7.4.2.4",
+    "build": "9",
+    "uuid": "87654321-dcba-4321-fe65-fedcba654321",
+    "lsp_version": "lsp-rel-20260406-1844",
+    "vdb_version": "378"
+}

--- a/tests/parsers/cisco_ftd/show_version/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_version/001_basic/input.txt
@@ -1,0 +1,6 @@
+-------------------[ M2-4215-A ]--------------------
+Model                     : Cisco Firepower 4215 Threat Defense (79) Version 7.4.2.4 (Build 9)
+UUID                      : 87654321-dcba-4321-fe65-fedcba654321
+LSP version               : lsp-rel-20260406-1844
+VDB version               : 378
+----------------------------------------------------

--- a/tests/parsers/cisco_ftd/show_version/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_version/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: FTD version output showing model, version, UUID, and signature versions
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary
- Added `show version` parser for Cisco FTD platform
- Extracts hostname, model, version, build, UUID, LSP version, and VDB version
- Includes test fixture from Firepower 4215 running 7.4.2.4

## Test plan
- [x] Parser unit test passes (`tests/parsers/test_parsers.py::test_parser[cisco_ftd/show_version/001_basic]`)
- [x] Fixture convention tests pass (no placeholders, no pipe keys, no list-of-dicts)
- [x] Full test suite passes (10213 tests)
- [x] `ruff check` clean
- [x] `ruff format` clean

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation
- **Human Oversight**: Code reviewed before commit

Generated with [Claude Code](https://claude.com/claude-code)