### PR TITLE
feat(cisco_ftd): add parser for `show route summary`

### DIFF
--- a/changes/+show-route-summary-cisco-ftd.parser_added
+++ b/changes/+show-route-summary-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show route summary` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_route_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_summary.py
@@ -70,6 +70,61 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
     tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ROUTING})
 
     @classmethod
+    def _parse_bgp_detail(
+        cls,
+        line: str,
+        last_source: str | None,
+        route_sources: dict[str, RouteSourceEntry],
+    ) -> bool:
+        """Parse a BGP detail line and update the last source entry.
+
+        Returns True if the line was consumed.
+        """
+        m = _BGP_DETAIL_RE.match(line)
+        if m and last_source is not None and last_source in route_sources:
+            route_sources[last_source]["external"] = int(m.group("external"))
+            route_sources[last_source]["internal"] = int(m.group("internal"))
+            route_sources[last_source]["local"] = int(m.group("local"))
+            return True
+        return False
+
+    @classmethod
+    def _parse_internal_source(cls, line: str) -> RouteSourceEntry | None:
+        """Parse an internal source line (missing subnets/replicates/overhead).
+
+        Returns the entry if matched, None otherwise.
+        """
+        m = _INTERNAL_SOURCE_RE.match(line.strip())
+        if not m:
+            return None
+        return {
+            "networks": int(m.group("networks")),
+            "subnets": 0,
+            "replicates": 0,
+            "overhead": 0,
+            "memory_bytes": int(m.group("memory")),
+        }
+
+    @classmethod
+    def _parse_standard_source(cls, line: str) -> tuple[str, RouteSourceEntry] | None:
+        """Parse a standard route source line.
+
+        Returns a (source_name, entry) tuple if matched, None otherwise.
+        """
+        m = _ROUTE_SOURCE_RE.match(line.strip())
+        if not m:
+            return None
+        source = m.group("source").strip()
+        entry: RouteSourceEntry = {
+            "networks": int(m.group("networks")),
+            "subnets": int(m.group("subnets")),
+            "replicates": int(m.group("replicates")),
+            "overhead": int(m.group("overhead")),
+            "memory_bytes": int(m.group("memory")),
+        }
+        return source, entry
+
+    @classmethod
     def parse(cls, output: str) -> ShowRouteSummaryResult:
         """Parse 'show route summary' output.
 
@@ -88,49 +143,28 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
         last_source: str | None = None
 
         for line in lines:
-            # Skip empty lines and header line
             if not line.strip() or line.strip().startswith("Route Source"):
                 continue
 
-            # Maximum paths
             m = _MAX_PATHS_RE.match(line.strip())
             if m:
                 maximum_paths = int(m.group("max_paths"))
                 continue
 
-            # BGP detail line (External/Internal/Local)
-            m = _BGP_DETAIL_RE.match(line)
-            if m and last_source is not None and last_source in route_sources:
-                route_sources[last_source]["external"] = int(m.group("external"))
-                route_sources[last_source]["internal"] = int(m.group("internal"))
-                route_sources[last_source]["local"] = int(m.group("local"))
+            if cls._parse_bgp_detail(line, last_source, route_sources):
                 continue
 
-            # Internal source (missing subnets/replicates/overhead columns)
-            m = _INTERNAL_SOURCE_RE.match(line.strip())
-            if m:
-                source = m.group("source").strip()
-                route_sources[source] = {
-                    "networks": int(m.group("networks")),
-                    "subnets": 0,
-                    "replicates": 0,
-                    "overhead": 0,
-                    "memory_bytes": int(m.group("memory")),
-                }
+            internal_entry = cls._parse_internal_source(line)
+            if internal_entry is not None:
+                source = _INTERNAL_SOURCE_RE.match(line.strip()).group("source").strip()  # type: ignore[union-attr]
+                route_sources[source] = internal_entry
                 last_source = source
                 continue
 
-            # Standard route source line
-            m = _ROUTE_SOURCE_RE.match(line.strip())
-            if m:
-                source = m.group("source").strip()
-                route_sources[source] = {
-                    "networks": int(m.group("networks")),
-                    "subnets": int(m.group("subnets")),
-                    "replicates": int(m.group("replicates")),
-                    "overhead": int(m.group("overhead")),
-                    "memory_bytes": int(m.group("memory")),
-                }
+            standard_result = cls._parse_standard_source(line)
+            if standard_result is not None:
+                source, entry = standard_result
+                route_sources[source] = entry
                 last_source = source
                 continue
 

--- a/src/muninn/parsers/cisco_ftd/show_route_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_summary.py
@@ -156,7 +156,9 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
 
             internal_entry = cls._parse_internal_source(line)
             if internal_entry is not None:
-                source = _INTERNAL_SOURCE_RE.match(line.strip()).group("source").strip()  # type: ignore[union-attr]
+                m = _INTERNAL_SOURCE_RE.match(line.strip())
+                assert m is not None
+                source = m.group("source").strip()
                 route_sources[source] = internal_entry
                 last_source = source
                 continue

--- a/src/muninn/parsers/cisco_ftd/show_route_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_summary.py
@@ -1,0 +1,148 @@
+"""Parser for 'show route summary' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, NotRequired, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class RouteSourceEntry(TypedDict):
+    """Schema for a single route source entry."""
+
+    networks: int
+    subnets: int
+    replicates: int
+    overhead: int
+    memory_bytes: int
+    external: NotRequired[int]
+    internal: NotRequired[int]
+    local: NotRequired[int]
+
+
+class ShowRouteSummaryResult(TypedDict):
+    """Schema for 'show route summary' parsed output on Cisco FTD."""
+
+    maximum_paths: int
+    route_sources: dict[str, RouteSourceEntry]
+
+
+# --- Compiled regex patterns ---
+
+_MAX_PATHS_RE = re.compile(r"IP routing table maximum-paths is (?P<max_paths>\d+)")
+
+_ROUTE_SOURCE_RE = re.compile(
+    r"^(?P<source>.+?)\s{2,}(?P<networks>\d+)\s+"
+    r"(?P<subnets>\d+)\s+"
+    r"(?P<replicates>\d+)\s+"
+    r"(?P<overhead>\d+)\s+"
+    r"(?P<memory>\d+)\s*$"
+)
+
+_INTERNAL_SOURCE_RE = re.compile(
+    r"^(?P<source>internal)\s+(?P<networks>\d+)\s+(?P<memory>\d+)\s*$"
+)
+
+_BGP_DETAIL_RE = re.compile(
+    r"^\s+External:\s*(?P<external>\d+)\s+"
+    r"Internal:\s*(?P<internal>\d+)\s+"
+    r"Local:\s*(?P<local>\d+)"
+)
+
+
+@register(OS.CISCO_FTD, "show route summary")
+class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
+    """Parser for 'show route summary' command on Cisco FTD.
+
+    Example output:
+        IP routing table maximum-paths is 8
+        Route Source    Networks    Subnets     Replicates  Overhead    Memory (bytes)
+        connected       3           32          0           3080        10360
+        static          1           0           0           88          296
+        bgp 65001       5           2           0           2288        2072
+          External: 7 Internal: 0 Local: 0
+        internal        5                                               4560
+        Total           14          34          0           5456        17288
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteSummaryResult:
+        """Parse 'show route summary' output.
+
+        Args:
+            output: Raw CLI output from 'show route summary' command.
+
+        Returns:
+            Parsed data with maximum paths and route source information.
+
+        Raises:
+            ValueError: If the output cannot be parsed.
+        """
+        lines = output.splitlines()
+        maximum_paths: int | None = None
+        route_sources: dict[str, RouteSourceEntry] = {}
+        last_source: str | None = None
+
+        for line in lines:
+            # Skip empty lines and header line
+            if not line.strip() or line.strip().startswith("Route Source"):
+                continue
+
+            # Maximum paths
+            m = _MAX_PATHS_RE.match(line.strip())
+            if m:
+                maximum_paths = int(m.group("max_paths"))
+                continue
+
+            # BGP detail line (External/Internal/Local)
+            m = _BGP_DETAIL_RE.match(line)
+            if m and last_source is not None and last_source in route_sources:
+                route_sources[last_source]["external"] = int(m.group("external"))
+                route_sources[last_source]["internal"] = int(m.group("internal"))
+                route_sources[last_source]["local"] = int(m.group("local"))
+                continue
+
+            # Internal source (missing subnets/replicates/overhead columns)
+            m = _INTERNAL_SOURCE_RE.match(line.strip())
+            if m:
+                source = m.group("source").strip()
+                route_sources[source] = {
+                    "networks": int(m.group("networks")),
+                    "subnets": 0,
+                    "replicates": 0,
+                    "overhead": 0,
+                    "memory_bytes": int(m.group("memory")),
+                }
+                last_source = source
+                continue
+
+            # Standard route source line
+            m = _ROUTE_SOURCE_RE.match(line.strip())
+            if m:
+                source = m.group("source").strip()
+                route_sources[source] = {
+                    "networks": int(m.group("networks")),
+                    "subnets": int(m.group("subnets")),
+                    "replicates": int(m.group("replicates")),
+                    "overhead": int(m.group("overhead")),
+                    "memory_bytes": int(m.group("memory")),
+                }
+                last_source = source
+                continue
+
+        if maximum_paths is None:
+            msg = "Could not find 'IP routing table maximum-paths' in output"
+            raise ValueError(msg)
+
+        if not route_sources:
+            msg = "No route sources found in output"
+            raise ValueError(msg)
+
+        return {
+            "maximum_paths": maximum_paths,
+            "route_sources": route_sources,
+        }

--- a/src/muninn/parsers/cisco_ftd/show_route_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_summary.py
@@ -125,18 +125,35 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
         return source, entry
 
     @classmethod
+    def _process_line(
+        cls,
+        line: str,
+        route_sources: dict[str, RouteSourceEntry],
+        last_source: str | None,
+    ) -> str | None:
+        """Process a single line, returning the updated last_source."""
+        if cls._parse_bgp_detail(line, last_source, route_sources):
+            return last_source
+
+        internal_entry = cls._parse_internal_source(line)
+        if internal_entry is not None:
+            m = _INTERNAL_SOURCE_RE.match(line.strip())
+            assert m is not None
+            source = m.group("source").strip()
+            route_sources[source] = internal_entry
+            return source
+
+        standard_result = cls._parse_standard_source(line)
+        if standard_result is not None:
+            source, entry = standard_result
+            route_sources[source] = entry
+            return source
+
+        return last_source
+
+    @classmethod
     def parse(cls, output: str) -> ShowRouteSummaryResult:
-        """Parse 'show route summary' output.
-
-        Args:
-            output: Raw CLI output from 'show route summary' command.
-
-        Returns:
-            Parsed data with maximum paths and route source information.
-
-        Raises:
-            ValueError: If the output cannot be parsed.
-        """
+        """Parse 'show route summary' output."""
         lines = output.splitlines()
         maximum_paths: int | None = None
         route_sources: dict[str, RouteSourceEntry] = {}
@@ -151,24 +168,7 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
                 maximum_paths = int(m.group("max_paths"))
                 continue
 
-            if cls._parse_bgp_detail(line, last_source, route_sources):
-                continue
-
-            internal_entry = cls._parse_internal_source(line)
-            if internal_entry is not None:
-                m = _INTERNAL_SOURCE_RE.match(line.strip())
-                assert m is not None
-                source = m.group("source").strip()
-                route_sources[source] = internal_entry
-                last_source = source
-                continue
-
-            standard_result = cls._parse_standard_source(line)
-            if standard_result is not None:
-                source, entry = standard_result
-                route_sources[source] = entry
-                last_source = source
-                continue
+            last_source = cls._process_line(line, route_sources, last_source)
 
         if maximum_paths is None:
             msg = "Could not find 'IP routing table maximum-paths' in output"

--- a/src/muninn/parsers/cisco_ftd/show_route_summary.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_summary.py
@@ -138,7 +138,8 @@ class ShowRouteSummaryParser(BaseParser["ShowRouteSummaryResult"]):
         internal_entry = cls._parse_internal_source(line)
         if internal_entry is not None:
             m = _INTERNAL_SOURCE_RE.match(line.strip())
-            assert m is not None
+            if m is None:
+                return last_source
             source = m.group("source").strip()
             route_sources[source] = internal_entry
             return source

--- a/tests/parsers/cisco_ftd/show_route_summary/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_route_summary/001_basic/expected.json
@@ -1,0 +1,43 @@
+{
+  "maximum_paths": 8,
+  "route_sources": {
+    "connected": {
+      "networks": 3,
+      "subnets": 63,
+      "replicates": 0,
+      "overhead": 5808,
+      "memory_bytes": 19536
+    },
+    "static": {
+      "networks": 1,
+      "subnets": 0,
+      "replicates": 0,
+      "overhead": 88,
+      "memory_bytes": 296
+    },
+    "bgp 65001": {
+      "networks": 5,
+      "subnets": 2,
+      "replicates": 0,
+      "overhead": 2288,
+      "memory_bytes": 2072,
+      "external": 7,
+      "internal": 0,
+      "local": 0
+    },
+    "internal": {
+      "networks": 8,
+      "subnets": 0,
+      "replicates": 0,
+      "overhead": 0,
+      "memory_bytes": 6688
+    },
+    "Total": {
+      "networks": 17,
+      "subnets": 65,
+      "replicates": 0,
+      "overhead": 8184,
+      "memory_bytes": 28592
+    }
+  }
+}

--- a/tests/parsers/cisco_ftd/show_route_summary/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_route_summary/001_basic/input.txt
@@ -1,0 +1,9 @@
+
+IP routing table maximum-paths is 8
+Route Source    Networks    Subnets     Replicates  Overhead    Memory (bytes)
+connected       3           63          0           5808        19536
+static          1           0           0           88          296
+bgp 65001       5           2           0           2288        2072
+  External: 7 Internal: 0 Local: 0
+internal        8                                               6688
+Total           17          65          0           8184        28592

--- a/tests/parsers/cisco_ftd/show_route_summary/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_route_summary/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: Route summary showing connected, static, BGP, and internal sources
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"


### PR DESCRIPTION
## Summary

- Adds parser for `show route summary` on Cisco FTD platform
- Extracts maximum-paths, per-source route statistics (networks, subnets, replicates, overhead, memory), and BGP External/Internal/Local detail
- Handles sparse-column format for the `internal` source row

## Test plan

- [x] Fixture-based test with real CLI output from Cisco Firepower 4215 (7.4.2.4)
- [x] `uv run pytest tests/parsers/ -k "show_route_summary" -v` — 14 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format` — no changes needed
- [x] `uv run pytest -q` — full suite 10213 passed

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: new parser implementation + test fixture + changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)