### PR TITLE
feat(cisco_ftd): add parser for `show route bgp`

### DIFF
--- a/changes/+show-route-bgp-cisco-ftd.parser_added
+++ b/changes/+show-route-bgp-cisco-ftd.parser_added
@@ -1,0 +1,1 @@
+Added parser support for `show route bgp` on Cisco FTD.

--- a/src/muninn/parsers/cisco_ftd/show_route_bgp.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_bgp.py
@@ -73,6 +73,40 @@ def _build_next_hop(match: re.Match[str]) -> NextHopEntry:
     )
 
 
+def _handle_continuation(
+    line: str, routes: dict[str, RouteEntry], current_route_key: str | None
+) -> bool:
+    """Try to parse line as an ECMP continuation and append to current route.
+
+    Returns True if the line was consumed as a continuation.
+    """
+    cont_match = _CONTINUATION_PATTERN.match(line)
+    if cont_match and current_route_key and current_route_key in routes:
+        routes[current_route_key]["next_hops"].append(_build_next_hop(cont_match))
+        return True
+    return False
+
+
+def _handle_route(line: str, routes: dict[str, RouteEntry]) -> str | None:
+    """Try to parse line as a BGP route entry and update routes dict.
+
+    Returns the route key (CIDR prefix) if the line was consumed, else None.
+    """
+    route_match = _ROUTE_PATTERN.match(line)
+    if not route_match:
+        return None
+    network = route_match.group("network")
+    mask = route_match.group("mask")
+    prefix_len = _mask_to_prefix_length(mask)
+    key = f"{network}/{prefix_len}"
+    next_hop = _build_next_hop(route_match)
+    if key in routes:
+        routes[key]["next_hops"].append(next_hop)
+    else:
+        routes[key] = RouteEntry(code=route_match.group("code"), next_hops=[next_hop])
+    return key
+
+
 @register(
     OS.CISCO_FTD, r"show route bgp\s*(?P<asn>\d*)", doc_template="show route bgp <asn>"
 )
@@ -113,32 +147,13 @@ class ShowRouteBgpParser(BaseParser[ShowRouteBgpResult]):
                 continue
 
             # Check for ECMP continuation line
-            cont_match = _CONTINUATION_PATTERN.match(line)
-            if cont_match:
-                if current_route_key and current_route_key in routes:
-                    routes[current_route_key]["next_hops"].append(
-                        _build_next_hop(cont_match)
-                    )
+            if _handle_continuation(line, routes, current_route_key):
                 continue
 
             # Check for route line
-            route_match = _ROUTE_PATTERN.match(line)
-            if route_match:
-                network = route_match.group("network")
-                mask = route_match.group("mask")
-                prefix_len = _mask_to_prefix_length(mask)
-                current_route_key = f"{network}/{prefix_len}"
-                code = route_match.group("code")
-                next_hop = _build_next_hop(route_match)
-
-                if current_route_key in routes:
-                    routes[current_route_key]["next_hops"].append(next_hop)
-                else:
-                    routes[current_route_key] = RouteEntry(
-                        code=code,
-                        next_hops=[next_hop],
-                    )
-                continue
+            new_key = _handle_route(line, routes)
+            if new_key is not None:
+                current_route_key = new_key
 
         if not routes:
             msg = "No BGP routes found in output"

--- a/src/muninn/parsers/cisco_ftd/show_route_bgp.py
+++ b/src/muninn/parsers/cisco_ftd/show_route_bgp.py
@@ -1,0 +1,150 @@
+"""Parser for 'show route bgp' command on Cisco FTD."""
+
+import re
+from typing import ClassVar, TypedDict
+
+from muninn.os import OS
+from muninn.parser import BaseParser
+from muninn.registry import register
+from muninn.tags import ParserTag
+
+
+class NextHopEntry(TypedDict):
+    """Schema for a single next-hop entry."""
+
+    next_hop: str
+    admin_distance: int
+    metric: int
+    uptime: str
+
+
+class RouteEntry(TypedDict):
+    """Schema for a single BGP route entry."""
+
+    code: str
+    next_hops: list[NextHopEntry]
+
+
+class ShowRouteBgpResult(TypedDict):
+    """Schema for 'show route bgp' parsed output on Cisco FTD."""
+
+    gateway_of_last_resort: str
+    routes: dict[str, RouteEntry]
+
+
+# Route line: B*  0.0.0.0 0.0.0.0 [20/0] via 172.16.2.135, 20:41:31
+_ROUTE_PATTERN = re.compile(
+    r"^(?P<code>B\S*)\s+"
+    r"(?P<network>\d+\.\d+\.\d+\.\d+)\s+"
+    r"(?P<mask>\d+\.\d+\.\d+\.\d+)\s+"
+    r"\[(?P<ad>\d+)/(?P<metric>\d+)\]\s+"
+    r"via\s+(?P<next_hop>\d+\.\d+\.\d+\.\d+),\s*"
+    r"(?P<uptime>\S+)\s*$"
+)
+
+# ECMP continuation line: [20/0] via 172.16.2.134, 20:41:31
+_CONTINUATION_PATTERN = re.compile(
+    r"^\s+"
+    r"\[(?P<ad>\d+)/(?P<metric>\d+)\]\s+"
+    r"via\s+(?P<next_hop>\d+\.\d+\.\d+\.\d+),\s*"
+    r"(?P<uptime>\S+)\s*$"
+)
+
+# Gateway of last resort line
+_GATEWAY_PATTERN = re.compile(
+    r"^Gateway of last resort is (?P<gateway>.+) to network (?P<network>\S+)$"
+)
+
+
+def _mask_to_prefix_length(mask: str) -> int:
+    """Convert dotted-decimal subnet mask to CIDR prefix length."""
+    octets = mask.split(".")
+    binary = "".join(f"{int(octet):08b}" for octet in octets)
+    return binary.count("1")
+
+
+def _build_next_hop(match: re.Match[str]) -> NextHopEntry:
+    """Build a NextHopEntry from a regex match."""
+    return NextHopEntry(
+        next_hop=match.group("next_hop"),
+        admin_distance=int(match.group("ad")),
+        metric=int(match.group("metric")),
+        uptime=match.group("uptime"),
+    )
+
+
+@register(
+    OS.CISCO_FTD, r"show route bgp\s*(?P<asn>\d*)", doc_template="show route bgp <asn>"
+)
+class ShowRouteBgpParser(BaseParser[ShowRouteBgpResult]):
+    """Parser for 'show route bgp' on Cisco FTD.
+
+    Parses BGP routes including ECMP paths with admin distance,
+    metric, and uptime. Supports optional ASN argument.
+    """
+
+    tags: ClassVar[frozenset[ParserTag]] = frozenset({ParserTag.ROUTING})
+
+    @classmethod
+    def parse(cls, output: str) -> ShowRouteBgpResult:
+        """Parse 'show route bgp' output on Cisco FTD.
+
+        Args:
+            output: Raw CLI output from command.
+
+        Returns:
+            Parsed BGP routing table with gateway and routes keyed by CIDR prefix.
+
+        Raises:
+            ValueError: If no BGP routes found in output.
+        """
+        routes: dict[str, RouteEntry] = {}
+        gateway_of_last_resort = ""
+        current_route_key: str | None = None
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            # Check for gateway of last resort
+            gw_match = _GATEWAY_PATTERN.match(line)
+            if gw_match:
+                gateway_of_last_resort = gw_match.group("gateway")
+                continue
+
+            # Check for ECMP continuation line
+            cont_match = _CONTINUATION_PATTERN.match(line)
+            if cont_match:
+                if current_route_key and current_route_key in routes:
+                    routes[current_route_key]["next_hops"].append(
+                        _build_next_hop(cont_match)
+                    )
+                continue
+
+            # Check for route line
+            route_match = _ROUTE_PATTERN.match(line)
+            if route_match:
+                network = route_match.group("network")
+                mask = route_match.group("mask")
+                prefix_len = _mask_to_prefix_length(mask)
+                current_route_key = f"{network}/{prefix_len}"
+                code = route_match.group("code")
+                next_hop = _build_next_hop(route_match)
+
+                if current_route_key in routes:
+                    routes[current_route_key]["next_hops"].append(next_hop)
+                else:
+                    routes[current_route_key] = RouteEntry(
+                        code=code,
+                        next_hops=[next_hop],
+                    )
+                continue
+
+        if not routes:
+            msg = "No BGP routes found in output"
+            raise ValueError(msg)
+
+        return ShowRouteBgpResult(
+            gateway_of_last_resort=gateway_of_last_resort,
+            routes=routes,
+        )

--- a/tests/parsers/cisco_ftd/show_route_bgp/001_basic/expected.json
+++ b/tests/parsers/cisco_ftd/show_route_bgp/001_basic/expected.json
@@ -1,0 +1,196 @@
+{
+  "gateway_of_last_resort": "172.16.2.135",
+  "routes": {
+    "0.0.0.0/0": {
+      "code": "B*",
+      "next_hops": [
+        {
+          "next_hop": "172.16.2.135",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "20:41:31"
+        },
+        {
+          "next_hop": "172.16.2.134",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "20:41:31"
+        },
+        {
+          "next_hop": "172.16.2.133",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "20:41:31"
+        }
+      ]
+    },
+    "198.51.100.0/24": {
+      "code": "B",
+      "next_hops": [
+        {
+          "next_hop": "172.16.2.135",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "20:41:31"
+        },
+        {
+          "next_hop": "172.16.2.134",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "20:41:31"
+        },
+        {
+          "next_hop": "172.16.2.133",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "20:41:31"
+        }
+      ]
+    },
+    "10.0.0.0/8": {
+      "code": "B",
+      "next_hops": [
+        {
+          "next_hop": "172.16.1.4",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.3",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.2",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.1",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        }
+      ]
+    },
+    "172.16.0.0/12": {
+      "code": "B",
+      "next_hops": [
+        {
+          "next_hop": "172.16.1.4",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.3",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.2",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.1",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        }
+      ]
+    },
+    "192.168.0.0/16": {
+      "code": "B",
+      "next_hops": [
+        {
+          "next_hop": "172.16.1.4",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.3",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.2",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.1",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        }
+      ]
+    },
+    "172.16.7.0/24": {
+      "code": "B",
+      "next_hops": [
+        {
+          "next_hop": "172.16.1.4",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.3",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.2",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.1",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        }
+      ]
+    },
+    "172.16.8.0/22": {
+      "code": "B",
+      "next_hops": [
+        {
+          "next_hop": "172.16.1.4",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.3",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.2",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        },
+        {
+          "next_hop": "172.16.1.1",
+          "admin_distance": 20,
+          "metric": 0,
+          "uptime": "1w0d"
+        }
+      ]
+    }
+  }
+}

--- a/tests/parsers/cisco_ftd/show_route_bgp/001_basic/input.txt
+++ b/tests/parsers/cisco_ftd/show_route_bgp/001_basic/input.txt
@@ -1,0 +1,37 @@
+
+Codes: L - local, C - connected, S - static, R - RIP, M - mobile, B - BGP
+       D - EIGRP, EX - EIGRP external, O - OSPF, IA - OSPF inter area 
+       N1 - OSPF NSSA external type 1, N2 - OSPF NSSA external type 2
+       E1 - OSPF external type 1, E2 - OSPF external type 2, V - VPN
+       i - IS-IS, su - IS-IS summary, L1 - IS-IS level-1, L2 - IS-IS level-2
+       ia - IS-IS inter area, * - candidate default, U - per-user static route
+       o - ODR, P - periodic downloaded static route, + - replicated route
+       SI - Static InterVRF, BI - BGP InterVRF
+Gateway of last resort is 172.16.2.135 to network 0.0.0.0
+
+B*       0.0.0.0 0.0.0.0 [20/0] via 172.16.2.135, 20:41:31
+                         [20/0] via 172.16.2.134, 20:41:31
+                         [20/0] via 172.16.2.133, 20:41:31
+B        198.51.100.0 255.255.255.0 [20/0] via 172.16.2.135, 20:41:31
+                               [20/0] via 172.16.2.134, 20:41:31
+                               [20/0] via 172.16.2.133, 20:41:31
+B        10.0.0.0 255.0.0.0 [20/0] via 172.16.1.4, 1w0d
+                            [20/0] via 172.16.1.3, 1w0d
+                            [20/0] via 172.16.1.2, 1w0d
+                            [20/0] via 172.16.1.1, 1w0d
+B        172.16.0.0 255.240.0.0 [20/0] via 172.16.1.4, 1w0d
+                                [20/0] via 172.16.1.3, 1w0d
+                                [20/0] via 172.16.1.2, 1w0d
+                                [20/0] via 172.16.1.1, 1w0d
+B        192.168.0.0 255.255.0.0 [20/0] via 172.16.1.4, 1w0d
+                                 [20/0] via 172.16.1.3, 1w0d
+                                 [20/0] via 172.16.1.2, 1w0d
+                                 [20/0] via 172.16.1.1, 1w0d
+B        172.16.7.0 255.255.255.0 [20/0] via 172.16.1.4, 1w0d
+                                    [20/0] via 172.16.1.3, 1w0d
+                                    [20/0] via 172.16.1.2, 1w0d
+                                    [20/0] via 172.16.1.1, 1w0d
+B        172.16.8.0 255.255.252.0 [20/0] via 172.16.1.4, 1w0d
+                                    [20/0] via 172.16.1.3, 1w0d
+                                    [20/0] via 172.16.1.2, 1w0d
+                                    [20/0] via 172.16.1.1, 1w0d

--- a/tests/parsers/cisco_ftd/show_route_bgp/001_basic/metadata.yaml
+++ b/tests/parsers/cisco_ftd/show_route_bgp/001_basic/metadata.yaml
@@ -1,0 +1,3 @@
+description: BGP routes showing ECMP paths with 4 next-hops per prefix
+platform: Cisco Firepower 4215
+software_version: "7.4.2.4"

--- a/tests/parsers/cisco_ftd/show_route_bgp/command.txt
+++ b/tests/parsers/cisco_ftd/show_route_bgp/command.txt
@@ -1,0 +1,1 @@
+show route bgp 65001

--- a/tests/parsers/test_fixture_json_conventions.py
+++ b/tests/parsers/test_fixture_json_conventions.py
@@ -164,6 +164,9 @@ _LIST_OF_DICTS_EXEMPT_EXPECTED_FILES: frozenset[str] = frozenset(
         # is_neighbors/ip_reachability/ipv6_reachability use list-of-dicts; no natural
         # unique key (multiple parallel links to same neighbor with different metrics).
         "iosxe/show_isis_database_detail/001_basic/expected.json",
+        # --- Cisco FTD ---
+        # next_hops uses list-of-dicts; no natural unique key for ECMP entries.
+        "cisco_ftd/show_route_bgp/001_basic/expected.json",
         # --- Cisco IOS-XR ---
         # routes uses list-of-dicts; no natural unique key for multiple BGP paths
         # (same network with multipath/ECMP entries and different next-hops).


### PR DESCRIPTION
## Summary
- Adds a new parser for `show route bgp` on Cisco FTD (OS.CISCO_FTD)
- Handles ECMP continuation lines with multiple next-hops per prefix
- Uses regex-based registration to support optional ASN argument (`show route bgp 65001`)
- Includes fixture from Cisco Firepower 4215 running 7.4.2.4

## Test plan
- [x] Parser test passes with real device output fixture (7 routes, ECMP with 3-4 next-hops each)
- [x] ruff lint and format pass
- [x] Full test suite passes (10213 tests)
- [ ] CI pipeline validates on merge

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~95%
- **AI Reason**: parser implementation + test fixture + changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)